### PR TITLE
fix: harden watchdog recovery lifecycle

### DIFF
--- a/config/examples/xrpld.toml
+++ b/config/examples/xrpld.toml
@@ -219,8 +219,8 @@ minimum_last_ledger_buffer = 2
 # in_memory_ledgers  = 256    # tracker eviction window
 
 # Stall watchdog (optional). An out-of-band goroutine that detects a wedged
-# event loop (consensus timer or ledger close) and escalates: warn + goroutine
-# dump, fatal log, then process abort so an orchestrator can restart the node.
+# consensus event loop and escalates: warning, fatal log, then process abort
+# with a bounded goroutine dump so an orchestrator can restart the node.
 # Enabled by default with rippled's 10/90/600s thresholds.
 # [watchdog]
 # disabled = false       # set true to turn the watchdog off entirely

--- a/config/watchdog.go
+++ b/config/watchdog.go
@@ -1,6 +1,9 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // WatchdogConfig represents the [watchdog] section: the out-of-band stall
 // detector that mirrors rippled's LoadManager deadlock detector. The zero value
@@ -25,14 +28,8 @@ func (w *WatchdogConfig) Validate() error {
 	if w.Disabled {
 		return nil
 	}
-	if w.WarnSeconds < 0 || w.FatalSeconds < 0 || w.AbortSeconds < 0 {
-		return fmt.Errorf("threshold seconds must be non-negative")
-	}
-	warn, fatal, abort := w.thresholds()
-	if !(warn < fatal && fatal < abort) {
-		return fmt.Errorf("thresholds must satisfy warn < fatal < abort, got %d < %d < %d", warn, fatal, abort)
-	}
-	return nil
+	_, _, _, err := w.Thresholds()
+	return err
 }
 
 // IsEnabled reports whether the watchdog should be armed.
@@ -44,6 +41,7 @@ const (
 	defaultWatchdogWarnSeconds  = 10
 	defaultWatchdogFatalSeconds = 90
 	defaultWatchdogAbortSeconds = 600
+	maxDurationSeconds          = int64(1<<63-1) / int64(time.Second)
 )
 
 // thresholds resolves the configured overrides against the rippled defaults.
@@ -61,20 +59,45 @@ func (w *WatchdogConfig) thresholds() (warn, fatal, abort int) {
 	return warn, fatal, abort
 }
 
