### PR TITLE
fix: harden OpenSSL peer TLS boundary

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -278,7 +278,7 @@ protocol = "peer"
 [port_override]
 port = 51236
 ip = "127.0.0.1"
-protocol = "peer"
+protocol = "http"
 ssl_ciphers = "port-ciphers"
 
 [node_db]

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -259,6 +259,39 @@ path = "/tmp/test/db"
 	assert.Equal(t, []string{"10.0.0.0/8", "192.168.0.0/16"}, port.SecureGateway)
 }
 
+func TestLoadConfig_ServerSSLCipherDefaults(t *testing.T) {
+	tempDir := t.TempDir()
+	mainConfigPath := writeConfig(t, tempDir, "xrpld.toml", `
+database_path = "/tmp/test/db"
+network_id = "main"
+debug_logfile = "/tmp/test/debug.log"
+
+[server]
+ports = ["port_inherited", "port_override"]
+ssl_ciphers = "server-ciphers"
+
+[port_inherited]
+port = 51235
+ip = "127.0.0.1"
+protocol = "peer"
+
+[port_override]
+port = 51236
+ip = "127.0.0.1"
+protocol = "peer"
+ssl_ciphers = "port-ciphers"
+
+[node_db]
+type = "pebble"
+path = "/tmp/test/db"
+`)
+
+	cfg, err := LoadConfig(Paths{Main: mainConfigPath})
+	require.NoError(t, err)
+	assert.Equal(t, "server-ciphers", cfg.Ports["port_inherited"].SSLCiphers)
+	assert.Equal(t, "port-ciphers", cfg.Ports["port_override"].SSLCiphers)
+}
+
 // TestLoadConfig_MinimalConfig verifies that the optional tuning sections
 // ([overlay], [transaction_queue], [sqlite], ledger_history, fetch_depth,
 // node_size, relay_*, max_transactions) may be omitted entirely.

--- a/config/loader.go
+++ b/config/loader.go
@@ -267,4 +267,7 @@ func applyServerDefaults(portViper *viper.Viper, serverDefaults ServerConfig) {
 	if len(serverDefaults.AllowedOrigins) > 0 {
 		portViper.SetDefault("allowed_origins", serverDefaults.AllowedOrigins)
 	}
+	if serverDefaults.SSLCiphers != "" {
+		portViper.SetDefault("ssl_ciphers", serverDefaults.SSLCiphers)
+	}
 }

