### PR TITLE
fix(rpc): add runtime diagnostics and durable identity

### DIFF
--- a/docs/operating.md
+++ b/docs/operating.md
@@ -154,10 +154,12 @@ as the liveness endpoint, but it is still subject to the configured per-port
 Origin and HTTP Basic Auth policy. Arbitrary GET query parameters are never
 dispatched as RPC commands.
 
-`server_info` and `server_state` omit rippled's optional job-queue `load`,
-requested `counters`, and `current_activities` fields. go-xrpl does not yet have
-equivalent job/performance instrumentation, so these fields remain unsupported
-rather than reporting placeholder data.
+`server_info` and `server_state` accept `counters` and report shared HTTP/WebSocket
+RPC timings, current RPC activity, and the node-store counters available from the
+configured backend. The required `job_queue` and current `jobs` containers are
+empty because go-xrpl has no central rippled-style JobQueue. For the same reason,
+the admin-only `load` field is omitted rather than populated with unrelated
+goroutine or client-admission statistics.
 
 ### TLS and reverse proxies
 

--- a/internal/node/identity_test.go
+++ b/internal/node/identity_test.go
@@ -1,0 +1,44 @@
+package node
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/config"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+)
+
+func TestConfigureStandaloneNodeIdentityPersists(t *testing.T) {
+	dir := t.TempDir()
+	configure := func(standalone bool) (string, error) {
+		runtime := &nodeRuntime{
+			appConfig:  &config.Config{DatabasePath: dir},
+			standalone: standalone,
+			services:   &types.ServiceContainer{},
+		}
+		err := runtime.configureStandaloneNodeIdentity()
+		return runtime.services.NodePublicKey, err
+	}
+
+	first, err := configure(true)
+	if err != nil {
+		t.Fatalf("first identity: %v", err)
+	}
+	second, err := configure(true)
+	if err != nil {
+		t.Fatalf("second identity: %v", err)
+	}
+	if first == "" || second != first {
+		t.Fatalf("persistent keys = %q, %q", first, second)
+	}
+	keyPath := filepath.Join(dir, "peers", "node_identity.key")
+	if info, err := os.Stat(keyPath); err != nil || info.Mode().Perm() != 0600 {
+		t.Fatalf("identity file = %#v, %v", info, err)
+	}
+
+	nonStandalone, err := configure(false)
+	if err != nil || nonStandalone != "" {
+		t.Fatalf("consensus identity path mutated services: key=%q err=%v", nonStandalone, err)
+	}
+}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -100,6 +100,7 @@ func rpcCapabilities(cfg *config.Config) types.RPCCapabilities {
 func newRPCServiceContainer(ledger types.LedgerService, cfg *config.Config) *types.ServiceContainer {
 	services := types.NewServiceContainer(ledger)
 	services.ClientLoad = types.NewClientLoadShedder()
+	services.RPCDiagnostics = rpc.NewRPCDiagnostics()
 	services.ServerInfoConfig = serverInfoConfigSnapshot(cfg)
 	services.Capabilities = rpcCapabilities(cfg)
 	if cfg != nil {

--- a/internal/node/rpc_capabilities_test.go
+++ b/internal/node/rpc_capabilities_test.go
@@ -20,6 +20,7 @@ func TestNewRPCServiceContainerFreezesCapabilities(t *testing.T) {
 	require.Zero(t, services.Capabilities.PathSearchMax)
 	require.True(t, services.BetaRPCAPI)
 	require.NotNil(t, services.ClientLoad)
+	require.NotNil(t, services.RPCDiagnostics)
 
 	cfg.SigningSupport = false
 	pathMax = 9

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/config"
@@ -253,6 +254,9 @@ func (r *nodeRuntime) configureMaintenance() error {
 
 	r.ledgerAdapter = rpcadapter.NewLedgerServiceAdapter(r.ledger)
 	r.services = newRPCServiceContainer(r.ledgerAdapter, r.appConfig)
+	if err := r.configureStandaloneNodeIdentity(); err != nil {
+		return err
+	}
 
 	// Advisory-delete state (can_delete RPC). Available in both standalone and
 	// consensus modes; gated by node_db advisory_delete and persisted under
@@ -453,6 +457,22 @@ func (r *nodeRuntime) configureMaintenance() error {
 			return toCleanerStatus(cleanerRef.Status())
 		}
 	}
+	return nil
+}
+
+func (r *nodeRuntime) configureStandaloneNodeIdentity() error {
+	if !r.standalone {
+		return nil
+	}
+	dataDir := r.appConfig.LocalStateDir()
+	if dataDir != "" {
+		dataDir = filepath.Join(dataDir, "peers")
+	}
+	identity, err := peermanagement.LoadOrCreateIdentity(dataDir)
+	if err != nil {
+		return fmt.Errorf("load node identity: %w", err)
+	}
+	r.services.NodePublicKey = identity.EncodedPublicKey()
 	return nil
 }
 

--- a/internal/peermanagement/identity.go
+++ b/internal/peermanagement/identity.go
@@ -185,6 +185,33 @@ func LoadIdentity(dataDir string) (*Identity, error) {
 	return NewIdentityFromPrivateKey(string(data))
 }
 
+// LoadOrCreateIdentity loads the durable node identity or creates it when the
+// configured directory has no usable key.
+func LoadOrCreateIdentity(dataDir string) (*Identity, error) {
+	if dataDir == "" {
+		return GenerateIdentity()
+	}
+	id, err := LoadIdentity(dataDir)
+	if err == nil {
+		return id, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) && !errors.Is(err, ErrInvalidPrivateKey) {
+		return nil, err
+	}
+	id, err = GenerateIdentity()
+	if err != nil {
+		return nil, err
+	}
+	if err := id.Save(dataDir); err != nil {
+		return nil, fmt.Errorf("save identity: %w", err)
+	}
+	return id, nil
+}
+
+func loadOrCreateIdentity(dataDir string) (*Identity, error) {
+	return LoadOrCreateIdentity(dataDir)
+}
+
 func (i *Identity) Save(dataDir string) error {
 	if err := os.MkdirAll(dataDir, 0700); err != nil {
 		return fmt.Errorf("failed to create data directory: %w", err)

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io/fs"
 	"log/slog"
 	mrand "math/rand/v2"
 	"net"
@@ -831,34 +830,6 @@ func (o *Overlay) OutboundCriticalQueueFailures() (local, shared uint64) {
 // IncPeerBadData is a single map lookup + atomic add.
 func (o *Overlay) chargeIgnoredSquelch(peerID PeerID) {
 	o.IncPeerBadData(peerID, "squelch-ignored")
-}
-
-// loadOrCreateIdentity loads existing identity or creates a new one.
-func loadOrCreateIdentity(dataDir string) (*Identity, error) {
-	if dataDir == "" {
-		return GenerateIdentity()
-	}
-
-	// Try to load existing identity
-	id, err := LoadIdentity(dataDir)
-	if err == nil {
-		return id, nil
-	}
-	if !errors.Is(err, fs.ErrNotExist) && !errors.Is(err, ErrInvalidPrivateKey) {
-		return nil, err
-	}
-
-	// Generate new identity
-	id, err = GenerateIdentity()
-	if err != nil {
-		return nil, err
-	}
-
-	if err := id.Save(dataDir); err != nil {
-		return nil, fmt.Errorf("save identity: %w", err)
-	}
-
-	return id, nil
 }
 
 // Run starts the overlay and blocks until the context is cancelled. An

--- a/internal/rpc/diagnostics.go
+++ b/internal/rpc/diagnostics.go
@@ -1,0 +1,109 @@
+package rpc
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+)
+
+type rpcDiagnostics struct {
+	mu      sync.Mutex
+	now     func() time.Time
+	nextID  uint64
+	methods map[string]types.RPCMethodDiagnostics
+	current map[uint64]rpcActivity
+}
+
+type rpcActivity struct {
+	method string
+	start  time.Time
+}
+
+func NewRPCDiagnostics() types.RPCDiagnostics {
+	return newRPCDiagnostics(time.Now)
+}
+
+func newRPCDiagnostics(now func() time.Time) *rpcDiagnostics {
+	return &rpcDiagnostics{
+		now:     now,
+		methods: make(map[string]types.RPCMethodDiagnostics),
+		current: make(map[uint64]rpcActivity),
+	}
+}
+
+func (d *rpcDiagnostics) Start(method string) func(bool) {
+	start := d.now()
+	d.mu.Lock()
+	d.nextID++
+	id := d.nextID
+	stats := d.methods[method]
+	stats.Started++
+	d.methods[method] = stats
+	d.current[id] = rpcActivity{method: method, start: start}
+	d.mu.Unlock()
+
+	var once sync.Once
+	return func(panicked bool) {
+		once.Do(func() {
+			end := d.now()
+			d.mu.Lock()
+			activity, ok := d.current[id]
+			if ok {
+				delete(d.current, id)
+				stats := d.methods[method]
+				if panicked {
+					stats.Errored++
+				} else {
+					stats.Finished++
+				}
+				stats.DurationUs += elapsedMicroseconds(activity.start, end)
+				d.methods[method] = stats
+			}
+			d.mu.Unlock()
+		})
+	}
+}
+
+func (d *rpcDiagnostics) Snapshot() types.RPCDiagnosticsSnapshot {
+	now := d.now()
+	d.mu.Lock()
+	methods := make(map[string]types.RPCMethodDiagnostics, len(d.methods))
+	for method, stats := range d.methods {
+		methods[method] = stats
+	}
+	type currentActivity struct {
+		id uint64
+		types.RPCActivity
+	}
+	current := make([]currentActivity, 0, len(d.current))
+	for id, activity := range d.current {
+		current = append(current, currentActivity{
+			id: id,
+			RPCActivity: types.RPCActivity{
+				Method:     activity.method,
+				DurationUs: elapsedMicroseconds(activity.start, now),
+			},
+		})
+	}
+	d.mu.Unlock()
+	sort.Slice(current, func(i, j int) bool {
+		if current[i].Method != current[j].Method {
+			return current[i].Method < current[j].Method
+		}
+		return current[i].id < current[j].id
+	})
+	activities := make([]types.RPCActivity, len(current))
+	for i := range current {
+		activities[i] = current[i].RPCActivity
+	}
+	return types.RPCDiagnosticsSnapshot{Methods: methods, Current: activities}
+}
+
+func elapsedMicroseconds(start, end time.Time) uint64 {
+	if !end.After(start) {
+		return 0
+	}
+	return uint64(end.Sub(start).Microseconds())
+}

--- a/internal/rpc/diagnostics_test.go
+++ b/internal/rpc/diagnostics_test.go
@@ -1,0 +1,110 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+)
+
+func TestRPCDiagnosticsSnapshotsAndCompletion(t *testing.T) {
+	now := time.Unix(100, 0)
+	diagnostics := newRPCDiagnostics(func() time.Time { return now })
+
+	finishInfo := diagnostics.Start("server_info")
+	now = now.Add(1250 * time.Microsecond)
+	active := diagnostics.Snapshot()
+	if got := active.Methods["server_info"].Started; got != 1 {
+		t.Fatalf("started = %d, want 1", got)
+	}
+	if len(active.Current) != 1 || active.Current[0].DurationUs != 1250 {
+		t.Fatalf("current = %#v", active.Current)
+	}
+
+	finishInfo(false)
+	finishInfo(false)
+	now = now.Add(250 * time.Microsecond)
+	finishState := diagnostics.Start("server_state")
+	now = now.Add(750 * time.Microsecond)
+	finishState(true)
+
+	snapshot := diagnostics.Snapshot()
+	if got := snapshot.Methods["server_info"]; got.Finished != 1 || got.Errored != 0 || got.DurationUs != 1250 {
+		t.Fatalf("server_info = %#v", got)
+	}
+	if got := snapshot.Methods["server_state"]; got.Finished != 0 || got.Errored != 1 || got.DurationUs != 750 {
+		t.Fatalf("server_state = %#v", got)
+	}
+	if len(snapshot.Current) != 0 {
+		t.Fatalf("current after finish = %#v", snapshot.Current)
+	}
+
+	delete(snapshot.Methods, "server_info")
+	if _, ok := diagnostics.Snapshot().Methods["server_info"]; !ok {
+		t.Fatal("mutating a snapshot changed collector state")
+	}
+}
+
+func TestRPCDiagnosticsConcurrentAccounting(t *testing.T) {
+	diagnostics := NewRPCDiagnostics()
+	const calls = 64
+	var wg sync.WaitGroup
+	for i := 0; i < calls; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			diagnostics.Start("ledger")(false)
+		}()
+	}
+	wg.Wait()
+	stats := diagnostics.Snapshot().Methods["ledger"]
+	if stats.Started != calls || stats.Finished != calls || stats.Errored != 0 {
+		t.Fatalf("stats = %#v", stats)
+	}
+}
+
+type diagnosticTestHandler struct {
+	panicValue any
+	rpcErr     *types.RpcError
+}
+
+func (h diagnosticTestHandler) Handle(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
+	if h.panicValue != nil {
+		panic(h.panicValue)
+	}
+	return nil, h.rpcErr
+}
+
+func (diagnosticTestHandler) RequiredRole() types.Role { return types.RoleGuest }
+func (diagnosticTestHandler) SupportedApiVersions() []int {
+	return []int{types.ApiVersion1, types.ApiVersion2}
+}
+func (diagnosticTestHandler) RequiredCondition() types.Condition { return types.NoCondition }
+
+func TestDispatchDiagnosticsTreatsRPCResultsAsFinished(t *testing.T) {
+	diagnostics := NewRPCDiagnostics()
+	services := &types.ServiceContainer{RPCDiagnostics: diagnostics}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	resolution := methodResolution{handler: diagnosticTestHandler{rpcErr: types.RpcErrorInvalidParams("bad request")}, resolved: true}
+	_, _ = dispatchResolvedMethod(nil, services, ctx, "normal_error", nil, resolution, rpcLog())
+	stats := diagnostics.Snapshot().Methods["normal_error"]
+	if stats.Finished != 1 || stats.Errored != 0 {
+		t.Fatalf("ordinary RPC error stats = %#v", stats)
+	}
+
+	resolution = methodResolution{handler: diagnosticTestHandler{panicValue: "boom"}, resolved: true}
+	_, _ = dispatchResolvedMethod(nil, services, ctx, "panic", nil, resolution, rpcLog())
+	stats = diagnostics.Snapshot().Methods["panic"]
+	if stats.Finished != 0 || stats.Errored != 1 {
+		t.Fatalf("panic stats = %#v", stats)
+	}
+}

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -112,10 +112,84 @@ func (m *ServerInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 	}
 
 	info := buildServerInfo(ctx, true)
+	if serverCountersRequested(params) {
+		addServerDiagnostics(info, ctx.Services)
+	}
 	if warnings := buildServerWarnings(ctx.Services, ctx.IsAdmin); len(warnings) > 0 {
 		info["warnings"] = warnings
 	}
 	return map[string]any{"info": info}, nil
+}
+
+func serverCountersRequested(params json.RawMessage) bool {
+	if len(params) == 0 {
+		return false
+	}
+	var object map[string]json.RawMessage
+	if json.Unmarshal(params, &object) != nil || object == nil {
+		return false
+	}
+	return jsonCppBoolRaw(object["counters"])
+}
+
+func addServerDiagnostics(info map[string]any, services *types.ServiceContainer) {
+	rpcCounters := make(map[string]any)
+	methods := make([]map[string]any, 0)
+	var snapshot types.RPCDiagnosticsSnapshot
+	if services != nil && services.RPCDiagnostics != nil {
+		snapshot = services.RPCDiagnostics.Snapshot()
+	}
+
+	var total types.RPCMethodDiagnostics
+	for method, stats := range snapshot.Methods {
+		if stats.Started == 0 {
+			continue
+		}
+		rpcCounters[method] = rpcDiagnosticsJSON(stats)
+		total.Started += stats.Started
+		total.Finished += stats.Finished
+		total.Errored += stats.Errored
+		total.DurationUs += stats.DurationUs
+	}
+	if total.Started != 0 {
+		rpcCounters["total"] = rpcDiagnosticsJSON(total)
+	}
+	for _, activity := range snapshot.Current {
+		methods = append(methods, map[string]any{
+			"method":      activity.Method,
+			"duration_us": strconv.FormatUint(activity.DurationUs, 10),
+		})
+	}
+
+	nodeStore := make(map[string]any)
+	if services != nil && services.GetCounts != nil {
+		if counts := services.GetCounts().NodeStore; counts != nil {
+			nodeStore["node_writes"] = strconv.FormatUint(counts.Writes, 10)
+			nodeStore["node_reads_total"] = strconv.FormatUint(counts.Reads, 10)
+			nodeStore["node_reads_hit"] = strconv.FormatUint(counts.FetchHits, 10)
+			nodeStore["node_written_bytes"] = strconv.FormatUint(counts.WriteBytes, 10)
+			nodeStore["node_read_bytes"] = strconv.FormatUint(counts.ReadBytes, 10)
+		}
+	}
+
+	info["counters"] = map[string]any{
+		"rpc":       rpcCounters,
+		"job_queue": map[string]any{},
+		"nodestore": nodeStore,
+	}
+	info["current_activities"] = map[string]any{
+		"jobs":    []map[string]any{},
+		"methods": methods,
+	}
+}
+
+func rpcDiagnosticsJSON(stats types.RPCMethodDiagnostics) map[string]any {
+	return map[string]any{
+		"started":     strconv.FormatUint(stats.Started, 10),
+		"finished":    strconv.FormatUint(stats.Finished, 10),
+		"errored":     strconv.FormatUint(stats.Errored, 10),
+		"duration_us": strconv.FormatUint(stats.DurationUs, 10),
+	}
 }
 
 func buildServerWarnings(services *types.ServiceContainer, isAdmin bool) []types.WarningObject {

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -134,11 +134,11 @@ func serverCountersRequested(params json.RawMessage) bool {
 
 func addServerDiagnostics(info map[string]any, services *types.ServiceContainer) {
 	rpcCounters := make(map[string]any)
-	methods := make([]map[string]any, 0)
 	var snapshot types.RPCDiagnosticsSnapshot
 	if services != nil && services.RPCDiagnostics != nil {
 		snapshot = services.RPCDiagnostics.Snapshot()
 	}
+	methods := make([]map[string]any, 0, len(snapshot.Current))
 
 	var total types.RPCMethodDiagnostics
 	for method, stats := range snapshot.Methods {

--- a/internal/rpc/handlers/server_state.go
+++ b/internal/rpc/handlers/server_state.go
@@ -16,6 +16,9 @@ func (m *ServerStateMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 	}
 
 	state := buildServerInfo(ctx, false)
+	if serverCountersRequested(params) {
+		addServerDiagnostics(state, ctx.Services)
+	}
 	if warnings := buildServerWarnings(ctx.Services, ctx.IsAdmin); len(warnings) > 0 {
 		state["warnings"] = warnings
 	}

--- a/internal/rpc/server_diagnostics_test.go
+++ b/internal/rpc/server_diagnostics_test.go
@@ -1,0 +1,138 @@
+package rpc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+)
+
+type staticRPCDiagnostics struct {
+	snapshot types.RPCDiagnosticsSnapshot
+}
+
+func (d staticRPCDiagnostics) Start(string) func(bool) { return func(bool) {} }
+func (d staticRPCDiagnostics) Snapshot() types.RPCDiagnosticsSnapshot {
+	return d.snapshot
+}
+
+func TestServerDiagnosticsWireShape(t *testing.T) {
+	services := servicesForServerInfo(newMockLedgerServiceServerInfo())
+	services.RPCDiagnostics = staticRPCDiagnostics{snapshot: types.RPCDiagnosticsSnapshot{
+		Methods: map[string]types.RPCMethodDiagnostics{
+			"account_info": {Started: 3, Finished: 2, Errored: 1, DurationUs: 4500},
+		},
+		Current: []types.RPCActivity{{Method: "server_info", DurationUs: 25}},
+	}}
+	services.GetCounts = func() types.CountsResult {
+		return types.CountsResult{NodeStore: &types.NodeStoreCounts{
+			Reads: 11, FetchHits: 7, Writes: 5, ReadBytes: 101, WriteBytes: 202,
+		}}
+	}
+
+	for _, test := range []struct {
+		name   string
+		method types.MethodHandler
+		root   string
+	}{
+		{name: "server_info", method: &handlers.ServerInfoMethod{}, root: "info"},
+		{name: "server_state", method: &handlers.ServerStateMethod{}, root: "state"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, IsAdmin: true, ApiVersion: 1, Services: services}
+			result, rpcErr := test.method.Handle(ctx, json.RawMessage(`{"counters":"yes"}`))
+			if rpcErr != nil {
+				t.Fatalf("Handle: %v", rpcErr)
+			}
+			body := result.(map[string]any)[test.root].(map[string]any)
+			counters := body["counters"].(map[string]any)
+			rpcCounters := counters["rpc"].(map[string]any)
+			method := rpcCounters["account_info"].(map[string]any)
+			if method["started"] != "3" || method["finished"] != "2" || method["errored"] != "1" || method["duration_us"] != "4500" {
+				t.Fatalf("method counters = %#v", method)
+			}
+			if total := rpcCounters["total"].(map[string]any); total["started"] != "3" {
+				t.Fatalf("total = %#v", total)
+			}
+			if len(counters["job_queue"].(map[string]any)) != 0 {
+				t.Fatalf("job_queue = %#v", counters["job_queue"])
+			}
+			nodeStore := counters["nodestore"].(map[string]any)
+			if nodeStore["node_reads_total"] != "11" || nodeStore["node_reads_hit"] != "7" || nodeStore["node_writes"] != "5" || nodeStore["node_read_bytes"] != "101" || nodeStore["node_written_bytes"] != "202" {
+				t.Fatalf("nodestore = %#v", nodeStore)
+			}
+			activities := body["current_activities"].(map[string]any)
+			if len(activities["jobs"].([]map[string]any)) != 0 {
+				t.Fatalf("jobs = %#v", activities["jobs"])
+			}
+			methods := activities["methods"].([]map[string]any)
+			if len(methods) != 1 || methods[0]["method"] != "server_info" || methods[0]["duration_us"] != "25" {
+				t.Fatalf("methods = %#v", methods)
+			}
+			if _, ok := body["load"]; ok {
+				t.Fatal("fabricated admin JobQueue load")
+			}
+		})
+	}
+}
+
+func TestServerDiagnosticsJsonCppCountersTruthiness(t *testing.T) {
+	services := servicesForServerInfo(newMockLedgerServiceServerInfo())
+	method := &handlers.ServerInfoMethod{}
+	ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleGuest, ApiVersion: 1, Services: services}
+	for _, test := range []struct {
+		value string
+		want  bool
+	}{
+		{value: `false`, want: false},
+		{value: `0`, want: false},
+		{value: `""`, want: false},
+		{value: `[]`, want: false},
+		{value: `{}`, want: false},
+		{value: `true`, want: true},
+		{value: `-1`, want: true},
+		{value: `"counters"`, want: true},
+		{value: `[0]`, want: true},
+		{value: `{"enabled":false}`, want: true},
+	} {
+		result, rpcErr := method.Handle(ctx, json.RawMessage(`{"counters":`+test.value+`}`))
+		if rpcErr != nil {
+			t.Fatalf("value %s: %v", test.value, rpcErr)
+		}
+		_, got := result.(map[string]any)["info"].(map[string]any)["counters"]
+		if got != test.want {
+			t.Fatalf("value %s: counters present=%v, want %v", test.value, got, test.want)
+		}
+	}
+}
+
+func TestHTTPServerDiagnosticsRejectsRawPositionalParameter(t *testing.T) {
+	for _, test := range []struct {
+		method string
+	}{
+		{method: "server_info"},
+		{method: "server_state"},
+	} {
+		t.Run(test.method, func(t *testing.T) {
+			services := servicesForServerInfo(newMockLedgerServiceServerInfo())
+			server := NewServer(ServerOptions{Timeout: time.Second, Services: services})
+			body := `{"method":"` + test.method + `","params":["counters"]}`
+			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+			req.Header.Set("Content-Type", "application/json")
+			recorder := httptest.NewRecorder()
+			server.ServeHTTP(recorder, req)
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d; body = %s", recorder.Code, http.StatusBadRequest, recorder.Body.String())
+			}
+			if got := recorder.Body.String(); got != "params unparseable\r\n" {
+				t.Fatalf("body = %q", got)
+			}
+		})
+	}
+}