-// WarnSecondsResolved returns the effective warn threshold in seconds.
-func (w *WatchdogConfig) WarnSecondsResolved() int {
-	warn, _, _ := w.thresholds()
-	return warn
-}
-
-// FatalSecondsResolved returns the effective fatal threshold in seconds.
-func (w *WatchdogConfig) FatalSecondsResolved() int {
-	_, fatal, _ := w.thresholds()
-	return fatal
-}
-
-// AbortSecondsResolved returns the effective abort threshold in seconds.
-func (w *WatchdogConfig) AbortSecondsResolved() int {
-	_, _, abort := w.thresholds()
-	return abort
+// Thresholds returns the validated effective watchdog thresholds.
+func (w *WatchdogConfig) Thresholds() (warn, fatal, abort time.Duration, err error) {
+	rawValues := []struct {
+		name    string
+		seconds int
+	}{
+		{name: "warn_seconds", seconds: w.WarnSeconds},
+		{name: "fatal_seconds", seconds: w.FatalSeconds},
+		{name: "abort_seconds", seconds: w.AbortSeconds},
+	}
+	for _, value := range rawValues {
+		if value.seconds < 0 {
+			return 0, 0, 0, fmt.Errorf("%s must be non-negative", value.name)
+		}
+	}
+	warnSeconds, fatalSeconds, abortSeconds := w.thresholds()
+	values := []struct {
+		name    string
+		seconds int
+	}{
+		{name: "warn_seconds", seconds: warnSeconds},
+		{name: "fatal_seconds", seconds: fatalSeconds},
+		{name: "abort_seconds", seconds: abortSeconds},
+	}
+	for _, value := range values {
+		if int64(value.seconds) > maxDurationSeconds {
+			return 0, 0, 0, fmt.Errorf("%s exceeds maximum duration (%d seconds)", value.name, maxDurationSeconds)
+		}
+	}
+	if !(warnSeconds < fatalSeconds && fatalSeconds < abortSeconds) {
+		return 0, 0, 0, fmt.Errorf(
+			"thresholds must satisfy warn < fatal < abort, got %d < %d < %d",
+			warnSeconds,
+			fatalSeconds,
+			abortSeconds,
+		)
+	}
+	return time.Duration(warnSeconds) * time.Second,
+		time.Duration(fatalSeconds) * time.Second,
+		time.Duration(abortSeconds) * time.Second,
+		nil
 }

--- a/config/watchdog_test.go
+++ b/config/watchdog_test.go
@@ -1,84 +1,117 @@
 package config
 
 import (
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
-func TestWatchdogConfig_Defaults(t *testing.T) {
-	var w WatchdogConfig // zero value
-	if !w.IsEnabled() {
-		t.Fatal("zero WatchdogConfig should be enabled")
+func TestWatchdogConfigDefaults(t *testing.T) {
+	var config WatchdogConfig
+	if !config.IsEnabled() {
+		t.Fatal("zero watchdog config should be enabled")
 	}
-	if err := w.Validate(); err != nil {
-		t.Fatalf("zero WatchdogConfig should validate: %v", err)
+	if err := config.Validate(); err != nil {
+		t.Fatalf("zero watchdog config should validate: %v", err)
 	}
-	if w.WarnSecondsResolved() != 10 || w.FatalSecondsResolved() != 90 || w.AbortSecondsResolved() != 600 {
-		t.Fatalf("unexpected defaults: %d/%d/%d",
-			w.WarnSecondsResolved(), w.FatalSecondsResolved(), w.AbortSecondsResolved())
+	warn, fatal, abort, err := config.Thresholds()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if warn != 10*time.Second || fatal != 90*time.Second || abort != 600*time.Second {
+		t.Fatalf("unexpected defaults: %s/%s/%s", warn, fatal, abort)
 	}
 }
 
-func TestWatchdogConfig_Disabled(t *testing.T) {
-	// A disabled watchdog validates even with otherwise-broken thresholds.
-	w := WatchdogConfig{Disabled: true, WarnSeconds: 99, FatalSeconds: 5}
-	if w.IsEnabled() {
+func TestWatchdogConfigDisabled(t *testing.T) {
+	config := WatchdogConfig{Disabled: true, WarnSeconds: -1, FatalSeconds: 5}
+	if config.IsEnabled() {
 		t.Fatal("disabled watchdog reports enabled")
 	}
-	if err := w.Validate(); err != nil {
-		t.Fatalf("disabled watchdog should validate: %v", err)
+	if err := config.Validate(); err != nil {
+		t.Fatalf("disabled watchdog should ignore thresholds: %v", err)
 	}
 }
 
-func TestWatchdogConfig_Overrides(t *testing.T) {
-	w := WatchdogConfig{WarnSeconds: 2, FatalSeconds: 4, AbortSeconds: 8}
-	if err := w.Validate(); err != nil {
-		t.Fatalf("valid overrides rejected: %v", err)
+func TestWatchdogConfigOverridesAndPartialDefaults(t *testing.T) {
+	tests := []struct {
+		name               string
+		config             WatchdogConfig
+		warn, fatal, abort time.Duration
+	}{
+		{
+			name:   "all overrides",
+			config: WatchdogConfig{WarnSeconds: 2, FatalSeconds: 4, AbortSeconds: 8},
+			warn:   2 * time.Second,
+			fatal:  4 * time.Second,
+			abort:  8 * time.Second,
+		},
+		{
+			name:   "partial override",
+			config: WatchdogConfig{WarnSeconds: 5},
+			warn:   5 * time.Second,
+			fatal:  90 * time.Second,
+			abort:  600 * time.Second,
+		},
 	}
-	if w.WarnSecondsResolved() != 2 || w.FatalSecondsResolved() != 4 || w.AbortSecondsResolved() != 8 {
-		t.Fatalf("overrides not applied")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			warn, fatal, abort, err := test.config.Thresholds()
+			if err != nil {
+				t.Fatalf("thresholds: %v", err)
+			}
+			if warn != test.warn || fatal != test.fatal || abort != test.abort {
+				t.Fatalf("thresholds = %s/%s/%s", warn, fatal, abort)
+			}
+		})
 	}
 }
 
-func TestWatchdogConfig_PartialOverrideUsesDefaults(t *testing.T) {
-	// Only the warn override set; fatal/abort fall back to defaults.
-	w := WatchdogConfig{WarnSeconds: 5}
-	if err := w.Validate(); err != nil {
-		t.Fatalf("partial override rejected: %v", err)
+func TestWatchdogConfigRejectsInvalidThresholds(t *testing.T) {
+	tests := []WatchdogConfig{
+		{WarnSeconds: -1},
+		{WarnSeconds: 90, FatalSeconds: 10, AbortSeconds: 600},
+		{WarnSeconds: 10, FatalSeconds: 600, AbortSeconds: 90},
+		{WarnSeconds: 10, FatalSeconds: 10, AbortSeconds: 600},
 	}
-	if w.WarnSecondsResolved() != 5 || w.FatalSecondsResolved() != 90 || w.AbortSecondsResolved() != 600 {
-		t.Fatalf("partial resolve wrong: %d/%d/%d",
-			w.WarnSecondsResolved(), w.FatalSecondsResolved(), w.AbortSecondsResolved())
-	}
-}
-
-func TestWatchdogConfig_RejectsUnordered(t *testing.T) {
-	cases := []WatchdogConfig{
-		{WarnSeconds: 90, FatalSeconds: 10, AbortSeconds: 600}, // warn > fatal
-		{WarnSeconds: 10, FatalSeconds: 600, AbortSeconds: 90}, // fatal > abort
-		{WarnSeconds: 10, FatalSeconds: 10, AbortSeconds: 600}, // warn == fatal
-	}
-	for i, w := range cases {
-		if err := w.Validate(); err == nil {
-			t.Errorf("case %d: expected ordering error, got nil", i)
+	for index, config := range tests {
+		if err := config.Validate(); err == nil {
+			t.Errorf("case %d: invalid thresholds accepted", index)
 		}
 	}
 }
 
-func TestWatchdogConfig_RejectsNegative(t *testing.T) {
-	w := WatchdogConfig{WarnSeconds: -1}
-	if err := w.Validate(); err == nil {
-		t.Fatal("negative threshold accepted")
+func TestWatchdogConfigDurationBounds(t *testing.T) {
+	if strconv.IntSize < 64 {
+		t.Skip("overflow boundary exceeds 32-bit int")
+	}
+	maximum := int(maxDurationSeconds)
+	valid := WatchdogConfig{
+		WarnSeconds:  maximum - 2,
+		FatalSeconds: maximum - 1,
+		AbortSeconds: maximum,
+	}
+	if _, _, _, err := valid.Thresholds(); err != nil {
+		t.Fatalf("maximum safe thresholds rejected: %v", err)
+	}
+
+	tests := []WatchdogConfig{
+		{WarnSeconds: maximum + 1, FatalSeconds: maximum + 2, AbortSeconds: maximum + 3},
+		{WarnSeconds: 1, FatalSeconds: maximum + 1, AbortSeconds: maximum + 2},
+		{WarnSeconds: 1, FatalSeconds: 2, AbortSeconds: maximum + 1},
+	}
+	for index, config := range tests {
+		if _, _, _, err := config.Thresholds(); err == nil || !strings.Contains(err.Error(), "exceeds maximum duration") {
+			t.Errorf("case %d: overflow error = %v", index, err)
+		}
 	}
 }
 
-func TestValidateConfig_IncludesWatchdog(t *testing.T) {
-	// ValidateConfig joins all section errors; assert the watchdog error is
-	// among them when its thresholds are misordered. Other sections of this
-	// bare config also fail, which is fine — we only check ours is surfaced.
-	cfg := &Config{Watchdog: WatchdogConfig{WarnSeconds: 100, FatalSeconds: 10, AbortSeconds: 600}}
-	err := ValidateConfig(cfg)
+func TestValidateConfigIncludesWatchdog(t *testing.T) {
+	config := &Config{Watchdog: WatchdogConfig{WarnSeconds: 100, FatalSeconds: 10, AbortSeconds: 600}}
+	err := ValidateConfig(config)
 	if err == nil || !strings.Contains(err.Error(), "watchdog:") {
-		t.Fatalf("ValidateConfig did not surface the watchdog error: %v", err)
+		t.Fatalf("ValidateConfig did not surface watchdog error: %v", err)
 	}
 }

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -265,6 +265,14 @@ output = "stdout" # stdout | stderr | /path/to/logfile
 # LedgerConsensus = "debug"
 # NodeStore       = "debug"
 
+# Stall watchdog (optional). Monitors consensus-loop liveness; stack capture is
+# reserved for the abort path.
+# [watchdog]
+# disabled = false
+# warn_seconds = 10
+# fatal_seconds = 90
+# abort_seconds = 600
+
 # =============================================================================
 # Server Configuration
 # =============================================================================

--- a/internal/consensus/rcl/stall_ping_test.go
+++ b/internal/consensus/rcl/stall_ping_test.go
@@ -50,3 +50,57 @@ func TestEngine_StallPingNilIsSafe(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond) // a few ticks; must not panic
 }
+
+func TestEngine_StallPingCanBeClearedWhileRunning(t *testing.T) {
+	adaptor := newMockAdaptor()
+	cfg := DefaultConfig()
+	cfg.Timing.LedgerMinClose = 10 * time.Millisecond
+	engine := NewEngine(adaptor, cfg)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	returned := make(chan struct{})
+	var oldPings atomic.Int64
+	engine.SetStallPing(func() {
+		if oldPings.Add(1) == 1 {
+			close(started)
+			<-release
+			close(returned)
+		}
+	})
+	if err := engine.Start(t.Context()); err != nil {
+		t.Fatalf("start engine: %v", err)
+	}
+	defer func() { _ = engine.Stop() }()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stall ping did not start")
+	}
+	engine.SetStallPing(nil)
+	close(release)
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("in-flight stall ping did not return")
+	}
+
+	replacementPings := make(chan struct{}, 2)
+	engine.SetStallPing(func() {
+		select {
+		case replacementPings <- struct{}{}:
+		default:
+		}
+	})
+	for range 2 {
+		select {
+		case <-replacementPings:
+		case <-time.After(2 * time.Second):
+			t.Fatal("replacement stall ping did not run")
+		}
+	}
+	if oldPings.Load() != 1 {
+		t.Fatalf("cleared stall ping ran %d times", oldPings.Load())
+	}
+}

--- a/internal/node/lifecycle_test.go
+++ b/internal/node/lifecycle_test.go
@@ -419,7 +419,7 @@ func TestNodeRuntimeStopOrder(t *testing.T) {
 	runtime := &nodeRuntime{
 		ctx:    ctx,
 		cancel: cancel,
-		cancelWatchdog: func() {
+		stopWatchdog: func() {
 			order = append(order, "watchdog")
 		},
 		stopSampler: func() {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -498,10 +498,7 @@ type validatorConfigLoader func(config.Paths) (*config.Config, error)
 
 const validatorReloadTimeout = 5 * time.Second
 
-// stallPinger is the optional surface the stall watchdog installs on the
-// consensus engine. Kept off the core consensus.Engine interface so test
-// mocks and alternative engines need not implement it; *rcl.Engine satisfies
-// it. Mirrors the optional-extension pattern of consensus.WireableAdaptor.
+// stallPinger is the heartbeat surface required when the watchdog is enabled.
 type stallPinger interface {
 	SetStallPing(ping func())
 }

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -498,7 +498,6 @@ type validatorConfigLoader func(config.Paths) (*config.Config, error)
 
 const validatorReloadTimeout = 5 * time.Second
 
-// stallPinger is the heartbeat surface required when the watchdog is enabled.
 type stallPinger interface {
 	SetStallPing(ping func())
 }

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -68,7 +68,7 @@ type nodeRuntime struct {
 	retentionFloor func() uint32
 	shutdownCh     chan struct{}
 	stopSampler    func()
-	cancelWatchdog context.CancelFunc
+	stopWatchdog   func()
 }
 
 func newNodeRuntime(
@@ -116,6 +116,7 @@ func (r *nodeRuntime) run() (runErr error) {
 		r.configureLedger,
 		r.configureMaintenance,
 		r.configureConsensus,
+		r.configureWatchdog,
 		r.bindRPC,
 		r.bindStreams,
 		r.bindTransports,
@@ -978,19 +979,38 @@ func (r *nodeRuntime) bindStreams() error {
 		)
 		return nil
 	}))
+	return nil
+}
 
-	if !r.standalone && r.appConfig.Watchdog.IsEnabled() {
-		wdCfg := watchdog.ConfigFromSeconds(
-			r.appConfig.Watchdog.WarnSecondsResolved(),
-			r.appConfig.Watchdog.FatalSecondsResolved(),
-			r.appConfig.Watchdog.AbortSecondsResolved(),
-		)
-		r.watchdog = watchdog.New(wdCfg, nil)
-		if r.consensus != nil {
-			if sp, ok := r.consensus.Engine.(stallPinger); ok {
-				sp.SetStallPing(r.watchdog.Register("consensus"))
-			}
-		}
+func (r *nodeRuntime) configureWatchdog() error {
+	if r.standalone || !r.appConfig.Watchdog.IsEnabled() {
+		return nil
+	}
+	warn, fatal, abort, err := r.appConfig.Watchdog.Thresholds()
+	if err != nil {
+		return fmt.Errorf("configure watchdog: %w", err)
+	}
+	wd, err := watchdog.New(warn, fatal, abort, nil)
+	if err != nil {
+		return fmt.Errorf("configure watchdog: %w", err)
+	}
+	if r.consensus == nil || r.consensus.Engine == nil {
+		return errors.New("configure watchdog: consensus heartbeat is unavailable")
+	}
+	target, ok := r.consensus.Engine.(stallPinger)
+	if !ok {
+		return fmt.Errorf("configure watchdog: consensus engine %T does not support stall heartbeats", r.consensus.Engine)
+	}
+	registration, err := wd.Register("consensus")
+	if err != nil {
+		return fmt.Errorf("configure watchdog: %w", err)
+	}
+	target.SetStallPing(registration.Ping)
+	r.watchdog = wd
+	r.stopWatchdog = func() {
+		target.SetStallPing(nil)
+		registration.Close()
+		wd.Stop()
 	}
 	return nil
 }
@@ -1044,24 +1064,10 @@ func (r *nodeRuntime) start() error {
 		r.serverLog.Info("gRPC server started", "name", r.transports.grpc.name, "addr", r.transports.grpc.address)
 	}
 
-	// Arm the out-of-band stall watchdog now that the server is up and
-	// servicing its event loops. Mirrors rippled arming activateStallDetector
-	// only at full start, and only outside standalone (ApplicationImp::run:
-	// guarded by !config_->standalone()). Standalone closes ledgers solely on
-	// the ledger_accept RPC, so an idle node produces no heartbeat and would
-	// otherwise self-abort; consensus mode drives a periodic heartbeat. The
-	// watchdog runs on its own goroutine and aborts the process if a monitored
-	// loop wedges, so a deadlocked node screams and can be restarted instead of
-	// going quiet.
 	if r.watchdog != nil {
-		wdCtx, cancelWatchdog := context.WithCancel(ctx)
-		r.cancelWatchdog = cancelWatchdog
-		go r.watchdog.Run(wdCtx)
-		r.serverLog.Info("Stall watchdog armed",
-			"warn_s", r.appConfig.Watchdog.WarnSecondsResolved(),
-			"fatal_s", r.appConfig.Watchdog.FatalSecondsResolved(),
-			"abort_s", r.appConfig.Watchdog.AbortSecondsResolved(),
-		)
+		if err := r.watchdog.Start(ctx); err != nil {
+			return fmt.Errorf("start watchdog: %w", err)
+		}
 	}
 	return nil
 }
@@ -1089,8 +1095,8 @@ func (r *nodeRuntime) wait() error {
 }
 
 func (r *nodeRuntime) stopRuntime() {
-	if r.cancelWatchdog != nil {
-		r.cancelWatchdog()
+	if r.stopWatchdog != nil {
+		r.stopWatchdog()
 	}
 	if r.stopSampler != nil {
 		r.stopSampler()

--- a/internal/node/watchdog_test.go
+++ b/internal/node/watchdog_test.go
@@ -1,0 +1,124 @@
+package node
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/config"
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/consensus/adaptor"
+	"github.com/LeJamon/go-xrpl/internal/consensus/rcl"
+)
+
+type watchdogEngine struct {
+	consensus.Engine
+	mu   sync.Mutex
+	ping func()
+}
+
+func (e *watchdogEngine) SetStallPing(ping func()) {
+	e.mu.Lock()
+	e.ping = ping
+	e.mu.Unlock()
+}
+
+func (e *watchdogEngine) hasPing() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.ping != nil
+}
+
+type engineWithoutWatchdog struct {
+	consensus.Engine
+}
+
+func TestConfigureWatchdogModeGate(t *testing.T) {
+	tests := []struct {
+		name       string
+		standalone bool
+		config     config.WatchdogConfig
+	}{
+		{name: "standalone", standalone: true},
+		{name: "disabled", config: config.WatchdogConfig{Disabled: true}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runtime := &nodeRuntime{
+				appConfig:  &config.Config{Watchdog: test.config},
+				standalone: test.standalone,
+			}
+			if err := runtime.configureWatchdog(); err != nil {
+				t.Fatalf("configure watchdog: %v", err)
+			}
+			if runtime.watchdog != nil || runtime.stopWatchdog != nil {
+				t.Fatal("inert mode configured a watchdog")
+			}
+		})
+	}
+}
+
+func TestConfigureWatchdogFailsClosedWithoutHeartbeat(t *testing.T) {
+	tests := []struct {
+		name      string
+		consensus *adaptor.Components
+		config    config.WatchdogConfig
+	}{
+		{name: "nil components"},
+		{name: "nil engine", consensus: &adaptor.Components{}},
+		{name: "unsupported engine", consensus: &adaptor.Components{Engine: &engineWithoutWatchdog{}}},
+		{
+			name:      "invalid thresholds",
+			consensus: &adaptor.Components{Engine: &watchdogEngine{}},
+			config:    config.WatchdogConfig{WarnSeconds: 100, FatalSeconds: 10, AbortSeconds: 600},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runtime := &nodeRuntime{
+				appConfig: &config.Config{Watchdog: test.config},
+				consensus: test.consensus,
+			}
+			if err := runtime.configureWatchdog(); err == nil {
+				t.Fatal("enabled watchdog accepted missing or invalid heartbeat wiring")
+			}
+			if runtime.watchdog != nil || runtime.stopWatchdog != nil {
+				t.Fatal("failed setup retained a watchdog")
+			}
+		})
+	}
+}
+
+func TestConfigureWatchdogAttachesAndDetachesHeartbeat(t *testing.T) {
+	engine := &watchdogEngine{}
+	runtime := &nodeRuntime{
+		appConfig: &config.Config{},
+		consensus: &adaptor.Components{Engine: engine},
+	}
+	if err := runtime.configureWatchdog(); err != nil {
+		t.Fatalf("configure watchdog: %v", err)
+	}
+	if runtime.watchdog == nil || runtime.stopWatchdog == nil || !engine.hasPing() {
+		t.Fatal("watchdog heartbeat was not fully attached")
+	}
+	if err := runtime.watchdog.Start(t.Context()); err != nil {
+		t.Fatalf("start watchdog: %v", err)
+	}
+	runtime.stopWatchdog()
+	if engine.hasPing() {
+		t.Fatal("watchdog heartbeat remained attached after stop")
+	}
+	if err := runtime.watchdog.Start(t.Context()); err == nil {
+		t.Fatal("closed heartbeat registration allowed a restart")
+	}
+}
+
+func TestConfigureWatchdogAcceptsRCLEngine(t *testing.T) {
+	runtime := &nodeRuntime{
+		appConfig: &config.Config{},
+		consensus: &adaptor.Components{Engine: &rcl.Engine{}},
+	}
+	if err := runtime.configureWatchdog(); err != nil {
+		t.Fatalf("configure watchdog with RCL engine: %v", err)
+	}
+	runtime.stopWatchdog()
+}

--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -84,7 +84,6 @@ func (r *Registration) Close() {
 type scheduleFunc func(time.Duration, func()) func()
 type reportToken byte
 
-// Watchdog owns heartbeat registrations and its monitoring goroutine.
 type Watchdog struct {
 	cfg    thresholds
 	logger *slog.Logger
@@ -288,7 +287,6 @@ func (w *Watchdog) observe() observation {
 	return result
 }
 
-// check performs one detection pass and reports whether terminal recovery began.
 func (w *Watchdog) check() bool {
 	if w.terminal.Load() {
 		return true

--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -1,275 +1,385 @@
-// Package watchdog implements an out-of-band stall detector for the node's
-// long-running event loops.
-//
-// The consensus engine's in-band missedHeartbeats counter (rcl/engine.go)
-// cannot catch a true deadlock: it lives inside the goroutine it watches, so
-// a timerEntry that never returns to its select loop also never increments the
-// counter. This watchdog runs on its own goroutine with its own ticker. Each
-// monitored loop is handed a Pinger and stamps a heartbeat once per iteration;
-// the watchdog measures the gap between now and the most recent heartbeat of
-// every registered loop and escalates as the gap grows.
-//
-// Behaviour mirrors rippled's LoadManager (LoadManager.cpp): warn at >=10s
-// without a heartbeat (repeated every reporting interval), fatal log at
-// >=90s, and process abort at >=600s with a full goroutine dump as the
-// terminal evidence. Like LoadManager, only loop LIVENESS is monitored —
-// never ledger-close progress — so a live node that is behind or resyncing
-// is left to self-heal. The abort path drains the async log queue and fsyncs
-// the stdout/stderr/file descriptors so the final abort record survives
-// os.Exit, which skips deferred Sync hooks. Only the stall-detection half of
-// LoadManager is reproduced here; the local-fee raise/lower half already
-// lives in internal/feetrack.
+// Package watchdog detects stalled node event loops and guarantees terminal
+// recovery when a stall reaches the abort threshold.
 package watchdog
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 )
 
 const (
-	// DefaultWarn is the rippled reportingIntervalSeconds: warn once the
-	// quietest loop has been silent this long, and repeat every interval.
-	DefaultWarn = 10 * time.Second
-
-	// DefaultFatal is the rippled stallFatalLogMessageTimeLimit: escalate the
-	// periodic report from warn to fatal once the stall reaches this long.
-	DefaultFatal = 90 * time.Second
-
-	// DefaultAbort is the rippled stallLogicErrorTimeLimit: the stall-recovery
-	// code is considered to have failed, so abort the process.
-	DefaultAbort = 600 * time.Second
-
-	// tickInterval matches rippled's 1s LoadManager cadence.
-	tickInterval = time.Second
+	tickInterval          = time.Second
+	terminalRecoveryGrace = 5 * time.Second
+	maxStackDumpBytes     = 8 << 20
 )
 
-// Config tunes the watchdog thresholds. The zero value is invalid; use
-// DefaultConfig and override as needed, or build one from config.WatchdogConfig.
-type Config struct {
-	// Warn is the silence threshold at which a warning is logged (and repeated).
-	Warn time.Duration
-	// Fatal is the silence threshold at which the periodic report becomes fatal.
-	Fatal time.Duration
-	// Abort is the silence threshold at which the process is aborted.
-	Abort time.Duration
+var (
+	errNoRegistrations = errors.New("watchdog has no active registrations")
+	errAlreadyStarted  = errors.New("watchdog is already started")
+)
+
+type thresholds struct {
+	warn  time.Duration
+	fatal time.Duration
+	abort time.Duration
 }
 
-// DefaultConfig returns the rippled-matching thresholds.
-func DefaultConfig() Config {
-	return Config{Warn: DefaultWarn, Fatal: DefaultFatal, Abort: DefaultAbort}
+type heartbeat struct {
+	generation     uint64
+	last           time.Time
+	reportedBucket int64
+	fatalReported  bool
 }
 
-// ConfigFromSeconds builds a Config from threshold values expressed in seconds,
-// the form the [watchdog] config section stores. Non-positive values fall back
-// to the rippled defaults via New.
-func ConfigFromSeconds(warn, fatal, abort int) Config {
-	return Config{
-		Warn:  time.Duration(warn) * time.Second,
-		Fatal: time.Duration(fatal) * time.Second,
-		Abort: time.Duration(abort) * time.Second,
+// Registration owns one generation of a named heartbeat.
+type Registration struct {
+	watchdog   *Watchdog
+	loop       string
+	generation uint64
+}
+
+// Ping records progress while this registration still owns the loop name.
+func (r *Registration) Ping() {
+	if r == nil || r.watchdog == nil {
+		return
 	}
+	w := r.watchdog
+	now := w.now()
+	w.mu.Lock()
+	state, ok := w.heartbeats[r.loop]
+	if ok && state.generation == r.generation {
+		if now.After(state.last) {
+			state.last = now
+			state.reportedBucket = 0
+			state.fatalReported = false
+		}
+		w.heartbeats[r.loop] = state
+	}
+	w.mu.Unlock()
 }
 
-// Pinger is the tiny surface a monitored loop holds. Each loop calls Ping once
-// per iteration to record that it is still making progress.
-type Pinger func()
+// Close releases the loop name if this registration still owns it.
+func (r *Registration) Close() {
+	if r == nil || r.watchdog == nil {
+		return
+	}
+	w := r.watchdog
+	w.mu.Lock()
+	if state, ok := w.heartbeats[r.loop]; ok && state.generation == r.generation {
+		delete(w.heartbeats, r.loop)
+	}
+	w.mu.Unlock()
+}
 
-// Watchdog tracks per-loop heartbeats and escalates when a loop goes silent.
-// It is safe for concurrent use: loops Ping from their own goroutines while the
-// Run goroutine reads heartbeats.
+type scheduleFunc func(time.Duration, func()) func()
+
+// Watchdog owns heartbeat registrations and its monitoring goroutine.
 type Watchdog struct {
-	cfg    Config
+	cfg    thresholds
 	logger *slog.Logger
 
-	// now, sync, and exit are injectable so tests can drive a virtual clock and
-	// observe the abort path without terminating the test process. In production
-	// now is time.Now, sync best-effort fsyncs the log descriptors, and exit is
-	// os.Exit(1). sync runs before exit on the abort path.
-	now  func() time.Time
-	sync func()
-	exit func()
+	now           func() time.Time
+	sync          func()
+	exit          func()
+	stack         func([]byte) int
+	stackSink     io.Writer
+	schedule      scheduleFunc
+	terminalGrace time.Duration
+	report        func(observation)
+	reporting     atomic.Bool
 
-	// stack captures all goroutine stacks right before an abort. Injectable so
-	// tests can assert it fires without parsing a real dump.
-	stack func() string
+	mu             sync.Mutex
+	heartbeats     map[string]heartbeat
+	nextGeneration uint64
 
-	// stackSink receives the full goroutine dump verbatim, bypassing the
-	// structured logger whose per-attribute cap truncates a large dump.
-	// Defaults to os.Stderr; tests point it at a buffer.
-	stackSink io.Writer
+	lifecycleMu sync.Mutex
+	cancel      context.CancelFunc
+	done        chan struct{}
 
-	mu         sync.Mutex
-	heartbeats map[string]time.Time
+	terminal  atomic.Bool
+	abortOnce sync.Once
 }
 
-// New builds a Watchdog with the given thresholds and logger. A nil logger
-// falls back to slog.Default. Thresholds that are non-positive are replaced
-// with their defaults so a partially-filled Config still produces a sane
-// watchdog.
-func New(cfg Config, logger *slog.Logger) *Watchdog {
-	if cfg.Warn <= 0 {
-		cfg.Warn = DefaultWarn
+// New constructs a watchdog with validated positive, ordered thresholds.
+func New(warn, fatal, abort time.Duration, logger *slog.Logger) (*Watchdog, error) {
+	if warn <= 0 || fatal <= 0 || abort <= 0 {
+		return nil, fmt.Errorf("watchdog thresholds must be positive")
 	}
-	if cfg.Fatal <= 0 {
-		cfg.Fatal = DefaultFatal
-	}
-	if cfg.Abort <= 0 {
-		cfg.Abort = DefaultAbort
+	if !(warn < fatal && fatal < abort) {
+		return nil, fmt.Errorf("watchdog thresholds must satisfy warn < fatal < abort, got %s < %s < %s", warn, fatal, abort)
 	}
 	if logger == nil {
 		logger = slog.Default()
 	}
 	w := &Watchdog{
-		cfg:        cfg,
-		logger:     logger.With("component", "watchdog"),
-		now:        time.Now,
-		sync:       syncLogDescriptors,
-		stack:      allGoroutineStacks,
-		stackSink:  os.Stderr,
-		heartbeats: make(map[string]time.Time),
+		cfg: thresholds{
+			warn:  warn,
+			fatal: fatal,
+			abort: abort,
+		},
+		logger:        logger.With("component", "watchdog"),
+		now:           time.Now,
+		sync:          syncLogDescriptors,
+		exit:          func() { os.Exit(1) },
+		stack:         allGoroutineStacks,
+		stackSink:     os.Stderr,
+		schedule:      scheduleAfter,
+		terminalGrace: terminalRecoveryGrace,
+		heartbeats:    make(map[string]heartbeat),
 	}
-	// exit terminates the process so an orchestrator can restart the wedged node
-	// — rippled's LogicError abort. sync (called by check before exit) drains the
-	// async log queue and fsyncs the descriptors so the abort record survives
-	// os.Exit, which under async logging would otherwise leave it still queued.
-	w.exit = func() { os.Exit(1) }
-	return w
+	w.report = w.logStallAsync
+	return w, nil
 }
 
-// Register adds a loop and stamps its first heartbeat as now, so a loop that
-// has not yet ticked is treated as healthy until its first expected iteration
-// rather than tripping the moment the watchdog arms. Returns a Pinger bound to
-// that loop. Registering the same name twice returns a fresh Pinger for it.
-func (w *Watchdog) Register(loop string) Pinger {
-	w.mu.Lock()
-	w.heartbeats[loop] = w.now()
-	w.mu.Unlock()
-	return func() { w.ping(loop) }
-}
-
-func (w *Watchdog) ping(loop string) {
-	now := w.now()
-	w.mu.Lock()
-	w.heartbeats[loop] = now
-	w.mu.Unlock()
-}
-
-// stalled returns the loop with the largest silence and that silence duration.
-// A watchdog with no registered loops reports zero stall.
-func (w *Watchdog) stalled() (loop string, silence time.Duration) {
-	now := w.now()
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	for name, last := range w.heartbeats {
-		if d := now.Sub(last); d > silence {
-			silence, loop = d, name
-		}
+// Register replaces any prior generation for loop and returns its new owner.
+func (w *Watchdog) Register(loop string) (*Registration, error) {
+	if loop == "" {
+		return nil, errors.New("watchdog loop name is empty")
 	}
-	return loop, silence
+	w.mu.Lock()
+	now := w.now()
+	w.nextGeneration++
+	if w.nextGeneration == 0 {
+		w.nextGeneration++
+	}
+	generation := w.nextGeneration
+	w.heartbeats[loop] = heartbeat{generation: generation, last: now}
+	w.mu.Unlock()
+	return &Registration{watchdog: w, loop: loop, generation: generation}, nil
 }
 
-// Run drives the detection ticker until ctx is cancelled. It blocks, so callers
-// launch it in its own goroutine. The watchdog must already have its loops
-// registered (and ideally pinged once) before Run arms — mirroring rippled
-// arming activateStallDetector only at full start.
-func (w *Watchdog) Run(ctx context.Context) {
-	w.run(ctx, tickInterval)
+// Start begins monitoring. At least one active registration is required.
+func (w *Watchdog) Start(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("watchdog start context is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("watchdog start context: %w", err)
+	}
+	w.lifecycleMu.Lock()
+	defer w.lifecycleMu.Unlock()
+	if w.done != nil {
+		return errAlreadyStarted
+	}
+	if w.terminal.Load() {
+		return errors.New("watchdog has already entered terminal recovery")
+	}
+	w.mu.Lock()
+	if len(w.heartbeats) == 0 {
+		w.mu.Unlock()
+		return errNoRegistrations
+	}
+	now := w.now()
+	for name, state := range w.heartbeats {
+		state.last = now
+		state.reportedBucket = 0
+		state.fatalReported = false
+		w.heartbeats[name] = state
+	}
+	w.mu.Unlock()
+
+	runCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	w.cancel = cancel
+	w.done = done
+	go func() {
+		defer close(done)
+		w.run(runCtx, tickInterval)
+	}()
+	w.logger.Info("stall watchdog armed",
+		"warn_s", int64(w.cfg.warn/time.Second),
+		"fatal_s", int64(w.cfg.fatal/time.Second),
+		"abort_s", int64(w.cfg.abort/time.Second),
+	)
+	return nil
+}
+
+// Stop cancels monitoring and waits for the goroutine to finish.
+func (w *Watchdog) Stop() {
+	w.lifecycleMu.Lock()
+	cancel, done := w.cancel, w.done
+	if done == nil {
+		w.lifecycleMu.Unlock()
+		return
+	}
+	cancel()
+	w.lifecycleMu.Unlock()
+
+	<-done
+
+	w.lifecycleMu.Lock()
+	if w.done == done {
+		w.cancel = nil
+		w.done = nil
+	}
+	w.lifecycleMu.Unlock()
 }
 
 func (w *Watchdog) run(ctx context.Context, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
-
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			w.check(interval)
+			if w.check() {
+				return
+			}
 		}
 	}
 }
 
-// check performs one detection pass. It reports on each whole reporting-interval
-// boundary (rippled's `timeSpentStalled % reportingIntervalSeconds == 0` gate),
-// escalating from warn to a fatal-level log once the stall reaches Fatal, and
-// aborts once it reaches Abort with a full goroutine dump as the terminal
-// evidence. The dump is deliberately abort-only: runtime.Stack(all) stops the
-// world, which would aggravate a merely-slow node at the 10s warn.
-func (w *Watchdog) check(tick time.Duration) {
-	loop, silence := w.stalled()
-	if silence < w.cfg.Warn {
+type observation struct {
+	loop       string
+	silence    time.Duration
+	shouldLog  bool
+	fatalLevel bool
+}
+
+func (w *Watchdog) observe() observation {
+	now := w.now()
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	var result observation
+	for name, state := range w.heartbeats {
+		silence := now.Sub(state.last)
+		if silence > result.silence || (silence == result.silence && (result.loop == "" || name < result.loop)) {
+			result.loop = name
+			result.silence = silence
+		}
+	}
+	if result.loop == "" || result.silence < w.cfg.warn {
+		return result
+	}
+
+	state := w.heartbeats[result.loop]
+	bucket := int64(result.silence / w.cfg.warn)
+	if bucket > state.reportedBucket {
+		state.reportedBucket = bucket
+		result.shouldLog = true
+	}
+	if result.silence >= w.cfg.fatal {
+		result.fatalLevel = true
+		if !state.fatalReported {
+			state.fatalReported = true
+			result.shouldLog = true
+		}
+	}
+	w.heartbeats[result.loop] = state
+	return result
+}
+
+// check performs one detection pass and reports whether terminal recovery began.
+func (w *Watchdog) check() bool {
+	if w.terminal.Load() {
+		return true
+	}
+	result := w.observe()
+	if result.loop == "" || result.silence < w.cfg.warn {
+		return false
+	}
+	if result.silence >= w.cfg.abort {
+		w.terminal.Store(true)
+		w.abortOnce.Do(func() { w.terminate(result) })
+		return true
+	}
+	if result.shouldLog {
+		w.report(result)
+	}
+	return false
+}
+
+func (w *Watchdog) logStallAsync(result observation) {
+	if !w.reporting.CompareAndSwap(false, true) {
 		return
 	}
-
-	// Fire only when the elapsed-tick count is a whole multiple of the warn
-	// interval, so the report cadence is the warn interval rather than the tick.
-	// When the tick is coarser than the warn interval every pass reports.
-	warnTicks := max(w.cfg.Warn/tick, 1)
-	if (silence/tick)%warnTicks == 0 {
-		secs := int64(silence / time.Second)
-		if silence < w.cfg.Fatal {
-			w.logger.Warn("server loop stalled",
-				"loop", loop, "stalled_s", secs)
-		} else {
-			// slog has no Fatal level; the level=fatal attr is the fatal marker,
-			// matching the log package's canonical "fatal" name (LevelName).
-			w.logger.Error("server loop stalled",
-				"loop", loop, "stalled_s", secs, "level", "fatal")
-		}
-	}
-
-	if silence >= w.cfg.Abort {
-		secs := int64(silence / time.Second)
-		// Straight to the sink, which the logger's attribute cap would
-		// otherwise truncate.
-		w.dumpToSink(loop, secs, w.stack())
-		w.logger.Error("fatal server stall detected — aborting",
-			"loop", loop, "stalled_s", secs)
-		w.sync()
-		w.exit()
-	}
+	go func() {
+		defer w.reporting.Store(false)
+		w.logStall(result)
+	}()
 }
 
-// dumpToSink writes the full goroutine dump verbatim to stackSink, framed by a
-// greppable banner so a post-mortem can locate it.
-func (w *Watchdog) dumpToSink(loop string, secs int64, dump string) {
+func (w *Watchdog) logStall(result observation) {
+	args := []any{"loop", result.loop, "stalled_s", int64(result.silence / time.Second)}
+	if result.fatalLevel {
+		w.logger.Log(context.Background(), xrpllog.LevelFatal, "server loop stalled", args...)
+		return
+	}
+	w.logger.Warn("server loop stalled", args...)
+}
+
+func (w *Watchdog) terminate(result observation) {
+	var exitOnce sync.Once
+	hardExit := func() { exitOnce.Do(w.exit) }
+	stopFallback := w.schedule(w.terminalGrace, hardExit)
+	defer func() {
+		if stopFallback != nil {
+			stopFallback()
+		}
+		hardExit()
+		_ = recover()
+	}()
+
+	if result.shouldLog {
+		w.logStall(result)
+	}
+	seconds := int64(result.silence / time.Second)
+	w.logger.Log(context.Background(), xrpllog.LevelFatal, "fatal server stall detected — aborting",
+		"loop", result.loop,
+		"stalled_s", seconds,
+	)
+
+	buffer := make([]byte, maxStackDumpBytes)
+	n := w.stack(buffer)
+	if n < 0 {
+		n = 0
+	}
+	if n > len(buffer) {
+		n = len(buffer)
+	}
+	w.dumpToSink(result.loop, seconds, buffer[:n], n == len(buffer))
+	w.sync()
+}
+
+func (w *Watchdog) dumpToSink(loop string, seconds int64, dump []byte, truncated bool) {
 	if w.stackSink == nil {
 		return
 	}
-	fmt.Fprintf(w.stackSink,
-		"\n=== watchdog fatal-stall goroutine dump (loop=%s stalled_s=%d) ===\n%s\n=== end watchdog dump ===\n",
-		loop, secs, dump)
+	_, _ = fmt.Fprintf(w.stackSink,
+		"\n=== watchdog fatal-stall goroutine dump (loop=%s stalled_s=%d) ===\n",
+		loop,
+		seconds,
+	)
+	_, _ = w.stackSink.Write(dump)
+	if truncated {
+		_, _ = io.WriteString(w.stackSink, "\n=== watchdog dump truncated ===")
+	}
+	_, _ = io.WriteString(w.stackSink, "\n=== end watchdog dump ===\n")
 }
 
-// syncLogDescriptors best-effort flushes the node's logs so the final abort
-// record survives os.Exit, which does not flush kernel-buffered output.
-// xrpllog.Sync runs first: it drains the async log queue into the destination
-// (and fsyncs a file-backed [logging] output). The stdout/stderr fsyncs then
-// cover the default and "stderr" config outputs. All errors are ignored — the
-// process is aborting regardless.
+func scheduleAfter(delay time.Duration, callback func()) func() {
+	timer := time.AfterFunc(delay, callback)
+	return func() { timer.Stop() }
+}
+
 func syncLogDescriptors() {
 	_ = xrpllog.Sync()
 	_ = os.Stderr.Sync()
 	_ = os.Stdout.Sync()
 }
 
-// allGoroutineStacks returns a dump of every goroutine's stack. The buffer
-// grows until the whole dump fits: runtime.Stack silently truncates to the
-// buffer length, and a wedged node under load can exceed a fixed 1 MiB.
-func allGoroutineStacks() string {
-	for size := 1 << 20; ; size *= 2 {
-		buf := make([]byte, size)
-		if n := runtime.Stack(buf, true); n < size {
-			return string(buf[:n])
-		}
-	}
+func allGoroutineStacks(buffer []byte) int {
+	return runtime.Stack(buffer, true)
 }

--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -82,21 +82,23 @@ func (r *Registration) Close() {
 }
 
 type scheduleFunc func(time.Duration, func()) func()
+type reportToken byte
 
 // Watchdog owns heartbeat registrations and its monitoring goroutine.
 type Watchdog struct {
 	cfg    thresholds
 	logger *slog.Logger
 
-	now           func() time.Time
-	sync          func()
-	exit          func()
-	stack         func([]byte) int
-	stackSink     io.Writer
-	schedule      scheduleFunc
-	terminalGrace time.Duration
-	report        func(observation)
-	reporting     atomic.Bool
+	now            func() time.Time
+	sync           func()
+	exit           func()
+	stack          func([]byte) int
+	stackSink      io.Writer
+	schedule       scheduleFunc
+	terminalGrace  time.Duration
+	report         func(observation)
+	warnReporting  atomic.Pointer[reportToken]
+	fatalReporting atomic.Pointer[reportToken]
 
 	mu             sync.Mutex
 	heartbeats     map[string]heartbeat
@@ -187,6 +189,7 @@ func (w *Watchdog) Start(ctx context.Context) error {
 		w.heartbeats[name] = state
 	}
 	w.mu.Unlock()
+	w.resetReportSlots()
 
 	runCtx, cancel := context.WithCancel(ctx)
 	done := make(chan struct{})
@@ -241,10 +244,11 @@ func (w *Watchdog) run(ctx context.Context, interval time.Duration) {
 }
 
 type observation struct {
-	loop       string
-	silence    time.Duration
-	shouldLog  bool
-	fatalLevel bool
+	loop          string
+	silence       time.Duration
+	shouldLog     bool
+	fatalLevel    bool
+	terminalOwner bool
 }
 
 func (w *Watchdog) observe() observation {
@@ -277,6 +281,9 @@ func (w *Watchdog) observe() observation {
 			result.shouldLog = true
 		}
 	}
+	if result.silence >= w.cfg.abort {
+		result.terminalOwner = w.terminal.CompareAndSwap(false, true)
+	}
 	w.heartbeats[result.loop] = state
 	return result
 }
@@ -287,13 +294,14 @@ func (w *Watchdog) check() bool {
 		return true
 	}
 	result := w.observe()
+	if w.terminal.Load() {
+		if result.terminalOwner {
+			w.abortOnce.Do(func() { w.terminate(result) })
+		}
+		return true
+	}
 	if result.loop == "" || result.silence < w.cfg.warn {
 		return false
-	}
-	if result.silence >= w.cfg.abort {
-		w.terminal.Store(true)
-		w.abortOnce.Do(func() { w.terminate(result) })
-		return true
 	}
 	if result.shouldLog {
 		w.report(result)
@@ -302,13 +310,23 @@ func (w *Watchdog) check() bool {
 }
 
 func (w *Watchdog) logStallAsync(result observation) {
-	if !w.reporting.CompareAndSwap(false, true) {
+	reporting := &w.warnReporting
+	if result.fatalLevel {
+		reporting = &w.fatalReporting
+	}
+	token := new(reportToken)
+	if !reporting.CompareAndSwap(nil, token) {
 		return
 	}
 	go func() {
-		defer w.reporting.Store(false)
+		defer reporting.CompareAndSwap(token, nil)
 		w.logStall(result)
 	}()
+}
+
+func (w *Watchdog) resetReportSlots() {
+	w.warnReporting.Store(nil)
+	w.fatalReporting.Store(nil)
 }
 
 func (w *Watchdog) logStall(result observation) {

--- a/internal/watchdog/watchdog_test.go
+++ b/internal/watchdog/watchdog_test.go
@@ -3,16 +3,20 @@ package watchdog
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
+	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	xrpllog "github.com/LeJamon/go-xrpl/log"
 )
 
-// fakeClock is a manually-advanced clock for deterministic stall tests.
 type fakeClock struct {
 	mu sync.Mutex
 	t  time.Time
@@ -28,269 +32,683 @@ func (c *fakeClock) now() time.Time {
 
 func (c *fakeClock) advance(d time.Duration) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	c.t = c.t.Add(d)
+	c.mu.Unlock()
 }
 
-// newTestWatchdog builds a watchdog with second-scale thresholds, a fake clock,
-// a recording exit func, and a recording stack func, all wired through the same
-// injection points production uses.
+type recordHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *recordHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *recordHandler) Handle(_ context.Context, record slog.Record) error {
+	h.mu.Lock()
+	h.records = append(h.records, record.Clone())
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *recordHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *recordHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *recordHandler) snapshot() []slog.Record {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]slog.Record(nil), h.records...)
+}
+
 func newTestWatchdog(t *testing.T) (*Watchdog, *fakeClock, *bytes.Buffer, *atomic.Int32, *atomic.Int32) {
 	t.Helper()
-	clk := newFakeClock()
-	var logBuf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-
+	clock := newFakeClock()
+	var logBuffer bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	w, err := New(10*time.Second, 90*time.Second, 600*time.Second, logger)
+	if err != nil {
+		t.Fatalf("new watchdog: %v", err)
+	}
 	var exits, stacks atomic.Int32
-	w := New(Config{Warn: 10 * time.Second, Fatal: 90 * time.Second, Abort: 600 * time.Second}, logger)
-	w.now = clk.now
+	w.now = clock.now
 	w.exit = func() { exits.Add(1) }
 	w.sync = func() {}
-	w.stack = func() string { stacks.Add(1); return "STACKDUMP" }
-	// Default the full-dump sink to discard so tests don't spam stderr; tests
-	// that assert on the dump override it with a buffer.
+	w.stack = func(buffer []byte) int {
+		stacks.Add(1)
+		return copy(buffer, "STACKDUMP")
+	}
 	w.stackSink = io.Discard
-	return w, clk, &logBuf, &exits, &stacks
+	w.report = w.logStall
+	return w, clock, &logBuffer, &exits, &stacks
 }
 
-func TestNew_DefaultsFillNonPositiveThresholds(t *testing.T) {
-	w := New(Config{}, nil)
-	if w.cfg.Warn != DefaultWarn || w.cfg.Fatal != DefaultFatal || w.cfg.Abort != DefaultAbort {
-		t.Fatalf("zero Config not defaulted: %+v", w.cfg)
+func mustRegister(t *testing.T, w *Watchdog, loop string) *Registration {
+	t.Helper()
+	registration, err := w.Register(loop)
+	if err != nil {
+		t.Fatalf("register %q: %v", loop, err)
 	}
+	return registration
 }
 
-func TestConfigFromSeconds(t *testing.T) {
-	c := ConfigFromSeconds(5, 30, 120)
-	if c.Warn != 5*time.Second || c.Fatal != 30*time.Second || c.Abort != 120*time.Second {
-		t.Fatalf("unexpected: %+v", c)
+func TestNewValidatesThresholds(t *testing.T) {
+	tests := []struct {
+		name               string
+		warn, fatal, abort time.Duration
+	}{
+		{name: "zero", warn: 0, fatal: time.Second, abort: 2 * time.Second},
+		{name: "negative", warn: -time.Second, fatal: time.Second, abort: 2 * time.Second},
+		{name: "warn equals fatal", warn: time.Second, fatal: time.Second, abort: 2 * time.Second},
+		{name: "fatal after abort", warn: time.Second, fatal: 3 * time.Second, abort: 2 * time.Second},
 	}
-}
-
-// A loop that keeps pinging never trips any threshold.
-func TestWatchdog_HealthyHeartbeatStaysQuiet(t *testing.T) {
-	w, clk, logBuf, exits, stacks := newTestWatchdog(t)
-	ping := w.Register("consensus")
-
-	// Advance well past the abort threshold, but ping every tick.
-	for i := 0; i < 700; i++ {
-		ping()
-		clk.advance(time.Second)
-		w.check(time.Second)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := New(test.warn, test.fatal, test.abort, nil); err == nil {
+				t.Fatal("invalid thresholds accepted")
+			}
+		})
 	}
-	if exits.Load() != 0 {
-		t.Fatalf("healthy loop aborted")
-	}
-	if stacks.Load() != 0 {
-		t.Fatalf("healthy loop dumped stacks")
-	}
-	if bytes.Contains(logBuf.Bytes(), []byte("stalled")) {
-		t.Fatalf("healthy loop logged a stall: %s", logBuf.String())
+	if _, err := New(time.Second, 2*time.Second, 3*time.Second, nil); err != nil {
+		t.Fatalf("valid thresholds rejected: %v", err)
 	}
 }
 
-// An unregistered (empty) watchdog reports no stall.
-func TestWatchdog_NoLoopsNeverTrips(t *testing.T) {
-	w, clk, _, exits, _ := newTestWatchdog(t)
-	for i := 0; i < 700; i++ {
-		clk.advance(time.Second)
-		w.check(time.Second)
-	}
-	if exits.Load() != 0 {
-		t.Fatalf("empty watchdog aborted")
+func TestRegisterRejectsEmptyName(t *testing.T) {
+	w, _, _, _, _ := newTestWatchdog(t)
+	if _, err := w.Register(""); err == nil {
+		t.Fatal("empty loop name accepted")
 	}
 }
 
-// A silent loop escalates warn → fatal → abort at the right thresholds,
-// dumping goroutine stacks exactly once — right before the abort — to the sink.
-func TestWatchdog_StallEscalatesWarnFatalAbort(t *testing.T) {
-	w, clk, logBuf, exits, stacks := newTestWatchdog(t)
+func TestWatchdogHealthyHeartbeatStaysQuiet(t *testing.T) {
+	w, clock, logBuffer, exits, stacks := newTestWatchdog(t)
+	registration := mustRegister(t, w, "consensus")
+	for range 700 {
+		registration.Ping()
+		clock.advance(time.Second)
+		w.check()
+	}
+	if exits.Load() != 0 || stacks.Load() != 0 {
+		t.Fatalf("healthy loop exited %d times and dumped %d stacks", exits.Load(), stacks.Load())
+	}
+	if strings.Contains(logBuffer.String(), "stalled") {
+		t.Fatalf("healthy loop logged a stall: %s", logBuffer.String())
+	}
+}
+
+func TestWatchdogStallEscalatesWarnFatalAbort(t *testing.T) {
+	w, clock, logBuffer, exits, stacks := newTestWatchdog(t)
 	var sink bytes.Buffer
 	w.stackSink = &sink
-	w.Register("ledger") // registered, then never pinged again.
+	mustRegister(t, w, "ledger")
 
 	var firstWarnAt, fatalAt, abortAt int
-	for sec := 1; sec <= 600; sec++ {
-		clk.advance(time.Second)
-		before := logBuf.Len()
-		exitsBefore := exits.Load()
-		w.check(time.Second)
-		line := logBuf.String()[before:]
-
-		if firstWarnAt == 0 && strings.Contains(line, "server loop stalled") &&
-			!strings.Contains(line, "level=fatal") {
-			firstWarnAt = sec
+	for second := 1; second <= 600; second++ {
+		clock.advance(time.Second)
+		before := logBuffer.Len()
+		terminal := w.check()
+		line := logBuffer.String()[before:]
+		if firstWarnAt == 0 && strings.Contains(line, "level=WARN") {
+			firstWarnAt = second
 		}
-		if fatalAt == 0 && strings.Contains(line, "level=fatal") {
-			fatalAt = sec
+		if fatalAt == 0 && strings.Contains(line, "level=ERROR+4") {
+			fatalAt = second
 		}
-		if exits.Load() > exitsBefore {
-			abortAt = sec
+		if terminal {
+			abortAt = second
 			break
 		}
 	}
-
-	if firstWarnAt != 10 {
-		t.Errorf("first warn at %ds, want 10s", firstWarnAt)
+	if firstWarnAt != 10 || fatalAt != 90 || abortAt != 600 {
+		t.Fatalf("escalation = warn %d, fatal %d, abort %d", firstWarnAt, fatalAt, abortAt)
 	}
-	if fatalAt != 90 {
-		t.Errorf("fatal log at %ds, want 90s", fatalAt)
+	if exits.Load() != 1 || stacks.Load() != 1 {
+		t.Fatalf("terminal actions = exits %d, stacks %d", exits.Load(), stacks.Load())
 	}
-	if abortAt != 600 {
-		t.Errorf("abort at %ds, want 600s", abortAt)
-	}
-	// Exactly one dump, at abort only — the warn path must not stop the world.
-	if got := stacks.Load(); got != 1 {
-		t.Errorf("goroutine dump fired %d times, want exactly 1 (abort only)", got)
-	}
-	if !bytes.Contains(sink.Bytes(), []byte("fatal-stall goroutine dump")) {
-		t.Errorf("fatal-stall dump not written to sink")
-	}
-	if !bytes.Contains(sink.Bytes(), []byte("STACKDUMP")) {
-		t.Errorf("sink missing the goroutine dump body")
+	if !strings.Contains(sink.String(), "fatal-stall goroutine dump") || !strings.Contains(sink.String(), "STACKDUMP") {
+		t.Fatalf("missing framed stack dump: %q", sink.String())
 	}
 }
 
-// The abort path flushes the log descriptors before terminating, and does so in
-// that order, so the final fatal record survives os.Exit.
-func TestWatchdog_AbortFlushesBeforeExit(t *testing.T) {
-	w, clk, _, exits, _ := newTestWatchdog(t)
-	w.Register("ledger") // registered, then never pinged again.
+func TestWatchdogUsesRealFatalLevel(t *testing.T) {
+	handler := &recordHandler{}
+	w, err := New(10*time.Second, 90*time.Second, 600*time.Second, slog.New(handler))
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock := newFakeClock()
+	w.now = clock.now
+	w.report = w.logStall
+	w.exit = func() {}
+	w.sync = func() {}
+	w.stack = func([]byte) int { return 0 }
+	w.stackSink = io.Discard
+	mustRegister(t, w, "consensus")
 
-	var seq []string
-	w.sync = func() { seq = append(seq, "sync") }
-	w.exit = func() { seq = append(seq, "exit"); exits.Add(1) }
+	clock.advance(90 * time.Second)
+	w.check()
+	clock.advance(510 * time.Second)
+	w.check()
 
-	for sec := 1; sec <= 600; sec++ {
-		clk.advance(time.Second)
-		w.check(time.Second)
-		if exits.Load() > 0 {
-			break
+	var periodicFatal, terminalFatal bool
+	for _, record := range handler.snapshot() {
+		if record.Level != xrpllog.LevelFatal {
+			continue
+		}
+		switch record.Message {
+		case "server loop stalled":
+			periodicFatal = true
+		case "fatal server stall detected — aborting":
+			terminalFatal = true
 		}
 	}
-
-	if exits.Load() != 1 {
-		t.Fatalf("abort fired %d times, want 1", exits.Load())
-	}
-	if len(seq) != 2 || seq[0] != "sync" || seq[1] != "exit" {
-		t.Fatalf("abort order = %v, want [sync exit]", seq)
+	if !periodicFatal || !terminalFatal {
+		t.Fatalf("fatal records missing: periodic=%v terminal=%v", periodicFatal, terminalFatal)
 	}
 }
 
-// The default (non-injected) sync hook is a real flush that runs without panic,
-// proving the production abort path has a live flush rather than a no-op.
-func TestWatchdog_DefaultSyncIsLive(t *testing.T) {
-	w := New(Config{}, slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
-	if w.sync == nil {
-		t.Fatal("default watchdog has a nil sync hook")
+func TestWatchdogReportsFirstCheckAfterBoundary(t *testing.T) {
+	tests := []struct {
+		name          string
+		steps         []time.Duration
+		wantLevels    []slog.Level
+		wantLogCounts []int
+	}{
+		{
+			name:          "warn 9 to 11",
+			steps:         []time.Duration{9 * time.Second, 2 * time.Second},
+			wantLevels:    []slog.Level{0, slog.LevelWarn},
+			wantLogCounts: []int{0, 1},
+		},
+		{
+			name:          "fatal 89 to 95",
+			steps:         []time.Duration{89 * time.Second, 6 * time.Second},
+			wantLevels:    []slog.Level{slog.LevelWarn, xrpllog.LevelFatal},
+			wantLogCounts: []int{1, 2},
+		},
+		{
+			name:          "multi interval jump",
+			steps:         []time.Duration{95 * time.Second},
+			wantLevels:    []slog.Level{xrpllog.LevelFatal},
+			wantLogCounts: []int{1},
+		},
 	}
-	// Best-effort fsync of stdout/stderr/file; must not panic or block.
-	w.sync()
-}
-
-// The periodic report fires on every warn-interval boundary, not every tick.
-func TestWatchdog_ReportsOnWarnIntervalBoundaries(t *testing.T) {
-	w, clk, logBuf, _, _ := newTestWatchdog(t)
-	w.Register("ledger")
-
-	warnLines := 0
-	for sec := 1; sec <= 80; sec++ {
-		clk.advance(time.Second)
-		before := logBuf.Len()
-		w.check(time.Second)
-		if strings.Contains(logBuf.String()[before:], "server loop stalled") {
-			warnLines++
-		}
-	}
-	// Boundaries at 10,20,30,40,50,60,70,80 → 8 reports.
-	if warnLines != 8 {
-		t.Fatalf("got %d warn reports over 80s, want 8", warnLines)
-	}
-}
-
-// A warn-level stall never dumps stacks: runtime.Stack(all) stops the world,
-// so the dump is reserved for the abort path.
-func TestWatchdog_WarnDoesNotDumpStacks(t *testing.T) {
-	w, clk, _, _, stacks := newTestWatchdog(t)
-	w.Register("ledger")
-
-	// Stall well past warn and fatal, but short of abort.
-	for sec := 1; sec <= 599; sec++ {
-		clk.advance(time.Second)
-		w.check(time.Second)
-	}
-	if stacks.Load() != 0 {
-		t.Fatalf("pre-abort stall dumped stacks %d times, want 0", stacks.Load())
-	}
-}
-
-// The slowest of several registered loops drives the report, and the report
-// names that loop.
-func TestWatchdog_NamesSlowestLoop(t *testing.T) {
-	w, clk, logBuf, _, _ := newTestWatchdog(t)
-	fast := w.Register("consensus")
-	w.Register("ledger") // never pinged → slowest.
-
-	for sec := 1; sec <= 10; sec++ {
-		fast() // keep consensus healthy
-		clk.advance(time.Second)
-		w.check(time.Second)
-	}
-	if !bytes.Contains(logBuf.Bytes(), []byte("loop=ledger")) {
-		t.Fatalf("report did not name the slowest loop: %s", logBuf.String())
-	}
-	if bytes.Contains(logBuf.Bytes(), []byte("loop=consensus")) {
-		t.Fatalf("report named the healthy loop: %s", logBuf.String())
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler := &recordHandler{}
+			w, err := New(10*time.Second, 90*time.Second, 600*time.Second, slog.New(handler))
+			if err != nil {
+				t.Fatal(err)
+			}
+			clock := newFakeClock()
+			w.now = clock.now
+			w.report = w.logStall
+			mustRegister(t, w, "ledger")
+			for index, step := range test.steps {
+				clock.advance(step)
+				w.check()
+				records := handler.snapshot()
+				if len(records) != test.wantLogCounts[index] {
+					t.Fatalf("step %d logged %d records, want %d", index, len(records), test.wantLogCounts[index])
+				}
+				if len(records) > 0 && test.wantLevels[index] != 0 && records[len(records)-1].Level != test.wantLevels[index] {
+					t.Fatalf("step %d level = %v, want %v", index, records[len(records)-1].Level, test.wantLevels[index])
+				}
+			}
+		})
 	}
 }
 
-// Run exits promptly on context cancellation and never aborts a healthy node.
-func TestWatchdog_RunStopsOnContextCancel(t *testing.T) {
-	w, _, _, exits, _ := newTestWatchdog(t)
-	ping := w.Register("ledger")
-	ping()
+func TestWatchdogReportsFatalCrossingBetweenWarnBuckets(t *testing.T) {
+	handler := &recordHandler{}
+	w, err := New(7*time.Second, 10*time.Second, 30*time.Second, slog.New(handler))
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock := newFakeClock()
+	w.now = clock.now
+	w.report = w.logStall
+	mustRegister(t, w, "ledger")
+	clock.advance(7 * time.Second)
+	w.check()
+	clock.advance(3 * time.Second)
+	w.check()
+	records := handler.snapshot()
+	if len(records) != 2 || records[1].Level != xrpllog.LevelFatal {
+		t.Fatalf("records = %+v, want warn then fatal", records)
+	}
+}
 
+func TestWatchdogPingStartsNewReportingEpisode(t *testing.T) {
+	handler := &recordHandler{}
+	w, err := New(10*time.Second, 90*time.Second, 600*time.Second, slog.New(handler))
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock := newFakeClock()
+	w.now = clock.now
+	w.report = w.logStall
+	registration := mustRegister(t, w, "ledger")
+	clock.advance(11 * time.Second)
+	w.check()
+	registration.Ping()
+	clock.advance(9 * time.Second)
+	w.check()
+	clock.advance(2 * time.Second)
+	w.check()
+	if got := len(handler.snapshot()); got != 2 {
+		t.Fatalf("reported %d episodes, want 2", got)
+	}
+}
+
+func TestRegistrationGenerationOwnership(t *testing.T) {
+	w, clock, logBuffer, _, _ := newTestWatchdog(t)
+	old := mustRegister(t, w, "ledger")
+	clock.advance(5 * time.Second)
+	current := mustRegister(t, w, "ledger")
+	clock.advance(5 * time.Second)
+	old.Ping()
+	old.Close()
+	clock.advance(6 * time.Second)
+	w.check()
+	if !strings.Contains(logBuffer.String(), "loop=ledger") {
+		t.Fatal("stale registration masked the current generation")
+	}
+	current.Ping()
+	current.Close()
+	clock.advance(600 * time.Second)
+	if w.check() {
+		t.Fatal("closed registration remained active")
+	}
+}
+
+func TestWatchdogDeterministicTiedStall(t *testing.T) {
+	w, clock, logBuffer, _, _ := newTestWatchdog(t)
+	mustRegister(t, w, "zeta")
+	mustRegister(t, w, "alpha")
+	clock.advance(10 * time.Second)
+	w.check()
+	if !strings.Contains(logBuffer.String(), "loop=alpha") || strings.Contains(logBuffer.String(), "loop=zeta") {
+		t.Fatalf("tied stall selection was not lexical: %s", logBuffer.String())
+	}
+}
+
+func TestWatchdogLifecycle(t *testing.T) {
+	w, _, _, _, _ := newTestWatchdog(t)
+	w.Stop()
+	if err := w.Start(t.Context()); !errors.Is(err, errNoRegistrations) {
+		t.Fatalf("empty start error = %v", err)
+	}
+	mustRegister(t, w, "ledger")
+	if err := w.Start(t.Context()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if err := w.Start(t.Context()); !errors.Is(err, errAlreadyStarted) {
+		t.Fatalf("second start error = %v", err)
+	}
+	w.Stop()
+	w.Stop()
+	if err := w.Start(t.Context()); err != nil {
+		t.Fatalf("restart: %v", err)
+	}
+	w.Stop()
+}
+
+func TestWatchdogStartRejectsCanceledContext(t *testing.T) {
+	w, _, _, _, _ := newTestWatchdog(t)
+	mustRegister(t, w, "ledger")
 	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := w.Start(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("start error = %v, want context canceled", err)
+	}
+	if w.done != nil {
+		t.Fatal("canceled start published lifecycle state")
+	}
+}
+
+func TestWatchdogStartRebasesHeartbeats(t *testing.T) {
+	w, clock, _, _, _ := newTestWatchdog(t)
+	mustRegister(t, w, "ledger")
+	clock.advance(600 * time.Second)
+	if err := w.Start(t.Context()); err != nil {
+		t.Fatalf("start after pre-arm delay: %v", err)
+	}
+	if w.check() {
+		t.Fatal("pre-arm delay counted as a stall")
+	}
+	w.Stop()
+
+	clock.advance(600 * time.Second)
+	if err := w.Start(t.Context()); err != nil {
+		t.Fatalf("restart after stopped interval: %v", err)
+	}
+	if w.check() {
+		t.Fatal("stopped interval counted as a stall")
+	}
+	w.Stop()
+}
+
+func TestWatchdogStartRebaseCannotBeUndoneByDelayedPing(t *testing.T) {
+	w, clock, _, _, _ := newTestWatchdog(t)
+	registration := mustRegister(t, w, "ledger")
+	oldNow := clock.now()
+	pingCaptured := make(chan struct{})
+	releasePing := make(chan struct{})
+	var calls atomic.Int32
+	w.now = func() time.Time {
+		if calls.Add(1) == 1 {
+			close(pingCaptured)
+			<-releasePing
+			return oldNow
+		}
+		return clock.now()
+	}
+	pingDone := make(chan struct{})
+	go func() {
+		registration.Ping()
+		close(pingDone)
+	}()
+	<-pingCaptured
+	clock.advance(600 * time.Second)
+	if err := w.Start(t.Context()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	clock.advance(95 * time.Second)
+	first := w.observe()
+	if !first.shouldLog || !first.fatalLevel || first.silence != 95*time.Second {
+		t.Fatalf("unexpected first observation: %+v", first)
+	}
+	close(releasePing)
+	<-pingDone
+	second := w.observe()
+	if second.shouldLog || !second.fatalLevel || second.silence != 95*time.Second {
+		t.Fatalf("delayed ping changed the active stall episode: %+v", second)
+	}
+	w.Stop()
+}
+
+func TestWatchdogTerminalRecoveryIsSingleShot(t *testing.T) {
+	w, clock, _, exits, stacks := newTestWatchdog(t)
+	mustRegister(t, w, "ledger")
+	clock.advance(600 * time.Second)
+	if !w.check() || !w.check() {
+		t.Fatal("terminal state was not latched")
+	}
+	if exits.Load() != 1 || stacks.Load() != 1 {
+		t.Fatalf("terminal recovery repeated: exits=%d stacks=%d", exits.Load(), stacks.Load())
+	}
+}
+
+func TestWatchdogTerminalDiagnosticPanicStillExits(t *testing.T) {
+	w, clock, _, exits, _ := newTestWatchdog(t)
+	w.stack = func([]byte) int { panic("stack capture failed") }
+	mustRegister(t, w, "ledger")
+	clock.advance(600 * time.Second)
+	if !w.check() {
+		t.Fatal("terminal recovery did not start")
+	}
+	if exits.Load() != 1 {
+		t.Fatalf("exit called %d times", exits.Load())
+	}
+}
+
+type blockingWriter struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (w *blockingWriter) Write(p []byte) (int, error) {
+	w.once.Do(func() { close(w.started) })
+	<-w.release
+	return len(p), nil
+}
+
+type blockingHandler struct {
+	started chan struct{}
+	release chan struct{}
+	blocked atomic.Bool
+}
+
+func (h *blockingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *blockingHandler) Handle(context.Context, slog.Record) error {
+	if h.blocked.CompareAndSwap(false, true) {
+		close(h.started)
+		<-h.release
+	}
+	return nil
+}
+
+func (h *blockingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *blockingHandler) WithGroup(string) slog.Handler      { return h }
+
+type allBlockingHandler struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (h *allBlockingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *allBlockingHandler) Handle(context.Context, slog.Record) error {
+	h.once.Do(func() { close(h.started) })
+	<-h.release
+	return nil
+}
+
+func (h *allBlockingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *allBlockingHandler) WithGroup(string) slog.Handler      { return h }
+
+func TestBlockedWarningLoggerCannotPreventTerminalRecovery(t *testing.T) {
+	w, clock, _, exits, _ := newTestWatchdog(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	w.logger = slog.New(&allBlockingHandler{started: started, release: release})
+	w.report = w.logStallAsync
+	scheduled := make(chan func(), 1)
+	w.schedule = func(_ time.Duration, callback func()) func() {
+		scheduled <- callback
+		return func() {}
+	}
+	mustRegister(t, w, "ledger")
+	clock.advance(10 * time.Second)
+	w.check()
+	<-started
+
+	clock.advance(590 * time.Second)
 	done := make(chan struct{})
 	go func() {
-		w.run(ctx, time.Millisecond)
+		w.check()
 		close(done)
 	}()
-
-	// Let a few real ticks fire; the clock is frozen at the registration time
-	// so silence stays zero and nothing trips.
-	time.Sleep(20 * time.Millisecond)
-	cancel()
-
+	callback := <-scheduled
+	callback()
+	if exits.Load() != 1 {
+		t.Fatalf("fallback exits = %d, want 1", exits.Load())
+	}
+	close(release)
 	select {
 	case <-done:
 	case <-time.After(time.Second):
-		t.Fatal("Run did not return after cancel")
-	}
-	if exits.Load() != 0 {
-		t.Fatalf("healthy run aborted")
+		t.Fatal("terminal recovery did not finish after logger release")
 	}
 }
 
-// SetStallPing-style Register returns a working, concurrency-safe pinger.
-func TestWatchdog_ConcurrentPing(t *testing.T) {
-	w, clk, _, _, _ := newTestWatchdog(t)
-	ping := w.Register("ledger")
+func TestWatchdogTerminalFallbackSurvivesBlockedDiagnostics(t *testing.T) {
+	for _, stage := range []string{"logger", "stack", "sink", "sync"} {
+		t.Run(stage, func(t *testing.T) {
+			w, clock, _, exits, _ := newTestWatchdog(t)
+			started := make(chan struct{})
+			release := make(chan struct{})
+			switch stage {
+			case "logger":
+				w.logger = slog.New(&blockingHandler{started: started, release: release})
+			case "stack":
+				w.stack = func([]byte) int {
+					close(started)
+					<-release
+					return 0
+				}
+			case "sink":
+				w.stackSink = &blockingWriter{started: started, release: release}
+			case "sync":
+				w.sync = func() {
+					close(started)
+					<-release
+				}
+			}
 
-	var wg sync.WaitGroup
-	for i := 0; i < 8; i++ {
-		wg.Add(1)
+			scheduled := make(chan func(), 1)
+			var fallbackCanceled atomic.Bool
+			w.schedule = func(_ time.Duration, callback func()) func() {
+				scheduled <- callback
+				return func() { fallbackCanceled.Store(true) }
+			}
+			mustRegister(t, w, "ledger")
+			clock.advance(600 * time.Second)
+			done := make(chan struct{})
+			go func() {
+				w.check()
+				close(done)
+			}()
+
+			callback := <-scheduled
+			<-started
+			callback()
+			if exits.Load() != 1 {
+				t.Fatalf("fallback exits = %d, want 1", exits.Load())
+			}
+			close(release)
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("terminal check did not finish after diagnostic release")
+			}
+			if !fallbackCanceled.Load() {
+				t.Fatal("fallback timer was not canceled after diagnostics")
+			}
+			if exits.Load() != 1 {
+				t.Fatalf("exit called %d times", exits.Load())
+			}
+		})
+	}
+}
+
+func TestWatchdogStackDumpIsBoundedAndMarked(t *testing.T) {
+	w, clock, _, _, _ := newTestWatchdog(t)
+	var stackBufferSize int
+	w.stack = func(buffer []byte) int {
+		stackBufferSize = len(buffer)
+		for index := range buffer {
+			buffer[index] = 'x'
+		}
+		return len(buffer)
+	}
+	var sink bytes.Buffer
+	w.stackSink = &sink
+	mustRegister(t, w, "ledger")
+	clock.advance(600 * time.Second)
+	w.check()
+	if stackBufferSize != maxStackDumpBytes {
+		t.Fatalf("stack buffer = %d, want %d", stackBufferSize, maxStackDumpBytes)
+	}
+	if !strings.Contains(sink.String(), "watchdog dump truncated") {
+		t.Fatal("truncated dump was not marked")
+	}
+}
+
+func TestWatchdogConcurrentRegistrationPingAndCheck(t *testing.T) {
+	w, _, _, _, _ := newTestWatchdog(t)
+	var current atomic.Pointer[Registration]
+	current.Store(mustRegister(t, w, "ledger"))
+	var group sync.WaitGroup
+	for range 4 {
+		group.Add(1)
 		go func() {
-			defer wg.Done()
-			for j := 0; j < 100; j++ {
-				ping()
+			defer group.Done()
+			for range 200 {
+				current.Load().Ping()
+				w.check()
 			}
 		}()
 	}
-	wg.Wait()
-	// After concurrent pings the loop is at the current (frozen) clock time.
-	clk.advance(5 * time.Second)
-	if _, silence := w.stalled(); silence != 5*time.Second {
-		t.Fatalf("silence = %v, want 5s", silence)
+	group.Add(1)
+	go func() {
+		defer group.Done()
+		for range 100 {
+			next, err := w.Register("ledger")
+			if err != nil {
+				t.Errorf("register: %v", err)
+				return
+			}
+			previous := current.Swap(next)
+			previous.Ping()
+			previous.Close()
+		}
+	}()
+	group.Wait()
+}
+
+func TestWatchdogTerminalFallbackSubprocess(t *testing.T) {
+	mode := os.Getenv("GOXRPL_WATCHDOG_BLOCK_STAGE")
+	if mode != "" {
+		w, err := New(time.Second, 2*time.Second, 3*time.Second, slog.New(slog.NewTextHandler(io.Discard, nil)))
+		if err != nil {
+			os.Exit(2)
+		}
+		clock := newFakeClock()
+		w.now = clock.now
+		w.terminalGrace = 50 * time.Millisecond
+		started := make(chan struct{})
+		switch mode {
+		case "stack":
+			w.stack = func([]byte) int { close(started); select {} }
+		case "sink":
+			w.stack = func([]byte) int { return 0 }
+			w.stackSink = &blockingWriter{started: started, release: make(chan struct{})}
+		case "sync":
+			w.stack = func([]byte) int { return 0 }
+			w.stackSink = io.Discard
+			w.sync = func() { close(started); select {} }
+		case "logger":
+			w.logger = slog.New(&allBlockingHandler{started: started, release: make(chan struct{})})
+		default:
+			os.Exit(2)
+		}
+		if _, err := w.Register("ledger"); err != nil {
+			os.Exit(2)
+		}
+		clock.advance(3 * time.Second)
+		w.check()
+		os.Exit(2)
+	}
+
+	for _, stage := range []string{"logger", "stack", "sink", "sync"} {
+		t.Run(stage, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			command := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestWatchdogTerminalFallbackSubprocess$")
+			command.Env = append(os.Environ(), "GOXRPL_WATCHDOG_BLOCK_STAGE="+stage)
+			err := command.Run()
+			if ctx.Err() != nil {
+				t.Fatalf("child exceeded terminal deadline: %v", ctx.Err())
+			}
+			var exitError *exec.ExitError
+			if !errors.As(err, &exitError) || exitError.ExitCode() != 1 {
+				t.Fatalf("child exit = %v, want status 1", err)
+			}
+		})
+	}
+}
+
+func TestAllGoroutineStacksUsesCallerBound(t *testing.T) {
+	buffer := make([]byte, 1<<20)
+	n := allGoroutineStacks(buffer)
+	if n <= 0 || n > len(buffer) {
+		t.Fatalf("stack length = %d, buffer = %d", n, len(buffer))
+	}
+	if !bytes.Contains(buffer[:n], []byte("goroutine")) {
+		t.Fatal("real stack capture missing goroutine framing")
 	}
 }

--- a/internal/watchdog/watchdog_test.go
+++ b/internal/watchdog/watchdog_test.go
@@ -321,6 +321,21 @@ func TestRegistrationGenerationOwnership(t *testing.T) {
 	}
 }
 
+func TestReplacementBeforeAbortObservationWins(t *testing.T) {
+	w, clock, _, exits, _ := newTestWatchdog(t)
+	mustRegister(t, w, "ledger")
+	clock.advance(600 * time.Second)
+	current := mustRegister(t, w, "ledger")
+
+	if w.check() {
+		t.Fatal("stale generation triggered terminal recovery")
+	}
+	if exits.Load() != 0 {
+		t.Fatalf("exit called %d times", exits.Load())
+	}
+	current.Close()
+}
+
 func TestWatchdogDeterministicTiedStall(t *testing.T) {
 	w, clock, logBuffer, _, _ := newTestWatchdog(t)
 	mustRegister(t, w, "zeta")
@@ -439,6 +454,17 @@ func TestWatchdogTerminalRecoveryIsSingleShot(t *testing.T) {
 	}
 }
 
+func TestAbortObservationClaimsTerminal(t *testing.T) {
+	w, clock, _, _, _ := newTestWatchdog(t)
+	mustRegister(t, w, "ledger")
+	clock.advance(600 * time.Second)
+
+	result := w.observe()
+	if !result.terminalOwner || !w.terminal.Load() {
+		t.Fatalf("abort observation did not claim terminal recovery: %+v", result)
+	}
+}
+
 func TestWatchdogTerminalDiagnosticPanicStillExits(t *testing.T) {
 	w, clock, _, exits, _ := newTestWatchdog(t)
 	w.stack = func([]byte) int { panic("stack capture failed") }
@@ -468,14 +494,18 @@ type blockingHandler struct {
 	started chan struct{}
 	release chan struct{}
 	blocked atomic.Bool
+	records chan slog.Record
 }
 
 func (h *blockingHandler) Enabled(context.Context, slog.Level) bool { return true }
 
-func (h *blockingHandler) Handle(context.Context, slog.Record) error {
+func (h *blockingHandler) Handle(_ context.Context, record slog.Record) error {
 	if h.blocked.CompareAndSwap(false, true) {
 		close(h.started)
 		<-h.release
+	}
+	if h.records != nil {
+		h.records <- record.Clone()
 	}
 	return nil
 }
@@ -532,6 +562,59 @@ func TestBlockedWarningLoggerCannotPreventTerminalRecovery(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("terminal recovery did not finish after logger release")
+	}
+}
+
+func TestBlockedWarningDoesNotSuppressFirstFatalReport(t *testing.T) {
+	w, clock, _, _, _ := newTestWatchdog(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	records := make(chan slog.Record, 2)
+	defer close(release)
+	w.logger = slog.New(&blockingHandler{started: started, release: release, records: records})
+	w.report = w.logStallAsync
+	mustRegister(t, w, "ledger")
+
+	clock.advance(10 * time.Second)
+	w.check()
+	<-started
+	clock.advance(80 * time.Second)
+	w.check()
+
+	select {
+	case record := <-records:
+		if record.Level != xrpllog.LevelFatal {
+			t.Fatalf("level = %v, want %v", record.Level, xrpllog.LevelFatal)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("fatal report was suppressed by blocked warning")
+	}
+}
+
+func TestResetReportSlotsAllowsNewWarningWhileOldLoggerBlocked(t *testing.T) {
+	w, clock, _, _, _ := newTestWatchdog(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	records := make(chan slog.Record, 2)
+	defer close(release)
+	w.logger = slog.New(&blockingHandler{started: started, release: release, records: records})
+	w.report = w.logStallAsync
+	mustRegister(t, w, "ledger")
+
+	clock.advance(10 * time.Second)
+	w.check()
+	<-started
+	w.resetReportSlots()
+	clock.advance(10 * time.Second)
+	w.check()
+
+	select {
+	case record := <-records:
+		if record.Level != slog.LevelWarn {
+			t.Fatalf("level = %v, want %v", record.Level, slog.LevelWarn)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("new warning was suppressed by an old blocked report")
 	}
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -57,7 +57,7 @@ type Logger interface {
 	Warn(msg string, args ...any)
 	// Error logs at Error level. For operation failures.
 	Error(msg string, args ...any)
-	// Fatal logs at Error level then calls os.Exit(1).
+	// Fatal logs at Fatal level then calls os.Exit(1).
 	Fatal(msg string, args ...any)
 
 	// With returns a new Logger with the given key-value pairs baked into every record.

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -201,6 +201,9 @@ func TestFatal_LogsAndCallsExit(t *testing.T) {
 	if !strings.Contains(buf.String(), "fatal-msg") {
 		t.Errorf("Fatal() did not log the message: %q", buf.String())
 	}
+	if !strings.Contains(buf.String(), "level=FATAL") {
+		t.Errorf("Fatal() did not use the fatal level: %q", buf.String())
+	}
 }
 
 // TestDefaultConfig verifies DefaultConfig() returns sensible defaults.

--- a/log/logger.go
+++ b/log/logger.go
@@ -39,14 +39,14 @@ func (l *logger) Error(msg string, args ...any) {
 	l.inner.Error(msg, args...)
 }
 
-// Fatal emits an Error record then exits. Sync runs before exit so the final
+// Fatal emits a Fatal record then exits. Sync runs before exit so the final
 // record reaches the destination even under async logging, where the record
 // would otherwise still be queued when defaultExit calls os.Exit (which skips
 // deferred Sync hooks). It does not fsync the os-level descriptor; callers that
 // need the file flushed to stable storage rely on Sync's file path or the
 // watchdog abort path's descriptor fsync.
 func (l *logger) Fatal(msg string, args ...any) {
-	l.inner.Error(msg, args...)
+	l.inner.Log(bgCtx, LevelFatal, msg, args...)
 	_ = Sync()
 	defaultExit()
 }


### PR DESCRIPTION
## Summary

- guarantee a bounded hard-exit fallback with capped terminal diagnostics even when logging or descriptor sync blocks
- make watchdog thresholds, heartbeat ownership, delayed escalation, and start/stop lifecycle explicit and fail closed
- require consensus heartbeat attachment when enabled, use the real fatal log level, and align generated/example configuration with runtime behavior

## Test plan

- [x] `go test -count=1 ./internal/watchdog ./internal/consensus/rcl ./internal/node ./config ./log ./internal/cli`
- [x] `go test -count=20 -shuffle=on ./internal/watchdog`
- [x] `go test -race -count=1 ./internal/watchdog ./internal/consensus/rcl ./internal/node`
- [x] `just vet`
- [x] `golangci-lint run`
- [x] `just lint`
- [x] `just build-all`
- [x] `just build-nocgo`

`go test -count=1 ./...` passes all changed and consumer packages. Its sole failure is the unrelated `internal/validator/list.TestAggregator_ApplyCollection_ExplicitEmptyLocalManifestDoesNotFallback` (`expected Invalid`, `actual Untrusted`), reproduced unchanged in a clean detached worktree at `origin/main` (`2b927a7c`).

Fixes #1512


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable stall watchdog thresholds with warning, fatal, and abort stages.
  * Added watchdog settings to generated configuration output.
  * Watchdog monitoring now supports safe heartbeat registration, startup, shutdown, and recovery.

* **Bug Fixes**
  * Improved handling of stalled consensus activity, diagnostics, and process termination.
  * Added validation for threshold ordering, negative values, and duration limits.
  * Fatal log messages are now recorded at the correct fatal level.

* **Documentation**
  * Updated watchdog and fatal logging descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->