### PR TITLE
fix: align server and ledger wire contracts (#1486)

### DIFF
--- a/crypto/rfc1751/rfc1751.go
+++ b/crypto/rfc1751/rfc1751.go
@@ -120,6 +120,20 @@ func btoe(data []byte) string {
 		dictionary[extract(buf, 55, 11)]
 }
 
+// WordFromBlob returns a stable RFC 1751 word for arbitrary binary data.
+func WordFromBlob(data []byte) string {
+	var hash uint32
+	for _, b := range data {
+		hash += uint32(b)
+		hash += hash << 10
+		hash ^= hash >> 6
+	}
+	hash += hash << 3
+	hash ^= hash >> 11
+	hash += hash << 15
+	return dictionary[hash%uint32(len(dictionary))]
+}
+
 // etob converts 6 English words to 8 bytes of binary data. On failure it
 // returns ErrMalformedInput, ErrWordNotInDictionary, or ErrParity.
 func etob(words []string) ([]byte, error) {

--- a/crypto/rfc1751/rfc1751_test.go
+++ b/crypto/rfc1751/rfc1751_test.go
@@ -55,6 +55,21 @@ func TestKeyToEnglishCanonicalVectors(t *testing.T) {
 	}
 }
 
+func TestWordFromBlob(t *testing.T) {
+	key := make([]byte, 33)
+	key[0] = 2
+	for i := 1; i < len(key); i++ {
+		key[i] = byte(i)
+	}
+
+	if got := WordFromBlob(key); got != "LANG" {
+		t.Fatalf("WordFromBlob() = %q, want LANG", got)
+	}
+	if got := WordFromBlob(nil); got != "A" {
+		t.Fatalf("WordFromBlob(nil) = %q, want A", got)
+	}
+}
+
 // Cross-implementation vectors lifted verbatim from rippled's
 // KeyGeneration_test.cpp. master_seed_hex is the 16-byte seed entropy;
 // master_key is what rippled's seedAs1751 (and go-xrpl's SeedToEnglish, used by

--- a/internal/ledger/service/ledger_query.go
+++ b/internal/ledger/service/ledger_query.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
-	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	ledgerselector "github.com/LeJamon/go-xrpl/internal/ledger/selector"
@@ -148,11 +147,6 @@ func parentCloseTimeRippleEpoch(parent *ledger.Ledger) uint32 {
 	return protocol.ToRippleTime(parent.CloseTime())
 }
 
-// formatCloseTimeHuman formats close time in XRPL human-readable format
-func formatCloseTimeHuman(t time.Time) string {
-	return t.UTC().Format("2006-Jan-02 15:04:05.000000000 UTC")
-}
-
 // GetLedgerData retrieves all ledger state entries with optional pagination
 func (q *queryFacade) GetLedgerData(ctx context.Context, ledgerIndex string, limit uint32, marker string) (*LedgerDataResult, error) {
 	s := q.service
@@ -192,7 +186,7 @@ func (q *queryFacade) GetLedgerData(ctx context.Context, ledgerIndex string, lim
 			AccountHash:         hdr.AccountHash,
 			CloseFlags:          hdr.CloseFlags,
 			CloseTime:           protocol.RippleSeconds(hdr.CloseTime),
-			CloseTimeHuman:      formatCloseTimeHuman(hdr.CloseTime),
+			CloseTimeHuman:      protocol.FormatCloseTimeHuman(hdr.CloseTime),
 			CloseTimeISO:        protocol.FormatCloseTimeISO(hdr.CloseTime),
 			CloseTimeResolution: uint32(hdr.CloseTimeResolution),
 			Closed:              targetLedger.IsClosed() || targetLedger.IsValidated(),

--- a/internal/rpc/account_currencies_test.go
+++ b/internal/rpc/account_currencies_test.go
@@ -318,6 +318,13 @@ func TestAccountCurrenciesBadInput(t *testing.T) {
 				assert.Equal(t, tc.expectedToken, rpcErr.ErrorString,
 					"Error token should match expected")
 			}
+			if tc.expectedCode == types.RpcACT_NOT_FOUND {
+				assert.Equal(t, map[string]any{
+					"error":         "actNotFound",
+					"error_code":    types.RpcACT_NOT_FOUND,
+					"error_message": "Account not found.",
+				}, rpcErr.ResponseFields())
+			}
 		})
 	}
 }

