### PR TITLE
fix(rpc): preserve subscription request contracts

### DIFF
--- a/internal/rpc/rpcsub.go
+++ b/internal/rpc/rpcsub.go
@@ -170,23 +170,39 @@ func (r *urlSubscriptionRegistry) Subscribe(ctx *types.RpcContext, request types
 		return nil, rpcErr
 	}
 
-	if rpcErr := r.ws.subscriptionManager.HandleSubscribeTransactional(lookup.sub.conn, request, true); rpcErr != nil {
-		var stopped *rpcSub
-		if lookup.created {
-			r.removeLocked(key, lookup.sub)
-			stopped = lookup.sub
-		} else {
-			lookup.sub.updateCredentials(lookup.username, true, lookup.password, true)
-		}
+	fail := func(rpcErr *types.RpcError) (map[string]any, *types.RpcError) {
+		stopped := r.rollbackLookupLocked(key, lookup)
 		r.mu.Unlock()
 		waitRPCSub(stopped)
 		return nil, rpcErr
 	}
+	prefix := request.WithoutBooks().WithoutAccountHistory()
+	if rpcErr := r.ws.subscriptionManager.ValidateSubscribe(lookup.sub.conn, prefix, true); rpcErr != nil {
+		return fail(rpcErr)
+	}
+	history, rpcErr := prepareAccountHistorySubscribe(ctx, request)
+	if rpcErr != nil {
+		return fail(rpcErr)
+	}
+	if rpcErr := history.validate(lookup.sub.conn); rpcErr != nil {
+		return fail(rpcErr)
+	}
+	if rpcErr := r.validateBooks(lookup.sub.conn, request, true); rpcErr != nil {
+		return fail(rpcErr)
+	}
+	if rpcErr := r.ws.subscriptionManager.HandleSubscribeTransactional(lookup.sub.conn, request.WithoutAccountHistory(), true); rpcErr != nil {
+		return fail(rpcErr)
+	}
+	history.apply(lookup.sub.conn)
 	for _, book := range request.Books {
 		setSubscriptionLoadCost(ctx, types.SubscriptionRequest{Books: []types.BookRequest{book}})
 	}
+	result := r.ws.buildSubscribeAck(ctx, request)
+	if history != nil {
+		result["warning"] = accountHistoryWarning
+	}
 	r.mu.Unlock()
-	return r.ws.buildSubscribeAck(ctx, request), nil
+	return result, nil
 }
 
 // Unsubscribe removes the listed streams/accounts/books from the url's
@@ -207,10 +223,25 @@ func (r *urlSubscriptionRegistry) Unsubscribe(ctx *types.RpcContext, request typ
 		r.mu.Unlock()
 		return map[string]any{}, nil
 	}
-	if rpcErr := r.ws.subscriptionManager.HandleUnsubscribeTransactional(sub.conn, request, true); rpcErr != nil {
+	prefix := request.WithoutBooks().WithoutAccountHistory()
+	if rpcErr := r.ws.subscriptionManager.ValidateUnsubscribe(sub.conn, prefix, true); rpcErr != nil {
 		r.mu.Unlock()
 		return nil, rpcErr
 	}
+	history, rpcErr := prepareAccountHistoryUnsubscribe(ctx, request)
+	if rpcErr != nil {
+		r.mu.Unlock()
+		return nil, rpcErr
+	}
+	if rpcErr := r.validateBooks(sub.conn, request, false); rpcErr != nil {
+		r.mu.Unlock()
+		return nil, rpcErr
+	}
+	if rpcErr := r.ws.subscriptionManager.HandleUnsubscribeTransactional(sub.conn, request.WithoutAccountHistory(), true); rpcErr != nil {
+		r.mu.Unlock()
+		return nil, rpcErr
+	}
+	history.apply(sub.conn)
 	stopped := r.tryRemoveLocked(key)
 	r.mu.Unlock()
 	waitRPCSub(stopped)
@@ -222,6 +253,33 @@ type rpcSubLookup struct {
 	created  bool
 	username string
 	password string
+}
+
+func (r *urlSubscriptionRegistry) rollbackLookupLocked(key string, lookup rpcSubLookup) *rpcSub {
+	if lookup.created {
+		r.removeLocked(key, lookup.sub)
+		return lookup.sub
+	}
+	lookup.sub.updateCredentials(lookup.username, true, lookup.password, true)
+	return nil
+}
+
+func (r *urlSubscriptionRegistry) validateBooks(conn *types.Connection, request types.SubscriptionRequest, subscribe bool) *types.RpcError {
+	validate := func(bookRequest types.SubscriptionRequest) *types.RpcError {
+		bookRequest.ApiVersion = request.ApiVersion
+		if subscribe {
+			return r.ws.subscriptionManager.ValidateSubscribe(conn, bookRequest, true)
+		}
+		return r.ws.subscriptionManager.ValidateUnsubscribe(conn, bookRequest, true)
+	}
+	wire := request.WireArrays()
+	if wire.Present {
+		return applySubscriptionBooks(wire.Books, validate)
+	}
+	if request.Books == nil {
+		return nil
+	}
+	return validate(types.SubscriptionRequest{Books: request.Books})
 }
 
 func (r *urlSubscriptionRegistry) findOrCreateLocked(request types.SubscriptionRequest, key, principal string) (rpcSubLookup, *types.RpcError) {
@@ -306,6 +364,9 @@ func (r *urlSubscriptionRegistry) tryRemoveLocked(key string) *rpcSub {
 	if r.ws.subscriptionManager.HasStreamSubscriptions(sub.conn.ID) {
 		return nil
 	}
+	if hasAccountHistorySubscriptions(r.ws.services, sub.conn) {
+		return nil
+	}
 	return r.removeLocked(key, sub)
 }
 
@@ -321,6 +382,7 @@ func (r *urlSubscriptionRegistry) removeLocked(key string, sub *rpcSub) *rpcSub 
 		}
 	}
 	r.ws.subscriptionManager.RemoveConnection(sub.conn.ID)
+	removeAccountHistoryConnection(r.ws.services, sub.conn)
 	sub.stop()
 	return sub
 }