--- a/internal/rpc/server_dispatch.go
+++ b/internal/rpc/server_dispatch.go
@@ -193,13 +193,21 @@ func dispatchResolvedMethod(
 		services.ClientLoad.Begin()
 		defer services.ClientLoad.End()
 	}
+	finishDiagnostics := startRPCDiagnostics(services, method)
 	result, rpcErr, recovered := invokeHandler(resolution.handler, ctx, params, method, log)
+	finishDiagnostics(recovered)
 	kind := loadtrack.LoadKind(ctx.LoadCost)
 	if recovered && kind == loadtrack.LoadReference {
 		kind = loadtrack.LoadException
 	}
 	finalizeLoad(tracker, ctx, method, kind, log)
 	return result, rpcErr
+}
+func startRPCDiagnostics(services *types.ServiceContainer, method string) func(bool) {
+	if services == nil || services.RPCDiagnostics == nil {
+		return func(bool) {}
+	}
+	return services.RPCDiagnostics.Start(method)
 }
 func dispatchNestedMethod(
 	registry *types.MethodRegistry,

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -383,6 +383,11 @@ type ServiceContainer struct {
 	// nil as "never shed".
 	ClientLoad *ClientLoadShedder
 
+	// RPCDiagnostics records completed and currently-running RPC handlers for
+	// server_info/server_state. It is shared by every transport so the snapshot
+	// represents the node rather than one listener.
+	RPCDiagnostics RPCDiagnostics
+
 	// GetCounts returns the runtime counters surfaced by the get_counts RPC
 	// (node-store I/O counters and locally-held transactions). Nil until the
 	// ledger service is wired — the handler then reports only the standalone
@@ -575,6 +580,31 @@ type NodeStoreCounts struct {
 	Writes     uint64 // node_writes
 	ReadBytes  uint64 // node_read_bytes
 	WriteBytes uint64 // node_written_bytes
+}
+
+// RPCDiagnostics records handler execution after admission and exposes an
+// immutable point-in-time snapshot. The finish callback receives true only
+// when the handler panicked; ordinary RPC error results are completed calls.
+type RPCDiagnostics interface {
+	Start(method string) (finish func(panicked bool))
+	Snapshot() RPCDiagnosticsSnapshot
+}
+
+type RPCDiagnosticsSnapshot struct {
+	Methods map[string]RPCMethodDiagnostics
+	Current []RPCActivity
+}
+
+type RPCMethodDiagnostics struct {
+	Started    uint64
+	Finished   uint64
+	Errored    uint64
+	DurationUs uint64
+}
+
+type RPCActivity struct {
+	Method     string
+	DurationUs uint64
 }
 
 // FullBelowCounts holds the shared SHAMap completeness-cache metrics.

--- a/internal/rpc/websocket_dispatch.go
+++ b/internal/rpc/websocket_dispatch.go
@@ -141,7 +141,10 @@ func (ws *WebSocketServer) handleSpecialCommand(wsConn *websocketConnection, ctx
 			ws.services.ClientLoad.Begin()
 			defer ws.services.ClientLoad.End()
 		}
-		return invokeWSSpecial(handler, wsConn, ctx, cmd)
+		finishDiagnostics := startRPCDiagnostics(ws.services, cmd.Command)
+		result, rpcErr, recovered := invokeWSSpecial(handler, wsConn, ctx, cmd)
+		finishDiagnostics(recovered)
+		return result, rpcErr, recovered
 	}()
 	kind := loadtrack.LoadKind(ctx.LoadCost)
 	if recovered && kind == loadtrack.LoadReference {

--- a/internal/rpc/websocket_special_dispatch_test.go
+++ b/internal/rpc/websocket_special_dispatch_test.go
@@ -15,8 +15,9 @@ import (
 func newSpecialDispatchHarness(t *testing.T) (*WebSocketServer, *websocketConnection, *types.RpcContext) {
 	t.Helper()
 	services := &types.ServiceContainer{
-		ClientLoad:   types.NewClientLoadShedder(),
-		Capabilities: types.RPCCapabilities{PathSearchMax: 3},
+		ClientLoad:     types.NewClientLoadShedder(),
+		RPCDiagnostics: NewRPCDiagnostics(),
+		Capabilities:   types.RPCCapabilities{PathSearchMax: 3},
 	}
 	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second, Services: services, LoadTracker: loadtrack.New()})
 	ws.methodRegistry.Register("subscribe", &stubHandler{})
@@ -169,6 +170,9 @@ func TestWebSocketSpecialDispatchRecoversPanic(t *testing.T) {
 	}
 	if got := ws.services.ClientLoad.InFlight(); got != 0 {
 		t.Fatalf("in-flight leaked after panic: %d", got)
+	}
+	if stats := ws.services.RPCDiagnostics.Snapshot().Methods["subscribe"]; stats.Started != 1 || stats.Finished != 0 || stats.Errored != 1 {
+		t.Fatalf("diagnostics = %#v", stats)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add concurrency-safe RPC counters and current-activity diagnostics from real runtime data.
- Persist standalone node identity and support JsonCpp-compatible counters requests.

## Verification
- Diagnostics, node identity, and full RPC tests
- Targeted race, vet, strict lint, no-CGO build, and oracle review

Refs #1486

Stack layer 12 of 16; depends on #1577.