### PR TITLE
fix: fail closed on ledger corruption (#1486)

### DIFF
--- a/internal/ledger/service/account_query.go
+++ b/internal/ledger/service/account_query.go
@@ -626,7 +626,12 @@ func enumerateAccountObjects(ctx context.Context, l *ledger.Ledger, accountID [2
 				return rerr
 			}
 			if data != nil {
-				if t, err := state.DecodeType(data); err == nil && wantType(t) {
+				t, derr := state.DecodeType(data)
+				if derr != nil {
+					if objTypeID == entry.TypeSignerList {
+						return derr
+					}
+				} else if wantType(t) {
 					result.AccountObjects = append(result.AccountObjects, AccountObjectItem{
 						Index:           protocol.Hash256Hex(itemKey),
 						LedgerEntryType: t.String(),

--- a/internal/ledger/service/account_query_test.go
+++ b/internal/ledger/service/account_query_test.go
@@ -401,7 +401,7 @@ func TestGetAccountObjects_TypeFilterAndErrors(t *testing.T) {
 	svc := newOfferTestService(t)
 	issuerAddr, _ := addressFromBytes(t, 0x10)
 	insertAccountRoot(t, svc, issuerAddr, 1_000_000_000_000, 0)
-	ownerAddr, _ := addressFromBytes(t, 0x20)
+	ownerAddr, ownerID := addressFromBytes(t, 0x20)
 	insertAccountRoot(t, svc, ownerAddr, 1_000_000_000_000, 0)
 
 	insertOffer(t, svc, ownerAddr, 1,
@@ -500,6 +500,25 @@ func TestGetAccountObjects_TypeFilterAndErrors(t *testing.T) {
 		_, err := svc.GetAccountObjects(context.Background(), stranger, "current", "", 0, "")
 		if !errors.Is(err, svcerr.ErrAccountNotFound) {
 			t.Fatalf("want ErrAccountNotFound, got %v", err)
+		}
+	})
+
+	t.Run("malformed signer list type is returned as an error", func(t *testing.T) {
+		signerKey := keylet.SignerList(ownerID)
+		malformed := make([]byte, 12)
+		malformed[0] = 0x11
+		malformed[1] = 0xff
+		malformed[2] = 0xff
+		if err := svc.openLedger.Insert(signerKey, malformed); err != nil {
+			t.Fatalf("insert malformed signer list: %v", err)
+		}
+		if _, err := state.DirInsert(svc.openLedger, keylet.OwnerDir(ownerID), signerKey.Key, false, nil); err != nil {
+			t.Fatalf("owner-dir insert malformed signer list: %v", err)
+		}
+
+		_, err := svc.GetAccountObjects(context.Background(), ownerAddr, "current", "SignerList", 0, "")
+		if err == nil {
+			t.Fatal("malformed signer list type must not be silently skipped")
 		}
 	})
 }

--- a/internal/ledger/service/events.go
+++ b/internal/ledger/service/events.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -14,6 +15,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 const invalidTransactionIndex = ^uint32(0)
@@ -761,30 +763,33 @@ func extractMentionedAccounts(rawSTTx []byte) []string {
 	return accounts
 }
 
-func proposedOwnerFunds(rawSTTx []byte, view *ledger.Ledger) string {
+func proposedOwnerFunds(rawSTTx []byte, view *ledger.Ledger) (string, bool, error) {
 	if len(rawSTTx) == 0 || view == nil {
-		return ""
+		return "", false, nil
 	}
 	txJSON, err := binarycodec.Decode(hex.EncodeToString(rawSTTx))
-	if err != nil || txJSON["TransactionType"] != "OfferCreate" {
-		return ""
+	if err != nil {
+		return "", false, fmt.Errorf("decode proposed transaction: %w", err)
+	}
+	if txJSON["TransactionType"] != "OfferCreate" {
+		return "", false, nil
 	}
 	account, _ := txJSON["Account"].(string)
 	if account == "" {
-		return ""
+		return "", false, nil
 	}
 	encodedAmount, err := json.Marshal(txJSON["TakerGets"])
 	if err != nil {
-		return ""
+		return "", false, nil
 	}
 	amount, err := state.AmountFromJSON(encodedAmount)
 	if err != nil {
-		return ""
+		return "", false, nil
 	}
 
 	_, accountBytes, err := addresscodec.DecodeClassicAddressToAccountID(account)
 	if err != nil || len(accountBytes) != 20 {
-		return ""
+		return "", false, nil
 	}
 	var accountID [20]byte
 	copy(accountID[:], accountBytes)
@@ -792,14 +797,31 @@ func proposedOwnerFunds(rawSTTx []byte, view *ledger.Ledger) string {
 	if amount.IsMPT() {
 		id, decodeErr := mptutil.DecodeID(amount.MPTIssuanceID())
 		if decodeErr != nil || accountID == mptutil.Issuer(id) {
-			return ""
+			return "", false, nil
 		}
-		funds, _ := mptutil.Funds(view, id, accountID, false)
-		return state.NewMPTAmountWithIssuanceID(funds, "", amount.MPTIssuanceID()).Value()
+		funds, result := mptutil.Funds(view, id, accountID, false)
+		switch result {
+		case ter.TesSUCCESS:
+		case ter.TecOBJECT_NOT_FOUND, ter.TecNO_AUTH:
+			funds = 0
+		default:
+			return "", true, fmt.Errorf("proposed owner funds: MPT funds failed: %s", result)
+		}
+		return state.NewMPTAmountWithIssuanceID(funds, "", amount.MPTIssuanceID()).Value(), true, nil
 	}
 	if !amount.IsNative() && amount.Issuer == account {
-		return ""
+		return "", false, nil
 	}
-	_, reserveBase, reserveInc := readFeesFromLedger(view)
-	return txcore.AccountFunds(view, accountID, amount, false, reserveBase, reserveInc).Value()
+	var reserveBase, reserveInc uint64
+	if amount.IsNative() {
+		_, reserveBase, reserveInc, err = readFeesFromLedgerContext(context.Background(), view)
+		if err != nil {
+			return "", true, fmt.Errorf("proposed owner funds: read fees: %w", err)
+		}
+	}
+	funds, err := txcore.AccountFundsNoFreezeStrict(view, accountID, amount, reserveBase, reserveInc)
+	if err != nil {
+		return "", true, err
+	}
+	return funds.Value(), true, nil
 }

--- a/internal/ledger/service/owner_funds_fail_closed_test.go
+++ b/internal/ledger/service/owner_funds_fail_closed_test.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/openledger"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+func TestProposedOwnerFundsFailureSuppressesPublication(t *testing.T) {
+	svc := newOfferTestService(t)
+	t.Cleanup(svc.Stop)
+
+	account, _ := addressFromBytes(t, 0x70)
+	issuer, _ := addressFromBytes(t, 0x80)
+	insertAccountRoot(t, svc, account, 1_000_000_000, 0)
+	raw, err := binarycodec.EncodeBytes(map[string]any{
+		"TransactionType": "OfferCreate",
+		"Account":         account,
+		"TakerGets":       "1000000",
+		"TakerPays": map[string]any{
+			"currency": "USD",
+			"issuer":   issuer,
+			"value":    "1",
+		},
+		"Fee":           "10",
+		"Sequence":      uint32(1),
+		"SigningPubKey": "",
+	})
+	if err != nil {
+		t.Fatalf("encode OfferCreate: %v", err)
+	}
+	parsed, err := tx.ParseFromBinary(raw)
+	if err != nil {
+		t.Fatalf("parse OfferCreate: %v", err)
+	}
+	if err := svc.openLedger.Update(keylet.Fees(), []byte{
+		0x11, 0x00, 0x73, 0xff, 0, 0, 0, 0, 0, 0, 0, 0,
+	}); err != nil {
+		t.Fatalf("corrupt FeeSettings: %v", err)
+	}
+
+	if _, applicable, err := proposedOwnerFunds(raw, svc.openLedger); err == nil || !applicable {
+		t.Fatalf("proposedOwnerFunds = applicable %t, err %v; want applicable error", applicable, err)
+	}
+	iouRaw, err := binarycodec.EncodeBytes(map[string]any{
+		"TransactionType": "OfferCreate",
+		"Account":         account,
+		"TakerGets": map[string]any{
+			"currency": "USD",
+			"issuer":   issuer,
+			"value":    "1",
+		},
+		"TakerPays":     "1000000",
+		"Fee":           "10",
+		"Sequence":      uint32(1),
+		"SigningPubKey": "",
+	})
+	if err != nil {
+		t.Fatalf("encode IOU OfferCreate: %v", err)
+	}
+	if funds, applicable, err := proposedOwnerFunds(iouRaw, svc.openLedger); err != nil || !applicable || funds != "0" {
+		t.Fatalf("IOU proposedOwnerFunds = (%q, %t, %v), want (0, true, nil)", funds, applicable, err)
+	}
+	published := make(chan SubmittedTxEvent, 1)
+	svc.SetSubmittedTxCallback(func(event SubmittedTxEvent) { published <- event })
+	svc.dispatchProposedTransaction(openledger.PendingTx{Parsed: parsed}, raw, openledger.SubmitOutcome{
+		Result:  ter.TesSUCCESS,
+		Applied: true,
+	}, svc.openLedger)
+	select {
+	case event := <-published:
+		t.Fatalf("corrupt owner funds published event: %+v", event)
+	case <-time.After(25 * time.Millisecond):
+	}
+}

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -288,12 +288,17 @@ func (s *Service) dispatchProposedTransaction(
 		!mayPublishProposedTransaction(ptx.Parsed.GetCommon().GetFlags()) {
 		return
 	}
+	ownerFunds, _, err := proposedOwnerFunds(rawBlob, current)
+	if err != nil {
+		s.logger.Error("failed to compute proposed transaction owner funds", "hash", fmt.Sprintf("%X", ptx.Hash), "err", err)
+		return
+	}
 	s.eventPublisher.dispatchSubmittedTxEvent(SubmittedTxEvent{
 		RawBlob:          append([]byte(nil), rawBlob...),
 		TxHash:           ptx.Hash,
 		AffectedAccounts: extractMentionedAccounts(rawBlob),
 		CurrentLedger:    current.Sequence(),
-		OwnerFunds:       proposedOwnerFunds(rawBlob, current),
+		OwnerFunds:       ownerFunds,
 		Result: Result{
 			Code:    int(outcome.Result),
 			Name:    outcome.Result.String(),
@@ -341,7 +346,7 @@ func readFeesFromLedgerContext(ctx context.Context, l *ledger.Ledger) (baseFee, 
 
 	feeSettings, err := state.ParseFeeSettings(data)
 	if err != nil {
-		return uint64(fees.Base), uint64(fees.Reserve), uint64(fees.Increment), nil
+		return 0, 0, 0, fmt.Errorf("parse FeeSettings: %w", err)
 	}
 	fees = mergeFeeSettings(fees, feeSettings)
 	return uint64(fees.Base), uint64(fees.Reserve), uint64(fees.Increment), nil
@@ -351,6 +356,13 @@ func readFeesFromLedgerContext(ctx context.Context, l *ledger.Ledger) (baseFee, 
 // ledger, falling back to the protocol defaults when its FeeSettings entry is unavailable.
 func FeesFromLedger(l *ledger.Ledger) (baseFee, reserveBase, reserveIncrement uint64) {
 	return readFeesFromLedger(l)
+}
+
+// FeesFromLedgerStrict returns the fee settings carried by l while preserving
+// storage and decoding failures. A missing FeeSettings entry uses the ledger's
+// configured fee values.
+func FeesFromLedgerStrict(l *ledger.Ledger) (baseFee, reserveBase, reserveIncrement uint64, err error) {
+	return readFeesFromLedgerContext(context.Background(), l)
 }
 
 // GetCurrentFees returns the current fee settings read from the FeeSettings

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -961,10 +961,15 @@ func (r *nodeRuntime) bindStreams() error {
 		// adapter store cannot drop the announce when the ledger isn't
 		// yet visible to GetLedgerBySequence.
 		bookView := newAcceptedLedgerView(*event.LedgerInfo)
-		payload := handlers.ComputeBookChangesFromTransactions(bookView, bookTransactions)
-		if data, err := json.Marshal(payload); err == nil {
-			r.wsServer.SubscriptionManager().BroadcastToStream(types.SubBookChanges, data, nil)
+		payload, err := handlers.ComputeBookChangesFromTransactionsStrict(bookView, bookTransactions)
+		if err != nil {
+			return fmt.Errorf("compute accepted ledger book changes: %w", err)
 		}
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("marshal accepted ledger book changes: %w", err)
+		}
+		r.wsServer.SubscriptionManager().BroadcastToStream(types.SubBookChanges, data, nil)
 
 		for _, publication := range publications {
 			r.publisher.PublishTransaction(publication.event, publication.projection.affectedAccounts)

--- a/internal/node/synthetic_meta_stream_test.go
+++ b/internal/node/synthetic_meta_stream_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
@@ -191,6 +192,94 @@ func TestPrepareAcceptedPublicationsRejectsWholeLedger(t *testing.T) {
 	require.Nil(t, bookTransactions)
 }
 
+func TestPrepareAcceptedPublicationsRejectsCorruptOwnerFundsState(t *testing.T) {
+	svc, err := service.New(service.Config{
+		Standalone:    true,
+		Startup:       service.StartupConfig{Mode: service.StartupFresh},
+		GenesisConfig: genesis.DefaultConfig(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	view := svc.GetOpenLedger()
+	require.NotNil(t, view)
+	require.NoError(t, view.Update(keylet.Fees(), []byte{
+		0x11, 0x00, 0x73, 0xff, 0, 0, 0, 0, 0, 0, 0, 0,
+	}))
+
+	accepted := service.ParseAcceptedTransaction(validatedOfferData(t, 0, 0))
+	require.NoError(t, accepted.ParseError())
+	event := &service.LedgerAcceptedEvent{
+		Ledger: view,
+		LedgerInfo: &service.LedgerInfo{
+			Sequence:  view.Sequence(),
+			Validated: true,
+			Closed:    true,
+		},
+		TransactionResults: []service.TransactionResultEvent{{
+			TxHash:      [32]byte{1},
+			Accepted:    accepted,
+			Validated:   true,
+			LedgerIndex: view.Sequence(),
+		}},
+	}
+
+	publications, bookTransactions, err := prepareAcceptedPublications(event, 0)
+	require.Error(t, err)
+	require.Nil(t, publications)
+	require.Nil(t, bookTransactions)
+}
+
+func TestPrepareAcceptedPublicationsReadsFeesOnlyForXRPOffers(t *testing.T) {
+	svc, err := service.New(service.Config{
+		Standalone:    true,
+		Startup:       service.StartupConfig{Mode: service.StartupFresh},
+		GenesisConfig: genesis.DefaultConfig(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	view := svc.GetOpenLedger()
+	require.NotNil(t, view)
+	require.NoError(t, view.Update(keylet.Fees(), []byte{
+		0x11, 0x00, 0x73, 0xff, 0, 0, 0, 0, 0, 0, 0, 0,
+	}))
+
+	for _, test := range []struct {
+		name string
+		data []byte
+	}{
+		{name: "Payment", data: validatedPaymentData(t, 0, 0)},
+		{name: "IOU OfferCreate", data: validatedIOUOfferData(t, 0, 0)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			accepted := service.ParseAcceptedTransaction(test.data)
+			require.NoError(t, accepted.ParseError())
+			event := &service.LedgerAcceptedEvent{
+				Ledger: view,
+				LedgerInfo: &service.LedgerInfo{
+					Sequence:  view.Sequence(),
+					Validated: true,
+					Closed:    true,
+				},
+				TransactionResults: []service.TransactionResultEvent{{
+					TxHash:      [32]byte{1},
+					Accepted:    accepted,
+					Validated:   true,
+					LedgerIndex: view.Sequence(),
+				}},
+			}
+
+			publications, bookTransactions, err := prepareAcceptedPublications(event, 0)
+			require.NoError(t, err)
+			require.Len(t, publications, 1)
+			require.Len(t, bookTransactions, 1)
+		})
+	}
+}
+
 func validatedPaymentData(t *testing.T, networkID, transactionIndex uint32) []byte {
 	t.Helper()
 	txJSON := map[string]any{
@@ -203,6 +292,45 @@ func validatedPaymentData(t *testing.T, networkID, transactionIndex uint32) []by
 		"SigningPubKey":   "",
 		"TransactionType": "Payment",
 	}
+	return validatedTransactionData(t, txJSON, transactionIndex)
+}
+
+func validatedOfferData(t *testing.T, networkID, transactionIndex uint32) []byte {
+	t.Helper()
+	txJSON := map[string]any{
+		"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"Fee":             "10",
+		"NetworkID":       networkID,
+		"Sequence":        uint32(1),
+		"SigningPubKey":   "",
+		"TakerGets":       "100",
+		"TakerPays":       "200",
+		"TransactionType": "OfferCreate",
+	}
+	return validatedTransactionData(t, txJSON, transactionIndex)
+}
+
+func validatedIOUOfferData(t *testing.T, networkID, transactionIndex uint32) []byte {
+	t.Helper()
+	txJSON := map[string]any{
+		"Account":       "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"Fee":           "10",
+		"NetworkID":     networkID,
+		"Sequence":      uint32(1),
+		"SigningPubKey": "",
+		"TakerGets": map[string]any{
+			"currency": "USD",
+			"issuer":   "rDsbeomae4FXwgQTJp9Rs64Qg9vDiTCdBv",
+			"value":    "1",
+		},
+		"TakerPays":       "200",
+		"TransactionType": "OfferCreate",
+	}
+	return validatedTransactionData(t, txJSON, transactionIndex)
+}
+
+func validatedTransactionData(t *testing.T, txJSON map[string]any, transactionIndex uint32) []byte {
+	t.Helper()
 	meta := map[string]any{
 		"AffectedNodes":     []any{},
 		"TransactionIndex":  transactionIndex,

--- a/internal/node/transaction_streams.go
+++ b/internal/node/transaction_streams.go
@@ -260,9 +260,22 @@ func buildProjectedValidatedTransactionEvent(
 		txFields["date"] = uint32(closeTime)
 	}
 	if event.Ledger != nil {
-		_, reserveBase, reserveInc := service.FeesFromLedger(event.Ledger)
-		if funds, ok := handlers.TransactionOwnerFunds(txFields, event.Ledger, reserveBase, reserveInc); ok {
-			txFields["owner_funds"] = funds
+		applicable, needsReserves := handlers.TransactionOwnerFundsRequirements(txFields)
+		var reserveBase, reserveInc uint64
+		if applicable && needsReserves {
+			_, reserveBase, reserveInc, err = service.FeesFromLedgerStrict(event.Ledger)
+			if err != nil {
+				return nil, ter.TemMALFORMED, fmt.Errorf("read accepted ledger fees: %w", err)
+			}
+		}
+		if applicable {
+			funds, ok, fundsErr := handlers.TransactionOwnerFunds(txFields, event.Ledger, reserveBase, reserveInc)
+			if fundsErr != nil {
+				return nil, ter.TemMALFORMED, fmt.Errorf("compute accepted transaction owner funds: %w", fundsErr)
+			}
+			if ok {
+				txFields["owner_funds"] = funds
+			}
 		}
 	}
 	encoded, err := json.Marshal(txFields)

--- a/internal/rpc/account_info_test.go
+++ b/internal/rpc/account_info_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -18,6 +19,10 @@ import (
 type mockLedgerService struct {
 	accountInfo          *types.AccountInfo
 	accountInfoErr       error
+	accountObjects       *types.AccountObjectsResult
+	accountObjectsErr    error
+	accountObjectsSet    bool
+	accountObjectPages   map[string]*types.AccountObjectsResult
 	currentLedgerIndex   uint32
 	closedLedgerIndex    uint32
 	validatedLedgerIndex uint32
@@ -140,8 +145,27 @@ func (m *mockLedgerService) GetLedgerEntry(_ context.Context, entryKey [32]byte,
 func (m *mockLedgerService) GetLedgerData(_ context.Context, ledgerIndex string, limit uint32, marker string) (*types.LedgerDataResult, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockLedgerService) GetAccountObjects(_ context.Context, account string, ledgerIndex string, objType string, limit uint32, _ string) (*types.AccountObjectsResult, error) {
-	return nil, errors.New("not implemented")
+func (m *mockLedgerService) GetAccountObjects(_ context.Context, account string, ledgerIndex string, objType string, limit uint32, marker string) (*types.AccountObjectsResult, error) {
+	if m.accountObjectPages != nil {
+		result, ok := m.accountObjectPages[marker]
+		if !ok {
+			return nil, errors.New("unexpected account objects marker")
+		}
+		return result, nil
+	}
+	if m.accountObjectsSet {
+		return m.accountObjects, m.accountObjectsErr
+	}
+	if m.accountObjectsErr != nil {
+		return nil, m.accountObjectsErr
+	}
+	if m.accountObjects != nil {
+		return m.accountObjects, nil
+	}
+	return &types.AccountObjectsResult{
+		Account:        account,
+		AccountObjects: []types.AccountObjectItem{},
+	}, nil
 }
 func (m *mockLedgerService) GetAccountChannels(_ context.Context, account string, destinationAccount string, ledgerIndex string, limit uint32, _ string) (*types.AccountChannelsResult, error) {
 	return nil, errors.New("not implemented")
@@ -746,6 +770,251 @@ func TestAccountInfoResponseFields(t *testing.T) {
 		signerLists := accountData["signer_lists"].([]any)
 		assert.NotNil(t, signerLists)
 	})
+}
+
+func TestAccountInfoSignerListsFailClosed(t *testing.T) {
+	const validAccount = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+
+	validSignerList, err := binarycodec.EncodeBytes(map[string]any{
+		"LedgerEntryType": "SignerList",
+		"Flags":           uint32(0),
+		"OwnerNode":       "0",
+		"SignerQuorum":    uint32(1),
+		"SignerEntries": []any{
+			map[string]any{
+				"SignerEntry": map[string]any{
+					"Account":      validAccount,
+					"SignerWeight": uint32(1),
+				},
+			},
+		},
+		"SignerListID":      uint32(0),
+		"PreviousTxnID":     "0000000000000000000000000000000000000000000000000000000000000000",
+		"PreviousTxnLgrSeq": uint32(1),
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		apiVersion int
+		setup      func(*mockLedgerService)
+		check      func(*testing.T, map[string]any)
+	}{
+		{
+			name:       "empty signer list is an array under API v1 account_data",
+			apiVersion: types.ApiVersion1,
+			setup: func(mock *mockLedgerService) {
+				mock.accountObjectsSet = true
+				mock.accountObjects = &types.AccountObjectsResult{AccountObjects: []types.AccountObjectItem{}}
+			},
+			check: func(t *testing.T, response map[string]any) {
+				accountData := response["account_data"].(map[string]any)
+				lists, ok := accountData["signer_lists"].([]any)
+				require.True(t, ok)
+				assert.Empty(t, lists)
+				assert.NotContains(t, response, "signer_lists")
+			},
+		},
+		{
+			name:       "empty signer list is an array at API v2 top level",
+			apiVersion: types.ApiVersion2,
+			setup: func(mock *mockLedgerService) {
+				mock.accountObjectsSet = true
+				mock.accountObjects = &types.AccountObjectsResult{AccountObjects: []types.AccountObjectItem{}}
+			},
+			check: func(t *testing.T, response map[string]any) {
+				lists, ok := response["signer_lists"].([]any)
+				require.True(t, ok)
+				assert.Empty(t, lists)
+				accountData := response["account_data"].(map[string]any)
+				assert.NotContains(t, accountData, "signer_lists")
+			},
+		},
+		{
+			name:       "decoded signer list keeps API v1 nesting",
+			apiVersion: types.ApiVersion1,
+			setup: func(mock *mockLedgerService) {
+				mock.accountObjectsSet = true
+				mock.accountObjects = &types.AccountObjectsResult{AccountObjects: []types.AccountObjectItem{{
+					Index: "aabb",
+					Data:  validSignerList,
+				}}}
+			},
+			check: func(t *testing.T, response map[string]any) {
+				accountData := response["account_data"].(map[string]any)
+				lists := accountData["signer_lists"].([]any)
+				require.Len(t, lists, 1)
+				assert.NotContains(t, response, "signer_lists")
+				assert.Equal(t, "AABB", lists[0].(map[string]any)["index"])
+			},
+		},
+		{
+			name:       "decoded signer list keeps API v2 top-level placement",
+			apiVersion: types.ApiVersion2,
+			setup: func(mock *mockLedgerService) {
+				mock.accountObjectsSet = true
+				mock.accountObjects = &types.AccountObjectsResult{AccountObjects: []types.AccountObjectItem{{
+					Index: "aabb",
+					Data:  validSignerList,
+				}}}
+			},
+			check: func(t *testing.T, response map[string]any) {
+				lists := response["signer_lists"].([]any)
+				require.Len(t, lists, 1)
+				accountData := response["account_data"].(map[string]any)
+				assert.NotContains(t, accountData, "signer_lists")
+				assert.Equal(t, "AABB", lists[0].(map[string]any)["index"])
+			},
+		},
+		{
+			name:       "signer list after a full owner directory page is returned",
+			apiVersion: types.ApiVersion2,
+			setup: func(mock *mockLedgerService) {
+				mock.accountObjectPages = map[string]*types.AccountObjectsResult{
+					"": {AccountObjects: []types.AccountObjectItem{}, Marker: "next"},
+					"next": {AccountObjects: []types.AccountObjectItem{{
+						Index: "aabb",
+						Data:  validSignerList,
+					}}},
+				}
+			},
+			check: func(t *testing.T, response map[string]any) {
+				lists := response["signer_lists"].([]any)
+				require.Len(t, lists, 1)
+				assert.Equal(t, "AABB", lists[0].(map[string]any)["index"])
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mock := newMockLedgerService()
+			mock.accountInfo = &types.AccountInfo{
+				Account:     validAccount,
+				Balance:     "100000000",
+				Sequence:    1,
+				LedgerIndex: 2,
+				Validated:   true,
+			}
+			test.setup(mock)
+			ctx := &types.RpcContext{
+				Context:    context.Background(),
+				Role:       types.RoleGuest,
+				ApiVersion: test.apiVersion,
+				Services:   newTestServices(mock),
+			}
+			paramsJSON, marshalErr := json.Marshal(map[string]any{
+				"account":      validAccount,
+				"signer_lists": true,
+			})
+			require.NoError(t, marshalErr)
+
+			result, rpcErr := (&handlers.AccountInfoMethod{}).Handle(ctx, paramsJSON)
+			require.Nil(t, rpcErr)
+			response := result.(map[string]any)
+			test.check(t, response)
+		})
+	}
+
+	for _, test := range []struct {
+		name     string
+		setup    func(*mockLedgerService)
+		wantCode int
+		wantMsg  string
+	}{
+		{
+			name:     "GetAccountObjects error",
+			wantCode: types.RpcINTERNAL,
+			wantMsg:  "Internal error.",
+			setup: func(mock *mockLedgerService) {
+				mock.accountObjectsSet = true
+				mock.accountObjectsErr = errors.New("owner directory unavailable")
+			},
+		},
+		{
+			name:     "nil GetAccountObjects result",
+			wantCode: types.RpcINTERNAL,
+			wantMsg:  "Internal error.",
+			setup: func(mock *mockLedgerService) {
+				mock.accountObjectsSet = true
+				mock.accountObjects = nil
+				mock.accountObjectsErr = nil
+			},
+		},
+		{
+			name:     "corrupt signer list aborts response",
+			wantCode: types.RpcINTERNAL,
+			wantMsg:  "Internal error.",
+			setup: func(mock *mockLedgerService) {
+				mock.accountObjectsSet = true
+				mock.accountObjects = &types.AccountObjectsResult{AccountObjects: []types.AccountObjectItem{
+					{Index: "aabb", Data: validSignerList},
+					{Index: "ccdd", Data: []byte{0x11, 0x00}},
+				}}
+			},
+		},
+		{
+			name:     "signer list ledger not found",
+			wantCode: types.RpcLGR_NOT_FOUND,
+			wantMsg:  "Ledger not found.",
+			setup: func(mock *mockLedgerService) {
+				mock.accountObjectsSet = true
+				mock.accountObjectsErr = svcerr.ErrLedgerNotFound
+			},
+		},
+		{
+			name:     "signer list repeated marker",
+			wantCode: types.RpcINTERNAL,
+			wantMsg:  "Internal error.",
+			setup: func(mock *mockLedgerService) {
+				mock.accountObjectPages = map[string]*types.AccountObjectsResult{
+					"":  {Marker: "a"},
+					"a": {Marker: "a"},
+				}
+			},
+		},
+		{
+			name:     "signer list marker cycle",
+			wantCode: types.RpcINTERNAL,
+			wantMsg:  "Internal error.",
+			setup: func(mock *mockLedgerService) {
+				mock.accountObjectPages = map[string]*types.AccountObjectsResult{
+					"":  {Marker: "a"},
+					"a": {Marker: "b"},
+					"b": {Marker: "a"},
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			mock := newMockLedgerService()
+			mock.accountInfo = &types.AccountInfo{
+				Account:     validAccount,
+				Balance:     "100000000",
+				Sequence:    1,
+				LedgerIndex: 2,
+				Validated:   true,
+			}
+			test.setup(mock)
+			ctx := &types.RpcContext{
+				Context:    context.Background(),
+				Role:       types.RoleGuest,
+				ApiVersion: types.ApiVersion2,
+				Services:   newTestServices(mock),
+			}
+			paramsJSON, marshalErr := json.Marshal(map[string]any{
+				"account":      validAccount,
+				"signer_lists": true,
+			})
+			require.NoError(t, marshalErr)
+
+			result, rpcErr := (&handlers.AccountInfoMethod{}).Handle(ctx, paramsJSON)
+			assert.Nil(t, result)
+			require.NotNil(t, rpcErr)
+			assert.Equal(t, test.wantCode, rpcErr.Code)
+			assert.Equal(t, test.wantMsg, rpcErr.Message)
+		})
+	}
 }
 
 // TestAccountInfoInvalidAccountTypes tests various invalid account parameter types

--- a/internal/rpc/handlers/account_info.go
+++ b/internal/rpc/handlers/account_info.go
@@ -176,7 +176,13 @@ func (m *AccountInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 
 	// Load signer lists if requested
 	if signerLists {
-		signerListEntries := m.loadSignerLists(ctx.Context, ctx.Services, canonicalAccount, ledgerIndex)
+		signerListEntries, signerListErr := m.loadSignerLists(ctx.Context, ctx.Services, canonicalAccount, ledgerIndex)
+		if signerListErr != nil {
+			if errors.Is(signerListErr, svcerr.ErrLedgerNotFound) {
+				return nil, types.RpcErrorLgrNotFound("Ledger not found.")
+			}
+			return nil, rpcInternalError("account_info: signer list lookup failed", signerListErr)
+		}
 		if ctx.ApiVersion > 1 {
 			// API v2: signer_lists at top level
 			response["signer_lists"] = signerListEntries
@@ -357,25 +363,37 @@ func buildAccountQueueData(services *types.ServiceContainer, account string) map
 }
 
 // loadSignerLists retrieves signer list objects for an account
-func (m *AccountInfoMethod) loadSignerLists(ctx context.Context, services *types.ServiceContainer, account string, ledgerIndex string) []any {
-	result, err := services.Ledger.GetAccountObjects(ctx, account, ledgerIndex, "SignerList", 10, "")
-	if err != nil || len(result.AccountObjects) == 0 {
-		return []any{}
-	}
-
-	var signerLists []any
-	for _, obj := range result.AccountObjects {
-		// Decode the raw SLE binary to JSON
-		hexData := hex.EncodeToString(obj.Data)
-		decoded, err := binarycodec.Decode(hexData)
+func (m *AccountInfoMethod) loadSignerLists(ctx context.Context, services *types.ServiceContainer, account string, ledgerIndex string) ([]any, error) {
+	signerLists := make([]any, 0, 1)
+	marker := ""
+	seenMarkers := make(map[string]struct{})
+	for {
+		result, err := services.Ledger.GetAccountObjects(ctx, account, ledgerIndex, "SignerList", 10, marker)
 		if err != nil {
-			continue
+			return nil, err
 		}
-		decoded["index"] = strings.ToUpper(obj.Index)
-		signerLists = append(signerLists, decoded)
+		if result == nil {
+			return nil, errors.New("account_info: signer list query returned nil result")
+		}
+		for _, obj := range result.AccountObjects {
+			hexData := hex.EncodeToString(obj.Data)
+			decoded, err := binarycodec.Decode(hexData)
+			if err != nil {
+				return nil, err
+			}
+			if decoded == nil {
+				return nil, errors.New("account_info: signer list query returned nil decoded object")
+			}
+			decoded["index"] = strings.ToUpper(obj.Index)
+			signerLists = append(signerLists, decoded)
+		}
+		if result.Marker == "" {
+			return signerLists, nil
+		}
+		if _, repeated := seenMarkers[result.Marker]; repeated {
+			return nil, errors.New("account_info: signer list query returned repeated marker")
+		}
+		seenMarkers[result.Marker] = struct{}{}
+		marker = result.Marker
 	}
-	if signerLists == nil {
-		return []any{}
-	}
-	return signerLists
 }

--- a/internal/rpc/handlers/book_changes.go
+++ b/internal/rpc/handlers/book_changes.go
@@ -86,6 +86,20 @@ func ComputeBookChangesFromTransactions(l BookChangesHeader, transactions []Book
 	return formatBookChanges(l, changes)
 }
 
+// ComputeBookChangesFromTransactionsStrict rejects incomplete accepted-ledger
+// projections instead of emitting a partial aggregate.
+func ComputeBookChangesFromTransactionsStrict(l BookChangesHeader, transactions []BookChangesTransaction) (map[string]any, error) {
+	if l == nil {
+		return nil, fmt.Errorf("book changes ledger header is nil")
+	}
+	for i, transaction := range transactions {
+		if transaction.Transaction == nil || transaction.Metadata == nil {
+			return nil, fmt.Errorf("book changes transaction %d is incomplete", i)
+		}
+	}
+	return ComputeBookChangesFromTransactions(l, transactions), nil
+}
+
 func formatBookChanges(l BookChangesHeader, changes map[string]*bookChange) map[string]any {
 	if l == nil {
 		return map[string]any{

--- a/internal/rpc/handlers/book_changes_arithmetic_test.go
+++ b/internal/rpc/handlers/book_changes_arithmetic_test.go
@@ -73,6 +73,45 @@ func TestComputeBookChangesCanonicalArithmeticAndRendering(t *testing.T) {
 	}
 }
 
+func TestComputeBookChangesFromTransactionsStrict(t *testing.T) {
+	ledger := mptBookChangesLedger{}
+
+	result, err := ComputeBookChangesFromTransactionsStrict(ledger, nil)
+	require.NoError(t, err)
+	encoded, err := json.Marshal(result)
+	require.NoError(t, err)
+	require.NotEqual(t, "null", string(encoded))
+	require.Equal(t, []map[string]any{}, result["changes"])
+
+	for _, test := range []struct {
+		name         string
+		ledger       BookChangesHeader
+		transactions []BookChangesTransaction
+	}{
+		{name: "nil ledger header"},
+		{
+			name:   "nil transaction projection",
+			ledger: ledger,
+			transactions: []BookChangesTransaction{{
+				Metadata: map[string]any{"AffectedNodes": []any{}},
+			}},
+		},
+		{
+			name:   "nil metadata projection",
+			ledger: ledger,
+			transactions: []BookChangesTransaction{{
+				Transaction: validBookChangesTxJSON(),
+			}},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := ComputeBookChangesFromTransactionsStrict(test.ledger, test.transactions)
+			require.Error(t, err)
+			require.Nil(t, result)
+		})
+	}
+}
+
 func validBookChangesTxJSON() map[string]any {
 	return map[string]any{
 		"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",

--- a/internal/rpc/handlers/ledger.go
+++ b/internal/rpc/handlers/ledger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"strconv"
@@ -97,20 +98,16 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 		CloseTime:      closeTimeSec,
 	}
 
-	_, reserveBase, reserveInc := ctx.Services.Ledger.GetCurrentFees()
-	var ownerFundsView types.LedgerStateView
-	ownerFundsReserveBase, ownerFundsReserveInc := reserveBase, reserveInc
+	var ownerFundsAnnotator *ledgerOwnerFundsAnnotator
 	if request.OwnerFunds && request.Expand {
-		ownerFundsView = ownerFundsLedgerView(ctx, targetLedger)
-		if ownerFundsView != nil {
-			ownerFundsReserveBase, ownerFundsReserveInc = reserveSettingsFromLedger(ownerFundsView, reserveBase, reserveInc)
-		}
+		ownerFundsAnnotator = &ledgerOwnerFundsAnnotator{ctx: ctx, ledger: targetLedger}
 	}
 
 	if request.Transactions {
 		var txList []any
 		apiVersion := ctx.ApiVersion
 		var decodeErr error
+		var ownerFundsErr error
 		visit := func(txHashKey [32]byte, txData []byte) bool {
 			hashStr := strings.ToUpper(hex.EncodeToString(txHashKey[:]))
 			if request.Expand {
@@ -132,13 +129,18 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 						}
 					}
 				}
-				if ownerFundsView != nil {
+				if ownerFundsAnnotator != nil {
 					storedTx, err := decodeTxBlob(txData)
 					if err != nil {
 						decodeErr = err
 						return false
 					}
-					if !annotateOwnerFunds(txEntry, storedTx.TxJSON, ownerFundsView, ownerFundsReserveBase, ownerFundsReserveInc) {
+					continueEnumeration, err := ownerFundsAnnotator.annotate(txEntry, storedTx.TxJSON)
+					if err != nil {
+						ownerFundsErr = err
+						return false
+					}
+					if !continueEnumeration {
 						return false
 					}
 				}
@@ -158,6 +160,9 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 		}
 		if iterErr != nil {
 			return nil, rpcInternalError("ledger: transaction iteration failed", iterErr)
+		}
+		if ownerFundsErr != nil {
+			return nil, rpcInternalError("ledger: transaction owner_funds failed", ownerFundsErr)
 		}
 		if decodeErr != nil {
 			// LedgerToJson treats a malformed stored transaction as a corrupt
@@ -194,15 +199,15 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 	}
 
 	if dumpQueue {
-		queueData, queueInternalError := buildLedgerQueueData(
+		queueData, queueInternalError, queueOwnerFundsErr := buildLedgerQueueData(
 			ctx,
 			request.Binary,
 			request.Expand,
-			request.OwnerFunds,
-			ownerFundsView,
-			ownerFundsReserveBase,
-			ownerFundsReserveInc,
+			ownerFundsAnnotator,
 		)
+		if queueOwnerFundsErr != nil {
+			return nil, rpcInternalError("ledger: queue owner_funds failed", queueOwnerFundsErr)
+		}
 		if len(queueData) > 0 {
 			response["queue_data"] = queueData
 		}
@@ -388,27 +393,69 @@ func ledgerDefaultResponse(ctx *types.RpcContext) (map[string]any, *types.RpcErr
 }
 
 // ownerFundsLedgerView resolves the state view for the target ledger so
-// owner_funds can be computed against it, mirroring rippled's accountFunds
-// call against fill.ledger (LedgerToJson.cpp:216-221). Returns nil when the
-// service can't supply a view for that ledger (mocks, unsupported selectors),
-// in which case the annotation is simply omitted.
-func ownerFundsLedgerView(ctx *types.RpcContext, l types.LedgerReader) types.LedgerStateView {
+// owner_funds can be computed against that ledger rather than current state.
+// Missing capabilities, lookup failures, and nil results are operational
+// errors because silently omitting owner_funds would produce a partial reply.
+func ownerFundsLedgerView(ctx *types.RpcContext, l types.LedgerReader) (types.LedgerStateView, error) {
 	src, ok := ctx.Services.Ledger.(types.LedgerViewSource)
 	if !ok {
-		return nil
+		return nil, errors.New("ledger service does not expose state views")
 	}
 	if l.IsClosed() {
 		view, _, err := src.GetLedgerViewByHash(l.Hash())
 		if err != nil {
-			return nil
+			return nil, err
 		}
-		return view
+		if view == nil {
+			return nil, errors.New("ledger view lookup returned nil")
+		}
+		return view, nil
 	}
 	view, _, err := src.GetLedgerViewBySeq(l.Sequence())
 	if err != nil {
-		return nil
+		return nil, err
 	}
-	return view
+	if view == nil {
+		return nil, errors.New("ledger view lookup returned nil")
+	}
+	return view, nil
+}
+
+type ledgerOwnerFundsAnnotator struct {
+	ctx          *types.RpcContext
+	ledger       types.LedgerReader
+	view         types.LedgerStateView
+	reservesRead bool
+	reserveBase  uint64
+	reserveInc   uint64
+}
+
+func (a *ledgerOwnerFundsAnnotator) annotate(txEntry, txJSON map[string]any) (bool, error) {
+	if ledgerOwnerFundsUnsupportedMPT(txJSON) {
+		return false, nil
+	}
+	applicable, needsReserves := TransactionOwnerFundsRequirements(txJSON)
+	if !applicable {
+		return true, nil
+	}
+	if a.view == nil {
+		view, err := ownerFundsLedgerView(a.ctx, a.ledger)
+		if err != nil {
+			return false, fmt.Errorf("owner_funds view lookup: %w", err)
+		}
+		a.view = view
+	}
+	if needsReserves && !a.reservesRead {
+		_, fallbackBase, fallbackInc := a.ctx.Services.Ledger.GetCurrentFees()
+		reserveBase, reserveInc, err := reserveSettingsFromLedger(a.view, fallbackBase, fallbackInc)
+		if err != nil {
+			return false, fmt.Errorf("owner_funds reserve lookup: %w", err)
+		}
+		a.reserveBase = reserveBase
+		a.reserveInc = reserveInc
+		a.reservesRead = true
+	}
+	return annotateOwnerFunds(txEntry, txJSON, a.view, a.reserveBase, a.reserveInc)
 }
 
 // annotateOwnerFunds adds owner_funds to an expanded OfferCreate tx entry
@@ -420,15 +467,19 @@ func annotateOwnerFunds(
 	txJSON map[string]any,
 	view types.LedgerStateView,
 	reserveBase, reserveInc uint64,
-) bool {
+) (bool, error) {
 	if ledgerOwnerFundsUnsupportedMPT(txJSON) {
-		return false
+		return false, nil
 	}
 
-	if funds, ok := TransactionOwnerFunds(txJSON, view, reserveBase, reserveInc); ok {
+	funds, ok, err := TransactionOwnerFunds(txJSON, view, reserveBase, reserveInc)
+	if err != nil {
+		return false, err
+	}
+	if ok {
 		txEntry["owner_funds"] = funds
 	}
-	return true
+	return true, nil
 }
 
 func ledgerOwnerFundsUnsupportedMPT(txJSON map[string]any) bool {
@@ -537,16 +588,15 @@ func dumpAccountState(ctx *types.RpcContext, l types.LedgerReader, binary, expan
 // empty or unwired.
 func buildLedgerQueueData(
 	ctx *types.RpcContext,
-	binary, expanded, ownerFunds bool,
-	ownerFundsView types.LedgerStateView,
-	reserveBase, reserveInc uint64,
-) ([]any, bool) {
+	binary, expanded bool,
+	ownerFundsAnnotator *ledgerOwnerFundsAnnotator,
+) ([]any, bool, error) {
 	if ctx.Services == nil || ctx.Services.QueueAllTxs == nil {
-		return nil, false
+		return nil, false, nil
 	}
 	txs := ctx.Services.QueueAllTxs()
 	if len(txs) == 0 {
-		return nil, false
+		return nil, false, nil
 	}
 
 	apiVersion := ctx.ApiVersion
@@ -573,11 +623,17 @@ func buildLedgerQueueData(
 		}
 
 		txBody := buildQueueTxBody(qtx, binary, expanded, apiVersion)
-		if ownerFunds && expanded && ownerFundsView != nil {
+		if expanded && ownerFundsAnnotator != nil {
 			body, ok := txBody.(map[string]any)
-			if ok && !annotateOwnerFunds(body, qtx.TxJSON, ownerFundsView, reserveBase, reserveInc) {
-				queueData = append(queueData, entry)
-				return queueData, true
+			if ok {
+				continueEnumeration, err := ownerFundsAnnotator.annotate(body, qtx.TxJSON)
+				if err != nil {
+					return nil, false, err
+				}
+				if !continueEnumeration {
+					queueData = append(queueData, entry)
+					return queueData, true, nil
+				}
 			}
 		}
 		if body, ok := txBody.(map[string]any); ok {
@@ -596,7 +652,7 @@ func buildLedgerQueueData(
 
 		queueData = append(queueData, entry)
 	}
-	return queueData, false
+	return queueData, false, nil
 }
 
 // buildQueueTxBody renders the queued transaction body the way

--- a/internal/rpc/handlers/owner_funds.go
+++ b/internal/rpc/handlers/owner_funds.go
@@ -2,12 +2,14 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -15,22 +17,55 @@ func TransactionOwnerFunds(
 	txJSON map[string]any,
 	view types.LedgerStateView,
 	reserveBase, reserveInc uint64,
-) (string, bool) {
+) (string, bool, error) {
+	accountID, amount, ok := transactionOwnerFundsInput(txJSON)
+	if !ok {
+		return "", false, nil
+	}
+
+	if amount.IsMPT() {
+		id, _ := mptutil.DecodeID(amount.MPTIssuanceID())
+		funds, result := mptutil.Funds(view, id, accountID, false)
+		switch result {
+		case ter.TesSUCCESS:
+		case ter.TecOBJECT_NOT_FOUND, ter.TecNO_AUTH:
+			funds = 0
+		default:
+			return "", true, fmt.Errorf("owner funds: MPT funds failed: %s", result)
+		}
+		return state.NewMPTAmountWithIssuanceID(funds, "", amount.MPTIssuanceID()).Value(), true, nil
+	}
+
+	funds, err := tx.AccountFundsNoFreezeStrict(view, accountID, amount, reserveBase, reserveInc)
+	if err != nil {
+		return "", true, err
+	}
+	return funds.Value(), true, nil
+}
+
+// TransactionOwnerFundsRequirements reports whether txJSON needs owner_funds
+// and whether that calculation depends on XRP reserve settings.
+func TransactionOwnerFundsRequirements(txJSON map[string]any) (applicable, needsReserves bool) {
+	_, amount, ok := transactionOwnerFundsInput(txJSON)
+	return ok, ok && amount.IsNative()
+}
+
+func transactionOwnerFundsInput(txJSON map[string]any) ([20]byte, state.Amount, bool) {
 	if txJSON["TransactionType"] != "OfferCreate" {
-		return "", false
+		return [20]byte{}, state.Amount{}, false
 	}
 	account, _ := txJSON["Account"].(string)
 	if account == "" {
-		return "", false
+		return [20]byte{}, state.Amount{}, false
 	}
 	amount, ok := parseTransactionAmount(txJSON["TakerGets"])
 	if !ok {
-		return "", false
+		return [20]byte{}, state.Amount{}, false
 	}
 
 	_, idBytes, err := addresscodec.DecodeClassicAddressToAccountID(account)
 	if err != nil || len(idBytes) != 20 {
-		return "", false
+		return [20]byte{}, state.Amount{}, false
 	}
 	var accountID [20]byte
 	copy(accountID[:], idBytes)
@@ -38,29 +73,47 @@ func TransactionOwnerFunds(
 	if amount.IsMPT() {
 		id, err := mptutil.DecodeID(amount.MPTIssuanceID())
 		if err != nil || accountID == mptutil.Issuer(id) {
-			return "", false
+			return [20]byte{}, state.Amount{}, false
 		}
-		funds, _ := mptutil.Funds(view, id, accountID, false)
-		return state.NewMPTAmountWithIssuanceID(funds, "", amount.MPTIssuanceID()).Value(), true
 	}
 	if !amount.IsNative() && amount.Issuer == account {
-		return "", false
+		return [20]byte{}, state.Amount{}, false
 	}
-
-	funds := tx.AccountFunds(view, accountID, amount, false, reserveBase, reserveInc)
-	return funds.Value(), true
+	return accountID, amount, true
 }
 
-func reserveSettingsFromLedger(view types.LedgerStateView, fallbackBase, fallbackInc uint64) (uint64, uint64) {
+func reserveSettingsFromLedger(view types.LedgerStateView, fallbackBase, fallbackInc uint64) (uint64, uint64, error) {
+	if view == nil {
+		return 0, 0, fmt.Errorf("reserve settings: nil ledger view")
+	}
 	data, err := view.Read(keylet.Fees())
-	if err != nil || data == nil {
-		return fallbackBase, fallbackInc
+	if err != nil {
+		return 0, 0, fmt.Errorf("reserve settings: read FeeSettings: %w", err)
+	}
+	if data == nil {
+		return fallbackBase, fallbackInc, nil
 	}
 	settings, err := state.ParseFeeSettings(data)
 	if err != nil {
-		return fallbackBase, fallbackInc
+		return 0, 0, fmt.Errorf("reserve settings: parse FeeSettings: %w", err)
 	}
-	return settings.GetReserveBase(), settings.GetReserveIncrement()
+	reserveBase, reserveInc := fallbackBase, fallbackInc
+	if settings.XRPFeesMode {
+		if settings.HasReserveBaseDrops {
+			reserveBase = settings.ReserveBaseDrops
+		}
+		if settings.HasReserveIncrementDrops {
+			reserveInc = settings.ReserveIncrementDrops
+		}
+	} else {
+		if settings.HasReserveBase {
+			reserveBase = uint64(settings.ReserveBase)
+		}
+		if settings.HasReserveIncrement {
+			reserveInc = uint64(settings.ReserveIncrement)
+		}
+	}
+	return reserveBase, reserveInc, nil
 }
 
 func parseTransactionAmount(raw any) (state.Amount, bool) {

--- a/internal/rpc/ledger_owner_funds_test.go
+++ b/internal/rpc/ledger_owner_funds_test.go
@@ -24,10 +24,14 @@ import (
 // ownerFundsView serves a single AccountRoot SLE so tx.AccountFunds can compute
 // XRP liquidity; every other read is empty.
 type ownerFundsView struct {
-	entries map[keylet.Keylet][]byte
+	entries    map[keylet.Keylet][]byte
+	readErrors map[keylet.Keylet]error
 }
 
 func (v *ownerFundsView) Read(k keylet.Keylet) ([]byte, error) {
+	if err := v.readErrors[k]; err != nil {
+		return nil, err
+	}
 	return v.entries[k], nil
 }
 func (v *ownerFundsView) Exists(keylet.Keylet) (bool, error)                 { return false, nil }
@@ -331,6 +335,75 @@ func TestLedgerOwnerFundsUsesTargetLedgerReservesIncludingZero(t *testing.T) {
 	require.Nil(t, rpcErr)
 	entry = resultToMap(t, result)["ledger"].(map[string]any)["transactions"].([]any)[0].(map[string]any)
 	assert.Equal(t, "1000000000", entry["owner_funds"])
+
+	partialFeeData, err := binarycodec.EncodeBytes(map[string]any{
+		"LedgerEntryType":       "FeeSettings",
+		"Flags":                 uint32(0),
+		"ReserveIncrementDrops": "3000000",
+	})
+	require.NoError(t, err)
+	view.entries[keylet.Fees()] = partialFeeData
+	result, rpcErr = (&handlers.LedgerMethod{}).Handle(ctx, paramsJSON)
+	require.Nil(t, rpcErr)
+	entry = resultToMap(t, result)["ledger"].(map[string]any)["transactions"].([]any)[0].(map[string]any)
+	assert.Equal(t, "990000000", entry["owner_funds"])
+
+	view.readErrors = map[keylet.Keylet]error{keylet.Fees(): errors.New("fee read failed")}
+	paymentData, err := json.Marshal(map[string]any{"tx_json": map[string]any{
+		"TransactionType": "Payment",
+		"Account":         account,
+		"Destination":     "rDsbeomae4FXwgQTJp9Rs64Qg9vDiTCdBv",
+		"Amount":          "1",
+		"Sequence":        1,
+		"Fee":             "10",
+		"SigningPubKey":   "",
+	}})
+	require.NoError(t, err)
+	reader.transactions[0].data = paymentData
+	result, rpcErr = (&handlers.LedgerMethod{}).Handle(ctx, paramsJSON)
+	require.Nil(t, rpcErr)
+	entry = resultToMap(t, result)["ledger"].(map[string]any)["transactions"].([]any)[0].(map[string]any)
+	assert.NotContains(t, entry, "owner_funds")
+
+	iouOfferData, err := json.Marshal(map[string]any{"tx_json": map[string]any{
+		"TransactionType": "OfferCreate",
+		"Account":         account,
+		"TakerGets": map[string]any{
+			"currency": "USD",
+			"issuer":   "rDsbeomae4FXwgQTJp9Rs64Qg9vDiTCdBv",
+			"value":    "1",
+		},
+		"TakerPays":     "1",
+		"Sequence":      1,
+		"Fee":           "10",
+		"SigningPubKey": "",
+	}})
+	require.NoError(t, err)
+	reader.transactions[0].data = iouOfferData
+	result, rpcErr = (&handlers.LedgerMethod{}).Handle(ctx, paramsJSON)
+	require.Nil(t, rpcErr)
+	entry = resultToMap(t, result)["ledger"].(map[string]any)["transactions"].([]any)[0].(map[string]any)
+	assert.Equal(t, "0", entry["owner_funds"])
+
+	reader.transactions[0].data = storedJSON
+	result, rpcErr = (&handlers.LedgerMethod{}).Handle(ctx, paramsJSON)
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
+
+	view.readErrors = nil
+	view.entries[keylet.Fees()] = []byte{0x11, 0xff}
+	result, rpcErr = (&handlers.LedgerMethod{}).Handle(ctx, paramsJSON)
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
+
+	view.entries[keylet.Fees()] = feeData
+	view.readErrors = map[keylet.Keylet]error{keylet.Account(accountID): errors.New("account read failed")}
+	result, rpcErr = (&handlers.LedgerMethod{}).Handle(ctx, paramsJSON)
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
 }
 
 func TestTransactionOwnerFundsMPT(t *testing.T) {
@@ -373,19 +446,42 @@ func TestTransactionOwnerFundsMPT(t *testing.T) {
 		"mpt_issuance_id": hex.EncodeToString(issuanceID[:]),
 	}
 
-	funds, ok := handlers.TransactionOwnerFunds(map[string]any{
+	funds, ok, fundsErr := handlers.TransactionOwnerFunds(map[string]any{
+		"TransactionType": "OfferCreate",
+		"Account":         holder,
+		"TakerGets":       takerGets,
+	}, view, 0, 0)
+	require.NoError(t, fundsErr)
+	require.True(t, ok)
+	assert.Equal(t, "75", funds)
+
+	view.readErrors = map[keylet.Keylet]error{keylet.MPTIssuance(issuanceID): errors.New("issuance read failed")}
+	_, ok, fundsErr = handlers.TransactionOwnerFunds(map[string]any{
 		"TransactionType": "OfferCreate",
 		"Account":         holder,
 		"TakerGets":       takerGets,
 	}, view, 0, 0)
 	require.True(t, ok)
-	assert.Equal(t, "75", funds)
+	require.Error(t, fundsErr)
 
-	_, ok = handlers.TransactionOwnerFunds(map[string]any{
+	view.readErrors = nil
+	delete(view.entries, keylet.MPTIssuance(issuanceID))
+	funds, ok, fundsErr = handlers.TransactionOwnerFunds(map[string]any{
+		"TransactionType": "OfferCreate",
+		"Account":         holder,
+		"TakerGets":       takerGets,
+	}, view, 0, 0)
+	require.NoError(t, fundsErr)
+	require.True(t, ok)
+	assert.Equal(t, "0", funds)
+	view.entries[keylet.MPTIssuance(issuanceID)] = issuanceData
+
+	_, ok, fundsErr = handlers.TransactionOwnerFunds(map[string]any{
 		"TransactionType": "OfferCreate",
 		"Account":         issuer,
 		"TakerGets":       takerGets,
 	}, view, 0, 0)
+	require.NoError(t, fundsErr)
 	assert.False(t, ok)
 
 	mptOffer := map[string]any{

--- a/internal/tx/utils.go
+++ b/internal/tx/utils.go
@@ -2,6 +2,9 @@ package tx
 
 import (
 	"encoding/hex"
+	"fmt"
+	"math"
+	"math/bits"
 	"strconv"
 
 	"github.com/LeJamon/go-xrpl/amendment"
@@ -553,4 +556,65 @@ func AccountFunds(view LedgerView, accountID [20]byte, amount Amount, fhZeroIfFr
 	}
 
 	return state.NewIssuedAmountFromValue(balance.IOU().Mantissa(), balance.IOU().Exponent(), amount.Currency, amount.Issuer)
+}
+
+// AccountFundsNoFreezeStrict returns owner funds without applying freeze
+// rules. Missing account or trust-line entries are a zero balance; storage,
+// decoding, and reserve-arithmetic failures are returned to the caller.
+func AccountFundsNoFreezeStrict(view LedgerView, accountID [20]byte, amount Amount, reserveBase, reserveIncrement uint64) (Amount, error) {
+	if view == nil {
+		return Amount{}, fmt.Errorf("account funds: nil ledger view")
+	}
+	if amount.IsNative() {
+		account, err := ReadAccountRoot(view, accountID)
+		if err != nil {
+			return Amount{}, fmt.Errorf("account funds: read account root: %w", err)
+		}
+		if account == nil {
+			return NewXRPAmount(0), nil
+		}
+		ownerCount := account.OwnerCount
+		if hook, ok := view.(ownerCountReadHookView); ok {
+			ownerCount = hook.OwnerCountHook(accountID, ownerCount)
+		}
+		high, reserveProduct := bits.Mul64(uint64(ownerCount), reserveIncrement)
+		if high != 0 {
+			return Amount{}, fmt.Errorf("account funds: reserve multiplication overflow")
+		}
+		reserve, carry := bits.Add64(reserveBase, reserveProduct, 0)
+		if carry != 0 {
+			return Amount{}, fmt.Errorf("account funds: reserve addition overflow")
+		}
+		if account.Balance <= reserve {
+			return NewXRPAmount(0), nil
+		}
+		liquid := account.Balance - reserve
+		if liquid > math.MaxInt64 {
+			return Amount{}, fmt.Errorf("account funds: liquid XRP exceeds int64")
+		}
+		return NewXRPAmount(int64(liquid)), nil
+	}
+
+	issuerID, err := state.DecodeAccountID(amount.Issuer)
+	if err != nil {
+		return Amount{}, fmt.Errorf("account funds: decode issuer: %w", err)
+	}
+	if accountID == issuerID {
+		return NewIssuedAmount(state.MaxMantissa, 0, amount.Currency, amount.Issuer), nil
+	}
+	line, err := ReadRippleState(view, accountID, issuerID, amount.Currency)
+	if err != nil {
+		return Amount{}, fmt.Errorf("account funds: read trust line: %w", err)
+	}
+	if line == nil {
+		return NewIssuedAmount(0, 0, amount.Currency, amount.Issuer), nil
+	}
+	balance := line.Balance
+	if state.CompareAccountIDs(accountID, issuerID) >= 0 {
+		balance = balance.Negate()
+	}
+	if balance.Signum() <= 0 {
+		return NewIssuedAmount(0, 0, amount.Currency, amount.Issuer), nil
+	}
+	return state.NewIssuedAmountFromValue(balance.IOU().Mantissa(), balance.IOU().Exponent(), amount.Currency, amount.Issuer), nil
 }

--- a/internal/tx/utils_test.go
+++ b/internal/tx/utils_test.go
@@ -1,11 +1,48 @@
 package tx
 
 import (
+	"math"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
+
+func TestAccountFundsNoFreezeStrictRejectsReserveOverflow(t *testing.T) {
+	var accountID [20]byte
+	accountID[0] = 1
+	account, err := state.EncodeAccountID(accountID)
+	if err != nil {
+		t.Fatalf("EncodeAccountID: %v", err)
+	}
+	data, err := state.SerializeAccountRoot(&state.AccountRoot{
+		Account:    account,
+		Balance:    1_000_000,
+		OwnerCount: math.MaxUint32,
+	})
+	if err != nil {
+		t.Fatalf("SerializeAccountRoot: %v", err)
+	}
+	view := newMockBaseView()
+	view.data[keylet.Account(accountID).Key] = data
+
+	if _, err := AccountFundsNoFreezeStrict(view, accountID, NewXRPAmount(1), 0, math.MaxUint64); err == nil {
+		t.Fatal("AccountFundsNoFreezeStrict multiplication overflow error = nil")
+	}
+
+	data, err = state.SerializeAccountRoot(&state.AccountRoot{
+		Account:    account,
+		Balance:    1_000_000,
+		OwnerCount: 1,
+	})
+	if err != nil {
+		t.Fatalf("SerializeAccountRoot: %v", err)
+	}
+	view.data[keylet.Account(accountID).Key] = data
+	if _, err := AccountFundsNoFreezeStrict(view, accountID, NewXRPAmount(1), math.MaxUint64, 1); err == nil {
+		t.Fatal("AccountFundsNoFreezeStrict addition overflow error = nil")
+	}
+}
 
 // TestLPTokenFrozenForIssuer_AMMUnresolvable covers the corrupt-ledger arm: an
 // issuer AccountRoot carrying sfAMMID whose referenced AMM SLE is absent. rippled


### PR DESCRIPTION
## Summary
- Fail closed on signer-list, owner-funds, reserve, book-change, and publication corruption.
- Preserve authoritative ledger semantics across pagination and stream broadcasts.

## Verification
- Focused RPC, node, ledger-service, and transaction tests
- Targeted race, vet, build, strict lint, and oracle review

Refs #1486

Stack layer 9 of 16; depends on #1574.