--- a/config/server.go
+++ b/config/server.go
@@ -22,6 +22,7 @@ type ServerConfig struct {
 	AdminPassword  string   `toml:"admin_password" mapstructure:"admin_password"`
 	AllowedOrigins []string `toml:"allowed_origins" mapstructure:"allowed_origins"` // Exact browser origins allowed on HTTP/WS ports
 	SecureGateway  []string `toml:"secure_gateway" mapstructure:"secure_gateway"`   // Default trusted proxy networks
+	SSLCiphers     string   `toml:"ssl_ciphers" mapstructure:"ssl_ciphers"`
 	// MaxConnections is the process-wide ceiling on concurrent HTTP + WebSocket
 	// connections. 0 keeps the bounded built-in default; a negative value
 	// disables the global cap (per-port limits still apply).

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -901,7 +901,10 @@ func OverlayOptionsFromConfig(appCfg *config.Config) []peermanagement.Option {
 	// Listen address from peer port config
 	_, peerPort, hasPeerPort := appCfg.PeerPort()
 	if hasPeerPort {
-		opts = append(opts, peermanagement.WithListenAddr(peerPort.BindAddress()))
+		opts = append(opts,
+			peermanagement.WithListenAddr(peerPort.BindAddress()),
+			peermanagement.WithSSLCiphers(peerPort.SSLCiphers),
+		)
 	} else {
 		opts = append(opts, peermanagement.WithListenAddr(""))
 	}

--- a/internal/consensus/adaptor/startup_cov_test.go
+++ b/internal/consensus/adaptor/startup_cov_test.go
@@ -599,7 +599,10 @@ func TestStup_OverlayOptionsFromConfig_NetworkID(t *testing.T) {
 func TestStup_OverlayOptionsFromConfig_PeerPort(t *testing.T) {
 	cfg := &config.Config{
 		Ports: map[string]config.PortConfig{
-			"peer": {Port: 51235, IP: "0.0.0.0", Protocol: "peer"},
+			"peer": {
+				Port: 51235, IP: "0.0.0.0", Protocol: "peer",
+				SSLCiphers: "DHE-RSA-AES128-GCM-SHA256",
+			},
 		},
 	}
 	pcfg := peermanagement.DefaultConfig()
@@ -607,6 +610,7 @@ func TestStup_OverlayOptionsFromConfig_PeerPort(t *testing.T) {
 		opt(&pcfg)
 	}
 	assert.Contains(t, pcfg.ListenAddr, "51235")
+	assert.Equal(t, "DHE-RSA-AES128-GCM-SHA256", pcfg.SSLCiphers)
 }
 
 func TestStup_OverlayOptionsFromConfig_BootstrapAndFixed(t *testing.T) {

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -94,6 +94,7 @@ type Config struct {
 	ListenAddr string
 	NetworkID  uint32
 	UserAgent  string
+	SSLCiphers string
 
 	// Peer limits
 	MaxPeers    int
@@ -257,6 +258,13 @@ type Option func(*Config)
 func WithListenAddr(addr string) Option {
 	return func(c *Config) {
 		c.ListenAddr = addr
+	}
+}
+
+// WithSSLCiphers sets the OpenSSL cipher-list expression used for peer TLS.
+func WithSSLCiphers(cipherList string) Option {
+	return func(c *Config) {
+		c.SSLCiphers = cipherList
 	}
 }
 

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -261,7 +261,6 @@ func WithListenAddr(addr string) Option {
 	}
 }
 
-// WithSSLCiphers sets the OpenSSL cipher-list expression used for peer TLS.
 func WithSSLCiphers(cipherList string) Option {
 	return func(c *Config) {
 		c.SSLCiphers = cipherList

--- a/internal/peermanagement/overlay_inbound.go
+++ b/internal/peermanagement/overlay_inbound.go
@@ -154,8 +154,9 @@ func (o *Overlay) startListener(ctx context.Context) (net.Listener, error) {
 	}
 
 	tlsListener, err := peertls.NewListener(tcpListener, &peertls.Config{
-		CertPEM: certPEM,
-		KeyPEM:  keyPEM,
+		CertPEM:    certPEM,
+		KeyPEM:     keyPEM,
+		CipherList: o.cfg.SSLCiphers,
 	})
 	if err != nil {
 		_ = tcpListener.Close()

--- a/internal/peermanagement/overlay_peers.go
+++ b/internal/peermanagement/overlay_peers.go
@@ -103,8 +103,9 @@ func (o *Overlay) connectReserved(addr string, bootstrapLease *bootstrapLease) e
 	}
 	cfg := PeerConfig{
 		PeerTLSConfig: &peertls.Config{
-			CertPEM: certPEM,
-			KeyPEM:  keyPEM,
+			CertPEM:    certPEM,
+			KeyPEM:     keyPEM,
+			CipherList: o.cfg.SSLCiphers,
 		},
 	}
 

--- a/internal/peermanagement/overlay_peers.go
+++ b/internal/peermanagement/overlay_peers.go
@@ -103,9 +103,8 @@ func (o *Overlay) connectReserved(addr string, bootstrapLease *bootstrapLease) e
 	}
 	cfg := PeerConfig{
 		PeerTLSConfig: &peertls.Config{
-			CertPEM:    certPEM,
-			KeyPEM:     keyPEM,
-			CipherList: o.cfg.SSLCiphers,
+			CertPEM: certPEM,
+			KeyPEM:  keyPEM,
 		},
 	}
 

--- a/internal/peermanagement/peertls/peertls.go
+++ b/internal/peermanagement/peertls/peertls.go
@@ -1,4 +1,4 @@
-// Package peertls provides the TLS 1.2 transport used by XRPL peers.
+// Package peertls provides the TLS 1.2-or-newer transport used by XRPL peers.
 package peertls
 
 import (
@@ -24,8 +24,9 @@ type GracefulConn interface {
 }
 
 type Config struct {
-	CertPEM []byte
-	KeyPEM  []byte
+	CertPEM    []byte
+	KeyPEM     []byte
+	CipherList string
 }
 
 // ErrSessionSigUnsupported reports that the build cannot provide XRPL's

--- a/internal/peermanagement/peertls/shim/shim.c
+++ b/internal/peermanagement/peertls/shim/shim.c
@@ -1,14 +1,19 @@
-/* shim.c - implementation of shim.h. */
-
 #include "shim.h"
 
 #include <limits.h>
 #include <openssl/bio.h>
+#include <openssl/dh.h>
 #include <openssl/err.h>
 #include <openssl/pem.h>
+#include <openssl/sha.h>
 #include <openssl/ssl.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifndef SSL_OP_NO_RENEGOTIATION
+#error "OpenSSL with SSL_OP_NO_RENEGOTIATION is required"
+#endif
 
 struct peertls_ctx {
     SSL_CTX* ctx;
@@ -17,9 +22,57 @@ struct peertls_ctx {
 
 struct peertls_ssl {
     SSL* ssl;
-    BIO* internal_bio;  /* bound to ssl */
-    BIO* network_bio;   /* the side Go pumps */
+    BIO* network_bio;
+    unsigned char* pending_write;
+    size_t pending_write_len;
+    unsigned char pending_write_digest[SHA256_DIGEST_LENGTH];
+    size_t pending_write_input_len;
+    size_t pending_write_result;
+    int pending_write_complete;
+    int write_failed;
 };
+
+static const char default_dh_parameters[] =
+    "-----BEGIN DH PARAMETERS-----\n"
+    "MIIBCAKCAQEApKSWfR7LKy0VoZ/SDCObCvJ5HKX2J93RJ+QN8kJwHh+uuA8G+t8Q\n"
+    "MDRjL5HanlV/sKN9HXqBc7eqHmmbqYwIXKUt9MUZTLNheguddxVlc2IjdP5i9Ps8\n"
+    "l7su8tnP0l1JvC6Rfv3epRsEAw/ZW/lC2IwkQPpOmvnENQhQ6TgrUzcGkv4Bn0X6\n"
+    "pxrDSBpZ+45oehGCUAtcbY8b02vu8zPFoxqo6V/+MIszGzldlik5bVqrJpVF6E8C\n"
+    "tRqHjj6KuDbPbjc+pRGvwx/BSO3SULxmYu9J1NOk090MU1CMt6IJY7TpEc9Xrac9\n"
+    "9yqY3xXZID240RRcaJ25+U4lszFPqP+CEwIBAg==\n"
+    "-----END DH PARAMETERS-----";
+
+static void begin_operation(char* error, size_t error_len) {
+    if (error != NULL && error_len > 0) error[0] = '\0';
+    ERR_clear_error();
+}
+
+static void set_error(char* error, size_t error_len, const char* message) {
+    if (error == NULL || error_len == 0) return;
+    if (message == NULL) message = "OpenSSL operation failed";
+    (void)snprintf(error, error_len, "%s", message);
+}
+
+static void capture_error(char* error, size_t error_len, const char* fallback) {
+    unsigned long current;
+    unsigned long last = 0;
+    while ((current = ERR_get_error()) != 0) last = current;
+    if (last != 0 && error != NULL && error_len > 0) {
+        ERR_error_string_n(last, error, error_len);
+        return;
+    }
+    set_error(error, error_len, fallback);
+}
+
+static int checked_int_length(size_t len, int* out,
+                              char* error, size_t error_len) {
+    if (len > INT_MAX) {
+        set_error(error, error_len, "buffer length exceeds OpenSSL int range");
+        return 0;
+    }
+    *out = (int)len;
+    return 1;
+}
 
 static int map_ssl_error(SSL* ssl, int rc) {
     int err = SSL_get_error(ssl, rc);
@@ -34,31 +87,105 @@ static int map_ssl_error(SSL* ssl, int rc) {
     }
 }
 
-peertls_ctx* peertls_ctx_new(int is_server) {
-    const SSL_METHOD* m = is_server ? TLS_server_method() : TLS_client_method();
-    SSL_CTX* ctx = SSL_CTX_new(m);
-    if (!ctx) return NULL;
+static int ssl_failure(SSL* ssl, int rc, char* error, size_t error_len) {
+    int code = map_ssl_error(ssl, rc);
+    capture_error(error, error_len, "OpenSSL TLS operation failed");
+    return code;
+}
 
-    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
-    SSL_CTX_set_max_proto_version(ctx, TLS1_2_VERSION);
-    SSL_CTX_set_cipher_list(ctx, "TLSv1.2:!CBC:!DSS:!PSK:!eNULL:!aNULL");
+static unsigned long required_options(void) {
+    return SSL_OP_ALL |
+           SSL_OP_NO_SSLv2 |
+           SSL_OP_NO_SSLv3 |
+           SSL_OP_NO_TLSv1 |
+           SSL_OP_NO_TLSv1_1 |
+           SSL_OP_SINGLE_DH_USE |
+           SSL_OP_NO_COMPRESSION |
+           SSL_OP_NO_RENEGOTIATION;
+}
 
-    long opts = SSL_OP_SINGLE_DH_USE | SSL_OP_NO_COMPRESSION;
-#ifdef SSL_OP_NO_RENEGOTIATION
-    opts |= SSL_OP_NO_RENEGOTIATION;
+static int configure_dh_parameters(SSL_CTX* ctx,
+                                   char* error, size_t error_len) {
+    BIO* bio = BIO_new_mem_buf(default_dh_parameters,
+                               (int)(sizeof(default_dh_parameters) - 1));
+    if (bio == NULL) {
+        capture_error(error, error_len, "failed to create DH parameter BIO");
+        return 0;
+    }
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    EVP_PKEY* parameters = PEM_read_bio_Parameters(bio, NULL);
+    if (parameters == NULL) {
+        capture_error(error, error_len, "failed to parse DH parameters");
+        BIO_free(bio);
+        return 0;
+    }
+    BIO_free(bio);
+    if (SSL_CTX_set0_tmp_dh_pkey(ctx, parameters) != 1) {
+        capture_error(error, error_len, "failed to install DH parameters");
+        EVP_PKEY_free(parameters);
+        return 0;
+    }
+#else
+    DH* parameters = PEM_read_bio_DHparams(bio, NULL, NULL, NULL);
+    if (parameters == NULL) {
+        capture_error(error, error_len, "failed to parse DH parameters");
+        BIO_free(bio);
+        return 0;
+    }
+    BIO_free(bio);
+    int installed = SSL_CTX_set_tmp_dh(ctx, parameters);
+    DH_free(parameters);
+    if (installed != 1) {
+        capture_error(error, error_len, "failed to install DH parameters");
+        return 0;
+    }
 #endif
-    SSL_CTX_set_options(ctx, opts);
+    return 1;
+}
 
-    /* Public-Key header is the trust anchor; X.509 verification is unused. */
+peertls_ctx* peertls_ctx_new(int is_server, const char* cipher_list,
+                             char* error, size_t error_len) {
+    begin_operation(error, error_len);
+    if (cipher_list == NULL) cipher_list = PEERTLS_DEFAULT_CIPHER_LIST;
+    if (cipher_list[0] == '\0') {
+        set_error(error, error_len, "cipher list must not be empty");
+        return NULL;
+    }
+
+    const SSL_METHOD* method = is_server ? TLS_server_method() : TLS_client_method();
+    SSL_CTX* ctx = SSL_CTX_new(method);
+    if (ctx == NULL) {
+        capture_error(error, error_len, "SSL_CTX_new failed");
+        return NULL;
+    }
+    if (SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION) != 1) {
+        capture_error(error, error_len, "failed to require TLS 1.2 or newer");
+        SSL_CTX_free(ctx);
+        return NULL;
+    }
+    if (SSL_CTX_set_cipher_list(ctx, cipher_list) != 1) {
+        capture_error(error, error_len, "cipher list selects no supported ciphers");
+        SSL_CTX_free(ctx);
+        return NULL;
+    }
+
+    unsigned long options = required_options();
+    unsigned long applied = SSL_CTX_set_options(ctx, options);
+    if ((applied & options) != options) {
+        set_error(error, error_len, "failed to apply required TLS options");
+        SSL_CTX_free(ctx);
+        return NULL;
+    }
+
     SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
-
-    /* Without this, DHE-RSA suites silently fail the handshake. */
-    if (is_server) {
-        SSL_CTX_set_dh_auto(ctx, 1);
+    if (!configure_dh_parameters(ctx, error, error_len)) {
+        SSL_CTX_free(ctx);
+        return NULL;
     }
 
     peertls_ctx* out = calloc(1, sizeof(*out));
-    if (!out) {
+    if (out == NULL) {
+        set_error(error, error_len, "failed to allocate TLS context wrapper");
         SSL_CTX_free(ctx);
         return NULL;
     }
@@ -68,62 +195,95 @@ peertls_ctx* peertls_ctx_new(int is_server) {
 }
 
 void peertls_ctx_free(peertls_ctx* ctx) {
-    if (!ctx) return;
-    if (ctx->ctx) SSL_CTX_free(ctx->ctx);
+    if (ctx == NULL) return;
+    SSL_CTX_free(ctx->ctx);
     free(ctx);
 }
 
 int peertls_ctx_use_cert_pem(peertls_ctx* ctx,
-                              const char* cert, int cert_len,
-                              const char* key,  int key_len) {
-    if (!ctx || !ctx->ctx) return PEERTLS_ERR_OTHER;
+                             const char* cert, size_t cert_len,
+                             const char* key, size_t key_len,
+                             char* error, size_t error_len) {
+    begin_operation(error, error_len);
+    if (ctx == NULL || ctx->ctx == NULL || cert == NULL || key == NULL) {
+        set_error(error, error_len, "invalid TLS context or PEM buffer");
+        return PEERTLS_ERR_OTHER;
+    }
+    int cert_int;
+    int key_int;
+    if (!checked_int_length(cert_len, &cert_int, error, error_len) ||
+        !checked_int_length(key_len, &key_int, error, error_len)) {
+        return PEERTLS_ERR_OTHER;
+    }
 
-    BIO* cb = BIO_new_mem_buf(cert, cert_len);
-    if (!cb) return PEERTLS_ERR_OTHER;
-    X509* x = PEM_read_bio_X509(cb, NULL, NULL, NULL);
-    BIO_free(cb);
-    if (!x) return PEERTLS_ERR_SSL;
-
-    if (SSL_CTX_use_certificate(ctx->ctx, x) != 1) {
-        X509_free(x);
+    BIO* cert_bio = BIO_new_mem_buf(cert, cert_int);
+    if (cert_bio == NULL) {
+        capture_error(error, error_len, "failed to create certificate BIO");
         return PEERTLS_ERR_SSL;
     }
-    X509_free(x);
-
-    BIO* kb = BIO_new_mem_buf(key, key_len);
-    if (!kb) return PEERTLS_ERR_OTHER;
-    EVP_PKEY* pk = PEM_read_bio_PrivateKey(kb, NULL, NULL, NULL);
-    BIO_free(kb);
-    if (!pk) return PEERTLS_ERR_SSL;
-
-    if (SSL_CTX_use_PrivateKey(ctx->ctx, pk) != 1) {
-        EVP_PKEY_free(pk);
+    X509* certificate = PEM_read_bio_X509(cert_bio, NULL, NULL, NULL);
+    if (certificate == NULL) {
+        capture_error(error, error_len, "failed to parse certificate PEM");
+        BIO_free(cert_bio);
         return PEERTLS_ERR_SSL;
     }
-    EVP_PKEY_free(pk);
+    BIO_free(cert_bio);
+
+    if (SSL_CTX_use_certificate(ctx->ctx, certificate) != 1) {
+        capture_error(error, error_len, "failed to install certificate");
+        X509_free(certificate);
+        return PEERTLS_ERR_SSL;
+    }
+    X509_free(certificate);
+
+    BIO* key_bio = BIO_new_mem_buf(key, key_int);
+    if (key_bio == NULL) {
+        capture_error(error, error_len, "failed to create private-key BIO");
+        return PEERTLS_ERR_SSL;
+    }
+    EVP_PKEY* private_key = PEM_read_bio_PrivateKey(key_bio, NULL, NULL, NULL);
+    if (private_key == NULL) {
+        capture_error(error, error_len, "failed to parse private-key PEM");
+        BIO_free(key_bio);
+        return PEERTLS_ERR_SSL;
+    }
+    BIO_free(key_bio);
+
+    if (SSL_CTX_use_PrivateKey(ctx->ctx, private_key) != 1) {
+        capture_error(error, error_len, "failed to install private key");
+        EVP_PKEY_free(private_key);
+        return PEERTLS_ERR_SSL;
+    }
+    EVP_PKEY_free(private_key);
 
     if (SSL_CTX_check_private_key(ctx->ctx) != 1) {
+        capture_error(error, error_len, "certificate and private key do not match");
         return PEERTLS_ERR_SSL;
     }
     return 0;
 }
 
-peertls_ssl* peertls_new(peertls_ctx* ctx) {
-    if (!ctx || !ctx->ctx) return NULL;
-
-    SSL* ssl = SSL_new(ctx->ctx);
-    if (!ssl) return NULL;
-
-    BIO* internal = NULL;
-    BIO* network  = NULL;
-    /* 0 = default 17 KiB ring, fits any TLS record. */
-    if (BIO_new_bio_pair(&internal, 0, &network, 0) != 1) {
-        SSL_free(ssl);
+peertls_ssl* peertls_new(peertls_ctx* ctx, char* error, size_t error_len) {
+    begin_operation(error, error_len);
+    if (ctx == NULL || ctx->ctx == NULL) {
+        set_error(error, error_len, "invalid TLS context");
         return NULL;
     }
 
-    SSL_set_bio(ssl, internal, internal);
+    SSL* ssl = SSL_new(ctx->ctx);
+    if (ssl == NULL) {
+        capture_error(error, error_len, "SSL_new failed");
+        return NULL;
+    }
 
+    BIO* internal = NULL;
+    BIO* network = NULL;
+    if (BIO_new_bio_pair(&internal, 0, &network, 0) != 1) {
+        capture_error(error, error_len, "BIO_new_bio_pair failed");
+        SSL_free(ssl);
+        return NULL;
+    }
+    SSL_set_bio(ssl, internal, internal);
     if (ctx->is_server) {
         SSL_set_accept_state(ssl);
     } else {
@@ -131,99 +291,277 @@ peertls_ssl* peertls_new(peertls_ctx* ctx) {
     }
 
     peertls_ssl* out = calloc(1, sizeof(*out));
-    if (!out) {
+    if (out == NULL) {
+        set_error(error, error_len, "failed to allocate TLS connection wrapper");
         SSL_free(ssl);
         BIO_free(network);
         return NULL;
     }
     out->ssl = ssl;
-    out->internal_bio = internal; /* freed by SSL_free */
     out->network_bio = network;
     return out;
 }
 
 void peertls_free(peertls_ssl* s) {
-    if (!s) return;
-    if (s->ssl) SSL_free(s->ssl);
-    if (s->network_bio) BIO_free(s->network_bio);
+    if (s == NULL) return;
+    SSL_free(s->ssl);
+    free(s->pending_write);
+    BIO_free(s->network_bio);
     free(s);
 }
 
-int peertls_handshake(peertls_ssl* s) {
-    if (!s || !s->ssl) return PEERTLS_ERR_OTHER;
-    ERR_clear_error();
-    int rc = SSL_do_handshake(s->ssl);
-    if (rc == 1) return 0;
-    /* rc == 0 is "controlled shutdown" per SSL_do_handshake(3), NOT success. */
-    return map_ssl_error(s->ssl, rc);
+static void release_pending_write_payload(peertls_ssl* s) {
+    free(s->pending_write);
+    s->pending_write = NULL;
+    s->pending_write_len = 0;
 }
 
-int peertls_shutdown(peertls_ssl* s) {
-    if (!s || !s->ssl) return PEERTLS_ERR_OTHER;
-    ERR_clear_error();
+static void clear_pending_write(peertls_ssl* s) {
+    release_pending_write_payload(s);
+    memset(s->pending_write_digest, 0, sizeof(s->pending_write_digest));
+    s->pending_write_input_len = 0;
+    s->pending_write_result = 0;
+    s->pending_write_complete = 0;
+}
+
+static int has_pending_write(const peertls_ssl* s) {
+    return s->pending_write != NULL || s->pending_write_complete;
+}
+
+static int abort_pending_write(peertls_ssl* s, const char* message,
+                               char* error, size_t error_len) {
+    SSL_free(s->ssl);
+    s->ssl = NULL;
+    clear_pending_write(s);
+    s->write_failed = 1;
+    set_error(error, error_len, message);
+    return PEERTLS_ERR_WRITE_RETRY;
+}
+
+int peertls_handshake(peertls_ssl* s, char* error, size_t error_len) {
+    begin_operation(error, error_len);
+    if (s == NULL || s->ssl == NULL || s->write_failed) {
+        set_error(error, error_len, "invalid TLS connection");
+        return PEERTLS_ERR_OTHER;
+    }
+    if (has_pending_write(s)) {
+        return abort_pending_write(s, "handshake interrupted a pending SSL_write",
+                                   error, error_len);
+    }
+    int rc = SSL_do_handshake(s->ssl);
+    if (rc == 1) return 0;
+    return ssl_failure(s->ssl, rc, error, error_len);
+}
+
+int peertls_shutdown(peertls_ssl* s, char* error, size_t error_len) {
+    begin_operation(error, error_len);
+    if (s == NULL || s->ssl == NULL || s->write_failed) {
+        set_error(error, error_len, "invalid TLS connection");
+        return PEERTLS_ERR_OTHER;
+    }
+    if (has_pending_write(s)) {
+        return abort_pending_write(s, "shutdown interrupted a pending SSL_write",
+                                   error, error_len);
+    }
     int rc = SSL_shutdown(s->ssl);
     if (rc == 1) return 0;
     if (rc == 0) return PEERTLS_ERR_WANT_READ;
-    return map_ssl_error(s->ssl, rc);
+    return ssl_failure(s->ssl, rc, error, error_len);
 }
 
-int peertls_read(peertls_ssl* s, void* buf, int len) {
-    if (!s || !s->ssl) return PEERTLS_ERR_OTHER;
-    ERR_clear_error();
-    int rc = SSL_read(s->ssl, buf, len);
+int peertls_read(peertls_ssl* s, void* buf, size_t len,
+                 char* error, size_t error_len) {
+    begin_operation(error, error_len);
+    if (s == NULL || s->ssl == NULL || s->write_failed ||
+        (buf == NULL && len != 0)) {
+        set_error(error, error_len, "invalid TLS connection or read buffer");
+        return PEERTLS_ERR_OTHER;
+    }
+    if (s->pending_write != NULL) {
+        int write_len = (int)s->pending_write_len;
+        int write_rc = SSL_write(s->ssl, s->pending_write, write_len);
+        if (write_rc > 0) {
+            s->pending_write_complete = 1;
+            s->pending_write_result = (size_t)write_rc;
+            release_pending_write_payload(s);
+        } else {
+            int code = ssl_failure(s->ssl, write_rc, error, error_len);
+            if (code != PEERTLS_ERR_WANT_READ &&
+                code != PEERTLS_ERR_WANT_WRITE) {
+                clear_pending_write(s);
+                s->write_failed = 1;
+            }
+            return code;
+        }
+    }
+    int int_len;
+    if (!checked_int_length(len, &int_len, error, error_len)) {
+        return PEERTLS_ERR_OTHER;
+    }
+    int rc = SSL_read(s->ssl, buf, int_len);
     if (rc > 0) return rc;
-    return map_ssl_error(s->ssl, rc);
+    return ssl_failure(s->ssl, rc, error, error_len);
 }
 
-int peertls_write(peertls_ssl* s, const void* buf, int len) {
-    if (!s || !s->ssl) return PEERTLS_ERR_OTHER;
-    ERR_clear_error();
-    int rc = SSL_write(s->ssl, buf, len);
-    if (rc > 0) return rc;
-    return map_ssl_error(s->ssl, rc);
+int peertls_write(peertls_ssl* s, const void* buf, size_t len,
+                  char* error, size_t error_len) {
+    begin_operation(error, error_len);
+    if (s == NULL || s->ssl == NULL || s->write_failed ||
+        (buf == NULL && len != 0)) {
+        set_error(error, error_len, "invalid or failed TLS connection");
+        return PEERTLS_ERR_OTHER;
+    }
+    int int_len;
+    if (!checked_int_length(len, &int_len, error, error_len)) {
+        return PEERTLS_ERR_OTHER;
+    }
+
+    if (s->pending_write_complete) {
+        unsigned char digest[SHA256_DIGEST_LENGTH];
+        if (len != s->pending_write_input_len ||
+            SHA256(buf, len, digest) == NULL ||
+            memcmp(s->pending_write_digest, digest, sizeof(digest)) != 0) {
+            return abort_pending_write(s, "SSL_write retry data or length changed",
+                                       error, error_len);
+        }
+        int result = (int)s->pending_write_result;
+        clear_pending_write(s);
+        return result;
+    }
+
+    if (len == 0) return 0;
+
+    if (s->pending_write == NULL) {
+        s->pending_write = malloc(len);
+        if (s->pending_write == NULL) {
+            set_error(error, error_len, "failed to allocate pending write buffer");
+            return PEERTLS_ERR_OTHER;
+        }
+        memcpy(s->pending_write, buf, len);
+        s->pending_write_len = len;
+        s->pending_write_input_len = len;
+        if (SHA256(buf, len, s->pending_write_digest) == NULL) {
+            clear_pending_write(s);
+            set_error(error, error_len, "failed to fingerprint pending write buffer");
+            return PEERTLS_ERR_OTHER;
+        }
+    } else if (len != s->pending_write_len ||
+               memcmp(s->pending_write, buf, len) != 0) {
+        return abort_pending_write(s, "SSL_write retry data or length changed",
+                                   error, error_len);
+    }
+
+    int rc = SSL_write(s->ssl, s->pending_write, int_len);
+    if (rc > 0) {
+        clear_pending_write(s);
+        return rc;
+    }
+    int code = ssl_failure(s->ssl, rc, error, error_len);
+    if (code != PEERTLS_ERR_WANT_READ && code != PEERTLS_ERR_WANT_WRITE) {
+        clear_pending_write(s);
+        s->write_failed = 1;
+    }
+    return code;
 }
 
-int peertls_bio_read(peertls_ssl* s, void* buf, int len) {
-    if (!s || !s->network_bio) return PEERTLS_ERR_OTHER;
+int peertls_bio_read(peertls_ssl* s, void* buf, size_t len,
+                     char* error, size_t error_len) {
+    begin_operation(error, error_len);
+    if (s == NULL || s->ssl == NULL || s->write_failed ||
+        s->network_bio == NULL || (buf == NULL && len != 0)) {
+        set_error(error, error_len, "invalid TLS connection or BIO read buffer");
+        return PEERTLS_ERR_OTHER;
+    }
+    int int_len;
+    if (!checked_int_length(len, &int_len, error, error_len)) {
+        return PEERTLS_ERR_OTHER;
+    }
     if (BIO_ctrl_pending(s->network_bio) == 0) return 0;
-    int rc = BIO_read(s->network_bio, buf, len);
+    int rc = BIO_read(s->network_bio, buf, int_len);
     if (rc > 0) return rc;
     if (BIO_should_retry(s->network_bio)) return 0;
+    capture_error(error, error_len, "BIO_read failed");
     return PEERTLS_ERR_SSL;
 }
 
-int peertls_bio_write(peertls_ssl* s, const void* buf, int len) {
-    if (!s || !s->network_bio) return PEERTLS_ERR_OTHER;
-    int rc = BIO_write(s->network_bio, buf, len);
+int peertls_bio_write(peertls_ssl* s, const void* buf, size_t len,
+                      char* error, size_t error_len) {
+    begin_operation(error, error_len);
+    if (s == NULL || s->ssl == NULL || s->write_failed ||
+        s->network_bio == NULL || (buf == NULL && len != 0)) {
+        set_error(error, error_len, "invalid TLS connection or BIO write buffer");
+        return PEERTLS_ERR_OTHER;
+    }
+    int int_len;
+    if (!checked_int_length(len, &int_len, error, error_len)) {
+        return PEERTLS_ERR_OTHER;
+    }
+    int rc = BIO_write(s->network_bio, buf, int_len);
     if (rc > 0) return rc;
     if (BIO_should_retry(s->network_bio)) return 0;
+    capture_error(error, error_len, "BIO_write failed");
     return PEERTLS_ERR_SSL;
 }
 
-int peertls_get_finished(peertls_ssl* s, void* buf, int len) {
-    if (!s || !s->ssl || len <= 0) return 0;
-    /* Returns the FULL Finished length even when buf is smaller; caller
-     * detects truncation via (returned > buf_len). */
-    size_t r = SSL_get_finished(s->ssl, buf, (size_t)len);
-    if (r > (size_t)INT_MAX) return INT_MAX;
-    return (int)r;
+size_t peertls_get_finished(peertls_ssl* s, void* buf, size_t len) {
+    if (s == NULL || s->ssl == NULL || s->write_failed ||
+        has_pending_write(s) ||
+        (buf == NULL && len != 0)) return 0;
+    return SSL_get_finished(s->ssl, buf, len);
 }
 
-int peertls_get_peer_finished(peertls_ssl* s, void* buf, int len) {
-    if (!s || !s->ssl || len <= 0) return 0;
-    size_t r = SSL_get_peer_finished(s->ssl, buf, (size_t)len);
-    if (r > (size_t)INT_MAX) return INT_MAX;
-    return (int)r;
+size_t peertls_get_peer_finished(peertls_ssl* s, void* buf, size_t len) {
+    if (s == NULL || s->ssl == NULL || s->write_failed ||
+        has_pending_write(s) ||
+        (buf == NULL && len != 0)) return 0;
+    return SSL_get_peer_finished(s->ssl, buf, len);
 }
 
-const char* peertls_last_error(void) {
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
-    static _Thread_local char buf[256];
-#else
-    static __thread char buf[256];
-#endif
-    unsigned long e = ERR_peek_last_error();
-    if (e == 0) return "";
-    ERR_error_string_n(e, buf, sizeof(buf));
-    return buf;
+int peertls_ctx_protocol_bounds(peertls_ctx* ctx,
+                                int* min_version, int* max_version) {
+    if (ctx == NULL || ctx->ctx == NULL ||
+        min_version == NULL || max_version == NULL) return 0;
+    long min = SSL_CTX_get_min_proto_version(ctx->ctx);
+    long max = SSL_CTX_get_max_proto_version(ctx->ctx);
+    if (min < INT_MIN || min > INT_MAX || max < INT_MIN || max > INT_MAX) {
+        return 0;
+    }
+    *min_version = (int)min;
+    *max_version = (int)max;
+    return 1;
+}
+
+unsigned long peertls_ctx_options(peertls_ctx* ctx) {
+    if (ctx == NULL || ctx->ctx == NULL) return 0;
+    return SSL_CTX_get_options(ctx->ctx);
+}
+
+unsigned long peertls_required_options(void) {
+    return required_options();
+}
+
+int peertls_ctx_set_protocol_bounds_for_test(
+        peertls_ctx* ctx, int min_version, int max_version,
+        char* error, size_t error_len) {
+    begin_operation(error, error_len);
+    if (ctx == NULL || ctx->ctx == NULL) {
+        set_error(error, error_len, "invalid TLS context");
+        return PEERTLS_ERR_OTHER;
+    }
+    if (SSL_CTX_set_min_proto_version(ctx->ctx, min_version) != 1 ||
+        SSL_CTX_set_max_proto_version(ctx->ctx, max_version) != 1) {
+        capture_error(error, error_len, "failed to set test protocol bounds");
+        return PEERTLS_ERR_SSL;
+    }
+    return 0;
+}
+
+int peertls_ssl_version(peertls_ssl* s) {
+    if (s == NULL || s->ssl == NULL || s->write_failed) return 0;
+    return SSL_version(s->ssl);
+}
+
+size_t peertls_pending_write_size(peertls_ssl* s) {
+    if (s == NULL) return 0;
+    return s->pending_write_len;
 }

--- a/internal/peermanagement/peertls/shim/shim.go
+++ b/internal/peermanagement/peertls/shim/shim.go
@@ -1,8 +1,6 @@
 //go:build cgo
 
-// Package shim is the cgo binding for the OpenSSL TLS shim used by
-// peertls. Every cgo call locks the OS thread because OpenSSL's error
-// queue is thread-local and we read it from Go on the same thread.
+// Package shim is the cgo binding for the OpenSSL TLS engine used by peertls.
 package shim
 
 // #cgo pkg-config: libssl libcrypto
@@ -13,98 +11,134 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	"runtime"
+	"math"
+	"sync"
 	"unsafe"
 )
 
-// Mirrored from shim.h.
+const errorBufferSize = C.PEERTLS_ERROR_SIZE
+
 const (
-	ErrCodeWantRead  = -1
-	ErrCodeWantWrite = -2
-	ErrCodeSyscall   = -3
-	ErrCodeSSL       = -4
-	ErrCodeZeroRet   = -5
-	ErrCodeOther     = -99
+	errCodeWantRead   = int(C.PEERTLS_ERR_WANT_READ)
+	errCodeWantWrite  = int(C.PEERTLS_ERR_WANT_WRITE)
+	errCodeSyscall    = int(C.PEERTLS_ERR_SYSCALL)
+	errCodeSSL        = int(C.PEERTLS_ERR_SSL)
+	errCodeZeroReturn = int(C.PEERTLS_ERR_ZERO_RET)
+	errCodeWriteRetry = int(C.PEERTLS_ERR_WRITE_RETRY)
 )
 
 var (
-	ErrWantRead  = errors.New("peertls/shim: SSL_ERROR_WANT_READ")
-	ErrWantWrite = errors.New("peertls/shim: SSL_ERROR_WANT_WRITE")
-	ErrSyscall   = errors.New("peertls/shim: SSL_ERROR_SYSCALL")
-	ErrSSL       = errors.New("peertls/shim: SSL_ERROR_SSL")
-	ErrZeroRet   = errors.New("peertls/shim: SSL_ERROR_ZERO_RETURN")
-	ErrOther     = errors.New("peertls/shim: unknown SSL error")
+	ErrWantRead   = errors.New("peertls/shim: SSL_ERROR_WANT_READ")
+	ErrWantWrite  = errors.New("peertls/shim: SSL_ERROR_WANT_WRITE")
+	ErrSyscall    = errors.New("peertls/shim: SSL_ERROR_SYSCALL")
+	ErrSSL        = errors.New("peertls/shim: SSL_ERROR_SSL")
+	ErrZeroRet    = errors.New("peertls/shim: SSL_ERROR_ZERO_RETURN")
+	ErrWriteRetry = errors.New(
+		"peertls/shim: SSL_write retry data or operation changed")
+	ErrOther   = errors.New("peertls/shim: OpenSSL operation failed")
+	ErrClosed  = errors.New("peertls/shim: closed handle")
+	ErrLength  = errors.New("peertls/shim: buffer exceeds OpenSSL int range")
+	ErrContext = errors.New("peertls/shim: TLS context construction failed")
 )
 
-func CodeToErr(code int) error {
-	switch code {
-	case ErrCodeWantRead:
-		return ErrWantRead
-	case ErrCodeWantWrite:
-		return ErrWantWrite
-	case ErrCodeSyscall:
-		return ErrSyscall
-	case ErrCodeSSL:
-		return ErrSSL
-	case ErrCodeZeroRet:
-		return ErrZeroRet
-	default:
-		return ErrOther
-	}
+type errorBuffer [errorBufferSize]byte
+
+func (b *errorBuffer) pointer() *C.char {
+	return (*C.char)(unsafe.Pointer(&b[0]))
 }
 
-// enrichLastError annotates ErrSSL/ErrSyscall with the thread-local
-// OpenSSL error string. Other shim errors are control-flow signals and
-// would surface stale strings.
-func enrichLastError(err error) error {
-	if err == nil {
-		return nil
+func (b *errorBuffer) detail() string {
+	if b[0] == 0 {
+		return ""
 	}
-	if !errors.Is(err, ErrSSL) && !errors.Is(err, ErrSyscall) {
-		return err
+	return C.GoString(b.pointer())
+}
+
+func codeError(code int, detail string) error {
+	var err error
+	switch code {
+	case errCodeWantRead:
+		return ErrWantRead
+	case errCodeWantWrite:
+		return ErrWantWrite
+	case errCodeSyscall:
+		err = ErrSyscall
+	case errCodeSSL:
+		err = ErrSSL
+	case errCodeZeroReturn:
+		return ErrZeroRet
+	case errCodeWriteRetry:
+		err = ErrWriteRetry
+	default:
+		err = ErrOther
 	}
-	detail := lastErrorLocked()
 	if detail == "" {
 		return err
 	}
 	return fmt.Errorf("%w: %s", err, detail)
 }
 
-func lastErrorLocked() string {
-	c := C.peertls_last_error()
-	if c == nil {
-		return ""
+func checkedOpenSSLLength(length int) (C.size_t, error) {
+	if length < 0 || uint64(length) > math.MaxInt32 {
+		return 0, ErrLength
 	}
-	return C.GoString(c)
+	return C.size_t(length), nil
 }
 
-type Ctx struct{ p *C.peertls_ctx }
+// Ctx owns an OpenSSL SSL_CTX. Its methods, including Free, are serialized.
+type Ctx struct {
+	mu sync.Mutex
+	p  *C.peertls_ctx
+}
 
-type SSL struct{ p *C.peertls_ssl }
+// SSL owns an OpenSSL SSL and its memory BIO pair. Its methods, including Free,
+// are serialized. Free may be called more than once.
+type SSL struct {
+	mu sync.Mutex
+	p  *C.peertls_ssl
+}
 
 func NewCtx(isServer bool) (*Ctx, error) {
+	return newCtx(isServer, "", false)
+}
+
+func NewCtxWithCipherList(isServer bool, cipherList string) (*Ctx, error) {
+	if cipherList == "" {
+		return nil, fmt.Errorf("%w: cipher list must not be empty", ErrContext)
+	}
+	return newCtx(isServer, cipherList, true)
+}
+
+func newCtx(isServer bool, cipherList string, override bool) (*Ctx, error) {
 	flag := C.int(0)
 	if isServer {
 		flag = 1
 	}
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-	p := C.peertls_ctx_new(flag)
+	var ciphers *C.char
+	if override {
+		ciphers = C.CString(cipherList)
+		defer C.free(unsafe.Pointer(ciphers))
+	}
+	var detail errorBuffer
+	p := C.peertls_ctx_new(flag, ciphers, detail.pointer(), C.size_t(len(detail)))
 	if p == nil {
-		if detail := lastErrorLocked(); detail != "" {
-			return nil, fmt.Errorf("peertls/shim: peertls_ctx_new failed: %s", detail)
+		if message := detail.detail(); message != "" {
+			return nil, fmt.Errorf("%w: %s", ErrContext, message)
 		}
-		return nil, errors.New("peertls/shim: peertls_ctx_new failed")
+		return nil, ErrContext
 	}
 	return &Ctx{p: p}, nil
 }
 
 func (c *Ctx) Free() {
-	if c == nil || c.p == nil {
+	if c == nil {
 		return
 	}
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.p == nil {
+		return
+	}
 	C.peertls_ctx_free(c.p)
 	c.p = nil
 }
@@ -113,145 +147,290 @@ func (c *Ctx) UseCertPEM(cert, key []byte) error {
 	if len(cert) == 0 || len(key) == 0 {
 		return errors.New("peertls/shim: cert and key must be non-empty")
 	}
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
+	certLen, err := checkedOpenSSLLength(len(cert))
+	if err != nil {
+		return err
+	}
+	keyLen, err := checkedOpenSSLLength(len(key))
+	if err != nil {
+		return err
+	}
+	if c == nil {
+		return ErrClosed
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.p == nil {
+		return ErrClosed
+	}
+	var detail errorBuffer
 	rc := C.peertls_ctx_use_cert_pem(
 		c.p,
-		(*C.char)(unsafe.Pointer(&cert[0])), C.int(len(cert)),
-		(*C.char)(unsafe.Pointer(&key[0])), C.int(len(key)),
+		(*C.char)(unsafe.Pointer(&cert[0])), certLen,
+		(*C.char)(unsafe.Pointer(&key[0])), keyLen,
+		detail.pointer(), C.size_t(len(detail)),
 	)
 	if rc != 0 {
-		return enrichLastError(CodeToErr(int(rc)))
+		return codeError(int(rc), detail.detail())
 	}
 	return nil
 }
 
-// NewSSL creates an SSL bound to a fresh BIO_pair under the context.
-// Free with SSL.Free; that releases the BIO too.
 func (c *Ctx) NewSSL() (*SSL, error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-	p := C.peertls_new(c.p)
+	if c == nil {
+		return nil, ErrClosed
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.p == nil {
+		return nil, ErrClosed
+	}
+	var detail errorBuffer
+	p := C.peertls_new(c.p, detail.pointer(), C.size_t(len(detail)))
 	if p == nil {
-		if detail := lastErrorLocked(); detail != "" {
-			return nil, fmt.Errorf("peertls/shim: peertls_new failed: %s", detail)
+		if message := detail.detail(); message != "" {
+			return nil, fmt.Errorf("peertls/shim: create connection: %s", message)
 		}
-		return nil, errors.New("peertls/shim: peertls_new failed")
+		return nil, errors.New("peertls/shim: create connection failed")
 	}
 	return &SSL{p: p}, nil
 }
 
+func (c *Ctx) protocolBounds() (int, int, error) {
+	if c == nil {
+		return 0, 0, ErrClosed
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.p == nil {
+		return 0, 0, ErrClosed
+	}
+	var minVersion C.int
+	var maxVersion C.int
+	if C.peertls_ctx_protocol_bounds(c.p, &minVersion, &maxVersion) != 1 {
+		return 0, 0, ErrOther
+	}
+	return int(minVersion), int(maxVersion), nil
+}
+
+func (c *Ctx) options() (uint64, uint64, error) {
+	if c == nil {
+		return 0, 0, ErrClosed
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.p == nil {
+		return 0, 0, ErrClosed
+	}
+	return uint64(C.peertls_ctx_options(c.p)),
+		uint64(C.peertls_required_options()), nil
+}
+
+func (c *Ctx) setProtocolBoundsForTest(minVersion, maxVersion int) error {
+	if c == nil {
+		return ErrClosed
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.p == nil {
+		return ErrClosed
+	}
+	var detail errorBuffer
+	rc := C.peertls_ctx_set_protocol_bounds_for_test(
+		c.p, C.int(minVersion), C.int(maxVersion),
+		detail.pointer(), C.size_t(len(detail)))
+	if rc != 0 {
+		return codeError(int(rc), detail.detail())
+	}
+	return nil
+}
+
 func (s *SSL) Free() {
-	if s == nil || s.p == nil {
+	if s == nil {
 		return
 	}
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.p == nil {
+		return
+	}
 	C.peertls_free(s.p)
 	s.p = nil
 }
 
-// Handshake returns nil on completion, ErrWantRead/ErrWantWrite if the
-// caller must pump I/O, or another error.
 func (s *SSL) Handshake() error {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-	rc := C.peertls_handshake(s.p)
-	if rc == 0 {
-		return nil
-	}
-	return enrichLastError(CodeToErr(int(rc)))
+	return s.run(false)
 }
 
-// Shutdown sends close_notify. ErrWantRead means the local alert was sent and
-// OpenSSL is waiting for the peer's close_notify response.
 func (s *SSL) Shutdown() error {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-	rc := C.peertls_shutdown(s.p)
+	return s.run(true)
+}
+
+func (s *SSL) run(shutdown bool) error {
+	if s == nil {
+		return ErrClosed
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.p == nil {
+		return ErrClosed
+	}
+	var detail errorBuffer
+	var rc C.int
+	if shutdown {
+		rc = C.peertls_shutdown(s.p, detail.pointer(), C.size_t(len(detail)))
+	} else {
+		rc = C.peertls_handshake(s.p, detail.pointer(), C.size_t(len(detail)))
+	}
 	if rc == 0 {
 		return nil
 	}
-	return enrichLastError(CodeToErr(int(rc)))
+	return codeError(int(rc), detail.detail())
 }
 
 func (s *SSL) Read(buf []byte) (int, error) {
+	if s == nil {
+		return 0, ErrClosed
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.p == nil {
+		return 0, ErrClosed
+	}
 	if len(buf) == 0 {
 		return 0, nil
 	}
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-	rc := C.peertls_read(s.p, unsafe.Pointer(&buf[0]), C.int(len(buf)))
+	length, err := checkedOpenSSLLength(len(buf))
+	if err != nil {
+		return 0, err
+	}
+	var detail errorBuffer
+	rc := C.peertls_read(s.p, unsafe.Pointer(&buf[0]), length,
+		detail.pointer(), C.size_t(len(detail)))
 	if rc > 0 {
 		return int(rc), nil
 	}
-	if rc == 0 {
-		return 0, ErrZeroRet
-	}
-	return 0, enrichLastError(CodeToErr(int(rc)))
+	return 0, codeError(int(rc), detail.detail())
 }
 
 func (s *SSL) Write(buf []byte) (int, error) {
+	if s == nil {
+		return 0, ErrClosed
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.p == nil {
+		return 0, ErrClosed
+	}
 	if len(buf) == 0 {
 		return 0, nil
 	}
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-	rc := C.peertls_write(s.p, unsafe.Pointer(&buf[0]), C.int(len(buf)))
+	length, err := checkedOpenSSLLength(len(buf))
+	if err != nil {
+		return 0, err
+	}
+	var detail errorBuffer
+	rc := C.peertls_write(s.p, unsafe.Pointer(&buf[0]), length,
+		detail.pointer(), C.size_t(len(detail)))
 	if rc > 0 {
 		return int(rc), nil
 	}
-	return 0, enrichLastError(CodeToErr(int(rc)))
+	return 0, codeError(int(rc), detail.detail())
 }
 
-// BIORead drains pending TLS records from the network BIO; returns 0
-// when the BIO is empty.
 func (s *SSL) BIORead(buf []byte) (int, error) {
-	if len(buf) == 0 {
-		return 0, nil
-	}
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-	rc := C.peertls_bio_read(s.p, unsafe.Pointer(&buf[0]), C.int(len(buf)))
-	if rc < 0 {
-		return 0, enrichLastError(CodeToErr(int(rc)))
-	}
-	return int(rc), nil
+	return s.bio(buf, false)
 }
 
-// BIOWrite feeds raw TLS records into OpenSSL. Has partial-accept
-// semantics: returns the number actually consumed.
 func (s *SSL) BIOWrite(buf []byte) (int, error) {
+	return s.bio(buf, true)
+}
+
+func (s *SSL) bio(buf []byte, write bool) (int, error) {
+	if s == nil {
+		return 0, ErrClosed
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.p == nil {
+		return 0, ErrClosed
+	}
 	if len(buf) == 0 {
 		return 0, nil
 	}
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-	rc := C.peertls_bio_write(s.p, unsafe.Pointer(&buf[0]), C.int(len(buf)))
+	length, err := checkedOpenSSLLength(len(buf))
+	if err != nil {
+		return 0, err
+	}
+	var detail errorBuffer
+	var rc C.int
+	if write {
+		rc = C.peertls_bio_write(s.p, unsafe.Pointer(&buf[0]), length,
+			detail.pointer(), C.size_t(len(detail)))
+	} else {
+		rc = C.peertls_bio_read(s.p, unsafe.Pointer(&buf[0]), length,
+			detail.pointer(), C.size_t(len(detail)))
+	}
 	if rc < 0 {
-		return 0, enrichLastError(CodeToErr(int(rc)))
+		return 0, codeError(int(rc), detail.detail())
 	}
 	return int(rc), nil
 }
 
-// GetFinished returns the FULL Finished length even when buf is smaller;
-// caller detects truncation via (returned > len(buf)).
 func (s *SSL) GetFinished(buf []byte) int {
-	if len(buf) == 0 {
+	if s == nil {
 		return 0
 	}
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-	n := C.peertls_get_finished(s.p, unsafe.Pointer(&buf[0]), C.int(len(buf)))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.p == nil {
+		return 0
+	}
+	var pointer unsafe.Pointer
+	if len(buf) != 0 {
+		pointer = unsafe.Pointer(&buf[0])
+	}
+	n := C.peertls_get_finished(s.p, pointer, C.size_t(len(buf)))
 	return int(n)
 }
 
 func (s *SSL) GetPeerFinished(buf []byte) int {
-	if len(buf) == 0 {
+	if s == nil {
 		return 0
 	}
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-	n := C.peertls_get_peer_finished(s.p, unsafe.Pointer(&buf[0]), C.int(len(buf)))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.p == nil {
+		return 0
+	}
+	var pointer unsafe.Pointer
+	if len(buf) != 0 {
+		pointer = unsafe.Pointer(&buf[0])
+	}
+	n := C.peertls_get_peer_finished(s.p, pointer, C.size_t(len(buf)))
 	return int(n)
+}
+
+func (s *SSL) version() int {
+	if s == nil {
+		return 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.p == nil {
+		return 0
+	}
+	return int(C.peertls_ssl_version(s.p))
+}
+
+func (s *SSL) pendingWriteSize() int {
+	if s == nil {
+		return 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.p == nil {
+		return 0
+	}
+	return int(C.peertls_pending_write_size(s.p))
 }

--- a/internal/peermanagement/peertls/shim/shim.h
+++ b/internal/peermanagement/peertls/shim/shim.h
@@ -1,16 +1,4 @@
-/* shim.h - thin OpenSSL shim for XRPL peer TLS.
- *
- * Connection model: the SSL object is bound to a memory BIO_pair (no fd
- * is passed to OpenSSL). Go pumps bytes between the network BIO and the
- * underlying net.Conn; OpenSSL only ever sees memory buffers. This
- * keeps deadlines, context cancellation, and goroutine teardown on the
- * Go side.
- *
- * Error convention: shim functions returning int return:
- *   >  0   bytes processed (read/write/bio_read/bio_write)
- *   == 0   clean shutdown / EOF
- *   <  0   negative SSL_get_error code (one of PEERTLS_ERR_*)
- */
+/* shim.h - thin OpenSSL shim for XRPL peer TLS. */
 
 #ifndef PEERTLS_SHIM_H
 #define PEERTLS_SHIM_H
@@ -24,60 +12,57 @@ extern "C" {
 typedef struct peertls_ctx peertls_ctx;
 typedef struct peertls_ssl peertls_ssl;
 
-/* Error codes (negative). Matches SSL_ERROR_* but stable across OpenSSL
- * versions and non-overlapping with positive byte counts. */
-#define PEERTLS_ERR_WANT_READ  -1
-#define PEERTLS_ERR_WANT_WRITE -2
-#define PEERTLS_ERR_SYSCALL    -3
-#define PEERTLS_ERR_SSL        -4
-#define PEERTLS_ERR_ZERO_RET   -5
-#define PEERTLS_ERR_OTHER      -99
+#define PEERTLS_ERROR_SIZE 256
+#define PEERTLS_DEFAULT_CIPHER_LIST "TLSv1.2:!CBC:!DSS:!PSK:!eNULL:!aNULL"
 
-/* Context lifecycle. is_server=1 for a server-role context (uses
- * TLS_server_method), 0 for client. The context owns the cert/key. */
-peertls_ctx* peertls_ctx_new(int is_server);
+#define PEERTLS_ERR_WANT_READ     -1
+#define PEERTLS_ERR_WANT_WRITE    -2
+#define PEERTLS_ERR_SYSCALL       -3
+#define PEERTLS_ERR_SSL           -4
+#define PEERTLS_ERR_ZERO_RET      -5
+#define PEERTLS_ERR_WRITE_RETRY   -6
+#define PEERTLS_ERR_OTHER        -99
+
+peertls_ctx* peertls_ctx_new(int is_server, const char* cipher_list,
+                             char* error, size_t error_len);
 void         peertls_ctx_free(peertls_ctx* ctx);
 
-/* Load an X509 certificate + private key from PEM buffers. Returns 0 on
- * success, negative error code on failure. */
 int peertls_ctx_use_cert_pem(peertls_ctx* ctx,
-                              const char* cert, int cert_len,
-                              const char* key,  int key_len);
+                             const char* cert, size_t cert_len,
+                             const char* key, size_t key_len,
+                             char* error, size_t error_len);
 
-/* SSL lifecycle. peertls_new returns a new SSL bound to a fresh
- * BIO_pair. Once created, all I/O goes through peertls_{read,write} and
- * peertls_bio_{read,write}. */
-peertls_ssl* peertls_new(peertls_ctx* ctx);
+peertls_ssl* peertls_new(peertls_ctx* ctx, char* error, size_t error_len);
 void         peertls_free(peertls_ssl* s);
 
-/* Drive the handshake. Returns 0 on success, PEERTLS_ERR_WANT_READ or
- * PEERTLS_ERR_WANT_WRITE if more network I/O is needed, or another
- * negative error. The Go pump loops on this function. */
-int peertls_handshake(peertls_ssl* s);
+int peertls_handshake(peertls_ssl* s, char* error, size_t error_len);
+int peertls_shutdown(peertls_ssl* s, char* error, size_t error_len);
 
-/* Send close_notify. A zero SSL_shutdown result is exposed as WANT_READ:
- * local close_notify was sent and the peer response is still outstanding. */
-int peertls_shutdown(peertls_ssl* s);
+int peertls_read(peertls_ssl* s, void* buf, size_t len,
+                 char* error, size_t error_len);
+int peertls_write(peertls_ssl* s, const void* buf, size_t len,
+                  char* error, size_t error_len);
 
-/* Encrypted application I/O. Same return convention as handshake. */
-int peertls_read (peertls_ssl* s, void* buf, int len);
-int peertls_write(peertls_ssl* s, const void* buf, int len);
+int peertls_bio_read(peertls_ssl* s, void* buf, size_t len,
+                     char* error, size_t error_len);
+int peertls_bio_write(peertls_ssl* s, const void* buf, size_t len,
+                      char* error, size_t error_len);
 
-/* Drain/fill the network BIO. peertls_bio_read pulls outgoing TLS
- * record bytes that OpenSSL has produced; peertls_bio_write feeds
- * incoming TLS record bytes from the wire into OpenSSL. Returns the
- * number of bytes processed; 0 means no bytes available / no space. */
-int peertls_bio_read (peertls_ssl* s, void* buf, int len);
-int peertls_bio_write(peertls_ssl* s, const void* buf, int len);
+/* These return the full Finished length even when len is smaller. */
+size_t peertls_get_finished(peertls_ssl* s, void* buf, size_t len);
+size_t peertls_get_peer_finished(peertls_ssl* s, void* buf, size_t len);
 
-/* TLS 1.2 Finished bytes. Returns the number of bytes copied (typically
- * 12 for TLS 1.2), or 0 if the handshake hasn't completed. */
-int peertls_get_finished     (peertls_ssl* s, void* buf, int len);
-int peertls_get_peer_finished(peertls_ssl* s, void* buf, int len);
-
-/* Returns a static pointer to the most recent SSL error string in this
- * thread. Only valid until the next OpenSSL call on this thread. */
-const char* peertls_last_error(void);
+/* Narrow state inspection used by direct shim tests. */
+int           peertls_ctx_protocol_bounds(peertls_ctx* ctx,
+                                          int* min_version,
+                                          int* max_version);
+unsigned long peertls_ctx_options(peertls_ctx* ctx);
+unsigned long peertls_required_options(void);
+int           peertls_ctx_set_protocol_bounds_for_test(
+                  peertls_ctx* ctx, int min_version, int max_version,
+                  char* error, size_t error_len);
+int           peertls_ssl_version(peertls_ssl* s);
+size_t        peertls_pending_write_size(peertls_ssl* s);
 
 #ifdef __cplusplus
 }

--- a/internal/peermanagement/peertls/shim/shim.h
+++ b/internal/peermanagement/peertls/shim/shim.h
@@ -1,5 +1,3 @@
-/* shim.h - thin OpenSSL shim for XRPL peer TLS. */
-
 #ifndef PEERTLS_SHIM_H
 #define PEERTLS_SHIM_H
 
@@ -52,7 +50,6 @@ int peertls_bio_write(peertls_ssl* s, const void* buf, size_t len,
 size_t peertls_get_finished(peertls_ssl* s, void* buf, size_t len);
 size_t peertls_get_peer_finished(peertls_ssl* s, void* buf, size_t len);
 
-/* Narrow state inspection used by direct shim tests. */
 int           peertls_ctx_protocol_bounds(peertls_ctx* ctx,
                                           int* min_version,
                                           int* max_version);

--- a/internal/peermanagement/peertls/shim/shim_test.go
+++ b/internal/peermanagement/peertls/shim/shim_test.go
@@ -1,0 +1,666 @@
+//go:build cgo
+
+package shim
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	tlsVersion10 = 0x0301
+	tlsVersion11 = 0x0302
+	tlsVersion12 = 0x0303
+	tlsVersion13 = 0x0304
+)
+
+var (
+	testCertOnce sync.Once
+	testCertPEM  []byte
+	testKeyPEM   []byte
+	testCertErr  error
+)
+
+func testCertificate(t testing.TB) ([]byte, []byte) {
+	t.Helper()
+	testCertOnce.Do(func() {
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			testCertErr = err
+			return
+		}
+		now := time.Now()
+		template := &x509.Certificate{
+			SerialNumber:          big.NewInt(1),
+			Subject:               pkix.Name{CommonName: "peertls shim test"},
+			NotBefore:             now.Add(-time.Minute),
+			NotAfter:              now.Add(time.Hour),
+			KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+			ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+			BasicConstraintsValid: true,
+		}
+		der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+		if err != nil {
+			testCertErr = err
+			return
+		}
+		testCertPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+		testKeyPEM = pem.EncodeToMemory(&pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(key),
+		})
+	})
+	if testCertErr != nil {
+		t.Fatal(testCertErr)
+	}
+	return append([]byte(nil), testCertPEM...), append([]byte(nil), testKeyPEM...)
+}
+
+func TestErrorMappingAndCheckedLength(t *testing.T) {
+	for _, test := range []struct {
+		code int
+		want error
+	}{
+		{errCodeWantRead, ErrWantRead},
+		{errCodeWantWrite, ErrWantWrite},
+		{errCodeSyscall, ErrSyscall},
+		{errCodeSSL, ErrSSL},
+		{errCodeZeroReturn, ErrZeroRet},
+		{errCodeWriteRetry, ErrWriteRetry},
+		{-12345, ErrOther},
+	} {
+		err := codeError(test.code, "operation detail")
+		if !errors.Is(err, test.want) {
+			t.Fatalf("codeError(%d) = %v, want %v", test.code, err, test.want)
+		}
+		if test.want != ErrWantRead && test.want != ErrWantWrite &&
+			test.want != ErrZeroRet && !strings.Contains(err.Error(), "operation detail") {
+			t.Fatalf("codeError(%d) lost detail: %v", test.code, err)
+		}
+	}
+
+	if _, err := checkedOpenSSLLength(-1); !errors.Is(err, ErrLength) {
+		t.Fatalf("negative length error = %v", err)
+	}
+	if _, err := checkedOpenSSLLength(math.MaxInt32); err != nil {
+		t.Fatalf("MaxInt32 rejected: %v", err)
+	}
+	if strconv.IntSize > 32 {
+		if _, err := checkedOpenSSLLength(math.MaxInt32 + 1); !errors.Is(err, ErrLength) {
+			t.Fatalf("oversized length error = %v", err)
+		}
+	}
+}
+
+func TestContextPolicyCipherValidationAndLifetime(t *testing.T) {
+	ctx, err := NewCtx(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	minVersion, maxVersion, err := ctx.protocolBounds()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if minVersion != tlsVersion12 || maxVersion != 0 {
+		t.Fatalf("protocol bounds = (%#x, %#x), want (%#x, 0)",
+			minVersion, maxVersion, tlsVersion12)
+	}
+	options, required, err := ctx.options()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if required == 0 || options&required != required {
+		t.Fatalf("TLS options = %#x, required %#x", options, required)
+	}
+	ctx.Free()
+	ctx.Free()
+	cert, key := testCertificate(t)
+	if err := ctx.UseCertPEM(cert, key); !errors.Is(err, ErrClosed) {
+		t.Fatalf("UseCertPEM after Free = %v", err)
+	}
+	if _, err := ctx.NewSSL(); !errors.Is(err, ErrClosed) {
+		t.Fatalf("NewSSL after Free = %v", err)
+	}
+
+	for _, cipherList := range []string{"", "not-a-real-cipher"} {
+		if _, err := NewCtxWithCipherList(false, cipherList); !errors.Is(err, ErrContext) {
+			t.Fatalf("cipher list %q error = %v", cipherList, err)
+		}
+	}
+}
+
+func TestBIOPartialFillAndEmptyDrain(t *testing.T) {
+	ctx, err := NewCtx(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ssl, err := ctx.NewSSL()
+	ctx.Free()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ssl.Free()
+	if n, err := ssl.BIORead(make([]byte, 1)); n != 0 || err != nil {
+		t.Fatalf("empty BIORead = (%d, %v)", n, err)
+	}
+	payload := make([]byte, 64*1024)
+	n, err := ssl.BIOWrite(payload)
+	if err != nil || n <= 0 || n >= len(payload) {
+		t.Fatalf("partial BIOWrite = (%d, %v), input=%d", n, err, len(payload))
+	}
+	if next, err := ssl.BIOWrite(payload[n:]); next != 0 || err != nil {
+		t.Fatalf("full BIOWrite retry = (%d, %v)", next, err)
+	}
+}
+
+func TestPEMFailureDoesNotContaminateLaterOperations(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	ctx, err := NewCtx(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ctx.UseCertPEM([]byte("not a certificate"), []byte("not a key"))
+	if !errors.Is(err, ErrSSL) || !strings.Contains(err.Error(), "PEM") {
+		t.Fatalf("malformed PEM error = %v", err)
+	}
+	ctx.Free()
+	_, err = ctx.NewSSL()
+	if !errors.Is(err, ErrClosed) || strings.Contains(err.Error(), "PEM") {
+		t.Fatalf("operation-local error after PEM failure = %v", err)
+	}
+
+	cert, _ := testCertificate(t)
+	otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(otherKey),
+	})
+	mismatch, err := NewCtx(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mismatch.Free()
+	if err := mismatch.UseCertPEM(cert, otherKeyPEM); !errors.Is(err, ErrSSL) {
+		t.Fatalf("mismatched certificate and key error = %v", err)
+	}
+
+	fresh, err := NewCtx(false)
+	if err != nil {
+		t.Fatalf("fresh context inherited stale error: %v", err)
+	}
+	defer fresh.Free()
+	ssl, err := fresh.NewSSL()
+	if err != nil {
+		t.Fatalf("fresh SSL inherited stale error: %v", err)
+	}
+	ssl.Free()
+}
+
+type testPair struct {
+	client *SSL
+	server *SSL
+}
+
+func newTestPair(t testing.TB, cipherList string, minVersion, maxVersion int) testPair {
+	t.Helper()
+	newContext := func(server bool) *Ctx {
+		var ctx *Ctx
+		var err error
+		if cipherList == "" {
+			ctx, err = NewCtx(server)
+		} else {
+			ctx, err = NewCtxWithCipherList(server, cipherList)
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		cert, key := testCertificate(t)
+		if err := ctx.UseCertPEM(cert, key); err != nil {
+			ctx.Free()
+			t.Fatal(err)
+		}
+		if minVersion != 0 || maxVersion != 0 {
+			if err := ctx.setProtocolBoundsForTest(minVersion, maxVersion); err != nil {
+				ctx.Free()
+				t.Fatal(err)
+			}
+		}
+		return ctx
+	}
+	clientCtx := newContext(false)
+	serverCtx := newContext(true)
+	client, err := clientCtx.NewSSL()
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, err := serverCtx.NewSSL()
+	clientCtx.Free()
+	serverCtx.Free()
+	if err != nil {
+		client.Free()
+		t.Fatal(err)
+	}
+	t.Cleanup(client.Free)
+	t.Cleanup(server.Free)
+	return testPair{client: client, server: server}
+}
+
+func transferTLS(from, to *SSL) (int, error) {
+	buf := make([]byte, 4096)
+	total := 0
+	for {
+		n, err := from.BIORead(buf)
+		if err != nil {
+			return total, err
+		}
+		if n == 0 {
+			return total, nil
+		}
+		total += n
+		for offset := 0; offset < n; {
+			written, err := to.BIOWrite(buf[offset:n])
+			if err != nil {
+				return total, err
+			}
+			if written == 0 {
+				return total, errors.New("BIO transfer made no progress")
+			}
+			offset += written
+		}
+	}
+}
+
+func driveHandshake(pair testPair) error {
+	clientDone := false
+	serverDone := false
+	for range 1000 {
+		if !clientDone {
+			err := pair.client.Handshake()
+			switch {
+			case err == nil:
+				clientDone = true
+			case errors.Is(err, ErrWantRead), errors.Is(err, ErrWantWrite):
+			default:
+				return fmt.Errorf("client handshake: %w", err)
+			}
+		}
+		if !serverDone {
+			err := pair.server.Handshake()
+			switch {
+			case err == nil:
+				serverDone = true
+			case errors.Is(err, ErrWantRead), errors.Is(err, ErrWantWrite):
+			default:
+				return fmt.Errorf("server handshake: %w", err)
+			}
+		}
+		if _, err := transferTLS(pair.client, pair.server); err != nil {
+			return err
+		}
+		if _, err := transferTLS(pair.server, pair.client); err != nil {
+			return err
+		}
+		if clientDone && serverDone {
+			return nil
+		}
+	}
+	return errors.New("TLS handshake did not converge")
+}
+
+func TestTLSVersionsFinishedAndDHEPolicy(t *testing.T) {
+	for _, version := range []int{tlsVersion12, tlsVersion13} {
+		t.Run(fmt.Sprintf("TLS_%x", version), func(t *testing.T) {
+			pair := newTestPair(t, "", version, version)
+			if got := pair.client.GetFinished(make([]byte, 64)); got != 0 {
+				t.Fatalf("Finished before handshake = %d", got)
+			}
+			if err := driveHandshake(pair); err != nil {
+				t.Fatal(err)
+			}
+			if pair.client.version() != version || pair.server.version() != version {
+				t.Fatalf("negotiated versions = (%#x, %#x), want %#x",
+					pair.client.version(), pair.server.version(), version)
+			}
+			assertFinishedPair(t, pair.client, pair.server)
+		})
+	}
+
+	pair := newTestPair(t, "DHE-RSA-AES128-GCM-SHA256", tlsVersion12, tlsVersion12)
+	if err := driveHandshake(pair); err != nil {
+		t.Fatalf("DHE handshake: %v", err)
+	}
+}
+
+func assertFinishedPair(t testing.TB, client, server *SSL) {
+	t.Helper()
+	clientFinished := make([]byte, 1024)
+	serverPeerFinished := make([]byte, 1024)
+	clientLen := client.GetFinished(clientFinished)
+	serverPeerLen := server.GetPeerFinished(serverPeerFinished)
+	if clientLen < 12 || clientLen != serverPeerLen ||
+		!bytes.Equal(clientFinished[:clientLen], serverPeerFinished[:serverPeerLen]) {
+		t.Fatalf("client Finished mismatch: local=%d peer=%d", clientLen, serverPeerLen)
+	}
+
+	serverFinished := make([]byte, 1024)
+	clientPeerFinished := make([]byte, 1024)
+	serverLen := server.GetFinished(serverFinished)
+	clientPeerLen := client.GetPeerFinished(clientPeerFinished)
+	if serverLen < 12 || serverLen != clientPeerLen ||
+		!bytes.Equal(serverFinished[:serverLen], clientPeerFinished[:clientPeerLen]) {
+		t.Fatalf("server Finished mismatch: local=%d peer=%d", serverLen, clientPeerLen)
+	}
+
+	small := make([]byte, 1)
+	if got := client.GetFinished(small); got != clientLen || small[0] != clientFinished[0] {
+		t.Fatalf("undersized Finished = (%d, %x), want (%d, %x)",
+			got, small[0], clientLen, clientFinished[0])
+	}
+	if got := client.GetFinished(nil); got != clientLen {
+		t.Fatalf("zero-capacity Finished length = %d, want %d", got, clientLen)
+	}
+}
+
+func TestTLS10And11AreRejected(t *testing.T) {
+	for _, version := range []int{tlsVersion10, tlsVersion11} {
+		t.Run(fmt.Sprintf("TLS_%x", version), func(t *testing.T) {
+			pair := newTestPair(t, "", version, version)
+			serverCtx, err := NewCtx(true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cert, key := testCertificate(t)
+			if err := serverCtx.UseCertPEM(cert, key); err != nil {
+				t.Fatal(err)
+			}
+			server, err := serverCtx.NewSSL()
+			serverCtx.Free()
+			if err != nil {
+				t.Fatal(err)
+			}
+			pair.server.Free()
+			pair.server = server
+			t.Cleanup(server.Free)
+			if err := driveHandshake(pair); err == nil {
+				t.Fatal("handshake unexpectedly accepted obsolete TLS version")
+			}
+		})
+	}
+}
+
+func TestRetryableWriteUsesStableCOwnedMemory(t *testing.T) {
+	pair := newTestPair(t, "", tlsVersion12, tlsVersion12)
+	if err := driveHandshake(pair); err != nil {
+		t.Fatal(err)
+	}
+	payload := bytes.Repeat([]byte("0123456789abcdef"), 4096)
+
+	if n, err := pair.client.Write(payload); n != 0 || !errors.Is(err, ErrWantWrite) {
+		t.Fatalf("initial large Write = (%d, %v)", n, err)
+	}
+	if got := pair.client.pendingWriteSize(); got != len(payload) {
+		t.Fatalf("pending write size = %d, want %d", got, len(payload))
+	}
+	runtime.GC()
+	if n, err := pair.client.Write(append([]byte(nil), payload...)); n != 0 || !errors.Is(err, ErrWantWrite) {
+		t.Fatalf("same-data moving retry = (%d, %v)", n, err)
+	}
+
+	received := make([]byte, 0, len(payload))
+	writeDone := false
+	for range 1000 {
+		if _, err := transferTLS(pair.client, pair.server); err != nil {
+			t.Fatal(err)
+		}
+		for {
+			buf := make([]byte, 8192)
+			n, err := pair.server.Read(buf)
+			if n > 0 {
+				received = append(received, buf[:n]...)
+			}
+			if errors.Is(err, ErrWantRead) {
+				break
+			}
+			if errors.Is(err, ErrWantWrite) {
+				if _, transferErr := transferTLS(pair.server, pair.client); transferErr != nil {
+					t.Fatal(transferErr)
+				}
+				continue
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		if !writeDone {
+			n, err := pair.client.Write(append([]byte(nil), payload...))
+			switch {
+			case err == nil:
+				if n != len(payload) {
+					t.Fatalf("completed Write = %d, want %d", n, len(payload))
+				}
+				writeDone = true
+			case errors.Is(err, ErrWantWrite), errors.Is(err, ErrWantRead):
+			default:
+				t.Fatal(err)
+			}
+		}
+		if writeDone && len(received) == len(payload) {
+			break
+		}
+	}
+	if !writeDone || !bytes.Equal(received, payload) {
+		t.Fatalf("large write completion=%v received=%d want=%d", writeDone, len(received), len(payload))
+	}
+	if got := pair.client.pendingWriteSize(); got != 0 {
+		t.Fatalf("pending write retained after success: %d", got)
+	}
+}
+
+func TestReadProgressReleasesCompletedPendingWrite(t *testing.T) {
+	pair := newTestPair(t, "", tlsVersion12, tlsVersion12)
+	if err := driveHandshake(pair); err != nil {
+		t.Fatal(err)
+	}
+	payload := bytes.Repeat([]byte("read-side-progress"), 4096)
+	if _, err := pair.client.Write(payload); !errors.Is(err, ErrWantWrite) {
+		t.Fatalf("initial Write error = %v", err)
+	}
+
+	received := make([]byte, 0, len(payload))
+	drainServer := func() {
+		t.Helper()
+		for {
+			buf := make([]byte, 8192)
+			n, err := pair.server.Read(buf)
+			if n > 0 {
+				received = append(received, buf[:n]...)
+			}
+			if errors.Is(err, ErrWantRead) {
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	completed := false
+	for range 1000 {
+		if _, err := transferTLS(pair.client, pair.server); err != nil {
+			t.Fatal(err)
+		}
+		drainServer()
+		_, err := pair.client.Read(make([]byte, 1))
+		if pair.client.pendingWriteSize() == 0 {
+			if !errors.Is(err, ErrWantRead) {
+				t.Fatalf("Read completing pending Write error = %v", err)
+			}
+			completed = true
+			break
+		}
+		if !errors.Is(err, ErrWantWrite) {
+			t.Fatalf("Read progressing pending Write error = %v", err)
+		}
+	}
+	if !completed {
+		t.Fatal("Read did not complete the pending Write")
+	}
+
+	retry := append([]byte(nil), payload...)
+	if n, err := pair.client.Write(retry); err != nil || n != len(payload) {
+		t.Fatalf("completed Write acknowledgment = (%d, %v), want (%d, nil)", n, err, len(payload))
+	}
+
+	for range 1000 {
+		if _, err := transferTLS(pair.client, pair.server); err != nil {
+			t.Fatal(err)
+		}
+		drainServer()
+		if len(received) == len(payload) {
+			break
+		}
+	}
+	if !bytes.Equal(received, payload) {
+		t.Fatalf("received %d bytes after read-side completion, want %d", len(received), len(payload))
+	}
+}
+
+func TestPendingWriteReleaseOnMismatchAndFree(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		end  func(*testing.T, *SSL, []byte)
+	}{
+		{
+			name: "mismatch",
+			end: func(t *testing.T, ssl *SSL, payload []byte) {
+				changed := append([]byte(nil), payload...)
+				changed[0] ^= 0xff
+				if _, err := ssl.Write(changed); !errors.Is(err, ErrWriteRetry) {
+					t.Fatalf("mismatched retry error = %v", err)
+				}
+				if got := ssl.pendingWriteSize(); got != 0 {
+					t.Fatalf("pending write after mismatch = %d", got)
+				}
+				if _, err := ssl.BIORead(make([]byte, 1)); !errors.Is(err, ErrOther) {
+					t.Fatalf("BIORead after mismatch error = %v", err)
+				}
+				if _, err := ssl.BIOWrite([]byte("x")); !errors.Is(err, ErrOther) {
+					t.Fatalf("BIOWrite after mismatch error = %v", err)
+				}
+			},
+		},
+		{
+			name: "free",
+			end: func(t *testing.T, ssl *SSL, _ []byte) {
+				ssl.Free()
+				ssl.Free()
+				if got := ssl.pendingWriteSize(); got != 0 {
+					t.Fatalf("pending write after Free = %d", got)
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			pair := newTestPair(t, "", tlsVersion12, tlsVersion12)
+			if err := driveHandshake(pair); err != nil {
+				t.Fatal(err)
+			}
+			payload := bytes.Repeat([]byte("x"), 64*1024)
+			if _, err := pair.client.Write(payload); !errors.Is(err, ErrWantWrite) {
+				t.Fatalf("initial Write error = %v", err)
+			}
+			test.end(t, pair.client, payload)
+		})
+	}
+}
+
+func TestCleanShutdownStateMachine(t *testing.T) {
+	pair := newTestPair(t, "", tlsVersion13, tlsVersion13)
+	if err := driveHandshake(pair); err != nil {
+		t.Fatal(err)
+	}
+	if err := pair.client.Shutdown(); !errors.Is(err, ErrWantRead) {
+		t.Fatalf("client first Shutdown = %v", err)
+	}
+	if _, err := transferTLS(pair.client, pair.server); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pair.server.Read(make([]byte, 1)); !errors.Is(err, ErrZeroRet) {
+		t.Fatalf("server read close_notify = %v", err)
+	}
+	serverErr := pair.server.Shutdown()
+	if serverErr != nil && !errors.Is(serverErr, ErrWantRead) {
+		t.Fatalf("server Shutdown = %v", serverErr)
+	}
+	if _, err := transferTLS(pair.server, pair.client); err != nil {
+		t.Fatal(err)
+	}
+	if err := pair.client.Shutdown(); err != nil {
+		t.Fatalf("client final Shutdown = %v", err)
+	}
+}
+
+func TestNilAndFreedHandles(t *testing.T) {
+	var ctx *Ctx
+	ctx.Free()
+	if _, err := ctx.NewSSL(); !errors.Is(err, ErrClosed) {
+		t.Fatalf("nil context NewSSL = %v", err)
+	}
+	var ssl *SSL
+	ssl.Free()
+	if err := ssl.Handshake(); !errors.Is(err, ErrClosed) {
+		t.Fatalf("nil SSL Handshake = %v", err)
+	}
+	if _, err := ssl.Read([]byte{0}); !errors.Is(err, ErrClosed) {
+		t.Fatalf("nil SSL Read = %v", err)
+	}
+	if _, err := ssl.Write([]byte{0}); !errors.Is(err, ErrClosed) {
+		t.Fatalf("nil SSL Write = %v", err)
+	}
+	if _, err := ssl.Read(nil); !errors.Is(err, ErrClosed) {
+		t.Fatalf("nil SSL zero-length Read = %v", err)
+	}
+	if _, err := ssl.Write(nil); !errors.Is(err, ErrClosed) {
+		t.Fatalf("nil SSL zero-length Write = %v", err)
+	}
+	if _, err := ssl.BIORead(nil); !errors.Is(err, ErrClosed) {
+		t.Fatalf("nil SSL zero-length BIORead = %v", err)
+	}
+	if _, err := ssl.BIOWrite(nil); !errors.Is(err, ErrClosed) {
+		t.Fatalf("nil SSL zero-length BIOWrite = %v", err)
+	}
+
+	ctx, err := NewCtx(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ctx.Free()
+	freed, err := ctx.NewSSL()
+	if err != nil {
+		t.Fatal(err)
+	}
+	freed.Free()
+	if _, err := freed.Read(nil); !errors.Is(err, ErrClosed) {
+		t.Fatalf("freed SSL zero-length Read = %v", err)
+	}
+	if _, err := freed.BIOWrite(nil); !errors.Is(err, ErrClosed) {
+		t.Fatalf("freed SSL zero-length BIOWrite = %v", err)
+	}
+}

--- a/internal/peermanagement/peertls/tls_openssl.go
+++ b/internal/peermanagement/peertls/tls_openssl.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -124,7 +125,13 @@ func newContext(cfg *Config, isServer bool) (*shim.Ctx, error) {
 	if cfg == nil || len(cfg.CertPEM) == 0 || len(cfg.KeyPEM) == 0 {
 		return nil, errors.New("peertls: Config requires CertPEM and KeyPEM")
 	}
-	ctx, err := shim.NewCtx(isServer)
+	var ctx *shim.Ctx
+	var err error
+	if cfg.CipherList == "" {
+		ctx, err = shim.NewCtx(isServer)
+	} else {
+		ctx, err = shim.NewCtxWithCipherList(isServer, cfg.CipherList)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -192,6 +199,7 @@ func (l *listener) Addr() net.Addr { return l.inner.Addr() }
 // Locks:
 //   - sslMu owns the engine, TLS state, and terminal TLS error.
 //   - inMu owns raw reads, pendingIn, and pendingReadErr.
+//   - writeMu serializes complete application Write calls.
 //   - outMu owns raw writes, pendingOut, and outputErr.
 //   - queuedOutMu owns TLS records waiting for the raw writer.
 //
@@ -209,6 +217,7 @@ type conn struct {
 	pendingIn      []byte
 	pendingReadErr error
 
+	writeMu    sync.Mutex
 	outMu      sync.Mutex
 	pendingOut []byte
 	outputErr  error
@@ -418,7 +427,7 @@ func (c *conn) pumpInboundLocked() error {
 
 func (c *conn) feedPendingInputLocked() error {
 	c.sslMu.Lock()
-	if c.state == stateClosed || c.state == stateShuttingDown || c.closed.Load() || c.ssl == nil {
+	if c.state == stateClosed || c.closed.Load() || c.ssl == nil {
 		c.sslMu.Unlock()
 		return net.ErrClosed
 	}
@@ -434,7 +443,7 @@ func (c *conn) feedPendingInputLocked() error {
 		return c.failTLS(err)
 	}
 	if n == 0 {
-		return c.failTLS(io.ErrNoProgress)
+		return io.ErrNoProgress
 	}
 	return nil
 }
@@ -636,13 +645,28 @@ func (c *conn) Read(b []byte) (int, error) {
 				if errors.As(err, &timeoutErr) && timeoutErr.Timeout() {
 					return 0, err
 				}
-				return 0, c.failTLS(err)
+				return 0, c.failTLS(fmt.Errorf("peertls: read ciphertext: %w", err))
 			}
 		case errors.Is(err, shim.ErrWantWrite):
-			if len(out) == 0 {
-				return 0, c.failTLS(io.ErrNoProgress)
+			if c.outMu.TryLock() {
+				flushErr := c.flushOutputLocked()
+				c.outMu.Unlock()
+				if flushErr != nil {
+					return 0, flushErr
+				}
+				continue
 			}
-			continue
+			if err := c.pumpInboundLocked(); err != nil {
+				if errors.Is(err, io.ErrNoProgress) {
+					runtime.Gosched()
+					continue
+				}
+				var timeoutErr net.Error
+				if errors.As(err, &timeoutErr) && timeoutErr.Timeout() {
+					return 0, err
+				}
+				return 0, c.failTLS(fmt.Errorf("peertls: read ciphertext while write pending: %w", err))
+			}
 		case errors.Is(err, shim.ErrZeroRet):
 			return 0, io.EOF
 		case err == nil:
@@ -654,8 +678,15 @@ func (c *conn) Read(b []byte) (int, error) {
 }
 
 func (c *conn) Write(b []byte) (int, error) {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
 	c.outMu.Lock()
-	defer c.releaseOutputLock()
+	outputLocked := true
+	defer func() {
+		if outputLocked {
+			c.releaseOutputLock()
+		}
+	}()
 	if err := c.operationStatus(); err != nil {
 		return 0, err
 	}
@@ -693,12 +724,26 @@ func (c *conn) Write(b []byte) (int, error) {
 		}
 		switch {
 		case errors.Is(err, shim.ErrWantWrite):
-			if n == 0 && len(out) == 0 {
-				return written, c.failTLS(io.ErrNoProgress)
-			}
 			continue
 		case errors.Is(err, shim.ErrWantRead):
-			return written, c.failTLS(errors.New("peertls: unexpected WANT_READ from SSL_write"))
+			c.releaseOutputLock()
+			outputLocked = false
+			c.inMu.Lock()
+			pumpErr := c.pumpInboundLocked()
+			c.inMu.Unlock()
+			c.outMu.Lock()
+			outputLocked = true
+			if pumpErr != nil {
+				var timeoutErr net.Error
+				if errors.As(pumpErr, &timeoutErr) && timeoutErr.Timeout() {
+					return written, pumpErr
+				}
+				return written, c.failTLS(pumpErr)
+			}
+			if flushErr := c.flushOutputLocked(); flushErr != nil {
+				return written, flushErr
+			}
+			continue
 		default:
 			return written, c.failTLS(err)
 		}
@@ -714,6 +759,8 @@ func (c *conn) ShutdownContext(ctx context.Context) (retErr error) {
 		_ = c.Close()
 		close(lockWaitDone)
 	})
+	c.inMu.Lock()
+	defer c.inMu.Unlock()
 	c.outMu.Lock()
 	defer c.releaseOutputLock()
 	defer func() {
@@ -762,9 +809,15 @@ func (c *conn) ShutdownContext(ctx context.Context) (retErr error) {
 			err = flushErr
 			break
 		}
-		if err == nil || errors.Is(err, shim.ErrWantRead) {
+		if err == nil {
 			err = nil
 			break
+		}
+		if errors.Is(err, shim.ErrWantRead) {
+			if err = c.pumpInboundLocked(); err != nil {
+				break
+			}
+			continue
 		}
 		if errors.Is(err, shim.ErrWantWrite) && len(out) == 0 {
 			err = io.ErrNoProgress

--- a/internal/peermanagement/peertls/tls_openssl.go
+++ b/internal/peermanagement/peertls/tls_openssl.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -198,10 +199,12 @@ func (l *listener) Addr() net.Addr { return l.inner.Addr() }
 
 // Locks:
 //   - sslMu owns the engine, TLS state, and terminal TLS error.
+//   - readMu serializes complete application Read calls.
 //   - inMu owns raw reads, pendingIn, and pendingReadErr.
 //   - writeMu serializes complete application Write calls.
 //   - outMu owns raw writes, pendingOut, and outputErr.
 //   - queuedOutMu owns TLS records waiting for the raw writer.
+//   - deadlineMu owns logical deadlines and cross-direction deadline state.
 //
 // No lock is held across raw I/O except its directional lock. Close closes the
 // raw connection before taking sslMu so blocked operations are interrupted.
@@ -213,21 +216,50 @@ type conn struct {
 	state       connState
 	terminalErr error
 
-	inMu           sync.Mutex
+	readMu         sync.Mutex
+	inMu           operationMutex
 	pendingIn      []byte
 	pendingReadErr error
+	inputVersion   atomic.Uint64
 
 	writeMu    sync.Mutex
-	outMu      sync.Mutex
+	outMu      operationMutex
 	pendingOut []byte
 	outputErr  error
 
 	queuedOutMu sync.Mutex
 	queuedOut   []byte
 
+	deadlineMu      sync.Mutex
+	readDeadline    time.Time
+	writeDeadline   time.Time
+	deadlineChanged chan struct{}
+	writeReading    bool
+	readWriting     bool
+
 	closed    atomic.Bool
 	closeOnce sync.Once
 	closeErr  error
+}
+
+type operationMutex chan struct{}
+
+func newOperationMutex() operationMutex {
+	m := make(operationMutex, 1)
+	m <- struct{}{}
+	return m
+}
+
+func (m operationMutex) Lock()   { <-m }
+func (m operationMutex) Unlock() { m <- struct{}{} }
+
+func (m operationMutex) TryLock() bool {
+	select {
+	case <-m:
+		return true
+	default:
+		return false
+	}
 }
 
 func newConn(inner net.Conn, cfg *Config, isServer bool) (*conn, error) {
@@ -247,7 +279,14 @@ func newConn(inner net.Conn, cfg *Config, isServer bool) (*conn, error) {
 }
 
 func newConnWithEngine(inner net.Conn, ssl tlsEngine) *conn {
-	return &conn{inner: inner, ssl: ssl, state: stateNew}
+	return &conn{
+		inner:           inner,
+		ssl:             ssl,
+		state:           stateNew,
+		inMu:            newOperationMutex(),
+		outMu:           newOperationMutex(),
+		deadlineChanged: make(chan struct{}),
+	}
 }
 
 // HandshakeContext performs the TLS handshake. A successful handshake is
@@ -392,7 +431,7 @@ func (c *conn) installContextDeadline(ctx context.Context) (func() error, error)
 		}
 		// net.Conn exposes no deadline getter. A context deadline necessarily
 		// overwrites any prior deadline and is cleared after this operation.
-		return c.inner.SetDeadline(time.Time{})
+		return c.SetDeadline(time.Time{})
 	}, nil
 }
 
@@ -438,6 +477,7 @@ func (c *conn) feedPendingInputLocked() error {
 	}
 	if n > 0 {
 		c.pendingIn = c.pendingIn[n:]
+		c.inputVersion.Add(1)
 	}
 	if err != nil {
 		return c.failTLS(err)
@@ -597,9 +637,133 @@ func (c *conn) operationStatusLocked() error {
 	return nil
 }
 
-func (c *conn) Read(b []byte) (int, error) {
-	c.inMu.Lock()
+func (c *conn) lockDirection(m operationMutex, forWrite bool) error {
+	for {
+		c.deadlineMu.Lock()
+		deadline := c.readDeadline
+		if forWrite {
+			deadline = c.writeDeadline
+		}
+		changed := c.deadlineChanged
+		c.deadlineMu.Unlock()
+
+		if deadline.IsZero() {
+			select {
+			case <-m:
+				return nil
+			case <-changed:
+				continue
+			}
+		}
+
+		wait := time.Until(deadline)
+		if wait <= 0 {
+			return os.ErrDeadlineExceeded
+		}
+		timer := time.NewTimer(wait)
+		select {
+		case <-m:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return nil
+		case <-changed:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+		case <-timer.C:
+			select {
+			case <-changed:
+				continue
+			default:
+				return os.ErrDeadlineExceeded
+			}
+		}
+	}
+}
+
+func (c *conn) lockInputForRead() error  { return c.lockDirection(c.inMu, false) }
+func (c *conn) lockInputForWrite() error { return c.lockDirection(c.inMu, true) }
+func (c *conn) lockOutputForWrite() error {
+	return c.lockDirection(c.outMu, true)
+}
+
+func (c *conn) pumpInboundForRead() error {
+	if err := c.lockInputForRead(); err != nil {
+		return err
+	}
 	defer c.inMu.Unlock()
+	return c.pumpInboundLocked()
+}
+
+func (c *conn) beginWriteRead() error {
+	c.deadlineMu.Lock()
+	defer c.deadlineMu.Unlock()
+	c.writeReading = true
+	return c.inner.SetReadDeadline(c.writeDeadline)
+}
+
+func (c *conn) endWriteRead() error {
+	c.deadlineMu.Lock()
+	defer c.deadlineMu.Unlock()
+	c.writeReading = false
+	return c.inner.SetReadDeadline(c.readDeadline)
+}
+
+func (c *conn) pumpInboundForWrite(inputVersion uint64) error {
+	if err := c.lockInputForWrite(); err != nil {
+		return err
+	}
+	defer c.inMu.Unlock()
+	if c.inputVersion.Load() != inputVersion {
+		return nil
+	}
+	if err := c.beginWriteRead(); err != nil {
+		_ = c.endWriteRead()
+		return err
+	}
+	err := c.pumpInboundLocked()
+	if restoreErr := c.endWriteRead(); err == nil {
+		err = restoreErr
+	}
+	return err
+}
+
+func (c *conn) beginReadWrite() error {
+	c.deadlineMu.Lock()
+	defer c.deadlineMu.Unlock()
+	c.readWriting = true
+	return c.inner.SetWriteDeadline(c.readDeadline)
+}
+
+func (c *conn) endReadWrite() error {
+	c.deadlineMu.Lock()
+	defer c.deadlineMu.Unlock()
+	c.readWriting = false
+	return c.inner.SetWriteDeadline(c.writeDeadline)
+}
+
+func (c *conn) flushReadOutputLocked(drainErr error) error {
+	if err := c.beginReadWrite(); err != nil {
+		_ = c.endReadWrite()
+		return err
+	}
+	err := c.flushStepOutputLocked(drainErr)
+	if restoreErr := c.endReadWrite(); err == nil {
+		err = restoreErr
+	}
+	return err
+}
+
+func (c *conn) Read(b []byte) (int, error) {
+	c.readMu.Lock()
+	defer c.readMu.Unlock()
 	if err := c.operationStatus(); err != nil {
 		return 0, err
 	}
@@ -624,7 +788,7 @@ func (c *conn) Read(b []byte) (int, error) {
 		var flushErr error
 		if len(out) > 0 || drainErr != nil {
 			if c.outMu.TryLock() {
-				flushErr = c.flushStepOutputLocked(drainErr)
+				flushErr = c.flushReadOutputLocked(drainErr)
 				c.outMu.Unlock()
 			} else {
 				if drainErr != nil {
@@ -640,32 +804,34 @@ func (c *conn) Read(b []byte) (int, error) {
 		}
 		switch {
 		case errors.Is(err, shim.ErrWantRead):
-			if err := c.pumpInboundLocked(); err != nil {
+			pumpErr := c.pumpInboundForRead()
+			if pumpErr != nil {
 				var timeoutErr net.Error
-				if errors.As(err, &timeoutErr) && timeoutErr.Timeout() {
-					return 0, err
+				if errors.As(pumpErr, &timeoutErr) && timeoutErr.Timeout() {
+					return 0, pumpErr
 				}
-				return 0, c.failTLS(fmt.Errorf("peertls: read ciphertext: %w", err))
+				return 0, c.failTLS(fmt.Errorf("peertls: read ciphertext: %w", pumpErr))
 			}
 		case errors.Is(err, shim.ErrWantWrite):
 			if c.outMu.TryLock() {
-				flushErr := c.flushOutputLocked()
+				flushErr := c.flushReadOutputLocked(nil)
 				c.outMu.Unlock()
 				if flushErr != nil {
 					return 0, flushErr
 				}
 				continue
 			}
-			if err := c.pumpInboundLocked(); err != nil {
-				if errors.Is(err, io.ErrNoProgress) {
+			pumpErr := c.pumpInboundForRead()
+			if pumpErr != nil {
+				if errors.Is(pumpErr, io.ErrNoProgress) {
 					runtime.Gosched()
 					continue
 				}
 				var timeoutErr net.Error
-				if errors.As(err, &timeoutErr) && timeoutErr.Timeout() {
-					return 0, err
+				if errors.As(pumpErr, &timeoutErr) && timeoutErr.Timeout() {
+					return 0, pumpErr
 				}
-				return 0, c.failTLS(fmt.Errorf("peertls: read ciphertext while write pending: %w", err))
+				return 0, c.failTLS(fmt.Errorf("peertls: read ciphertext while write pending: %w", pumpErr))
 			}
 		case errors.Is(err, shim.ErrZeroRet):
 			return 0, io.EOF
@@ -680,13 +846,16 @@ func (c *conn) Read(b []byte) (int, error) {
 func (c *conn) Write(b []byte) (int, error) {
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
-	c.outMu.Lock()
-	outputLocked := true
+	outputLocked := false
 	defer func() {
 		if outputLocked {
 			c.releaseOutputLock()
 		}
 	}()
+	if err := c.lockOutputForWrite(); err != nil {
+		return 0, err
+	}
+	outputLocked = true
 	if err := c.operationStatus(); err != nil {
 		return 0, err
 	}
@@ -699,6 +868,7 @@ func (c *conn) Write(b []byte) (int, error) {
 
 	written := 0
 	for written < len(b) {
+		inputVersion := c.inputVersion.Load()
 		c.sslMu.Lock()
 		if err := c.operationStatusLocked(); err != nil {
 			c.sslMu.Unlock()
@@ -728,10 +898,10 @@ func (c *conn) Write(b []byte) (int, error) {
 		case errors.Is(err, shim.ErrWantRead):
 			c.releaseOutputLock()
 			outputLocked = false
-			c.inMu.Lock()
-			pumpErr := c.pumpInboundLocked()
-			c.inMu.Unlock()
-			c.outMu.Lock()
+			pumpErr := c.pumpInboundForWrite(inputVersion)
+			if lockErr := c.lockOutputForWrite(); lockErr != nil {
+				return written, lockErr
+			}
 			outputLocked = true
 			if pumpErr != nil {
 				var timeoutErr net.Error
@@ -759,6 +929,10 @@ func (c *conn) ShutdownContext(ctx context.Context) (retErr error) {
 		_ = c.Close()
 		close(lockWaitDone)
 	})
+	c.readMu.Lock()
+	defer c.readMu.Unlock()
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
 	c.inMu.Lock()
 	defer c.inMu.Unlock()
 	c.outMu.Lock()
@@ -859,9 +1033,49 @@ func (c *conn) Close() error {
 func (c *conn) LocalAddr() net.Addr  { return c.inner.LocalAddr() }
 func (c *conn) RemoteAddr() net.Addr { return c.inner.RemoteAddr() }
 
-func (c *conn) SetDeadline(t time.Time) error      { return c.inner.SetDeadline(t) }
-func (c *conn) SetReadDeadline(t time.Time) error  { return c.inner.SetReadDeadline(t) }
-func (c *conn) SetWriteDeadline(t time.Time) error { return c.inner.SetWriteDeadline(t) }
+func (c *conn) notifyDeadlineChangeLocked() {
+	close(c.deadlineChanged)
+	c.deadlineChanged = make(chan struct{})
+}
+
+func (c *conn) SetDeadline(t time.Time) error {
+	c.deadlineMu.Lock()
+	defer c.deadlineMu.Unlock()
+	c.readDeadline = t
+	c.writeDeadline = t
+	c.notifyDeadlineChangeLocked()
+	return c.inner.SetDeadline(t)
+}
+
+func (c *conn) SetReadDeadline(t time.Time) error {
+	c.deadlineMu.Lock()
+	defer c.deadlineMu.Unlock()
+	c.readDeadline = t
+	c.notifyDeadlineChangeLocked()
+	var errs []error
+	if !c.writeReading {
+		errs = append(errs, c.inner.SetReadDeadline(t))
+	}
+	if c.readWriting {
+		errs = append(errs, c.inner.SetWriteDeadline(t))
+	}
+	return errors.Join(errs...)
+}
+
+func (c *conn) SetWriteDeadline(t time.Time) error {
+	c.deadlineMu.Lock()
+	defer c.deadlineMu.Unlock()
+	c.writeDeadline = t
+	c.notifyDeadlineChangeLocked()
+	var errs []error
+	if !c.readWriting {
+		errs = append(errs, c.inner.SetWriteDeadline(t))
+	}
+	if c.writeReading {
+		errs = append(errs, c.inner.SetReadDeadline(t))
+	}
+	return errors.Join(errs...)
+}
 
 func (c *conn) SharedValue() ([]byte, error) {
 	localCopy, peerCopy, err := c.snapshotFinishedLocked()

--- a/internal/peermanagement/peertls/tls_openssl_test.go
+++ b/internal/peermanagement/peertls/tls_openssl_test.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"math/big"
 	"net"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -591,6 +592,42 @@ type scriptedRawConn struct {
 	closed    bool
 }
 
+type readStartedConn struct {
+	net.Conn
+	started chan struct{}
+	once    sync.Once
+}
+
+type writeStartedConn struct {
+	net.Conn
+	started chan struct{}
+	once    sync.Once
+}
+
+func (c *writeStartedConn) Write(p []byte) (int, error) {
+	c.once.Do(func() { close(c.started) })
+	return c.Conn.Write(p)
+}
+
+func (c *readStartedConn) Read(p []byte) (int, error) {
+	c.once.Do(func() { close(c.started) })
+	return c.Conn.Read(p)
+}
+
+type writeWantReadEngine struct {
+	scriptedEngine
+	started chan struct{}
+	once    sync.Once
+}
+
+func (e *writeWantReadEngine) Write(p []byte) (int, error) {
+	n, err := e.scriptedEngine.Write(p)
+	if errors.Is(err, shim.ErrWantRead) {
+		e.once.Do(func() { close(e.started) })
+	}
+	return n, err
+}
+
 func (c *scriptedRawConn) Read(p []byte) (int, error) {
 	if len(c.reads) == 0 {
 		return 0, io.EOF
@@ -804,6 +841,170 @@ func TestOutputFlushIsLosslessAndAccountsPlaintext(t *testing.T) {
 	})
 	if n, err := c.Write([]byte("x")); n != 1 || !errors.Is(err, io.ErrNoProgress) {
 		t.Fatalf("zero raw-write progress = (%d, %v)", n, err)
+	}
+}
+
+func TestCrossDirectionIOHonorsOperationDeadline(t *testing.T) {
+	t.Run("write waiting for read", func(t *testing.T) {
+		raw, peer := net.Pipe()
+		defer peer.Close()
+		c := readyScriptedConn(raw, &scriptedEngine{
+			writes: []engineResult{{err: shim.ErrWantRead}},
+		})
+		defer c.Close()
+		requireDeadline(t, c.SetWriteDeadline(time.Now().Add(25*time.Millisecond)))
+
+		n, err := c.Write([]byte("x"))
+		if n != 0 || !errors.Is(err, os.ErrDeadlineExceeded) {
+			t.Fatalf("Write = (%d, %v), want deadline exceeded", n, err)
+		}
+	})
+
+	t.Run("read waiting for write", func(t *testing.T) {
+		raw, peer := net.Pipe()
+		defer peer.Close()
+		c := readyScriptedConn(raw, &scriptedEngine{
+			reads: []engineResult{{err: shim.ErrWantWrite, out: []byte("control")}},
+		})
+		defer c.Close()
+		requireDeadline(t, c.SetReadDeadline(time.Now().Add(25*time.Millisecond)))
+
+		n, err := c.Read(make([]byte, 1))
+		if n != 0 || !errors.Is(err, os.ErrDeadlineExceeded) {
+			t.Fatalf("Read = (%d, %v), want deadline exceeded", n, err)
+		}
+	})
+
+	t.Run("read waiting for input owner", func(t *testing.T) {
+		rawConn, peer := net.Pipe()
+		defer peer.Close()
+		raw := &readStartedConn{Conn: rawConn, started: make(chan struct{})}
+		c := readyScriptedConn(raw, &scriptedEngine{
+			reads:  []engineResult{{err: shim.ErrWantRead}},
+			writes: []engineResult{{err: shim.ErrWantRead}},
+		})
+		defer c.Close()
+		requireDeadline(t, c.SetWriteDeadline(time.Now().Add(time.Second)))
+
+		writeDone := make(chan error, 1)
+		go func() {
+			_, err := c.Write([]byte("x"))
+			writeDone <- err
+		}()
+		select {
+		case <-raw.started:
+		case <-time.After(time.Second):
+			t.Fatal("Write did not start cross-direction input")
+		}
+		requireDeadline(t, c.SetReadDeadline(time.Now().Add(25*time.Millisecond)))
+
+		n, err := c.Read(make([]byte, 1))
+		if n != 0 || !errors.Is(err, os.ErrDeadlineExceeded) {
+			t.Fatalf("Read = (%d, %v), want deadline exceeded", n, err)
+		}
+		_ = c.Close()
+		select {
+		case <-writeDone:
+		case <-time.After(time.Second):
+			t.Fatal("Write did not unblock after Close")
+		}
+	})
+
+	t.Run("write waiting for output owner", func(t *testing.T) {
+		rawConn, peer := net.Pipe()
+		defer peer.Close()
+		raw := &writeStartedConn{Conn: rawConn, started: make(chan struct{})}
+		c := readyScriptedConn(raw, &scriptedEngine{
+			reads:  []engineResult{{err: shim.ErrWantWrite, out: []byte("control")}},
+			writes: []engineResult{{n: 1}},
+		})
+		defer c.Close()
+		requireDeadline(t, c.SetReadDeadline(time.Now().Add(time.Second)))
+
+		readDone := make(chan error, 1)
+		go func() {
+			_, err := c.Read(make([]byte, 1))
+			readDone <- err
+		}()
+		select {
+		case <-raw.started:
+		case <-time.After(time.Second):
+			t.Fatal("Read did not start cross-direction output")
+		}
+		requireDeadline(t, c.SetWriteDeadline(time.Now().Add(25*time.Millisecond)))
+
+		n, err := c.Write([]byte("x"))
+		if n != 0 || !errors.Is(err, os.ErrDeadlineExceeded) {
+			t.Fatalf("Write = (%d, %v), want deadline exceeded", n, err)
+		}
+		_ = c.Close()
+		select {
+		case <-readDone:
+		case <-time.After(time.Second):
+			t.Fatal("Read did not unblock after Close")
+		}
+	})
+}
+
+func TestWriteWantReadProgressesWithBlockedApplicationRead(t *testing.T) {
+	rawConn, peer := net.Pipe()
+	defer peer.Close()
+	raw := &readStartedConn{Conn: rawConn, started: make(chan struct{})}
+	engine := &writeWantReadEngine{
+		scriptedEngine: scriptedEngine{
+			reads:  []engineResult{{err: shim.ErrWantRead}, {err: shim.ErrWantRead}},
+			writes: []engineResult{{err: shim.ErrWantRead}, {n: 1}},
+		},
+		started: make(chan struct{}),
+	}
+	c := readyScriptedConn(raw, engine)
+	defer c.Close()
+	requireDeadline(t, c.SetWriteDeadline(time.Now().Add(time.Second)))
+
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := c.Read(make([]byte, 1))
+		readDone <- err
+	}()
+	select {
+	case <-raw.started:
+	case <-time.After(time.Second):
+		t.Fatal("Read did not start raw input")
+	}
+
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := c.Write([]byte("x"))
+		writeDone <- err
+	}()
+	select {
+	case <-engine.started:
+	case <-time.After(time.Second):
+		t.Fatal("Write did not request TLS input")
+	}
+	if _, err := peer.Write([]byte("control")); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-writeDone:
+		if err != nil {
+			t.Fatalf("Write error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Write remained blocked after control-only input")
+	}
+	_ = c.Close()
+	select {
+	case <-readDone:
+	case <-time.After(time.Second):
+		t.Fatal("Read did not unblock after Close")
+	}
+}
+
+func requireDeadline(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("set deadline: %v", err)
 	}
 }
 
@@ -1052,6 +1253,17 @@ type shutdownBarrierEngine struct {
 	once    sync.Once
 }
 
+type shutdownSignalEngine struct {
+	scriptedEngine
+	started chan struct{}
+	once    sync.Once
+}
+
+func (e *shutdownSignalEngine) Shutdown() error {
+	e.once.Do(func() { close(e.started) })
+	return nil
+}
+
 func (e *shutdownBarrierEngine) Shutdown() error {
 	e.once.Do(func() { close(e.started) })
 	<-e.release
@@ -1083,6 +1295,30 @@ func TestShutdownContextConcurrentClose(t *testing.T) {
 	}
 	if !engine.freed || c.ssl != nil {
 		t.Fatalf("TLS engine not freed: freed=%v, ssl=%v", engine.freed, c.ssl)
+	}
+}
+
+func TestShutdownContextWaitsForActiveWrite(t *testing.T) {
+	engine := &shutdownSignalEngine{started: make(chan struct{})}
+	c := readyScriptedConn(&scriptedRawConn{}, engine)
+	c.writeMu.Lock()
+
+	done := make(chan error, 1)
+	go func() { done <- c.ShutdownContext(context.Background()) }()
+	select {
+	case <-engine.started:
+		t.Fatal("shutdown entered TLS while a Write was active")
+	case <-time.After(20 * time.Millisecond):
+	}
+	c.writeMu.Unlock()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not proceed after Write completed")
 	}
 }
 

--- a/internal/peermanagement/peertls/tls_openssl_test.go
+++ b/internal/peermanagement/peertls/tls_openssl_test.go
@@ -12,6 +12,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io"
 	"math/big"
 	"net"
@@ -55,7 +56,33 @@ func newTestConnPair(t testing.TB) (PeerConn, PeerConn) {
 	t.Helper()
 	clientCert, clientKey := generateTestCert(t)
 	serverCert, serverKey := generateTestCert(t)
-	clientWire, serverWire := net.Pipe()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	acceptResult := make(chan struct {
+		conn net.Conn
+		err  error
+	}, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		acceptResult <- struct {
+			conn net.Conn
+			err  error
+		}{conn: conn, err: acceptErr}
+	}()
+	clientWire, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		_ = listener.Close()
+		t.Fatalf("Dial: %v", err)
+	}
+	accepted := <-acceptResult
+	_ = listener.Close()
+	if accepted.err != nil {
+		_ = clientWire.Close()
+		t.Fatalf("Accept: %v", accepted.err)
+	}
+	serverWire := accepted.conn
 
 	clientConn, err := Client(clientWire, &Config{CertPEM: clientCert, KeyPEM: clientKey})
 	if err != nil {
@@ -100,7 +127,11 @@ func TestHandshake_SessionSigRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Listen: %v", err)
 	}
-	serverConfig := &Config{CertPEM: serverCert, KeyPEM: serverKey}
+	serverConfig := &Config{
+		CertPEM:    serverCert,
+		KeyPEM:     serverKey,
+		CipherList: "TLSv1.2:!CBC:!DSS:!PSK:!eNULL:!aNULL",
+	}
 	wrapped, err := NewListener(ln, serverConfig)
 	if err != nil {
 		_ = ln.Close()
@@ -109,6 +140,7 @@ func TestHandshake_SessionSigRoundTrip(t *testing.T) {
 	defer wrapped.Close()
 	serverConfig.CertPEM = []byte("mutated")
 	serverConfig.KeyPEM = []byte("mutated")
+	serverConfig.CipherList = "not-a-real-cipher"
 
 	dialer := &net.Dialer{Timeout: 2 * time.Second}
 	tcpClient, err := dialer.Dial("tcp", ln.Addr().String())
@@ -361,12 +393,18 @@ func TestHandshake_LargeConcurrentRoundTrip(t *testing.T) {
 		if err == nil && n != len(clientPayload) {
 			err = io.ErrShortWrite
 		}
+		if err != nil {
+			err = fmt.Errorf("client Write: %w", err)
+		}
 		errCh <- err
 	}()
 	go func() {
 		n, err := serverConn.Write(serverPayload)
 		if err == nil && n != len(serverPayload) {
 			err = io.ErrShortWrite
+		}
+		if err != nil {
+			err = fmt.Errorf("server Write: %w", err)
 		}
 		errCh <- err
 	}()
@@ -376,6 +414,9 @@ func TestHandshake_LargeConcurrentRoundTrip(t *testing.T) {
 		if err == nil && !bytes.Equal(got, serverPayload) {
 			err = errors.New("client received corrupted payload")
 		}
+		if err != nil {
+			err = fmt.Errorf("client Read: %w", err)
+		}
 		errCh <- err
 	}()
 	go func() {
@@ -384,13 +425,20 @@ func TestHandshake_LargeConcurrentRoundTrip(t *testing.T) {
 		if err == nil && !bytes.Equal(got, clientPayload) {
 			err = errors.New("server received corrupted payload")
 		}
+		if err != nil {
+			err = fmt.Errorf("server Read: %w", err)
+		}
 		errCh <- err
 	}()
 
+	var operationErrors []error
 	for range 4 {
 		if err := <-errCh; err != nil {
-			t.Fatal(err)
+			operationErrors = append(operationErrors, err)
 		}
+	}
+	for _, err := range operationErrors {
+		t.Error(err)
 	}
 }
 
@@ -706,6 +754,15 @@ func TestOutputFlushIsLosslessAndAccountsPlaintext(t *testing.T) {
 	}
 
 	raw = &scriptedRawConn{}
+	c = readyScriptedConn(raw, &scriptedEngine{reads: []engineResult{
+		{err: shim.ErrWantWrite, out: []byte("write-progress")}, {n: 1},
+	}})
+	if n, err := c.Read(make([]byte, 1)); n != 1 || err != nil ||
+		!bytes.Equal(raw.written, []byte("write-progress")) {
+		t.Fatalf("Read progressing pending Write = (%d, %v), output=%q", n, err, raw.written)
+	}
+
+	raw = &scriptedRawConn{}
 	c = readyScriptedConn(raw, &scriptedEngine{writes: []engineResult{
 		{err: shim.ErrWantWrite, out: []byte("flight")},
 		{n: 1, out: []byte("record")},
@@ -720,6 +777,26 @@ func TestOutputFlushIsLosslessAndAccountsPlaintext(t *testing.T) {
 	})
 	if _, err := c.Write([]byte("x")); !errors.Is(err, io.ErrNoProgress) {
 		t.Fatalf("zero-progress WANT_WRITE error = %v", err)
+	}
+
+	raw = &scriptedRawConn{reads: []rawRead{{data: []byte("peer-control")}}}
+	engine := &scriptedEngine{writes: []engineResult{{err: shim.ErrWantRead}, {n: 1}}}
+	c = readyScriptedConn(raw, engine)
+	if n, err := c.Write([]byte("x")); n != 1 || err != nil ||
+		!bytes.Equal(engine.in, []byte("peer-control")) {
+		t.Fatalf("WANT_READ Write = (%d, %v), input=%q", n, err, engine.in)
+	}
+
+	timeoutErr := refreshableTimeoutError{}
+	raw = &scriptedRawConn{reads: []rawRead{{err: timeoutErr}}}
+	c = readyScriptedConn(raw, &scriptedEngine{writes: []engineResult{
+		{err: shim.ErrWantRead}, {n: 1},
+	}})
+	if n, err := c.Write([]byte("x")); n != 0 || !errors.As(err, &timeoutErr) {
+		t.Fatalf("WANT_READ Write timeout = (%d, %v)", n, err)
+	}
+	if n, err := c.Write([]byte("x")); n != 1 || err != nil {
+		t.Fatalf("Write after timeout = (%d, %v)", n, err)
 	}
 
 	c = readyScriptedConn(&scriptedRawConn{writes: []engineResult{{n: 0}}}, &scriptedEngine{
@@ -914,6 +991,12 @@ func TestClosedStateAndConstructorValidation(t *testing.T) {
 		t.Fatalf("NewListener malformed config = %v, closed=%v", err, ln.closed)
 	}
 	ln = &trackingListener{}
+	if _, err := NewListener(ln, &Config{
+		CertPEM: cert, KeyPEM: key, CipherList: "not-a-real-cipher",
+	}); err == nil || ln.closed {
+		t.Fatalf("NewListener invalid cipher config = %v, closed=%v", err, ln.closed)
+	}
+	ln = &trackingListener{}
 	listener, err := NewListener(ln, &Config{CertPEM: cert, KeyPEM: key})
 	if err != nil {
 		t.Fatal(err)
@@ -1013,7 +1096,12 @@ func TestShutdownContextSendsCloseNotify(t *testing.T) {
 		if n, err := server.Read(make([]byte, 1)); n != 0 || !errors.Is(err, io.EOF) {
 			t.Fatalf("peer Read after graceful shutdown = (%d, %v)", n, err)
 		}
+		peerDone := make(chan error, 1)
+		go func() { peerDone <- server.(GracefulConn).ShutdownContext(ctx) }()
 		if err := <-done; err != nil {
+			t.Fatal(err)
+		}
+		if err := <-peerDone; err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -1023,8 +1111,20 @@ func TestShutdownContextSendsCloseNotify(t *testing.T) {
 		if err := client.Close(); err != nil {
 			t.Fatal(err)
 		}
-		if n, err := server.Read(make([]byte, 1)); n != 0 || !errors.Is(err, io.ErrUnexpectedEOF) {
+		if n, err := server.Read(make([]byte, 1)); n != 0 || err == nil || errors.Is(err, io.EOF) {
 			t.Fatalf("peer Read after abrupt close = (%d, %v)", n, err)
 		}
 	})
+}
+
+func TestShutdownContextWaitsForPeerAlert(t *testing.T) {
+	client, _ := newTestConnPair(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err := client.(GracefulConn).ShutdownContext(ctx)
+	var timeout net.Error
+	if !errors.Is(err, context.DeadlineExceeded) &&
+		(!errors.As(err, &timeout) || !timeout.Timeout()) {
+		t.Fatalf("ShutdownContext without peer alert = %v", err)
+	}
 }


### PR DESCRIPTION
## Summary
- make retryable OpenSSL writes use stable C-owned memory with exact retry validation and fail-closed handle semantics
- match rippled's TLS 1.2-or-newer policy, expose the configured cipher list, and keep diagnostics local to each C operation
- harden full-duplex I/O and graceful shutdown while adding direct shim and parent transport regression coverage

## Test plan
- [x] `go test -count=10 ./internal/peermanagement/peertls/shim ./internal/peermanagement/peertls`
- [x] `go test -race ./internal/peermanagement/peertls/shim ./internal/peermanagement/peertls`
- [x] `GOEXPERIMENT=cgocheck2 go test ./internal/peermanagement/peertls/shim ./internal/peermanagement/peertls`
- [x] ASan and UBSan runs for the shim and parent transport packages
- [x] `just vet`, strict `golangci-lint`, `just build-all`, and `just build-nocgo`
- [ ] `go test ./...` — blocked by pre-existing `TestAggregator_ApplyCollection_ExplicitEmptyLocalManifestDoesNotFallback` failure, reproduced on unchanged `origin/main`

Fixes #1476


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable TLS cipher lists for peer connections.
  * Server-level cipher settings are inherited by ports unless overridden.
  * Peer TLS connections now require TLS 1.2 or newer.
* **Bug Fixes**
  * Improved encrypted data transfer, shutdowns, timeouts, and retry handling.
  * Added clearer diagnostics for invalid TLS settings, certificates, keys, and connection failures.
* **Tests**
  * Expanded coverage for cipher configuration, TLS versions, concurrent operations, deadlines, and graceful shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->