@@ -351,6 +413,7 @@ func (r *urlSubscriptionRegistry) Close() {
 	r.cancel()
 	for _, sub := range subs {
 		r.ws.subscriptionManager.RemoveConnection(sub.conn.ID)
+		removeAccountHistoryConnection(r.ws.services, sub.conn)
 		sub.stop()
 	}
 	for _, sub := range subs {

--- a/internal/rpc/subscription/manager.go
+++ b/internal/rpc/subscription/manager.go
@@ -137,6 +137,17 @@ func (sm *Manager) HandleSubscribeTransactional(conn *types.Connection, request 
 	return nil
 }
 
+// ValidateSubscribe applies a request to an isolated copy of a connection's
+// state. URL subscriptions use it to validate all independently-owned pieces
+// before committing any of them.
+func (sm *Manager) ValidateSubscribe(conn *types.Connection, request types.SubscriptionRequest, isAdmin bool) *types.RpcError {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	probe := &types.Connection{Subscriptions: cloneSubscriptions(conn.Subscriptions)}
+	probe.SetAPIVersion(conn.APIVersion())
+	return sm.handleSubscribeLocked(probe, request, isAdmin)
+}
+
 func (sm *Manager) handleSubscribeLocked(conn *types.Connection, request types.SubscriptionRequest, isAdmin bool) *types.RpcError {
 	w := request.WireArrays()
 	conn.SetAPIVersion(request.ApiVersion)
@@ -163,9 +174,33 @@ func (sm *Manager) handleSubscribeLocked(conn *types.Connection, request types.S
 		conn.Subscriptions[key] = types.SubscriptionConfig{}
 	}
 
+	// accounts_proposed takes precedence over the deprecated rt_accounts alias
+	// when both members are present.
+	proposedRaw, proposedTyped := w.RTAccounts, request.RTAccounts
+	if w.AccountsProposed != nil || (!w.Present && request.AccountsProposed != nil) {
+		proposedRaw, proposedTyped = w.AccountsProposed, request.AccountsProposed
+	}
+	proposedPresent, proposed, rpcErr := resolveAccounts(w.Present, proposedRaw, proposedTyped)
+	if rpcErr != nil {
+		return rpcErr
+	}
+	if proposedPresent {
+		if len(proposed) == 0 {
+			return types.RpcErrorActMalformed("Account malformed.")
+		}
+		for _, acc := range proposed {
+			if !isValidXRPLAddress(acc) {
+				return types.RpcErrorActMalformed("Account malformed.")
+			}
+		}
+		existing := conn.Subscriptions[types.SubAccountsProposed]
+		conn.Subscriptions[types.SubAccountsProposed] = types.SubscriptionConfig{
+			Accounts: mergeAccounts(existing.Accounts, proposed),
+		}
+	}
+
 	// accounts (Subscribe.cpp:192-200): a present-but-empty array, a non-string
-	// id, or an unparseable id all make parseAccountIds return an empty set →
-	// rpcACT_MALFORMED.
+	// id, or an unparseable id all make parseAccountIds return an empty set.
 	accountsPresent, accounts, rpcErr := resolveAccounts(w.Present, w.Accounts, request.Accounts)
 	if rpcErr != nil {
 		return rpcErr
@@ -179,32 +214,9 @@ func (sm *Manager) handleSubscribeLocked(conn *types.Connection, request types.S
 				return types.RpcErrorActMalformed("Account malformed.")
 			}
 		}
-		// Accumulate onto the existing subscription rather than replacing it.
 		existing := conn.Subscriptions[types.SubAccounts]
 		conn.Subscriptions[types.SubAccounts] = types.SubscriptionConfig{
 			Accounts: mergeAccounts(existing.Accounts, accounts),
-		}
-	}
-
-	// accounts_proposed (Subscribe.cpp:181-189), same semantics as accounts.
-	proposedPresent, proposed, rpcErr := resolveAccounts(w.Present, w.AccountsProposed, request.AccountsProposed)
-	if rpcErr != nil {
-		return rpcErr
-	}
-	if proposedPresent {
-		if len(proposed) == 0 {
-			return types.RpcErrorActMalformed("Account malformed.")
-		}
-		for _, acc := range proposed {
-			if !isValidXRPLAddress(acc) {
-				return types.RpcErrorActMalformed("Account malformed.")
-			}
-		}
-		// Accumulate, mirroring the accounts branch above (rippled's
-		// subAccount with rt=true).
-		existing := conn.Subscriptions[types.SubAccountsProposed]
-		conn.Subscriptions[types.SubAccountsProposed] = types.SubscriptionConfig{
-			Accounts: mergeAccounts(existing.Accounts, proposed),
 		}
 	}
 
@@ -643,6 +655,16 @@ func (sm *Manager) HandleUnsubscribeTransactional(conn *types.Connection, reques
 	return nil
 }
 
+// ValidateUnsubscribe is the non-mutating counterpart to
+// HandleUnsubscribeTransactional.
+func (sm *Manager) ValidateUnsubscribe(conn *types.Connection, request types.SubscriptionRequest, isAdmin bool) *types.RpcError {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	probe := &types.Connection{Subscriptions: cloneSubscriptions(conn.Subscriptions)}
+	probe.SetAPIVersion(conn.APIVersion())
+	return sm.handleUnsubscribeLocked(probe, request, isAdmin)
+}
+
 func restoreSubscriptions(dst, snapshot map[types.SubscriptionType]types.SubscriptionConfig) {
 	if dst == nil {
 		return
@@ -672,6 +694,44 @@ func (sm *Manager) handleUnsubscribeLocked(conn *types.Connection, request types
 			key = types.SubTransactionsProposed
 		}
 		delete(conn.Subscriptions, key)
+	}
+
+	proposedRaw, proposedTyped := w.RTAccounts, request.RTAccounts
+	if w.AccountsProposed != nil || (!w.Present && request.AccountsProposed != nil) {
+		proposedRaw, proposedTyped = w.AccountsProposed, request.AccountsProposed
+	}
+	proposedPresent, proposed, rpcErr := resolveAccounts(w.Present, proposedRaw, proposedTyped)
+	if rpcErr != nil {
+		return rpcErr
+	}
+	if proposedPresent {
+		if len(proposed) == 0 {
+			return types.RpcErrorActMalformed("Account malformed.")
+		}
+		for _, acc := range proposed {
+			if !isValidXRPLAddress(acc) {
+				return types.RpcErrorActMalformed("Account malformed.")
+			}
+		}
+		if existing, ok := conn.Subscriptions[types.SubAccountsProposed]; ok {
+			accountsToRemove := make(map[string]bool)
+			for _, acc := range proposed {
+				accountsToRemove[acc] = true
+			}
+			var remainingAccounts []string
+			for _, acc := range existing.Accounts {
+				if !accountsToRemove[acc] {
+					remainingAccounts = append(remainingAccounts, acc)
+				}
+			}
+			if len(remainingAccounts) > 0 {
+				conn.Subscriptions[types.SubAccountsProposed] = types.SubscriptionConfig{
+					Accounts: remainingAccounts,
+				}
+			} else {
+				delete(conn.Subscriptions, types.SubAccountsProposed)
+			}
+		}
 	}
 
 	// accounts (Unsubscribe.cpp:127-135): empty array / non-string / bad id →
@@ -706,41 +766,6 @@ func (sm *Manager) handleUnsubscribeLocked(conn *types.Connection, request types
 				}
 			} else {
 				delete(conn.Subscriptions, types.SubAccounts)
-			}
-		}
-	}
-
-	// accounts_proposed (Unsubscribe.cpp:116-124), same semantics as accounts.
-	proposedPresent, proposed, rpcErr := resolveAccounts(w.Present, w.AccountsProposed, request.AccountsProposed)
-	if rpcErr != nil {
-		return rpcErr
-	}
-	if proposedPresent {
-		if len(proposed) == 0 {
-			return types.RpcErrorActMalformed("Account malformed.")
-		}
-		for _, acc := range proposed {
-			if !isValidXRPLAddress(acc) {
-				return types.RpcErrorActMalformed("Account malformed.")
-			}
-		}
-		if existing, ok := conn.Subscriptions[types.SubAccountsProposed]; ok {
-			accountsToRemove := make(map[string]bool)
-			for _, acc := range proposed {
-				accountsToRemove[acc] = true
-			}
-			var remainingAccounts []string
-			for _, acc := range existing.Accounts {
-				if !accountsToRemove[acc] {
-					remainingAccounts = append(remainingAccounts, acc)
-				}
-			}
-			if len(remainingAccounts) > 0 {
-				conn.Subscriptions[types.SubAccountsProposed] = types.SubscriptionConfig{
-					Accounts: remainingAccounts,
-				}
-			} else {
-				delete(conn.Subscriptions, types.SubAccountsProposed)
 			}
 		}
 	}