--- a/internal/rpc/handlers/account_currencies.go
+++ b/internal/rpc/handlers/account_currencies.go
@@ -60,7 +60,7 @@ func (m *AccountCurrenciesMethod) Handle(ctx *types.RpcContext, params json.RawM
 			return nil, rerr
 		}
 		if errors.Is(err, svcerr.ErrAccountNotFound) {
-			return nil, types.RpcErrorActNotFound("Account not found.").WithExtra(ledgerFields)
+			return nil, types.RpcErrorActNotFound("Account not found.")
 		}
 		if errors.Is(err, svcerr.ErrAccountMalformed) {
 			return nil, types.RpcErrorActMalformed("Account malformed.")

--- a/internal/rpc/handlers/ledger.go
+++ b/internal/rpc/handlers/ledger.go
@@ -270,7 +270,7 @@ func buildLedgerJSON(l types.LedgerReader, binaryMode, full bool, apiVersion int
 	result["close_time_resolution"] = l.CloseTimeResolution()
 	if l.CloseTime() != 0 {
 		closeTime := protocol.FromRippleTime(uint32(max(l.CloseTime(), 0)))
-		result["close_time_human"] = closeTime.UTC().Format("2006-Jan-02 15:04:05.000000000 UTC")
+		result["close_time_human"] = protocol.FormatCloseTimeHuman(closeTime)
 		result["close_time_iso"] = protocol.FormatCloseTimeISO(closeTime)
 		if l.CloseFlags()&ledgerheader.LCFNoConsensusTime != 0 {
 			result["close_time_estimated"] = true

--- a/internal/rpc/handlers/ledger_header.go
+++ b/internal/rpc/handlers/ledger_header.go
@@ -125,7 +125,7 @@ func buildLedgerSummaryJSON(lr types.LedgerReader, closed bool, apiVersion int) 
 	// close_time_human and close_time_iso only when closeTime > 0
 	if ct > 0 {
 		closeTimeUTC := protocol.FromRippleTime(uint32(ct))
-		ledgerObj["close_time_human"] = closeTimeUTC.Format("2006-Jan-02 15:04:05.000000000 UTC")
+		ledgerObj["close_time_human"] = protocol.FormatCloseTimeHuman(closeTimeUTC)
 		ledgerObj["close_time_iso"] = protocol.FormatCloseTimeISO(closeTimeUTC)
 
 		// close_time_estimated only when there was no consensus on close time

--- a/internal/rpc/handlers/ledger_request.go
+++ b/internal/rpc/handlers/ledger_request.go
@@ -21,16 +21,13 @@ func ledgerInfoJSON(l types.LedgerReader) map[string]any {
 	parent := l.ParentHash()
 	txHash, stateHash := ledgerMapHashes(l)
 	closeTimeSec := l.CloseTime()
-	closeTime := protocol.FromRippleTime(uint32(max(closeTimeSec, 0)))
 	seqStr := strconv.FormatUint(uint64(l.Sequence()), 10)
 
-	return map[string]any{
+	result := map[string]any{
 		"accepted":              true,
 		"account_hash":          strings.ToUpper(hex.EncodeToString(stateHash[:])),
 		"close_flags":           l.CloseFlags(),
 		"close_time":            closeTimeSec,
-		"close_time_human":      closeTime.UTC().Format("2006-Jan-02 15:04:05.000000000 UTC"),
-		"close_time_iso":        protocol.FormatCloseTimeISO(closeTime),
 		"close_time_resolution": l.CloseTimeResolution(),
 		"closed":                l.IsClosed(),
 		"ledger_hash":           strings.ToUpper(hex.EncodeToString(hash[:])),
@@ -42,6 +39,12 @@ func ledgerInfoJSON(l types.LedgerReader) map[string]any {
 		"total_coins":           strconv.FormatUint(l.TotalDrops(), 10),
 		"transaction_hash":      strings.ToUpper(hex.EncodeToString(txHash[:])),
 	}
+	if closeTimeSec > 0 {
+		closeTime := protocol.FromRippleTime(uint32(closeTimeSec))
+		result["close_time_human"] = protocol.FormatCloseTimeHuman(closeTime)
+		result["close_time_iso"] = protocol.FormatCloseTimeISO(closeTime)
+	}
+	return result
 }
 
 // LedgerRequestMethod handles the ledger_request RPC method: it returns a

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/crypto/rfc1751"
 	"github.com/LeJamon/go-xrpl/internal/observability"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/protocol"
@@ -77,6 +78,30 @@ func resolveHostID() string {
 	return "go-xrpl"
 }
 
+func serverHostID(services *types.ServiceContainer, admin bool) string {
+	if admin {
+		return cachedHostID
+	}
+	if services != nil {
+		key, err := addresscodec.DecodeNodePublicKey(services.NodePublicKey)
+		if err == nil && len(key) == addresscodec.NodePublicKeyLength {
+			return rfc1751.WordFromBlob(key)
+		}
+	}
+	return "go-xrpl"
+}
+
+func serverSystemTime(services *types.ServiceContainer) time.Time {
+	if services != nil && services.SystemTime != nil {
+		return services.SystemTime()
+	}
+	return time.Now()
+}
+
+func formatServerTime(t time.Time) string {
+	return t.UTC().Format("2006-Jan-02 15:04:05.000000 UTC")
+}
+
 // ServerInfoMethod handles the server_info RPC method.
 // This is the "human-readable" variant (rippled human=true).
 type ServerInfoMethod struct{ BaseHandler }
@@ -139,6 +164,7 @@ func buildServerWarnings(services *types.ServiceContainer, isAdmin bool) []types
 // When human is false it produces the server_state format (drops integers, converge_time, load_base, etc.).
 func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 	services := ctx.Services
+	now := serverSystemTime(services)
 	serverInfo := services.Ledger.GetServerInfo()
 	configSnapshot := services.ServerInfoConfig
 	baseFee, reserveBase, reserveIncrement := services.Ledger.GetCurrentFees()
@@ -231,7 +257,7 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 	// (human) and server_state (machine) like rippled's shared getServerInfo.
 	if ctx.IsAdmin {
 		info["pubkey_validator"] = resolveValidatorPubKey(services)
-		validatorList := resolveValidatorListSnapshot(services, time.Now())
+		validatorList := resolveValidatorListSnapshot(services, now)
 		if human {
 			info["validator_list"] = validatorList.summary
 		} else {
@@ -241,17 +267,10 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 
 	// hostid: only in human mode (server_info), matching rippled
 	if human {
-		info["hostid"] = cachedHostID
+		info["hostid"] = serverHostID(services, ctx.IsAdmin)
 	}
 
-	// time: rippled uses different formats for human vs machine
-	if human {
-		// rippled human format: "2024-Jan-15 12:34:56.789012 UTC"
-		info["time"] = time.Now().UTC().Format("2006-Jan-02 15:04:05.000000 UTC")
-	} else {
-		// rippled machine format: ISO 8601
-		info["time"] = time.Now().UTC().Format(time.RFC3339)
-	}
+	info["time"] = formatServerTime(now)
 
 	// last_close: converge_time_s (float seconds) for human, converge_time (int ms) for machine
 	proposers := 0
@@ -364,7 +383,6 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 	}
 
 	if haveLedger {
-		now := time.Now()
 		age, ageOK := ledgerAge(ledgerCloseTime, now)
 		if human {
 			baseFeeXRP := float64(baseFee) / 1_000_000.0

--- a/internal/rpc/ledger_header_test.go
+++ b/internal/rpc/ledger_header_test.go
@@ -117,7 +117,7 @@ func TestLedgerHeaderBasicRequest(t *testing.T) {
 
 		// close_time_human should be present when closeTime > 0
 		if reader.closeTime > 0 {
-			assert.Contains(t, ledger, "close_time_human")
+			assert.Equal(t, "2024-Aug-03 11:33:50 UTC", ledger["close_time_human"])
 			assert.Contains(t, ledger, "close_time_iso")
 		}
 	})

--- a/internal/rpc/ledger_request_test.go
+++ b/internal/rpc/ledger_request_test.go
@@ -39,7 +39,7 @@ func (m *ledgerRequestMock) GetLedgerBySequence(seq uint32) (types.LedgerReader,
 func TestLedgerRequest_ServesLocalLedgerByHash(t *testing.T) {
 	var hash [32]byte
 	hash[0], hash[31] = 0xAB, 0xCD
-	lr := &mockLedgerReader{seq: 5, hash: hash, closed: true, validated: true, totalDrops: 99000000}
+	lr := &mockLedgerReader{seq: 5, hash: hash, closed: true, validated: true, totalDrops: 99000000, closeTime: 776000030}
 
 	mock := &ledgerRequestMock{
 		mockLedgerService: newMockLedgerService(),
@@ -63,6 +63,8 @@ func TestLedgerRequest_ServesLocalLedgerByHash(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, strings.ToUpper(hex.EncodeToString(hash[:])), ledger["ledger_hash"])
 	assert.Equal(t, "5", ledger["ledger_index"])
+	assert.Equal(t, "2024-Aug-03 11:33:50 UTC", ledger["close_time_human"])
+	assert.Equal(t, "2024-08-03T11:33:50Z", ledger["close_time_iso"])
 }
 
 func TestLedgerRequest_ServesLocalLedgerByIndex(t *testing.T) {
@@ -88,6 +90,10 @@ func TestLedgerRequest_ServesLocalLedgerByIndex(t *testing.T) {
 	resp, ok := result.(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, uint32(1), resp["ledger_index"])
+	ledger, ok := resp["ledger"].(map[string]any)
+	require.True(t, ok)
+	assert.NotContains(t, ledger, "close_time_human")
+	assert.NotContains(t, ledger, "close_time_iso")
 }
 
 // TestLedgerRequest_AcquiringTargetReturnsBareSnapshot covers rippled's common

--- a/internal/rpc/ledger_test.go
+++ b/internal/rpc/ledger_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -317,7 +318,7 @@ func TestLedgerBasicRequest(t *testing.T) {
 				"account_hash":          handlers.FormatLedgerHash(currentReader.StateMapHash()),
 				"close_flags":           float64(currentReader.CloseFlags()),
 				"close_time":            float64(currentReader.CloseTime()),
-				"close_time_human":      closeTime.Format("2006-Jan-02 15:04:05.000000000 UTC"),
+				"close_time_human":      protocol.FormatCloseTimeHuman(closeTime),
 				"close_time_iso":        closeTime.Format(time.RFC3339),
 				"close_time_resolution": float64(currentReader.CloseTimeResolution()),
 				"ledger_hash":           handlers.FormatLedgerHash(currentReader.Hash()),
@@ -982,7 +983,7 @@ func TestLedgerResponseStructure(t *testing.T) {
 			"account_hash":          handlers.FormatLedgerHash(reader.StateMapHash()),
 			"close_flags":           float64(reader.CloseFlags()),
 			"close_time":            float64(reader.CloseTime()),
-			"close_time_human":      closeTime.Format("2006-Jan-02 15:04:05.000000000 UTC"),
+			"close_time_human":      protocol.FormatCloseTimeHuman(closeTime),
 			"close_time_iso":        closeTime.Format(time.RFC3339),
 			"close_time_resolution": float64(reader.CloseTimeResolution()),
 			"closed":                true,

--- a/internal/rpc/server_info_test.go
+++ b/internal/rpc/server_info_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"math"
+	"os"
 	"testing"
 	"time"
 
@@ -110,6 +111,39 @@ func TestServerInfoRoleAliasesAreAdminOnly(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestServerInfoHostIDPrivacy(t *testing.T) {
+	mock := newMockLedgerServiceServerInfo()
+	services := servicesForServerInfo(mock)
+
+	guest := callServerStatus(t, &types.RpcContext{
+		Context:  t.Context(),
+		Services: services,
+	}, true)
+	assert.Equal(t, "LANG", guest["hostid"])
+
+	admin := callServerStatus(t, &types.RpcContext{
+		Context:  t.Context(),
+		Services: services,
+		IsAdmin:  true,
+	}, true)
+	hostname, err := os.Hostname()
+	if err != nil || hostname == "" {
+		hostname = "go-xrpl"
+	}
+	assert.Equal(t, hostname, admin["hostid"])
+
+	state := callServerStatus(t, &types.RpcContext{
+		Context:  t.Context(),
+		Services: services,
+		IsAdmin:  true,
+	}, false)
+	assert.NotContains(t, state, "hostid")
+
+	services.NodePublicKey = "invalid"
+	guest = callServerStatus(t, &types.RpcContext{Context: t.Context(), Services: services}, true)
+	assert.Equal(t, "go-xrpl", guest["hostid"])
 }
 
 func TestServerInfoNetworkLedgerWaiting(t *testing.T) {
@@ -997,8 +1031,9 @@ func TestServerInfoStateAccounting(t *testing.T) {
 func TestServerInfoTimeField(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
 	services := servicesForServerInfo(mock)
-
-	method := &handlers.ServerInfoMethod{}
+	services.SystemTime = func() time.Time {
+		return time.Date(2026, time.August, 3, 14, 5, 6, 789012345, time.FixedZone("test", 2*60*60))
+	}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
@@ -1006,22 +1041,8 @@ func TestServerInfoTimeField(t *testing.T) {
 		Services:   services,
 	}
 
-	t.Run("time field present and formatted", func(t *testing.T) {
-		result, rpcErr := method.Handle(ctx, nil)
-		require.Nil(t, rpcErr)
-
-		resultJSON, _ := json.Marshal(result)
-		var resp map[string]any
-		json.Unmarshal(resultJSON, &resp)
-		info := resp["info"].(map[string]any)
-
-		assert.Contains(t, info, "time")
-		timeStr, ok := info["time"].(string)
-		assert.True(t, ok)
-		assert.NotEmpty(t, timeStr)
-		// Time format should include UTC
-		assert.Contains(t, timeStr, "UTC")
-	})
+	assert.Equal(t, "2026-Aug-03 12:05:06.789012 UTC", callServerStatus(t, ctx, true)["time"])
+	assert.Equal(t, "2026-Aug-03 12:05:06.789012 UTC", callServerStatus(t, ctx, false)["time"])
 }
 
 // Fee Calculation Tests

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -210,6 +210,8 @@ type ServiceContainer struct {
 
 	// NodePublicKey is the base58-encoded node identity public key (e.g. "n9...")
 	NodePublicKey string
+	// SystemTime supplies the wall clock used in time-bearing RPC projections.
+	SystemTime func() time.Time
 
 	// ServerInfoConfig is the immutable startup configuration and build
 	// metadata surfaced by server_info and server_state.

--- a/protocol/time.go
+++ b/protocol/time.go
@@ -5,6 +5,7 @@ import (
 )
 
 const closeTimeISOLayout = "2006-01-02T15:04:05Z"
+const closeTimeHumanLayout = "2006-Jan-02 15:04:05 UTC"
 
 // RippleSeconds converts a wall-clock time to seconds since the XRPL epoch.
 // Go's zero time encodes as zero.
@@ -34,4 +35,13 @@ func FormatCloseTimeISO(t time.Time) string {
 		t = FromRippleTime(0)
 	}
 	return t.UTC().Format(closeTimeISOLayout)
+}
+
+// FormatCloseTimeHuman formats a ledger close time in the human-readable
+// whole-second form used by XRPL ledger responses.
+func FormatCloseTimeHuman(t time.Time) string {
+	if t.IsZero() {
+		t = FromRippleTime(0)
+	}
+	return t.UTC().Format(closeTimeHumanLayout)
 }

--- a/protocol/time_test.go
+++ b/protocol/time_test.go
@@ -69,3 +69,22 @@ func TestFormatCloseTimeISO(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatCloseTimeHuman(t *testing.T) {
+	tests := []struct {
+		name string
+		in   time.Time
+		want string
+	}{
+		{name: "zero", want: "2000-Jan-01 00:00:00 UTC"},
+		{name: "fraction discarded", in: time.Date(2026, time.August, 3, 12, 5, 6, 789012345, time.FixedZone("test", 2*60*60)), want: "2026-Aug-03 10:05:06 UTC"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := FormatCloseTimeHuman(test.in); got != test.want {
+				t.Fatalf("FormatCloseTimeHuman(%v) = %q, want %q", test.in, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Shroud guest host identity and preserve admin-only hostname disclosure.
- Centralize exact server and ledger time rendering and account error envelopes.

## Verification
- Server, ledger, and account wire-contract tests
- Targeted race, vet, strict lint, no-CGO build, and oracle review

Refs #1486

Stack layer 11 of 16; depends on #1576.