### PR TITLE
fix: preserve unsigned aggregate prices (#1486)

### DIFF
--- a/internal/ledger/state/xrpl_number.go
+++ b/internal/ledger/state/xrpl_number.go
@@ -317,6 +317,14 @@ func NewXRPLNumber(mantissa int64, exponent int) XRPLNumber {
 	return newNumber(mantissa, exponent, MantissaScaleSmall, RoundToNearest)
 }
 
+// NewXRPLNumberFromUint creates a positive small-scale Number from the full
+// uint64 mantissa domain.
+func NewXRPLNumberFromUint(mantissa uint64, exponent int) XRPLNumber {
+	n := XRPLNumber{mantissa: mantissa, exponent: exponent, scale: MantissaScaleSmall}
+	n.normalize(RoundToNearest)
+	return n
+}
+
 // NewXRPLNumberRounded creates a small-scale Number normalized under mode.
 func NewXRPLNumberRounded(mantissa int64, exponent int, mode RoundingMode) XRPLNumber {
 	return newNumber(mantissa, exponent, MantissaScaleSmall, mode)

--- a/internal/ledger/state/xrpl_number_scale_test.go
+++ b/internal/ledger/state/xrpl_number_scale_test.go
@@ -19,6 +19,25 @@ func newNumberInternal(negative bool, mantissa uint64, exponent int, scale Manti
 	return n
 }
 
+func TestNewXRPLNumberFromUint(t *testing.T) {
+	tests := []struct {
+		mantissa uint64
+		exponent int
+		want     string
+	}{
+		{mantissa: math.MaxInt64, want: "9223372036854776e3"},
+		{mantissa: uint64(math.MaxInt64) + 1, want: "9223372036854776e3"},
+		{mantissa: math.MaxUint64, want: "1844674407370955e4"},
+		{mantissa: math.MaxUint64, exponent: -255, want: "1844674407370955e-251"},
+	}
+
+	for _, test := range tests {
+		number := NewXRPLNumberFromUint(test.mantissa, test.exponent)
+		require.Equal(t, test.want, number.String())
+		require.Positive(t, number.Signum())
+	}
+}
+
 // numberMin / numberMax / numberLowest mirror Number::min/max/lowest for a scale.
 func numberMin(scale MantissaScale) XRPLNumber {
 	minM, _, _ := scale.params()

--- a/internal/rpc/get_aggregate_price_conformance_test.go
+++ b/internal/rpc/get_aggregate_price_conformance_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"math"
 	"strconv"
 	"strings"
 	"testing"
@@ -81,7 +82,7 @@ func TestGetAggregatePriceProjectionAndXRPLArithmetic(t *testing.T) {
 	entire := result["entire_set"].(map[string]any)
 	assert.Equal(t, "74.45", entire["mean"])
 	assert.Equal(t, uint16(10), entire["size"])
-	assert.Equal(t, "0.3027650354097492", entire["standard_deviation"])
+	assert.Equal(t, "0.3027650354097491666", entire["standard_deviation"])
 
 	request["ledger_index"] = "validated"
 	result = callAggregatePrice(t, service, request)
@@ -89,6 +90,41 @@ func TestGetAggregatePriceProjectionAndXRPLArithmetic(t *testing.T) {
 	assert.Equal(t, strings.Repeat("0", 64), result["ledger_hash"])
 	assert.Equal(t, true, result["validated"])
 	assert.NotContains(t, result, "ledger_current_index")
+}
+
+func TestGetAggregatePricePreservesUnsignedAssetPrices(t *testing.T) {
+	tests := []struct {
+		name  string
+		price uint64
+		scale uint8
+		want  string
+	}{
+		{name: "max int64", price: math.MaxInt64, want: "9223372036854776e3"},
+		{name: "max int64 plus one", price: uint64(math.MaxInt64) + 1, want: "9223372036854776e3"},
+		{name: "max uint64", price: math.MaxUint64, want: "1844674407370955e4"},
+		{name: "minimum STAmount exponent", price: math.MaxUint64, scale: 100, want: "1844674407370955e-96"},
+		{name: "below minimum STAmount exponent", price: math.MaxUint64, scale: 101, want: "0"},
+		{name: "max scale", price: math.MaxUint64, scale: math.MaxUint8, want: "0"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := newAggregatePriceLedgerService()
+			key, node := aggregateOracleNode(t, ownerForAggregatePriceTest, 1, 100, "XRP", "USD", test.price, test.scale, "", 0)
+			service.entries[key] = &types.LedgerEntryResult{Node: node}
+
+			result := callAggregatePrice(t, service, map[string]any{
+				"base_asset":  "XRP",
+				"quote_asset": "USD",
+				"oracles": []map[string]any{{
+					"account":            ownerForAggregatePriceTest,
+					"oracle_document_id": 1,
+				}},
+			})
+			assert.Equal(t, test.want, result["median"])
+			assert.Equal(t, test.want, result["entire_set"].(map[string]any)["mean"])
+		})
+	}
 }
 
 func TestGetAggregatePriceSkipsMissingOracleEntries(t *testing.T) {
@@ -108,6 +144,23 @@ func TestGetAggregatePriceSkipsMissingOracleEntries(t *testing.T) {
 	assert.Equal(t, uint16(1), result["entire_set"].(map[string]any)["size"])
 }
 
+func TestGetAggregatePriceNilOracleResultReturnsInternal(t *testing.T) {
+	service := newAggregatePriceLedgerService()
+	key, _ := aggregateOracleNode(t, ownerForAggregatePriceTest, 1, 100, "XRP", "USD", 740, 0, "", 0)
+	service.entries[key] = nil
+	result, rpcErr := callAggregatePriceError(t, service, map[string]any{
+		"base_asset":  "XRP",
+		"quote_asset": "USD",
+		"oracles": []map[string]any{{
+			"account":            ownerForAggregatePriceTest,
+			"oracle_document_id": 1,
+		}},
+	})
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
+}
+
 func TestGetAggregatePriceLookupErrorReturnsInternal(t *testing.T) {
 	service := newAggregatePriceLedgerService()
 	service.entryErr = errors.New("node store unavailable")
@@ -125,21 +178,36 @@ func TestGetAggregatePriceLookupErrorReturnsInternal(t *testing.T) {
 }
 
 func TestGetAggregatePriceMalformedOracleBytesReturnsInternal(t *testing.T) {
-	service := newAggregatePriceLedgerService()
-	key, _ := aggregateOracleNode(t, ownerForAggregatePriceTest, 1, 100, "XRP", "USD", 740, 0, "", 0)
-	service.entries[key] = &types.LedgerEntryResult{Node: []byte{0xff}}
-
-	result, rpcErr := callAggregatePriceError(t, service, map[string]any{
-		"base_asset":  "XRP",
-		"quote_asset": "USD",
-		"oracles": []map[string]any{{
-			"account":            ownerForAggregatePriceTest,
-			"oracle_document_id": 1,
-		}},
+	accountRoot, err := state.SerializeAccountRoot(&state.AccountRoot{
+		Account:  ownerForAggregatePriceTest,
+		Balance:  1,
+		Sequence: 1,
 	})
-	assert.Nil(t, result)
-	require.NotNil(t, rpcErr)
-	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
+	require.NoError(t, err)
+
+	for name, node := range map[string][]byte{
+		"invalid binary": {0xff},
+		"empty object":   {},
+		"wrong type":     accountRoot,
+	} {
+		t.Run(name, func(t *testing.T) {
+			service := newAggregatePriceLedgerService()
+			key, _ := aggregateOracleNode(t, ownerForAggregatePriceTest, 1, 100, "XRP", "USD", 740, 0, "", 0)
+			service.entries[key] = &types.LedgerEntryResult{Node: node}
+
+			result, rpcErr := callAggregatePriceError(t, service, map[string]any{
+				"base_asset":  "XRP",
+				"quote_asset": "USD",
+				"oracles": []map[string]any{{
+					"account":            ownerForAggregatePriceTest,
+					"oracle_document_id": 1,
+				}},
+			})
+			assert.Nil(t, result)
+			require.NotNil(t, rpcErr)
+			assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
+		})
+	}
 }
 
 func TestGetAggregatePriceHistoricalLookupErrorReturnsInternal(t *testing.T) {

--- a/internal/rpc/handlers/get_aggregate_price.go
+++ b/internal/rpc/handlers/get_aggregate_price.go
@@ -149,7 +149,10 @@ func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawM
 			return nil, rpcInternalError("get_aggregate_price: oracle lookup failed", err).WithExtra(lookupFields)
 		}
 		if entry == nil {
-			continue
+			return nil, rpcInternalError("get_aggregate_price: oracle lookup returned no result", nil).WithExtra(lookupFields)
+		}
+		if _, err := state.ParseOracle(entry.Node); err != nil {
+			return nil, rpcInternalError("get_aggregate_price: oracle decoding failed", err).WithExtra(lookupFields)
 		}
 		decoded, err := binarycodec.Decode(hex.EncodeToString(entry.Node))
 		if err != nil {
@@ -371,7 +374,7 @@ func aggregatePriceFromNode(node map[string]any, baseAsset, quoteAsset string) (
 			}
 		}
 		return aggregatePricePoint{
-			price:          newAggregatePriceAmount(int64(assetPrice), -int(scale)),
+			price:          newAggregatePriceAmountUnsigned(assetPrice, -int(scale)),
 			lastUpdateTime: lastUpdateTime,
 		}, true
 	}
@@ -422,6 +425,10 @@ func aggregateUint32(value any) (uint32, bool) {
 
 func newAggregatePriceAmount(mantissa int64, exponent int) aggregatePriceAmount {
 	return aggregatePriceAmountFromNumber(state.NewXRPLNumber(mantissa, exponent))
+}
+
+func newAggregatePriceAmountUnsigned(mantissa uint64, exponent int) aggregatePriceAmount {
+	return aggregatePriceAmountFromNumber(state.NewXRPLNumberFromUint(mantissa, exponent))
 }
 
 func aggregatePriceAmountFromNumber(number state.XRPLNumber) aggregatePriceAmount {
@@ -507,15 +514,25 @@ func aggregatePriceStats(prices []aggregatePricePoint) (aggregatePriceAmount, st
 	}
 	mean = mean.divide(newAggregatePriceAmount(int64(len(prices)), 0))
 
-	standardDeviation := state.NewXRPLNumber(0, 0)
+	standardDeviation := state.NewXRPLNumberScaled(0, 0, state.MantissaScaleLarge, state.RoundToNearest)
 	if len(prices) > 1 {
 		for _, point := range prices {
-			difference := point.price.subtract(mean).number
+			amountDifference := point.price.subtract(mean).number
+			difference := state.NewXRPLNumberScaled(
+				amountDifference.Mantissa(),
+				amountDifference.Exponent(),
+				state.MantissaScaleLarge,
+				state.RoundToNearest,
+			)
 			standardDeviation = standardDeviation.Add(difference.Mul(difference))
 		}
-		standardDeviation = aggregatePriceRoot2(
-			standardDeviation.Div(state.NewXRPLNumberFromInt(int64(len(prices) - 1))),
+		divisor := state.NewXRPLNumberScaled(
+			int64(len(prices)-1),
+			0,
+			state.MantissaScaleLarge,
+			state.RoundToNearest,
 		)
+		standardDeviation = standardDeviation.Div(divisor).Root2()
 	}
 	return mean, standardDeviation
 }
@@ -526,38 +543,6 @@ func aggregatePriceMedian(prices []aggregatePricePoint) aggregatePriceAmount {
 		return prices[middle].price
 	}
 	return prices[middle-1].price.add(prices[middle].price).divide(newAggregatePriceAmount(2, 0))
-}
-
-func aggregatePriceRoot2(value state.XRPLNumber) state.XRPLNumber {
-	one := state.NewXRPLNumberFromInt(1)
-	if value.Equal(one) || value.IsZero() {
-		return value
-	}
-	if value.Signum() < 0 {
-		panic("aggregate price Number root of negative value")
-	}
-
-	exponent := value.Exponent() + 16
-	if exponent%2 != 0 {
-		exponent++
-	}
-	scaled := state.NewXRPLNumber(value.Mantissa(), value.Exponent()-exponent)
-	a0 := state.NewXRPLNumberFromInt(18)
-	a1 := state.NewXRPLNumberFromInt(144)
-	a2 := state.NewXRPLNumberFromInt(-60)
-	denominator := state.NewXRPLNumberFromInt(105)
-	result := a2.Mul(scaled).Add(a1).Mul(scaled).Add(a0).Div(denominator)
-	two := state.NewXRPLNumberFromInt(2)
-	var previous, previousPrevious state.XRPLNumber
-	for {
-		previousPrevious = previous
-		previous = result
-		result = result.Add(scaled.Div(result)).Div(two)
-		if result.Equal(previous) || result.Equal(previousPrevious) {
-			break
-		}
-	}
-	return state.NewXRPLNumber(result.Mantissa(), result.Exponent()+exponent/2)
 }
 
 func (m *GetAggregatePriceMethod) RequiredCondition() types.Condition {

--- a/internal/rpc/handlers/get_aggregate_price_test.go
+++ b/internal/rpc/handlers/get_aggregate_price_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 )
 
@@ -45,8 +46,8 @@ func TestAggregatePriceSTAmountAndNumberStats(t *testing.T) {
 	if got := mean.text(); got != "74.45" {
 		t.Fatalf("mean = %s, want 74.45", got)
 	}
-	if got := standardDeviation.String(); got != "0.3027650354097492" {
-		t.Fatalf("standard deviation = %s, want 0.3027650354097492", got)
+	if got := standardDeviation.String(); got != "0.3027650354097491666" {
+		t.Fatalf("standard deviation = %s, want 0.3027650354097491666", got)
 	}
 	if got := aggregatePriceMedian(prices).text(); got != "74.45" {
 		t.Fatalf("median = %s, want 74.45", got)
@@ -56,7 +57,64 @@ func TestAggregatePriceSTAmountAndNumberStats(t *testing.T) {
 	if got := trimmedMean.text(); got != "74.45" {
 		t.Fatalf("trimmed mean = %s, want 74.45", got)
 	}
-	if got := trimmedStandardDeviation.String(); got != "0.187082869338697" {
-		t.Fatalf("trimmed standard deviation = %s, want 0.187082869338697", got)
+	if got := trimmedStandardDeviation.String(); got != "0.1870828693386970693" {
+		t.Fatalf("trimmed standard deviation = %s, want 0.1870828693386970693", got)
+	}
+}
+
+func TestAggregatePriceUnsignedBoundaries(t *testing.T) {
+	tests := []struct {
+		name     string
+		price    uint64
+		scale    int
+		want     string
+		wantSign int
+	}{
+		{name: "max int64", price: math.MaxInt64, want: "9223372036854776e3", wantSign: 1},
+		{name: "max int64 plus one", price: uint64(math.MaxInt64) + 1, want: "9223372036854776e3", wantSign: 1},
+		{name: "max uint64", price: math.MaxUint64, want: "1844674407370955e4", wantSign: 1},
+		{name: "minimum STAmount exponent", price: math.MaxUint64, scale: 100, want: "1844674407370955e-96", wantSign: 1},
+		{name: "below minimum STAmount exponent", price: math.MaxUint64, scale: 101, want: "0", wantSign: 0},
+		{name: "max scale underflows STAmount", price: math.MaxUint64, scale: 255, want: "0", wantSign: 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			amount := newAggregatePriceAmountUnsigned(test.price, -test.scale)
+			if got := amount.text(); got != test.want {
+				t.Fatalf("price = %s, want %s", got, test.want)
+			}
+			if got := amount.number.Signum(); got != test.wantSign {
+				t.Fatalf("sign = %d, want %d", got, test.wantSign)
+			}
+		})
+	}
+}
+
+func TestAggregatePriceUnsignedStats(t *testing.T) {
+	prices := []aggregatePricePoint{
+		{price: newAggregatePriceAmountUnsigned(math.MaxInt64, 0)},
+		{price: newAggregatePriceAmountUnsigned(uint64(math.MaxInt64)+1, 0)},
+		{price: newAggregatePriceAmountUnsigned(math.MaxUint64, 0)},
+		{price: newAggregatePriceAmountUnsigned(math.MaxUint64, 0)},
+	}
+
+	mean, standardDeviation := aggregatePriceStats(prices)
+	if got := mean.text(); got != "1383505805528216e4" {
+		t.Fatalf("mean = %s, want 1383505805528216e4", got)
+	}
+	if got := standardDeviation.String(); got != "5325116328314170655" {
+		t.Fatalf("standard deviation = %s, want 5325116328314170655", got)
+	}
+	if got := aggregatePriceMedian(prices).text(); got != "1383505805528217e4" {
+		t.Fatalf("median = %s, want 1383505805528217e4", got)
+	}
+
+	trimmedMean, trimmedStandardDeviation := aggregatePriceStats(prices[1:3])
+	if got := trimmedMean.text(); got != "1383505805528217e4" {
+		t.Fatalf("trimmed mean = %s, want 1383505805528217e4", got)
+	}
+	if got := trimmedStandardDeviation.String(); got != "6521908912666389825" {
+		t.Fatalf("trimmed standard deviation = %s, want 6521908912666389825", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Preserve the full unsigned AssetPrice domain without signed overflow.
- Match rippled STAmount statistics precision and reject incomplete oracle state.

## Verification
- Aggregate-price state and RPC tests
- Targeted race, vet, strict lint, and conformance review

Refs #1486

Stack layer 10 of 16; depends on #1575.