--- a/internal/rpc/subscription_contracts_test.go
+++ b/internal/rpc/subscription_contracts_test.go
@@ -1,0 +1,468 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
+	"github.com/LeJamon/go-xrpl/internal/rpc/loadtrack"
+	"github.com/LeJamon/go-xrpl/internal/rpc/subscription"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	historyAccountA = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	historyAccountB = "rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY"
+)
+
+type historySubscriptionProvider struct {
+	mu            sync.Mutex
+	subscriptions map[*types.Connection]map[string]bool
+	removed       map[*types.Connection]bool
+	subscribeErr  *types.RpcError
+	streamContext context.Context
+}
+
+func newHistorySubscriptionProvider() *historySubscriptionProvider {
+	return &historySubscriptionProvider{
+		subscriptions: make(map[*types.Connection]map[string]bool),
+		removed:       make(map[*types.Connection]bool),
+	}
+}
+
+func (p *historySubscriptionProvider) ValidateSubscribe(conn *types.Connection, account string) *types.RpcError {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.subscribeErr != nil {
+		return p.subscribeErr
+	}
+	if _, exists := p.subscriptions[conn][account]; exists {
+		return types.RpcErrorInvalidParams("Invalid parameters.")
+	}
+	return nil
+}
+
+func (p *historySubscriptionProvider) Subscribe(conn *types.Connection, account string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.streamContext = conn.Context()
+	accounts := p.subscriptions[conn]
+	if accounts == nil {
+		accounts = make(map[string]bool)
+		p.subscriptions[conn] = accounts
+	}
+	accounts[account] = true
+}
+
+func (p *historySubscriptionProvider) Unsubscribe(conn *types.Connection, account string, historyOnly bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	accounts := p.subscriptions[conn]
+	if historyOnly {
+		if _, exists := accounts[account]; exists {
+			accounts[account] = false
+		}
+		return
+	}
+	delete(accounts, account)
+	if len(accounts) == 0 {
+		delete(p.subscriptions, conn)
+	}
+}
+
+func (p *historySubscriptionProvider) RemoveConnection(conn *types.Connection) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.subscriptions, conn)
+	p.removed[conn] = true
+}
+
+func (p *historySubscriptionProvider) HasSubscriptions(conn *types.Connection) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.subscriptions[conn]) != 0
+}
+
+func (p *historySubscriptionProvider) state(conn *types.Connection, account string) (present, replaying bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	replaying, present = p.subscriptions[conn][account]
+	return present, replaying
+}
+
+func (p *historySubscriptionProvider) wasRemoved(conn *types.Connection) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.removed[conn]
+}
+
+func (p *historySubscriptionProvider) streamDone() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.streamContext == nil {
+		return true
+	}
+	select {
+	case <-p.streamContext.Done():
+		return true
+	default:
+		return false
+	}
+}
+
+func TestSubscriptionRequestPreservesMissingWireFields(t *testing.T) {
+	var request types.SubscriptionRequest
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"rt_accounts":null,
+		"account_history_tx_stream":{"account":"`+historyAccountA+`","stop_history_tx_only":false}
+	}`), &request))
+
+	wire := request.WireArrays()
+	require.True(t, wire.Present)
+	assert.JSONEq(t, `null`, string(wire.RTAccounts))
+	assert.JSONEq(t, `{"account":"`+historyAccountA+`","stop_history_tx_only":false}`, string(wire.AccountHistory))
+	require.NotNil(t, request.AccountHistory)
+	assert.Equal(t, historyAccountA, request.AccountHistory.Account)
+}
+
+func TestRTAccountsAliasAndCanonicalPrecedence(t *testing.T) {
+	manager := subscription.NewManager()
+
+	t.Run("deprecated alias subscribes proposed accounts", func(t *testing.T) {
+		conn := types.NewConnection("rt-alias", make(chan []byte, 1))
+		var request types.SubscriptionRequest
+		require.NoError(t, json.Unmarshal([]byte(`{"rt_accounts":["`+historyAccountA+`"]}`), &request))
+		require.Nil(t, manager.HandleSubscribe(conn, request, false))
+		assert.Equal(t, []string{historyAccountA}, conn.Subscriptions[types.SubAccountsProposed].Accounts)
+
+		var unsubscribe types.SubscriptionRequest
+		require.NoError(t, json.Unmarshal([]byte(`{"rt_accounts":["`+historyAccountA+`"]}`), &unsubscribe))
+		require.Nil(t, manager.HandleUnsubscribe(conn, unsubscribe, false))
+		_, exists := conn.Subscriptions[types.SubAccountsProposed]
+		assert.False(t, exists)
+	})
+
+	t.Run("canonical member wins even when alias is valid", func(t *testing.T) {
+		conn := types.NewConnection("canonical", make(chan []byte, 1))
+		var request types.SubscriptionRequest
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"accounts_proposed":["`+historyAccountB+`"],
+			"rt_accounts":["`+historyAccountA+`"]
+		}`), &request))
+		require.Nil(t, manager.HandleSubscribe(conn, request, false))
+		assert.Equal(t, []string{historyAccountB}, conn.Subscriptions[types.SubAccountsProposed].Accounts)
+	})
+
+	t.Run("present malformed canonical member does not fall back", func(t *testing.T) {
+		conn := types.NewConnection("canonical-malformed", make(chan []byte, 1))
+		var request types.SubscriptionRequest
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"accounts_proposed":[],
+			"rt_accounts":["`+historyAccountA+`"]
+		}`), &request))
+		rpcErr := manager.HandleSubscribe(conn, request, false)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, "actMalformed", rpcErr.ErrorString)
+		_, exists := conn.Subscriptions[types.SubAccountsProposed]
+		assert.False(t, exists)
+	})
+}
+
+func TestAccountHistorySubscribeCapabilityAndValidation(t *testing.T) {
+	t.Run("transaction table gate precedes nested validation", func(t *testing.T) {
+		ws, conn, ctx := newSpecialDispatchHarness(t)
+		ctx.Services.Ledger = &txTablesOffLedger{newMockLedgerService()}
+		ctx.Services.AccountHistorySubscriptions = newHistorySubscriptionProvider()
+		ctx.LoadCost = uint32(loadtrack.LoadReference)
+
+		_, rpcErr := ws.executeSubscribe(conn, ctx, types.WebSocketCommand{
+			Params: json.RawMessage(`{"streams":["ledger"],"account_history_tx_stream":false}`),
+		})
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, "notEnabled", rpcErr.ErrorString)
+		assert.Equal(t, uint32(loadtrack.LoadReference), ctx.LoadCost)
+		_, streamAdded := conn.Subscriptions[types.SubLedger]
+		assert.True(t, streamAdded)
+	})
+
+	t.Run("missing replay provider fails closed", func(t *testing.T) {
+		ws, conn, ctx := newSpecialDispatchHarness(t)
+		ctx.Services.Ledger = newMockLedgerService()
+		_, rpcErr := ws.executeSubscribe(conn, ctx, types.WebSocketCommand{
+			Params: json.RawMessage(`{"account_history_tx_stream":{"account":"` + historyAccountA + `"}}`),
+		})
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, "notEnabled", rpcErr.ErrorString)
+	})
+
+	t.Run("success sets medium load warning and rejects duplicates", func(t *testing.T) {
+		ws, conn, ctx := newSpecialDispatchHarness(t)
+		provider := newHistorySubscriptionProvider()
+		ctx.Services.Ledger = newMockLedgerService()
+		ctx.Services.AccountHistorySubscriptions = provider
+		ctx.LoadCost = uint32(loadtrack.LoadReference)
+		command := types.WebSocketCommand{
+			Params: json.RawMessage(`{"account_history_tx_stream":{"account":"` + historyAccountA + `"}}`),
+		}
+
+		result, rpcErr := ws.executeSubscribe(conn, ctx, command)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, accountHistoryWarning, result.(map[string]any)["warning"])
+		assert.Equal(t, uint32(loadtrack.LoadMedium), ctx.LoadCost)
+		present, replaying := provider.state(conn.Connection, historyAccountA)
+		assert.True(t, present)
+		assert.True(t, replaying)
+
+		_, rpcErr = ws.executeSubscribe(conn, ctx, command)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, "invalidParams", rpcErr.ErrorString)
+	})
+
+	t.Run("bad account is invalidParams after medium charge", func(t *testing.T) {
+		ws, conn, ctx := newSpecialDispatchHarness(t)
+		ctx.Services.Ledger = newMockLedgerService()
+		ctx.Services.AccountHistorySubscriptions = newHistorySubscriptionProvider()
+		ctx.LoadCost = uint32(loadtrack.LoadReference)
+
+		_, rpcErr := ws.executeSubscribe(conn, ctx, types.WebSocketCommand{
+			Params: json.RawMessage(`{"account_history_tx_stream":{"account":"not-an-account"}}`),
+		})
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, "invalidParams", rpcErr.ErrorString)
+		assert.Equal(t, uint32(loadtrack.LoadMedium), ctx.LoadCost)
+	})
+}
+
+func TestAccountHistoryUnsubscribeModesAndCleanup(t *testing.T) {
+	ws, conn, ctx := newSpecialDispatchHarness(t)
+	provider := newHistorySubscriptionProvider()
+	ctx.Services.Ledger = newMockLedgerService()
+	ctx.Services.AccountHistorySubscriptions = provider
+
+	subscribe := types.WebSocketCommand{
+		Params: json.RawMessage(`{"account_history_tx_stream":{"account":"` + historyAccountA + `"}}`),
+	}
+	_, rpcErr := ws.executeSubscribe(conn, ctx, subscribe)
+	require.Nil(t, rpcErr)
+
+	_, rpcErr = ws.executeUnsubscribe(conn, ctx, types.WebSocketCommand{
+		Params: json.RawMessage(`{"account_history_tx_stream":{"account":"` + historyAccountA + `","stop_history_tx_only":true}}`),
+	})
+	require.Nil(t, rpcErr)
+	present, replaying := provider.state(conn.Connection, historyAccountA)
+	assert.True(t, present)
+	assert.False(t, replaying)
+
+	_, rpcErr = ws.executeUnsubscribe(conn, ctx, types.WebSocketCommand{
+		Params: json.RawMessage(`{"account_history_tx_stream":{"account":"` + historyAccountA + `","stop_history_tx_only":"true"}}`),
+	})
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, "invalidParams", rpcErr.ErrorString)
+
+	_, rpcErr = ws.executeUnsubscribe(conn, ctx, types.WebSocketCommand{
+		Params: json.RawMessage(`{"account_history_tx_stream":{"account":"` + historyAccountA + `","stop_history_tx_only":null}}`),
+	})
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, "invalidParams", rpcErr.ErrorString)
+
+	_, rpcErr = ws.executeUnsubscribe(conn, ctx, types.WebSocketCommand{
+		Params: json.RawMessage(`{"account_history_tx_stream":{"account":"` + historyAccountA + `"}}`),
+	})
+	require.Nil(t, rpcErr)
+	present, _ = provider.state(conn.Connection, historyAccountA)
+	assert.False(t, present)
+
+	_, rpcErr = ws.executeSubscribe(conn, ctx, subscribe)
+	require.Nil(t, rpcErr)
+	ws.detachConnection(conn)
+	assert.False(t, provider.HasSubscriptions(conn.Connection))
+	assert.True(t, provider.wasRemoved(conn.Connection))
+}
+
+func TestAccountHistoryUnsubscribeWithoutProviderIsNoOp(t *testing.T) {
+	ws, conn, ctx := newSpecialDispatchHarness(t)
+	ctx.Services.Ledger = &txTablesOffLedger{newMockLedgerService()}
+
+	_, rpcErr := ws.executeUnsubscribe(conn, ctx, types.WebSocketCommand{
+		Params: json.RawMessage(`{"account_history_tx_stream":{"account":"not-an-account"}}`),
+	})
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, "invalidParams", rpcErr.ErrorString)
+
+	result, rpcErr := ws.executeUnsubscribe(conn, ctx, types.WebSocketCommand{
+		Params: json.RawMessage(`{"account_history_tx_stream":{"account":"` + historyAccountA + `"}}`),
+	})
+	require.Nil(t, rpcErr)
+	assert.Empty(t, result.(map[string]any))
+}
+
+func TestAccountHistoryURLSubscriptionRetention(t *testing.T) {
+	sink := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer sink.Close()
+
+	provider := newHistorySubscriptionProvider()
+	services := &types.ServiceContainer{
+		Ledger:                      newMockLedgerService(),
+		AccountHistorySubscriptions: provider,
+	}
+	ws := NewWebSocketServer(WebSocketServerOptions{Services: services})
+	defer ws.urlSubs.Close()
+	requestContext, cancelRequest := context.WithCancel(context.Background())
+	ctx := &types.RpcContext{
+		Context:    requestContext,
+		Role:       types.RoleAdmin,
+		IsAdmin:    true,
+		ApiVersion: types.DefaultApiVersion,
+		Services:   services,
+	}
+	request := types.SubscriptionRequest{
+		URL:            sink.URL,
+		AccountHistory: &types.AccountHistorySubscriptionRequest{Account: historyAccountA},
+	}
+
+	result, rpcErr := ws.urlSubs.Subscribe(ctx, request)
+	require.Nil(t, rpcErr)
+	cancelRequest()
+	assert.False(t, provider.streamDone())
+	assert.Equal(t, accountHistoryWarning, result["warning"])
+	require.Len(t, ws.urlSubs.subs, 1)
+	var conn *types.Connection
+	for _, sub := range ws.urlSubs.subs {
+		conn = sub.conn
+	}
+	require.NotNil(t, conn)
+
+	services.Ledger = &txTablesOffLedger{newMockLedgerService()}
+	request.AccountHistory.StopHistoryTxOnly = true
+	_, rpcErr = ws.urlSubs.Unsubscribe(ctx, request)
+	require.Nil(t, rpcErr)
+	assert.Len(t, ws.urlSubs.subs, 1)
+	present, replaying := provider.state(conn, historyAccountA)
+	assert.True(t, present)
+	assert.False(t, replaying)
+
+	request.AccountHistory.StopHistoryTxOnly = false
+	_, rpcErr = ws.urlSubs.Unsubscribe(ctx, request)
+	require.Nil(t, rpcErr)
+	assert.Empty(t, ws.urlSubs.subs)
+	assert.False(t, provider.HasSubscriptions(conn))
+	assert.True(t, provider.wasRemoved(conn))
+}
+
+func TestAccountHistoryURLValidationIsOrderedAndAtomic(t *testing.T) {
+	sink := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer sink.Close()
+	provider := newHistorySubscriptionProvider()
+	services := &types.ServiceContainer{
+		Ledger:                      newMockLedgerService(),
+		AccountHistorySubscriptions: provider,
+	}
+	ws := NewWebSocketServer(WebSocketServerOptions{Services: services})
+	defer ws.urlSubs.Close()
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleAdmin,
+		IsAdmin:    true,
+		ApiVersion: types.DefaultApiVersion,
+		Services:   services,
+	}
+
+	_, rpcErr := ws.urlSubs.Subscribe(ctx, types.SubscriptionRequest{
+		URL:     sink.URL,
+		Streams: []types.SubscriptionType{types.SubTransactions},
+	})
+	require.Nil(t, rpcErr)
+	var conn *types.Connection
+	for _, sub := range ws.urlSubs.subs {
+		conn = sub.conn
+	}
+	require.NotNil(t, conn)
+
+	provider.subscribeErr = types.RpcErrorInternal()
+	_, rpcErr = ws.urlSubs.Subscribe(ctx, types.SubscriptionRequest{
+		URL:            sink.URL,
+		Streams:        []types.SubscriptionType{types.SubLedger},
+		AccountHistory: &types.AccountHistorySubscriptionRequest{Account: historyAccountA},
+	})
+	require.NotNil(t, rpcErr)
+	assert.True(t, ws.subscriptionManager.IsSubscribed(conn.ID, types.SubTransactions))
+	assert.False(t, ws.subscriptionManager.IsSubscribed(conn.ID, types.SubLedger))
+
+	provider.subscribeErr = nil
+	ctx.LoadCost = uint32(loadtrack.LoadReference)
+	var malformed types.SubscriptionRequest
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"url":"`+sink.URL+`",
+		"streams":["not_a_stream"],
+		"account_history_tx_stream":false
+	}`), &malformed))
+	_, rpcErr = ws.urlSubs.Subscribe(ctx, malformed)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, "malformedStream", rpcErr.ErrorString)
+	assert.Equal(t, uint32(loadtrack.LoadReference), ctx.LoadCost)
+
+	_, rpcErr = ws.urlSubs.Subscribe(ctx, types.SubscriptionRequest{
+		URL:            sink.URL,
+		Streams:        []types.SubscriptionType{types.SubLedger},
+		AccountHistory: &types.AccountHistorySubscriptionRequest{Account: historyAccountA},
+	})
+	require.Nil(t, rpcErr)
+	var invalidUnsubscribe types.SubscriptionRequest
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"url":"`+sink.URL+`",
+		"streams":["ledger"],
+		"account_history_tx_stream":{"account":"`+historyAccountA+`","stop_history_tx_only":null}
+	}`), &invalidUnsubscribe))
+	_, rpcErr = ws.urlSubs.Unsubscribe(ctx, invalidUnsubscribe)
+	require.NotNil(t, rpcErr)
+	assert.True(t, ws.subscriptionManager.IsSubscribed(conn.ID, types.SubLedger))
+	present, _ := provider.state(conn, historyAccountA)
+	assert.True(t, present)
+}
+
+func TestAccountHistoryHTTPURLMethods(t *testing.T) {
+	sink := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer sink.Close()
+	provider := newHistorySubscriptionProvider()
+	services := &types.ServiceContainer{
+		Ledger:                      newMockLedgerService(),
+		AccountHistorySubscriptions: provider,
+	}
+	ws := NewWebSocketServer(WebSocketServerOptions{Services: services})
+	defer ws.urlSubs.Close()
+	services.URLSubscriptions = ws.urlSubs
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleAdmin,
+		IsAdmin:    true,
+		ApiVersion: types.DefaultApiVersion,
+		Services:   services,
+	}
+	params := json.RawMessage(`{
+		"url":"` + sink.URL + `",
+		"account_history_tx_stream":{"account":"` + historyAccountA + `"}
+	}`)
+
+	result, rpcErr := (&handlers.SubscribeMethod{}).Handle(ctx, params)
+	require.Nil(t, rpcErr)
+	assert.Equal(t, accountHistoryWarning, result.(map[string]any)["warning"])
+	require.Len(t, ws.urlSubs.subs, 1)
+	var conn *types.Connection
+	for _, sub := range ws.urlSubs.subs {
+		conn = sub.conn
+	}
+	present, replaying := provider.state(conn, historyAccountA)
+	assert.True(t, present)
+	assert.True(t, replaying)
+
+	result, rpcErr = (&handlers.UnsubscribeMethod{}).Handle(ctx, params)
+	require.Nil(t, rpcErr)
+	assert.Empty(t, result.(map[string]any))
+	assert.Empty(t, ws.urlSubs.subs)
+}

--- a/internal/rpc/subscription_history.go
+++ b/internal/rpc/subscription_history.go
@@ -1,0 +1,173 @@
+package rpc
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/loadtrack"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+)
+
+const accountHistoryWarning = "account_history_tx_stream is an experimental feature and likely to be removed in the future"
+
+type preparedAccountHistorySubscribe struct {
+	service types.AccountHistorySubscriptionService
+	account string
+}
+
+func prepareAccountHistorySubscribe(ctx *types.RpcContext, request types.SubscriptionRequest) (*preparedAccountHistorySubscribe, *types.RpcError) {
+	present := accountHistoryPresent(request)
+	if !present {
+		return nil, nil
+	}
+	services := rpcServices(ctx)
+	if services == nil || services.Ledger == nil {
+		return nil, types.RpcErrorNotEnabled("")
+	}
+	if tables, ok := services.Ledger.(types.TxTablesProvider); ok && !tables.UseTxTables() {
+		return nil, types.RpcErrorNotEnabled("")
+	}
+	if services.AccountHistorySubscriptions == nil {
+		return nil, types.RpcErrorNotEnabled("")
+	}
+	if ctx != nil {
+		ctx.LoadCost = uint32(loadtrack.LoadMedium)
+	}
+	account, _, rpcErr := parseAccountHistoryRequest(request, false)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	return &preparedAccountHistorySubscribe{
+		service: services.AccountHistorySubscriptions,
+		account: account,
+	}, nil
+}
+
+func (p *preparedAccountHistorySubscribe) validate(conn *types.Connection) *types.RpcError {
+	if p == nil {
+		return nil
+	}
+	return p.service.ValidateSubscribe(conn, p.account)
+}
+
+func (p *preparedAccountHistorySubscribe) apply(conn *types.Connection) {
+	if p != nil {
+		p.service.Subscribe(conn, p.account)
+	}
+}
+
+func applyAccountHistorySubscribe(ctx *types.RpcContext, conn *types.Connection, request types.SubscriptionRequest) (string, *types.RpcError) {
+	prepared, rpcErr := prepareAccountHistorySubscribe(ctx, request)
+	if rpcErr != nil {
+		return "", rpcErr
+	}
+	if prepared == nil {
+		return "", nil
+	}
+	if rpcErr := prepared.validate(conn); rpcErr != nil {
+		return "", rpcErr
+	}
+	prepared.apply(conn)
+	return accountHistoryWarning, nil
+}
+
+func applyAccountHistoryUnsubscribe(ctx *types.RpcContext, conn *types.Connection, request types.SubscriptionRequest) *types.RpcError {
+	prepared, rpcErr := prepareAccountHistoryUnsubscribe(ctx, request)
+	if rpcErr != nil {
+		return rpcErr
+	}
+	prepared.apply(conn)
+	return nil
+}
+
+type preparedAccountHistoryUnsubscribe struct {
+	service     types.AccountHistorySubscriptionService
+	account     string
+	historyOnly bool
+}
+
+func prepareAccountHistoryUnsubscribe(ctx *types.RpcContext, request types.SubscriptionRequest) (*preparedAccountHistoryUnsubscribe, *types.RpcError) {
+	if !accountHistoryPresent(request) {
+		return nil, nil
+	}
+	account, historyOnly, rpcErr := parseAccountHistoryRequest(request, true)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	services := rpcServices(ctx)
+	var service types.AccountHistorySubscriptionService
+	if services != nil {
+		service = services.AccountHistorySubscriptions
+	}
+	return &preparedAccountHistoryUnsubscribe{
+		service:     service,
+		account:     account,
+		historyOnly: historyOnly,
+	}, nil
+}
+
+func (p *preparedAccountHistoryUnsubscribe) apply(conn *types.Connection) {
+	if p != nil && p.service != nil {
+		p.service.Unsubscribe(conn, p.account, p.historyOnly)
+	}
+}
+
+func accountHistoryPresent(request types.SubscriptionRequest) bool {
+	wire := request.WireArrays()
+	if wire.Present {
+		return wire.AccountHistory != nil
+	}
+	return request.AccountHistory != nil
+}
+
+func parseAccountHistoryRequest(request types.SubscriptionRequest, unsubscribe bool) (string, bool, *types.RpcError) {
+	wire := request.WireArrays()
+	if !wire.Present {
+		if request.AccountHistory == nil || !types.IsValidClassicAddress(request.AccountHistory.Account) {
+			return "", false, types.RpcErrorInvalidParams("Invalid parameters.")
+		}
+		return request.AccountHistory.Account, unsubscribe && request.AccountHistory.StopHistoryTxOnly, nil
+	}
+
+	var nested map[string]json.RawMessage
+	if err := json.Unmarshal(wire.AccountHistory, &nested); err != nil || nested == nil {
+		return "", false, types.RpcErrorInvalidParams("Invalid parameters.")
+	}
+	rawAccount, ok := nested["account"]
+	if !ok {
+		return "", false, types.RpcErrorInvalidParams("Invalid parameters.")
+	}
+	var account string
+	if err := json.Unmarshal(rawAccount, &account); err != nil || !types.IsValidClassicAddress(account) {
+		return "", false, types.RpcErrorInvalidParams("Invalid parameters.")
+	}
+
+	historyOnly := false
+	if unsubscribe {
+		if rawStop, ok := nested["stop_history_tx_only"]; ok {
+			trimmed := bytes.TrimSpace(rawStop)
+			if !bytes.Equal(trimmed, []byte("true")) && !bytes.Equal(trimmed, []byte("false")) {
+				return "", false, types.RpcErrorInvalidParams("Invalid parameters.")
+			}
+			historyOnly = bytes.Equal(trimmed, []byte("true"))
+		}
+	}
+	return account, historyOnly, nil
+}
+
+func rpcServices(ctx *types.RpcContext) *types.ServiceContainer {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.Services
+}
+
+func removeAccountHistoryConnection(services *types.ServiceContainer, conn *types.Connection) {
+	if services != nil && services.AccountHistorySubscriptions != nil {
+		services.AccountHistorySubscriptions.RemoveConnection(conn)
+	}
+}
+
+func hasAccountHistorySubscriptions(services *types.ServiceContainer, conn *types.Connection) bool {
+	return services != nil && services.AccountHistorySubscriptions != nil && services.AccountHistorySubscriptions.HasSubscriptions(conn)
+}

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -469,6 +469,11 @@ type ServiceContainer struct {
 	// WebSocket server is wired — the handlers then report notSupported.
 	URLSubscriptions URLSubscriptionService
 
+	// AccountHistorySubscriptions is the optional provider for rippled's
+	// experimental account_history_tx_stream. Nil means the node cannot perform
+	// the historical replay/live handoff and subscribe requests return notEnabled.
+	AccountHistorySubscriptions AccountHistorySubscriptionService
+
 	// QueueAccountTxs returns the transactions currently queued in the TxQ
 	// for one account, sorted by SeqProxy. Backs account_info's queue_data
 	// (rippled TxQ::getAccountTxs → AccountInfo.cpp:193-283). Nil in
@@ -497,6 +502,19 @@ type URLSubscriptionService interface {
 	// subscription and drops the registry entry once no stream
 	// subscriptions remain. An unknown url is silent success.
 	Unsubscribe(ctx *RpcContext, request SubscriptionRequest) (map[string]any, *RpcError)
+}
+
+// AccountHistorySubscriptionService owns the historical replay and its live
+// continuation for account_history_tx_stream. Subscribe is called only after
+// request, transaction-table, and provider validation; implementations derive
+// asynchronous work from conn.Context(). Unsubscribe is an idempotent no-op for
+// unknown accounts.
+type AccountHistorySubscriptionService interface {
+	ValidateSubscribe(conn *Connection, account string) *RpcError
+	Subscribe(conn *Connection, account string)
+	Unsubscribe(conn *Connection, account string, historyOnly bool)
+	RemoveConnection(conn *Connection)
+	HasSubscriptions(conn *Connection) bool
 }
 
 // QueuedTxInfo is the per-transaction view of a TxQ candidate surfaced by

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -268,13 +268,15 @@ const (
 
 // Subscription request structure
 type SubscriptionRequest struct {
-	Streams          []SubscriptionType `json:"streams,omitempty"`
-	Accounts         []string           `json:"accounts,omitempty"`
-	AccountsProposed []string           `json:"accounts_proposed,omitempty"`
-	Books            []BookRequest      `json:"books,omitempty"`
-	URL              string             `json:"url,omitempty"`
-	URLUsername      string             `json:"url_username,omitempty"`
-	URLPassword      string             `json:"url_password,omitempty"`
+	Streams          []SubscriptionType                 `json:"streams,omitempty"`
+	Accounts         []string                           `json:"accounts,omitempty"`
+	AccountsProposed []string                           `json:"accounts_proposed,omitempty"`
+	RTAccounts       []string                           `json:"rt_accounts,omitempty"`
+	AccountHistory   *AccountHistorySubscriptionRequest `json:"account_history_tx_stream,omitempty"`
+	Books            []BookRequest                      `json:"books,omitempty"`
+	URL              string                             `json:"url,omitempty"`
+	URLUsername      string                             `json:"url_username,omitempty"`
+	URLPassword      string                             `json:"url_password,omitempty"`
 	// Username / Password are the deprecated aliases rippled still accepts
 	// for url_username / url_password. When present they take precedence,
 	// and they alone trigger credential updates on an already-registered
@@ -285,8 +287,8 @@ type SubscriptionRequest struct {
 	// subscription payload. A zero value uses DefaultApiVersion.
 	ApiVersion int `json:"-"`
 
-	// wire holds the as-received JSON of the array-valued fields, captured at
-	// decode time. The typed slices above collapse the four shapes rippled
+	// wire holds the as-received JSON of shape-sensitive fields, captured at
+	// decode time. Typed values collapse the shapes rippled
 	// distinguishes via isMember/isArray — absent, null, non-array, and empty
 	// array — into a single nil-or-empty slice, so the subscription manager
 	// reads wire to reproduce rippled's per-shape error codes. nil when the
@@ -300,6 +302,8 @@ type wireSubscriptionArrays struct {
 	streams          json.RawMessage
 	accounts         json.RawMessage
 	accountsProposed json.RawMessage
+	rtAccounts       json.RawMessage
+	accountHistory   json.RawMessage
 	books            json.RawMessage
 	url              json.RawMessage
 	username         json.RawMessage
@@ -307,13 +311,15 @@ type wireSubscriptionArrays struct {
 }
 
 // WireSubscriptionArrays exposes the raw JSON the wire carried for the
-// array-valued subscription fields. Present is false when the request was not
+// shape-sensitive subscription fields. Present is false when the request was not
 // decoded from JSON, in which case the manager falls back to the typed slices.
 type WireSubscriptionArrays struct {
 	Present          bool
 	Streams          json.RawMessage
 	Accounts         json.RawMessage
 	AccountsProposed json.RawMessage
+	RTAccounts       json.RawMessage
+	AccountHistory   json.RawMessage
 	Books            json.RawMessage
 }
 
@@ -327,8 +333,23 @@ func (r *SubscriptionRequest) WireArrays() WireSubscriptionArrays {
 		Streams:          r.wire.streams,
 		Accounts:         r.wire.accounts,
 		AccountsProposed: r.wire.accountsProposed,
+		RTAccounts:       r.wire.rtAccounts,
+		AccountHistory:   r.wire.accountHistory,
 		Books:            r.wire.books,
 	}
+}
+
+// WithoutAccountHistory returns a copy that preserves every wire field except
+// account_history_tx_stream. The transport handles that field through the
+// optional history-stream capability rather than the ordinary stream manager.
+func (r SubscriptionRequest) WithoutAccountHistory() SubscriptionRequest {
+	r.AccountHistory = nil
+	if r.wire != nil {
+		wire := *r.wire
+		wire.accountHistory = nil
+		r.wire = &wire
+	}
+	return r
 }
 
 // WithoutBooks returns a copy that preserves every wire field except books.
@@ -342,7 +363,7 @@ func (r SubscriptionRequest) WithoutBooks() SubscriptionRequest {
 	return r
 }
 
-// UnmarshalJSON captures the raw JSON of the array-valued fields before
+// UnmarshalJSON captures the raw JSON of shape-sensitive fields before
 // decoding the typed fields, so the subscription manager can apply rippled's
 // per-field, per-shape error codes — a typed slice cannot tell an absent field
 // from a null, an empty array, or a non-array value. Shape mismatches on the
@@ -357,6 +378,8 @@ func (r *SubscriptionRequest) UnmarshalJSON(data []byte) error {
 		streams:          m["streams"],
 		accounts:         m["accounts"],
 		accountsProposed: m["accounts_proposed"],
+		rtAccounts:       m["rt_accounts"],
+		accountHistory:   m["account_history_tx_stream"],
 		books:            m["books"],
 		url:              m["url"],
 		username:         m["username"],
@@ -365,6 +388,8 @@ func (r *SubscriptionRequest) UnmarshalJSON(data []byte) error {
 	_ = json.Unmarshal(m["streams"], &r.Streams)
 	_ = json.Unmarshal(m["accounts"], &r.Accounts)
 	_ = json.Unmarshal(m["accounts_proposed"], &r.AccountsProposed)
+	_ = json.Unmarshal(m["rt_accounts"], &r.RTAccounts)
+	_ = json.Unmarshal(m["account_history_tx_stream"], &r.AccountHistory)
 	_ = json.Unmarshal(m["books"], &r.Books)
 	_ = json.Unmarshal(m["url"], &r.URL)
 	_ = json.Unmarshal(m["url_username"], &r.URLUsername)
@@ -372,6 +397,14 @@ func (r *SubscriptionRequest) UnmarshalJSON(data []byte) error {
 	_ = json.Unmarshal(m["username"], &r.Username)
 	_ = json.Unmarshal(m["password"], &r.Password)
 	return nil
+}
+
+// AccountHistorySubscriptionRequest is the nested request carried by
+// account_history_tx_stream. StopHistoryTxOnly is meaningful only for
+// unsubscribe; its exact wire type and presence are validated from WireArrays.
+type AccountHistorySubscriptionRequest struct {
+	Account           string `json:"account"`
+	StopHistoryTxOnly bool   `json:"stop_history_tx_only,omitempty"`
 }
 
 // HasURL reports whether the request selects rippled's url (RPCSub) branch.

--- a/internal/rpc/websocket_lifecycle.go
+++ b/internal/rpc/websocket_lifecycle.go
@@ -33,6 +33,7 @@ func (ws *WebSocketServer) detachConnection(wsConn *websocketConnection) {
 	delete(ws.connections, wsConn.ID)
 	ws.connectionsMutex.Unlock()
 	ws.subscriptionManager.RemoveConnection(wsConn.ID)
+	removeAccountHistoryConnection(ws.services, wsConn.Connection)
 }
 
 // closeSocket cancels the connection context and closes the underlying

--- a/internal/rpc/websocket_subscribe.go
+++ b/internal/rpc/websocket_subscribe.go
@@ -36,12 +36,16 @@ func (ws *WebSocketServer) executeSubscribe(wsConn *websocketConnection, ctx *ty
 	// The embedded canonical connection is the same object the subscription
 	// manager already tracks and carries the bounded queue and disconnect
 	// callback.
-	prefix, err := subscriptionRequestExcluding(cmd.Params, "books")
+	prefix, err := subscriptionRequestExcluding(cmd.Params, "books", "account_history_tx_stream")
 	if err != nil {
 		return nil, types.RpcErrorInvalidParams("Invalid subscription parameters.")
 	}
 	prefix.ApiVersion = ctx.ApiVersion
 	if rpcErr := ws.subscriptionManager.HandleSubscribe(wsConn.Connection, prefix, ctx.IsAdmin); rpcErr != nil {
+		return nil, rpcErr
+	}
+	historyWarning, rpcErr := applyAccountHistorySubscribe(ctx, wsConn.Connection, request)
+	if rpcErr != nil {
 		return nil, rpcErr
 	}
 	if rpcErr := applySubscriptionBooks(request.WireArrays().Books, func(bookRequest types.SubscriptionRequest) *types.RpcError {
@@ -56,6 +60,9 @@ func (ws *WebSocketServer) executeSubscribe(wsConn *websocketConnection, ctx *ty
 	}
 
 	result := ws.buildSubscribeAck(ctx, request)
+	if historyWarning != "" {
+		result["warning"] = historyWarning
+	}
 	return result, nil
 }
 func subscriptionRequestExcluding(params json.RawMessage, fields ...string) (types.SubscriptionRequest, error) {
@@ -116,16 +123,19 @@ func subscriptionRequestForBooks(books json.RawMessage) (types.SubscriptionReque
 	err = json.Unmarshal(data, &request)
 	return request, err
 }
-func (ws *WebSocketServer) finishUnsubscribe(wsConn *websocketConnection, request types.SubscriptionRequest, params json.RawMessage, isAdmin bool) *types.RpcError {
-	prefix, err := subscriptionRequestExcluding(params, "books")
+func (ws *WebSocketServer) finishUnsubscribe(wsConn *websocketConnection, request types.SubscriptionRequest, params json.RawMessage, ctx *types.RpcContext) *types.RpcError {
+	prefix, err := subscriptionRequestExcluding(params, "books", "account_history_tx_stream")
 	if err != nil {
 		return types.RpcErrorInvalidParams("Invalid unsubscription parameters.")
 	}
-	if rpcErr := ws.subscriptionManager.HandleUnsubscribe(wsConn.Connection, prefix, isAdmin); rpcErr != nil {
+	if rpcErr := ws.subscriptionManager.HandleUnsubscribe(wsConn.Connection, prefix, ctx.IsAdmin); rpcErr != nil {
+		return rpcErr
+	}
+	if rpcErr := applyAccountHistoryUnsubscribe(ctx, wsConn.Connection, request); rpcErr != nil {
 		return rpcErr
 	}
 	return applySubscriptionBooks(request.WireArrays().Books, func(bookRequest types.SubscriptionRequest) *types.RpcError {
-		return ws.subscriptionManager.HandleUnsubscribe(wsConn.Connection, bookRequest, isAdmin)
+		return ws.subscriptionManager.HandleUnsubscribe(wsConn.Connection, bookRequest, ctx.IsAdmin)
 	})
 }
 func setSubscriptionLoadCost(ctx *types.RpcContext, request types.SubscriptionRequest) {
@@ -155,7 +165,7 @@ func (ws *WebSocketServer) executeUnsubscribe(wsConn *websocketConnection, ctx *
 		return result, nil
 	}
 
-	if rpcErr := ws.finishUnsubscribe(wsConn, request, cmd.Params, ctx.IsAdmin); rpcErr != nil {
+	if rpcErr := ws.finishUnsubscribe(wsConn, request, cmd.Params, ctx); rpcErr != nil {
 		return nil, rpcErr
 	}
 


### PR DESCRIPTION
## Summary
- Preserve rt_accounts and account-history subscription request fields losslessly.
- Gate history subscriptions on real capabilities and implement history-only stop semantics.

## Verification
- Subscription lifecycle and full RPC tests
- Targeted race, vet, strict lint, diff checks, and independent review

Refs #1486

Stack layer 13 of 16; depends on #1578.