### PR TITLE
fix(rpc): make ledger extensions deterministic

### DIFF
--- a/internal/ledger/service/lifecycle.go
+++ b/internal/ledger/service/lifecycle.go
@@ -18,12 +18,12 @@ import (
 // standalone only). Pending txs are re-applied in CanonicalTXSet order on a fresh
 // copy of the LCL.
 func (s *Service) AcceptLedger(ctx context.Context) (uint32, error) {
-	return s.AcceptLedgerAt(ctx, time.Time{})
+	return s.acceptLedgerAt(ctx, time.Time{})
 }
 
-// AcceptLedgerAt is AcceptLedger with an explicit close_time (zero → time.Now()),
-// used by replay tests to keep close_time byte-identical.
-func (s *Service) AcceptLedgerAt(ctx context.Context, explicitCloseTime time.Time) (uint32, error) {
+// acceptLedgerAt lets replay tests keep close_time byte-identical without
+// exposing deterministic clock control through the RPC service or wire.
+func (s *Service) acceptLedgerAt(ctx context.Context, explicitCloseTime time.Time) (uint32, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.historyComponent.mu.Lock()

--- a/internal/ledger/service/startup_test.go
+++ b/internal/ledger/service/startup_test.go
@@ -335,7 +335,7 @@ func TestService_StartupReplayStagesParentAndRebuildsTarget(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, hasTx)
 
-	seq, err := svc.AcceptLedgerAt(ctx, time.Unix(1, 0))
+	seq, err := svc.acceptLedgerAt(ctx, time.Unix(1, 0))
 	require.NoError(t, err)
 	require.Equal(t, target.Sequence(), seq)
 	replayed := svc.GetClosedLedger()

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -192,7 +192,7 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte, 
 		}
 	}
 
-	// Standalone-mode close (AcceptLedgerAt) still drains pendingTxs
+	// Standalone-mode close still drains pendingTxs
 	// for the canonical re-sort. Append on apply so the legacy path
 	// keeps working alongside the openLedgerView ingress.
 	if outcome.Applied && rawBlob != nil {

--- a/internal/rpc/account_channels_test.go
+++ b/internal/rpc/account_channels_test.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"testing"
 
-	"time"
-
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -52,9 +50,6 @@ func (m *mockAccountChannelsLedgerService) GetValidatedLedgerIndex() uint32 {
 	return m.validatedLedgerIndex
 }
 func (m *mockAccountChannelsLedgerService) AcceptLedger(context.Context) (uint32, error) {
-	return m.closedLedgerIndex + 1, nil
-}
-func (m *mockAccountChannelsLedgerService) AcceptLedgerAt(context.Context, time.Time) (uint32, error) {
 	return m.closedLedgerIndex + 1, nil
 }
 func (m *mockAccountChannelsLedgerService) IsStandalone() bool { return m.standalone }

--- a/internal/rpc/account_currencies_test.go
+++ b/internal/rpc/account_currencies_test.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"testing"
 
-	"time"
-
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -54,9 +52,6 @@ func (m *mockAccountCurrenciesLedgerService) GetValidatedLedgerIndex() uint32 {
 	return m.validatedLedgerIndex
 }
 func (m *mockAccountCurrenciesLedgerService) AcceptLedger(context.Context) (uint32, error) {
-	return m.closedLedgerIndex + 1, nil
-}
-func (m *mockAccountCurrenciesLedgerService) AcceptLedgerAt(context.Context, time.Time) (uint32, error) {
 	return m.closedLedgerIndex + 1, nil
 }
 func (m *mockAccountCurrenciesLedgerService) IsStandalone() bool { return m.standalone }

--- a/internal/rpc/account_info_test.go
+++ b/internal/rpc/account_info_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
@@ -51,9 +50,6 @@ func (m *mockLedgerService) GetCurrentLedgerIndex() uint32   { return m.currentL
 func (m *mockLedgerService) GetClosedLedgerIndex() uint32    { return m.closedLedgerIndex }
 func (m *mockLedgerService) GetValidatedLedgerIndex() uint32 { return m.validatedLedgerIndex }
 func (m *mockLedgerService) AcceptLedger(context.Context) (uint32, error) {
-	return m.closedLedgerIndex + 1, nil
-}
-func (m *mockLedgerService) AcceptLedgerAt(context.Context, time.Time) (uint32, error) {
 	return m.closedLedgerIndex + 1, nil
 }
 func (m *mockLedgerService) IsStandalone() bool                    { return m.standalone }

--- a/internal/rpc/account_lines_test.go
+++ b/internal/rpc/account_lines_test.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"testing"
 
-	"time"
-
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -50,9 +48,6 @@ func (m *mockAccountLinesLedgerService) GetValidatedLedgerIndex() uint32 {
 	return m.validatedLedgerIndex
 }
 func (m *mockAccountLinesLedgerService) AcceptLedger(context.Context) (uint32, error) {
-	return m.closedLedgerIndex + 1, nil
-}
-func (m *mockAccountLinesLedgerService) AcceptLedgerAt(context.Context, time.Time) (uint32, error) {
 	return m.closedLedgerIndex + 1, nil
 }
 func (m *mockAccountLinesLedgerService) IsStandalone() bool                    { return m.standalone }

--- a/internal/rpc/account_nfts_test.go
+++ b/internal/rpc/account_nfts_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"time"
-
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -53,9 +51,6 @@ func (m *mockAccountNFTsLedgerService) GetValidatedLedgerIndex() uint32 {
 	return m.validatedLedgerIndex
 }
 func (m *mockAccountNFTsLedgerService) AcceptLedger(context.Context) (uint32, error) {
-	return m.closedLedgerIndex + 1, nil
-}
-func (m *mockAccountNFTsLedgerService) AcceptLedgerAt(context.Context, time.Time) (uint32, error) {
 	return m.closedLedgerIndex + 1, nil
 }
 func (m *mockAccountNFTsLedgerService) IsStandalone() bool { return m.standalone }

--- a/internal/rpc/adapter/core.go
+++ b/internal/rpc/adapter/core.go
@@ -2,7 +2,6 @@ package adapter
 
 import (
 	"context"
-	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -57,11 +56,6 @@ func (a *LedgerServiceAdapter) GetValidatedLedgerIndex() uint32 {
 // AcceptLedger closes the current open ledger (standalone mode only)
 func (a *LedgerServiceAdapter) AcceptLedger(ctx context.Context) (uint32, error) {
 	return a.svc.AcceptLedger(ctx)
-}
-
-// AcceptLedgerAt is AcceptLedger with an explicit close_time.
-func (a *LedgerServiceAdapter) AcceptLedgerAt(ctx context.Context, closeTime time.Time) (uint32, error) {
-	return a.svc.AcceptLedgerAt(ctx, closeTime)
 }
 
 // IsStandalone returns true if running in standalone mode

--- a/internal/rpc/deposit_authorized_test.go
+++ b/internal/rpc/deposit_authorized_test.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	"time"
-
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -78,9 +76,6 @@ func (m *mockDepositAuthorizedLedgerService) GetValidatedLedgerIndex() uint32 {
 	return m.validatedLedgerIndex
 }
 func (m *mockDepositAuthorizedLedgerService) AcceptLedger(context.Context) (uint32, error) {
-	return m.closedLedgerIndex + 1, nil
-}
-func (m *mockDepositAuthorizedLedgerService) AcceptLedgerAt(context.Context, time.Time) (uint32, error) {
 	return m.closedLedgerIndex + 1, nil
 }
 func (m *mockDepositAuthorizedLedgerService) IsStandalone() bool { return m.standalone }

--- a/internal/rpc/gateway_balances_test.go
+++ b/internal/rpc/gateway_balances_test.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	"time"
-
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -53,9 +51,6 @@ func (m *mockGatewayBalancesLedgerService) GetValidatedLedgerIndex() uint32 {
 	return m.validatedLedgerIndex
 }
 func (m *mockGatewayBalancesLedgerService) AcceptLedger(context.Context) (uint32, error) {
-	return m.closedLedgerIndex + 1, nil
-}
-func (m *mockGatewayBalancesLedgerService) AcceptLedgerAt(context.Context, time.Time) (uint32, error) {
 	return m.closedLedgerIndex + 1, nil
 }
 func (m *mockGatewayBalancesLedgerService) IsStandalone() bool { return m.standalone }

--- a/internal/rpc/handlers/ledger_accept.go
+++ b/internal/rpc/handlers/ledger_accept.go
@@ -2,11 +2,8 @@ package handlers
 
 import (
 	"encoding/json"
-	"fmt"
-	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
-	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 // LedgerAcceptMethod handles the ledger_accept RPC method
@@ -23,28 +20,7 @@ func (m *LedgerAcceptMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		return nil, types.RpcErrorNotStandalone("ledger_accept is only available in standalone mode")
 	}
 
-	// Optional close_time (XRPL ripple-epoch seconds). Not a rippled
-	// RPC field — goxrpl-specific extension for differential testing
-	// against rippled standalone, where unsynchronized time.Now()
-	// clocks would otherwise produce divergent ledger headers.
-	// Malformed input is an error rather than a silent fallback to
-	// time.Now() so callers asking for determinism don't get a
-	// non-deterministic close.
-	var req struct {
-		CloseTime *uint32 `json:"close_time,omitempty"`
-	}
-	closeTime := time.Time{}
-	if len(params) > 0 {
-		if err := json.Unmarshal(params, &req); err != nil {
-			return nil, types.NewRpcError(types.RpcINVALID_PARAMS, "invalidParams", "invalidParams",
-				fmt.Sprintf("ledger_accept: malformed params: %v", err))
-		}
-		if req.CloseTime != nil {
-			closeTime = time.Unix(int64(*req.CloseTime)+protocol.RippleEpochUnix, 0).UTC()
-		}
-	}
-
-	closedSeq, err := ctx.Services.Ledger.AcceptLedgerAt(ctx.Context, closeTime)
+	closedSeq, err := ctx.Services.Ledger.AcceptLedger(ctx.Context)
 	if err != nil {
 		return nil, rpcInternalError("ledger_accept: accepting ledger failed", err)
 	}

--- a/internal/rpc/handlers/ledger_range.go
+++ b/internal/rpc/handlers/ledger_range.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"slices"
 
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
@@ -43,12 +44,17 @@ func (m *LedgerRangeMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		return nil, rpcInternalError("ledger_range: ledger query failed", err)
 	}
 
-	// Build ledgers array
-	ledgers := make([]map[string]any, 0, len(result.Hashes))
-	for seq, hash := range result.Hashes {
+	sequences := make([]uint32, 0, len(result.Hashes))
+	for seq := range result.Hashes {
+		sequences = append(sequences, seq)
+	}
+	slices.Sort(sequences)
+
+	ledgers := make([]map[string]any, 0, len(sequences))
+	for _, seq := range sequences {
 		ledgers = append(ledgers, map[string]any{
 			"ledger_index": seq,
-			"ledger_hash":  FormatLedgerHash(hash),
+			"ledger_hash":  FormatLedgerHash(result.Hashes[seq]),
 		})
 	}
 

--- a/internal/rpc/ledger_extensions_test.go
+++ b/internal/rpc/ledger_extensions_test.go
@@ -1,0 +1,71 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/stretchr/testify/require"
+)
+
+type ledgerExtensionsMock struct {
+	*mockLedgerService
+	acceptCalls int
+	rangeResult *types.LedgerRangeResult
+}
+
+func (m *ledgerExtensionsMock) AcceptLedger(context.Context) (uint32, error) {
+	m.acceptCalls++
+	return 8, nil
+}
+
+func (m *ledgerExtensionsMock) GetLedgerRange(context.Context, uint32, uint32) (*types.LedgerRangeResult, error) {
+	return m.rangeResult, nil
+}
+
+func TestLedgerAcceptDoesNotExposeCloseTimeControl(t *testing.T) {
+	ledger := &ledgerExtensionsMock{mockLedgerService: newMockLedgerService()}
+	ctx := &types.RpcContext{
+		Context:  context.Background(),
+		Services: &types.ServiceContainer{Ledger: ledger},
+	}
+
+	result, rpcErr := (&handlers.LedgerAcceptMethod{}).Handle(ctx, json.RawMessage(`{"close_time":1}`))
+	require.Nil(t, rpcErr)
+	require.Equal(t, 1, ledger.acceptCalls)
+	require.Equal(t, map[string]any{"ledger_current_index": uint32(9)}, result)
+}
+
+func TestLedgerRangeSortsLedgersBySequence(t *testing.T) {
+	hashes := map[uint32][32]byte{
+		9: {0x99},
+		7: {0x77},
+		8: {0x88},
+	}
+	ledger := &ledgerExtensionsMock{
+		mockLedgerService: newMockLedgerService(),
+		rangeResult: &types.LedgerRangeResult{
+			LedgerFirst: 7,
+			LedgerLast:  9,
+			Hashes:      hashes,
+		},
+	}
+	ctx := &types.RpcContext{
+		Context:  context.Background(),
+		Services: &types.ServiceContainer{Ledger: ledger},
+	}
+
+	for range 20 {
+		result, rpcErr := (&handlers.LedgerRangeMethod{}).Handle(ctx, json.RawMessage(`{"start_ledger":7,"stop_ledger":9}`))
+		require.Nil(t, rpcErr)
+		response := result.(map[string]any)
+		ledgers := response["ledgers"].([]map[string]any)
+		require.Equal(t, []uint32{7, 8, 9}, []uint32{
+			ledgers[0]["ledger_index"].(uint32),
+			ledgers[1]["ledger_index"].(uint32),
+			ledgers[2]["ledger_index"].(uint32),
+		})
+	}
+}

--- a/internal/rpc/nft_offers_test.go
+++ b/internal/rpc/nft_offers_test.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"testing"
 
-	"time"
-
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -48,9 +46,6 @@ func (m *mockNFTOffersLedgerService) GetCurrentLedgerIndex() uint32   { return m
 func (m *mockNFTOffersLedgerService) GetClosedLedgerIndex() uint32    { return m.closedLedgerIndex }
 func (m *mockNFTOffersLedgerService) GetValidatedLedgerIndex() uint32 { return m.validatedLedgerIndex }
 func (m *mockNFTOffersLedgerService) AcceptLedger(context.Context) (uint32, error) {
-	return m.closedLedgerIndex + 1, nil
-}
-func (m *mockNFTOffersLedgerService) AcceptLedgerAt(context.Context, time.Time) (uint32, error) {
 	return m.closedLedgerIndex + 1, nil
 }
 func (m *mockNFTOffersLedgerService) IsStandalone() bool { return m.standalone }

--- a/internal/rpc/noripple_check_test.go
+++ b/internal/rpc/noripple_check_test.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"testing"
 
-	"time"
-
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -50,9 +48,6 @@ func (m *mockNoRippleCheckLedgerService) GetValidatedLedgerIndex() uint32 {
 	return m.validatedLedgerIndex
 }
 func (m *mockNoRippleCheckLedgerService) AcceptLedger(context.Context) (uint32, error) {
-	return m.closedLedgerIndex + 1, nil
-}
-func (m *mockNoRippleCheckLedgerService) AcceptLedgerAt(context.Context, time.Time) (uint32, error) {
 	return m.closedLedgerIndex + 1, nil
 }
 func (m *mockNoRippleCheckLedgerService) IsStandalone() bool { return m.standalone }

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -832,7 +832,6 @@ type LedgerNavigator interface {
 	GetClosedLedgerIndex() uint32
 	GetValidatedLedgerIndex() uint32
 	AcceptLedger(ctx context.Context) (uint32, error)
-	AcceptLedgerAt(ctx context.Context, closeTime time.Time) (uint32, error)
 	IsStandalone() bool
 }
 

--- a/internal/testing/rpcenv/adapter.go
+++ b/internal/testing/rpcenv/adapter.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/codec/addresscodec"
@@ -103,10 +102,6 @@ func (a *ledgerAdapter) GetValidatedLedgerIndex() uint32 {
 func (a *ledgerAdapter) AcceptLedger(ctx context.Context) (uint32, error) {
 	a.env.Close()
 	return a.GetClosedLedgerIndex(), nil
-}
-
-func (a *ledgerAdapter) AcceptLedgerAt(ctx context.Context, _ time.Time) (uint32, error) {
-	return a.AcceptLedger(ctx)
 }
 
 func (a *ledgerAdapter) IsStandalone() bool { return true }


### PR DESCRIPTION
## Summary
- Remove deterministic close-time control from the ledger_accept wire and RPC service contract.
- Sort retained ledger_range extension output by ledger sequence.

## Verification
- Replay, extension, full RPC, and rpcenv tests
- Targeted race, vet, strict lint, and diff checks

Refs #1486

Stack layer 15 of 16; depends on #1580.