### PR TITLE
fix: harden validator list rotation state

### DIFF
--- a/internal/consensus/adaptor/router_validator_list.go
+++ b/internal/consensus/adaptor/router_validator_list.go
@@ -480,7 +480,7 @@ func splitValidatorListCollection(coll *message.ValidatorListCollection, maxSize
 		Blobs:    append([]message.ValidatorBlobInfo(nil), coll.Blobs[begin:end]...),
 	}
 	frame, err := message.EncodeFrame(part)
-	if err == nil && (len(frame) <= maxSize || begin == end) {
+	if err == nil && len(frame) <= maxSize {
 		return []validatorListFrame{{
 			frame: frame,
 			hash:  sha512half.Sum(validatorListCollectionSemanticHash(part)),

--- a/internal/consensus/adaptor/router_validator_list.go
+++ b/internal/consensus/adaptor/router_validator_list.go
@@ -237,6 +237,11 @@ func validatorListCollectionSemanticHash(coll *message.ValidatorListCollection) 
 	out = appendUint32BE(out, coll.Version)
 	out = appendLengthPrefixed(out, coll.Manifest)
 	for _, b := range coll.Blobs {
+		if b.HasManifest() {
+			out = append(out, 1)
+		} else {
+			out = append(out, 0)
+		}
 		out = appendLengthPrefixed(out, b.Manifest)
 		out = appendLengthPrefixed(out, b.Blob)
 		out = appendLengthPrefixed(out, b.Signature)

--- a/internal/consensus/adaptor/router_validator_list.go
+++ b/internal/consensus/adaptor/router_validator_list.go
@@ -489,6 +489,12 @@ func splitValidatorListCollection(coll *message.ValidatorListCollection, maxSize
 	if err != nil && !errors.Is(err, message.ErrMessageTooLarge) {
 		return nil, fmt.Errorf("encode TMValidatorListCollection: %w", err)
 	}
+	if begin == end {
+		if err != nil {
+			return nil, fmt.Errorf("encode TMValidatorListCollection: empty collection exceeds message limit: %w", err)
+		}
+		return nil, fmt.Errorf("encode TMValidatorListCollection: empty collection frame is %d bytes, limit %d", len(frame), maxSize)
+	}
 	if end-begin == 1 {
 		return splitValidatorListCollection(coll, maxSize, begin, end, true)
 	}

--- a/internal/consensus/adaptor/router_validator_list.go
+++ b/internal/consensus/adaptor/router_validator_list.go
@@ -2,6 +2,7 @@ package adaptor
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -174,11 +175,6 @@ func (r *Router) handleValidatorListCollection(msg *peermanagement.InboundMessag
 
 	chargePeerForDisposition(r, msg.PeerID, "vl-coll", worst)
 
-	if worst.IsBadData() {
-		// Don't relay a frame containing a poison blob.
-		return
-	}
-
 	// Record per-peer sequence using the highest blob sequence observed
 	// across the collection.
 	if pubKey != (validatorlist.PublisherKey{}) && maxSeq > 0 && anyRelay {
@@ -313,6 +309,10 @@ type peerFrameSender interface {
 type RouterBroadcaster struct {
 	overlay *peermanagement.Overlay
 	sender  peerFrameSender
+	// maxCollectionFrameSize is a test seam for exercising rippled's
+	// deterministic collection splitting without allocating 64 MB frames.
+	// Zero uses the protocol maximum.
+	maxCollectionFrameSize int
 	// suppression is the optional shared hash registry. When wired,
 	// SendList / SendCollection record each (hash, peer) pair after a
 	// successful send so future inbound from that peer with the same
@@ -405,6 +405,34 @@ func (b *RouterBroadcaster) SendCollection(peerID uint64, manifestBytes []byte, 
 	if b == nil || b.sender == nil {
 		return fmt.Errorf("router broadcaster: nil sender")
 	}
+	maxSize := b.maxCollectionFrameSize
+	if maxSize <= 0 || maxSize > message.MaxMessageSize {
+		maxSize = message.MaxMessageSize
+	}
+	frames, err := buildValidatorListCollectionFrames(manifestBytes, blobs, version, maxSize)
+	if err != nil {
+		return err
+	}
+	for _, outgoing := range frames {
+		if b.suppression != nil && b.suppression.peerHasHash(outgoing.hash, peerID) {
+			continue
+		}
+		if err := b.sender.SendToPeer(peerID, outgoing.frame); err != nil {
+			return err
+		}
+		if b.suppression != nil {
+			b.suppression.recordPeer(outgoing.hash, peerID)
+		}
+	}
+	return nil
+}
+
+type validatorListFrame struct {
+	frame []byte
+	hash  [32]byte
+}
+
+func buildValidatorListCollectionFrames(manifestBytes []byte, blobs []validatorlist.BroadcastBlob, version uint32, maxSize int) ([]validatorListFrame, error) {
 	coll := &message.ValidatorListCollection{
 		Version:  version,
 		Manifest: manifestBytes,
@@ -416,19 +444,57 @@ func (b *RouterBroadcaster) SendCollection(peerID uint64, manifestBytes []byte, 
 			Signature: blob.Signature,
 		})
 	}
-	frame, err := message.EncodeFrame(coll)
+	return splitValidatorListCollection(coll, maxSize, 0, len(coll.Blobs), false)
+}
+
+func splitValidatorListCollection(coll *message.ValidatorListCollection, maxSize, begin, end int, splitting bool) ([]validatorListFrame, error) {
+	if splitting && end-begin == 1 {
+		blob := coll.Blobs[begin]
+		manifest := coll.Manifest
+		if blob.HasManifest() {
+			manifest = blob.Manifest
+		}
+		vl := &message.ValidatorList{
+			Manifest:  manifest,
+			Blob:      blob.Blob,
+			Signature: blob.Signature,
+			Version:   1,
+		}
+		frame, err := message.EncodeFrame(vl)
+		if err != nil {
+			return nil, fmt.Errorf("encode split TMValidatorList: %w", err)
+		}
+		return []validatorListFrame{{
+			frame: frame,
+			hash:  sha512half.Sum(validatorListSemanticHash(vl)),
+		}}, nil
+	}
+	part := &message.ValidatorListCollection{
+		Version:  coll.Version,
+		Manifest: coll.Manifest,
+		Blobs:    append([]message.ValidatorBlobInfo(nil), coll.Blobs[begin:end]...),
+	}
+	frame, err := message.EncodeFrame(part)
+	if err == nil && (len(frame) <= maxSize || begin == end) {
+		return []validatorListFrame{{
+			frame: frame,
+			hash:  sha512half.Sum(validatorListCollectionSemanticHash(part)),
+		}}, nil
+	}
+	if err != nil && !errors.Is(err, message.ErrMessageTooLarge) {
+		return nil, fmt.Errorf("encode TMValidatorListCollection: %w", err)
+	}
+	if end-begin == 1 {
+		return splitValidatorListCollection(coll, maxSize, begin, end, true)
+	}
+	mid := (begin + end) / 2
+	left, err := splitValidatorListCollection(coll, maxSize, begin, mid, true)
 	if err != nil {
-		return fmt.Errorf("encode TMValidatorListCollection: %w", err)
+		return nil, err
 	}
-	hash := sha512half.Sum(validatorListCollectionSemanticHash(coll))
-	if b.suppression != nil && b.suppression.peerHasHash(hash, peerID) {
-		return nil
+	right, err := splitValidatorListCollection(coll, maxSize, mid, end, true)
+	if err != nil {
+		return nil, err
 	}
-	if err := b.sender.SendToPeer(peerID, frame); err != nil {
-		return err
-	}
-	if b.suppression != nil {
-		b.suppression.recordPeer(hash, peerID)
-	}
-	return nil
+	return append(left, right...), nil
 }

--- a/internal/consensus/adaptor/router_validator_list_cov_test.go
+++ b/internal/consensus/adaptor/router_validator_list_cov_test.go
@@ -241,9 +241,9 @@ func TestRvl_HandleVL_DecodeError(t *testing.T) {
 	assert.Equal(t, "vl-decode", calls[0].reason)
 }
 
-// TestRvl_HandleVL_Untrusted charges the peer with useless-untrusted when publisher
-// is unknown (no publishers configured → Untrusted result).
-func TestRvl_HandleVL_Untrusted(t *testing.T) {
+// Empty publisher manifests are malformed signatures and charge the peer as
+// bad signature data.
+func TestRvl_HandleVL_MalformedPublisherManifest(t *testing.T) {
 	r, rs := rvl_newRouterWithVL(t)
 	vl := &message.ValidatorList{Version: 1, Manifest: []byte("m"), Blob: []byte("b"), Signature: []byte("s")}
 	r.handleValidatorList(&peermanagement.InboundMessage{
@@ -254,10 +254,10 @@ func TestRvl_HandleVL_Untrusted(t *testing.T) {
 	calls := rs.getBadDataCalls()
 	require.Len(t, calls, 1)
 	assert.Equal(t, uint64(3), calls[0].peerID)
-	assert.Equal(t, "vl-useless-untrusted", calls[0].reason)
+	assert.Equal(t, "vl-badsig-invalid", calls[0].reason)
 }
 
-func TestRvl_HandleVL_Duplicate(t *testing.T) {
+func TestRvl_HandleVL_MalformedPublisherManifestDuplicate(t *testing.T) {
 	r, rs := rvl_newRouterWithVL(t)
 	vl := &message.ValidatorList{Version: 1, Manifest: []byte("m2"), Blob: []byte("b2"), Signature: []byte("s2")}
 	payload := encodePayload(t, vl)
@@ -265,7 +265,7 @@ func TestRvl_HandleVL_Duplicate(t *testing.T) {
 	r.handleValidatorList(&peermanagement.InboundMessage{PeerID: 10, Type: message.TypeValidatorList, Payload: payload})
 	calls1 := rs.getBadDataCalls()
 	require.Len(t, calls1, 1)
-	assert.Equal(t, "vl-useless-untrusted", calls1[0].reason)
+	assert.Equal(t, "vl-badsig-invalid", calls1[0].reason)
 
 	// Second delivery from different peer — same content → dedup fires.
 	r.handleValidatorList(&peermanagement.InboundMessage{PeerID: 11, Type: message.TypeValidatorList, Payload: payload})
@@ -285,11 +285,11 @@ func TestRvl_HandleVL_NilMsgSeen(t *testing.T) {
 	r.handleValidatorList(&peermanagement.InboundMessage{PeerID: 50, Type: message.TypeValidatorList, Payload: payload})
 	r.handleValidatorList(&peermanagement.InboundMessage{PeerID: 51, Type: message.TypeValidatorList, Payload: payload})
 
-	// Both processed independently — two Untrusted charges, no duplicate charge.
+	// Both processed independently — two malformed-signature charges, no duplicate charge.
 	calls := rs.getBadDataCalls()
 	assert.Len(t, calls, 2)
 	for _, c := range calls {
-		assert.Equal(t, "vl-useless-untrusted", c.reason)
+		assert.Equal(t, "vl-badsig-invalid", c.reason)
 	}
 }
 
@@ -354,7 +354,7 @@ func TestRvl_HandleVLC_NoBlobs(t *testing.T) {
 	assert.True(t, reasons["vl-coll-no-blobs"])
 }
 
-func TestRvl_HandleVLC_Untrusted(t *testing.T) {
+func TestRvl_HandleVLC_MalformedPublisherManifest(t *testing.T) {
 	r, rs := rvl_newRouterWithVL(t)
 	coll := &message.ValidatorListCollection{
 		Version:  2,
@@ -369,7 +369,7 @@ func TestRvl_HandleVLC_Untrusted(t *testing.T) {
 	calls := rs.getBadDataCalls()
 	require.Len(t, calls, 1)
 	assert.Equal(t, uint64(16), calls[0].peerID)
-	assert.Equal(t, "vl-coll-useless-untrusted", calls[0].reason)
+	assert.Equal(t, "vl-coll-badsig-invalid", calls[0].reason)
 }
 
 func TestRvl_HandleVLC_Duplicate(t *testing.T) {
@@ -588,6 +588,52 @@ func TestRvl_SendCollection_MultipleBlobs(t *testing.T) {
 	err := b.SendCollection(88, []byte("pub-manifest"), blobs, 3)
 	require.NoError(t, err)
 	require.Len(t, ts.getCalls(), 1)
+}
+
+func TestRvl_SendCollection_SplitsOversizeLikeRippled(t *testing.T) {
+	ts := &rvl_trackingSender{}
+	b := NewRouterBroadcaster(nil, ts)
+	b.maxCollectionFrameSize = 40
+	blobs := []validatorlist.BroadcastBlob{
+		{Manifest: []byte("local-1"), Blob: []byte("blob-1"), Signature: []byte("sig-1")},
+		{Manifest: []byte("local-2"), Blob: []byte("blob-2"), Signature: []byte("sig-2")},
+		{Blob: []byte("blob-3"), Signature: []byte("sig-3")},
+	}
+	require.NoError(t, b.SendCollection(88, []byte("publisher"), blobs, 2))
+	calls := ts.getCalls()
+	require.Len(t, calls, 3)
+	wantManifests := [][]byte{[]byte("local-1"), []byte("local-2"), []byte("publisher")}
+	for i, call := range calls {
+		header, err := message.DecodeHeader(call.frame)
+		require.NoError(t, err)
+		require.Equal(t, message.TypeValidatorList, header.MessageType)
+		decoded, err := message.Decode(header.MessageType, call.frame[header.HeaderSize():])
+		require.NoError(t, err)
+		vl, ok := decoded.(*message.ValidatorList)
+		require.True(t, ok)
+		require.Equal(t, uint32(1), vl.Version)
+		require.Equal(t, wantManifests[i], vl.Manifest)
+		require.Equal(t, blobs[i].Blob, vl.Blob)
+	}
+}
+
+func TestRvl_SendCollection_SplitsOversizeSingleton(t *testing.T) {
+	ts := &rvl_trackingSender{}
+	b := NewRouterBroadcaster(nil, ts)
+	b.maxCollectionFrameSize = 1
+	blob := validatorlist.BroadcastBlob{Manifest: []byte("local"), Blob: []byte("blob"), Signature: []byte("sig")}
+	require.NoError(t, b.SendCollection(88, []byte("publisher"), []validatorlist.BroadcastBlob{blob}, 2))
+
+	calls := ts.getCalls()
+	require.Len(t, calls, 1)
+	header, err := message.DecodeHeader(calls[0].frame)
+	require.NoError(t, err)
+	require.Equal(t, message.TypeValidatorList, header.MessageType)
+	decoded, err := message.Decode(header.MessageType, calls[0].frame[header.HeaderSize():])
+	require.NoError(t, err)
+	vl := decoded.(*message.ValidatorList)
+	require.Equal(t, uint32(1), vl.Version)
+	require.Equal(t, blob.Manifest, vl.Manifest)
 }
 
 func TestRvl_SendList_NoSuppression(t *testing.T) {

--- a/internal/consensus/adaptor/router_validator_list_cov_test.go
+++ b/internal/consensus/adaptor/router_validator_list_cov_test.go
@@ -562,6 +562,15 @@ func TestRvl_SendCollection_EmptyBlobs(t *testing.T) {
 	assert.Len(t, ts.getCalls(), 1)
 }
 
+func TestRvl_SendCollection_OversizeEmptyBlobs(t *testing.T) {
+	ts := &rvl_trackingSender{}
+	b := NewRouterBroadcaster(nil, ts)
+	b.maxCollectionFrameSize = 1
+	err := b.SendCollection(33, []byte("manifest"), nil, 2)
+	require.Error(t, err)
+	assert.Empty(t, ts.getCalls())
+}
+
 func TestRvl_SendCollection_SuppressionDedup(t *testing.T) {
 	ts := &rvl_trackingSender{}
 	r, _ := makeRouterWithBadDataRecorder(t)

--- a/internal/consensus/adaptor/router_validator_list_cov_test.go
+++ b/internal/consensus/adaptor/router_validator_list_cov_test.go
@@ -123,6 +123,20 @@ func TestRvl_CollectionSemanticHash_EmptyBlobs(t *testing.T) {
 	assert.Equal(t, []byte{0, 0, 0, 2}, h[:4])
 }
 
+func TestRvl_CollectionSemanticHashDistinguishesManifestPresence(t *testing.T) {
+	omitted := &message.ValidatorListCollection{
+		Version:  2,
+		Manifest: []byte("m"),
+		Blobs:    []message.ValidatorBlobInfo{{Blob: []byte("b"), Signature: []byte("s")}},
+	}
+	presentEmpty := &message.ValidatorListCollection{
+		Version:  2,
+		Manifest: []byte("m"),
+		Blobs:    []message.ValidatorBlobInfo{{Manifest: []byte{}, Blob: []byte("b"), Signature: []byte("s")}},
+	}
+	assert.NotEqual(t, validatorListCollectionSemanticHash(omitted), validatorListCollectionSemanticHash(presentEmpty))
+}
+
 func TestRvl_ChargePeer_None(t *testing.T) {
 	r, rs := makeRouterWithBadDataRecorder(t)
 	chargePeerForDisposition(r, 1, "vl", validatorlist.Accepted)

--- a/internal/consensus/adaptor/router_validator_list_cov_test.go
+++ b/internal/consensus/adaptor/router_validator_list_cov_test.go
@@ -255,8 +255,6 @@ func TestRvl_HandleVL_DecodeError(t *testing.T) {
 	assert.Equal(t, "vl-decode", calls[0].reason)
 }
 
-// Empty publisher manifests are malformed signatures and charge the peer as
-// bad signature data.
 func TestRvl_HandleVL_MalformedPublisherManifest(t *testing.T) {
 	r, rs := rvl_newRouterWithVL(t)
 	vl := &message.ValidatorList{Version: 1, Manifest: []byte("m"), Blob: []byte("b"), Signature: []byte("s")}
@@ -299,7 +297,6 @@ func TestRvl_HandleVL_NilMsgSeen(t *testing.T) {
 	r.handleValidatorList(&peermanagement.InboundMessage{PeerID: 50, Type: message.TypeValidatorList, Payload: payload})
 	r.handleValidatorList(&peermanagement.InboundMessage{PeerID: 51, Type: message.TypeValidatorList, Payload: payload})
 
-	// Both processed independently — two malformed-signature charges, no duplicate charge.
 	calls := rs.getBadDataCalls()
 	assert.Len(t, calls, 2)
 	for _, c := range calls {

--- a/internal/manifest/cache.go
+++ b/internal/manifest/cache.go
@@ -323,7 +323,8 @@ func (c *Cache) GetSequence(masterKey [33]byte) (uint32, bool) {
 }
 
 // WithCurrent runs fn while the identified non-revoked manifest remains
-// current. The callback must not call methods on this Cache.
+// current. The callback must be brief and must not call methods on this Cache
+// or acquire locks ordered before this cache's mutex.
 func (c *Cache) WithCurrent(masterKey, signingKey [33]byte, sequence uint32, fn func()) bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/internal/manifest/cache.go
+++ b/internal/manifest/cache.go
@@ -322,6 +322,19 @@ func (c *Cache) GetSequence(masterKey [33]byte) (uint32, bool) {
 	return m.sequence, true
 }
 
+// WithCurrent runs fn while the identified non-revoked manifest remains
+// current. The callback must not call methods on this Cache.
+func (c *Cache) WithCurrent(masterKey, signingKey [33]byte, sequence uint32, fn func()) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	m, ok := c.byMaster[masterKey]
+	if !ok || m.Revoked() || m.sequence != sequence || m.signingKey != signingKey {
+		return false
+	}
+	fn()
+	return true
+}
+
 // GetDomain returns the stored manifest's domain string. Second return
 // is false on unknown, revoked, or when no domain was recorded.
 func (c *Cache) GetDomain(masterKey [33]byte) (string, bool) {

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -764,12 +764,9 @@ func (r *nodeRuntime) configureConsensus() error {
 					listed[mk] = struct{}{}
 				}
 				if vlAgg != nil {
-					for _, p := range vlAgg.PublisherSnapshot() {
-						if p.Status != validatorlist.StatusAvailable {
-							continue
-						}
-						for _, mk := range p.Validators {
-							listed[mk] = struct{}{}
+					for master := range snap {
+						if vlAgg.IsMasterListed(master) {
+							listed[master] = struct{}{}
 						}
 					}
 				}

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -1844,7 +1844,7 @@ func chargeForReason(reason string) resource.Charge {
 	}
 	switch {
 	case reason == "vl-coll-no-blobs",
-		strings.HasSuffix(reason, "-heavy-no-blobs"):
+		strings.Contains(reason, "-heavy-"):
 		return resource.FeeHeavyBurdenPeer
 	case strings.Contains(reason, "-badsig-"):
 		return resource.FeeInvalidSignature
@@ -1870,6 +1870,8 @@ func wirePreflightChargeReason(err error) string {
 			return "manifests-oversize"
 		case message.WireLimitGetObjectTransactions:
 			return "get-objects-transactions-oversize"
+		case message.WireLimitValidatorBlobs:
+			return "vl-coll-heavy-too-many-blobs"
 		}
 	}
 	return "wire-invalid"

--- a/internal/peermanagement/peer_wire_preflight_test.go
+++ b/internal/peermanagement/peer_wire_preflight_test.go
@@ -67,6 +67,13 @@ func TestPeerWirePreflightChargesAndDropsBeforeDispatch(t *testing.T) {
 			reason:  "get-objects-transactions-oversize",
 			charge:  resource.FeeMalformedRequest,
 		},
+		{
+			name:    "validator list collection",
+			msgType: message.TypeValidatorListCollection,
+			payload: peerRepeatedMessageField(3, 6),
+			reason:  "vl-coll-heavy-too-many-blobs",
+			charge:  resource.FeeHeavyBurdenPeer,
+		},
 	}
 
 	for i, test := range tests {

--- a/internal/peermanagement/peer_wire_preflight_test.go
+++ b/internal/peermanagement/peer_wire_preflight_test.go
@@ -78,6 +78,9 @@ func TestPeerWirePreflightChargesAndDropsBeforeDispatch(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			preflightErr := message.Preflight(test.msgType, test.payload)
+			require.Equal(t, test.reason, wirePreflightChargeReason(preflightErr))
+
 			frame, err := message.BuildWireMessage(test.msgType, test.payload)
 			require.NoError(t, err)
 			if test.compress {

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -65,7 +65,6 @@ func (s PublisherStatus) String() string {
 	}
 }
 
-// publisherState is the per-publisher state the aggregator maintains.
 // Tracks the current accepted list plus a queue of future-dated
 // "remaining" lists (rippled's PublisherList.remaining at
 // ValidatorList.h:75-83) so a publisher rotation announced ahead of
@@ -140,8 +139,6 @@ type publisherState struct {
 	// promoteRemainingLocked. Empty when no rotation is pending.
 	Remaining map[uint32]*pendingList
 
-	// MaxSequence is the largest sequence ever accepted or stored in
-	// `Remaining`.
 	// Mirrors rippled's PublisherListCollection.maxSequence; combined
 	// with `Remaining` it drives the pending-vs-known_sequence decision
 	// at applyList (ValidatorList.cpp:1414-1432).
@@ -154,9 +151,6 @@ type publisherState struct {
 	MaxSequenceSet bool
 }
 
-// pendingList is one entry in publisherState.Remaining — a fully-verified
-// future-dated list that will become current at validFrom. Wire bytes are
-// retained so the post-promotion broadcast can re-emit the canonical form.
 type pendingList struct {
 	Sequence            uint32
 	Effective           time.Time
@@ -182,8 +176,6 @@ type pendingEmbeddedManifest struct {
 	Raw []byte
 }
 
-// siteInfoState is the per-URL polling state surfaced via the
-// validator_list_sites RPC.
 type siteInfoState struct {
 	URI             string
 	LastFetched     time.Time
@@ -237,7 +229,6 @@ type PublisherInfo struct {
 	MaxSequenceSet      bool
 }
 
-// SiteInfo is the immutable value projection of one configured polling site.
 type SiteInfo struct {
 	URI                string
 	LastFetched        time.Time
@@ -381,8 +372,6 @@ type Aggregator struct {
 	cacheWriteMu sync.Mutex
 	cacheWritten map[PublisherKey]uint64
 
-	// cacheOps is an optional per-aggregator filesystem seam used by the
-	// cache retry tests. A zero value selects the os-backed operations.
 	cacheOps cacheFileOps
 
 	changes changeDispatcher

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -440,15 +440,10 @@ func New(cfg Config) (*Aggregator, error) {
 	// construction and emitted unconditionally in getJson.
 	defaultRefreshSec := int(defaultRefreshInterval / time.Second)
 	sites := make([]*siteInfoState, 0, len(cfg.SiteURIs))
-	seenSites := make(map[string]struct{}, len(cfg.SiteURIs))
 	for _, u := range cfg.SiteURIs {
 		if err := validateSiteURI(u); err != nil {
 			return nil, fmt.Errorf("invalid validator site uri %q: %w", u, err)
 		}
-		if _, ok := seenSites[u]; ok {
-			continue
-		}
-		seenSites[u] = struct{}{}
 		sites = append(sites, &siteInfoState{
 			URI:            u,
 			NextRefresh:    initialNextRefresh,
@@ -678,6 +673,32 @@ func (a *Aggregator) SetNextRefresh(uri string, nextRefresh time.Time) {
 	}
 }
 
+func (a *Aggregator) siteOccurrenceLocked(uri string, occurrence int) *siteInfoState {
+	for _, site := range a.sites {
+		if site.URI != uri {
+			continue
+		}
+		if occurrence == 0 {
+			return site
+		}
+		occurrence--
+	}
+	return nil
+}
+
+func (a *Aggregator) setNextRefreshOccurrence(uri string, occurrence int, nextRefresh time.Time) {
+	if nextRefresh.IsZero() {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	site := a.siteOccurrenceLocked(uri, occurrence)
+	if site == nil {
+		return
+	}
+	site.NextRefresh = nextRefresh
+}
+
 // UpdateSiteState records the outcome of an HTTP poll attempt against a
 // configured publisher URL. The poller goroutine calls this after each
 // fetch attempt; the data flows through to the validator_list_sites
@@ -710,6 +731,28 @@ func (a *Aggregator) UpdateSiteState(uri string, lastFetched, lastSuccess time.T
 	}
 }
 
+func (a *Aggregator) updateSiteStateOccurrence(uri string, occurrence int, lastFetched, lastSuccess time.Time, lastErr string, lastDisp Disposition, refreshSec int, nextRefresh time.Time) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	s := a.siteOccurrenceLocked(uri, occurrence)
+	if s == nil {
+		return
+	}
+	s.LastFetched = lastFetched
+	if !lastSuccess.IsZero() {
+		s.LastSuccess = lastSuccess
+	}
+	s.LastError = lastErr
+	s.LastDisposition = lastDisp
+	s.LastDispositionSet = true
+	if refreshSec > 0 {
+		s.RefreshSeconds = refreshSec
+	}
+	if !nextRefresh.IsZero() {
+		s.NextRefresh = nextRefresh
+	}
+}
+
 // Tick performs a time-driven promotion sweep across every publisher
 // and emits OnChange if the resulting trusted union changed. Callers
 // should invoke this periodically (rippled drives it from updateTrusted
@@ -721,18 +764,25 @@ func (a *Aggregator) UpdateSiteState(uri string, lastFetched, lastSuccess time.T
 func (a *Aggregator) Tick() {
 	a.mu.Lock()
 	now := a.clock()
-	promoted := make([]PublisherKey, 0, len(a.state))
+	type promotion struct {
+		publisher PublisherKey
+		sequence  uint32
+	}
+	promoted := make([]promotion, 0, len(a.state))
 	for pubKey, s := range a.state {
-		if a.promoteRemainingLocked(s, now) {
-			promoted = append(promoted, pubKey)
+		if sequence := a.promoteRemainingLocked(s, now); sequence != 0 {
+			promoted = append(promoted, promotion{publisher: pubKey, sequence: sequence})
+		}
+		if s.Status == StatusExpired {
+			s.Validators = nil
 		}
 	}
 	a.recomputeAndEmitLocked()
 	a.mu.Unlock()
 	a.flushCacheWrites()
 	a.dispatchChanges()
-	for _, pubKey := range promoted {
-		a.BroadcastLatest(pubKey, 0)
+	for _, item := range promoted {
+		a.broadcastLatest(item.publisher, 0, item.sequence)
 	}
 }
 
@@ -740,9 +790,13 @@ func (a *Aggregator) Tick() {
 // key is revoked by a fresh manifest. Mirrors rippled's
 // removePublisherList(StatusRevoked) branch in verify(). Also clears
 // the retained wire bytes so a revoked publisher is never rebroadcast.
-func (a *Aggregator) handleRevocation(pubKey PublisherKey) {
+func (a *Aggregator) handleRevocation(pubKey PublisherKey, asyncDispatch bool) {
 	a.mu.Lock()
-	defer a.dispatchChanges()
+	if asyncDispatch {
+		defer a.dispatchChangesAsync()
+	} else {
+		defer a.dispatchChanges()
+	}
 	defer a.flushCacheWrites()
 	defer a.mu.Unlock()
 	s, ok := a.state[pubKey]
@@ -770,7 +824,11 @@ func (a *Aggregator) handleRevocation(pubKey PublisherKey) {
 // tracks every count recompute (ingest, Tick, trusted-set reads).
 func (a *Aggregator) computeValidatorCountsLocked(now time.Time) map[[33]byte]int {
 	counts := make(map[[33]byte]int, 64)
+	listedMasters := make(map[[33]byte]struct{}, 64)
 	for _, s := range a.state {
+		for _, k := range s.Validators {
+			listedMasters[k] = struct{}{}
+		}
 		if s.Status != StatusAvailable {
 			continue
 		}
@@ -791,18 +849,16 @@ func (a *Aggregator) computeValidatorCountsLocked(now time.Time) map[[33]byte]in
 			counts[k]++
 		}
 	}
-	listed := make(map[consensus.NodeID]struct{}, len(counts))
-	listedMasters := make(map[[33]byte]struct{}, len(counts))
-	for k := range counts {
+	listed := make(map[consensus.NodeID]struct{}, len(listedMasters))
+	for k := range listedMasters {
 		listed[consensus.CalcNodeID(k)] = struct{}{}
-		listedMasters[k] = struct{}{}
 	}
 	a.listed.Store(&listed)
 	a.listedMasters.Store(&listedMasters)
 	return counts
 }
 
-// IsListed reports whether node's master key appears in at least one live
+// IsListed reports whether node's master key appears in at least one retained
 // publisher list — rippled's ValidatorList::listed, one tier below trusted.
 // Lock-free (atomic snapshot) so the consensus validation path can query it
 // without ordering against a.mu.
@@ -815,7 +871,7 @@ func (a *Aggregator) IsListed(node consensus.NodeID) bool {
 	return ok
 }
 
-// IsMasterListed reports whether a validator master key appears in a live
+// IsMasterListed reports whether a validator master key appears in a retained
 // configured publisher list.
 func (a *Aggregator) IsMasterListed(master [33]byte) bool {
 	listed := a.listedMasters.Load()

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -1,7 +1,6 @@
 package list
 
 import (
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -11,9 +10,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/crypto"
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/manifest"
-	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 )
 
 // PublisherKey is the 33-byte master public key of a list publisher
@@ -66,15 +65,12 @@ func (s PublisherStatus) String() string {
 	}
 }
 
-// PublisherState is the per-publisher state the aggregator maintains.
+// publisherState is the per-publisher state the aggregator maintains.
 // Tracks the current accepted list plus a queue of future-dated
 // "remaining" lists (rippled's PublisherList.remaining at
 // ValidatorList.h:75-83) so a publisher rotation announced ahead of
 // time can be applied at the right moment.
-//
-// Exposed via Snapshot() for RPC and observability — callers receive a
-// deep copy and may NOT mutate the aggregator's internal state.
-type PublisherState struct {
+type publisherState struct {
 	MasterKey  PublisherKey
 	SigningKey [33]byte
 	Status     PublisherStatus
@@ -127,9 +123,14 @@ type PublisherState struct {
 	// `RawSignature` is hex-encoded ASCII. The aggregator stores them
 	// verbatim — no re-encoding — so what we relay is byte-identical
 	// to what an honest peer would have sent us.
-	RawManifest  []byte
-	RawBlob      []byte
-	RawSignature []byte
+	// RawManifest is the collection-level publisher manifest. A v2 blob may
+	// carry a per-blob manifest override; that value is retained separately
+	// so relay/cache code can preserve the nil-vs-present distinction.
+	RawManifest         []byte
+	RawLocalManifest    []byte
+	RawLocalManifestSet bool
+	RawBlob             []byte
+	RawSignature        []byte
 
 	// Remaining is the queue of future-dated lists for this publisher,
 	// keyed by sequence and ordered by validFrom. Mirrors rippled's
@@ -137,9 +138,10 @@ type PublisherState struct {
 	// rotation announced ahead of `effective` time lands here and is
 	// promoted into the current slot once its validFrom passes — see
 	// promoteRemainingLocked. Empty when no rotation is pending.
-	Remaining map[uint32]*PendingList
+	Remaining map[uint32]*pendingList
 
-	// MaxSequence is the largest sequence ever stored in `Remaining`.
+	// MaxSequence is the largest sequence ever accepted or stored in
+	// `Remaining`.
 	// Mirrors rippled's PublisherListCollection.maxSequence; combined
 	// with `Remaining` it drives the pending-vs-known_sequence decision
 	// at applyList (ValidatorList.cpp:1414-1432).
@@ -152,26 +154,37 @@ type PublisherState struct {
 	MaxSequenceSet bool
 }
 
-// PendingList is one entry in PublisherState.Remaining — a fully-verified
+// pendingList is one entry in publisherState.Remaining — a fully-verified
 // future-dated list that will become current at validFrom. Wire bytes are
 // retained so the post-promotion broadcast can re-emit the canonical form.
-type PendingList struct {
-	Sequence     uint32
-	Effective    time.Time
-	EffectiveSet bool
-	Expiration   time.Time
-	Validators   [][33]byte
-	SiteURI      string
-	Version      uint32
-	SigningKey   [33]byte
-	RawManifest  []byte
-	RawBlob      []byte
-	RawSignature []byte
+type pendingList struct {
+	Sequence            uint32
+	Effective           time.Time
+	EffectiveSet        bool
+	Expiration          time.Time
+	Validators          [][33]byte
+	SiteURI             string
+	Version             uint32
+	SigningKey          [33]byte
+	RawManifest         []byte
+	RawLocalManifest    []byte
+	RawLocalManifestSet bool
+	RawBlob             []byte
+	RawSignature        []byte
+	EmbeddedManifests   []pendingEmbeddedManifest
 }
 
-// SiteState is the per-URL polling state surfaced via the
+// pendingEmbeddedManifest retains a validator manifest from a future-dated
+// blob until that blob becomes current. The manifest is applied to the
+// validator cache only at promotion, matching rippled's updatePublisherList
+// timing.
+type pendingEmbeddedManifest struct {
+	Raw []byte
+}
+
+// siteInfoState is the per-URL polling state surfaced via the
 // validator_list_sites RPC.
-type SiteState struct {
+type siteInfoState struct {
 	URI             string
 	LastFetched     time.Time
 	LastSuccess     time.Time
@@ -189,6 +202,51 @@ type SiteState struct {
 	// is scheduled. Mirrors rippled's ValidatorSite::Site::nextRefresh
 	// surfaced via `next_refresh_time` in the validator_list_sites RPC.
 	NextRefresh time.Time
+}
+
+// RemainingInfo is the immutable value projection of a future-dated list.
+// Wire buffers remain private to relay/cache code.
+type RemainingInfo struct {
+	Sequence            uint32
+	Effective           time.Time
+	EffectiveSet        bool
+	Expiration          time.Time
+	Validators          [][33]byte
+	SiteURI             string
+	Version             uint32
+	RawLocalManifestSet bool
+}
+
+// PublisherInfo is an immutable value projection of publisher state. Slices
+// and maps are copied for each snapshot.
+type PublisherInfo struct {
+	MasterKey           PublisherKey
+	SigningKey          [33]byte
+	Status              PublisherStatus
+	Sequence            uint32
+	Effective           time.Time
+	EffectiveSet        bool
+	Expiration          time.Time
+	Validators          [][33]byte
+	SiteURI             string
+	LastUpdate          time.Time
+	Version             uint32
+	RawLocalManifestSet bool
+	Remaining           map[uint32]*RemainingInfo
+	MaxSequence         uint32
+	MaxSequenceSet      bool
+}
+
+// SiteInfo is the immutable value projection of one configured polling site.
+type SiteInfo struct {
+	URI                string
+	LastFetched        time.Time
+	LastSuccess        time.Time
+	LastError          string
+	LastDisposition    Disposition
+	LastDispositionSet bool
+	RefreshSeconds     int
+	NextRefresh        time.Time
 }
 
 // Aggregator is the central publisher-trust subsystem. It owns the
@@ -214,11 +272,11 @@ type Aggregator struct {
 	// in `publishers`. Pre-populated with empty StatusUnavailable
 	// entries so the RPC surface is non-empty from the moment of
 	// startup.
-	state map[PublisherKey]*PublisherState
+	state map[PublisherKey]*publisherState
 
 	// sites holds per-URL polling state for every URL in
 	// validator_list_sites. Updated by the HTTP poller; read by RPC.
-	sites []*SiteState
+	sites []*siteInfoState
 
 	validatorManifests *manifest.Cache
 	publisherManifests *manifest.Cache
@@ -231,18 +289,9 @@ type Aggregator struct {
 
 	staticValidatorCount int
 
-	// onChange is invoked whenever the recomputed trusted set differs
-	// from the previously emitted one. Wired by Components.NewFromConfig
-	// to push into Adaptor.SetTrustedValidators.
-	//
-	// LOCK INVARIANT: the callback runs *under* a.mu. Implementations
-	// must not, directly or transitively, call back into the aggregator
-	// (any exported method here re-locks a.mu and would deadlock). The
-	// production wiring satisfies this by routing the call to
-	// Adaptor.SetTrustedValidators, which takes its own lock and does
-	// not reach back into the aggregator. Any future caller that
-	// reschedules work or fans out to other subscribers must hop off
-	// this goroutine before re-entering the aggregator.
+	// onChange is captured into immutable change events while a.mu is held.
+	// Events are delivered after the mutation unlocks, so callbacks may
+	// re-enter the aggregator and slow callbacks do not hold a.mu.
 	onChange func(validators []consensus.NodeID, masterKeys [][33]byte)
 
 	// lastEmitted is the most recently published trusted set (master
@@ -276,6 +325,11 @@ type Aggregator struct {
 	// clock returns the wall-clock time the aggregator uses to gate
 	// effective / expiration comparisons. Overridable for tests.
 	clock func() time.Time
+
+	// beforeListCommit is a private deterministic test seam. Production code
+	// leaves it nil; tests use it to mutate the independent manifest cache
+	// after verification and before the commit-time recheck.
+	beforeListCommit func()
 
 	logger *slog.Logger
 
@@ -318,6 +372,7 @@ type Aggregator struct {
 	// used to order mutations across concurrent flushers.
 	pendingCacheWrites map[PublisherKey]pendingCacheWrite
 	cacheWriteSeq      uint64
+	cacheGeneration    uint64
 
 	// cacheWriteMu serializes the disk syscalls in flushCacheWrites;
 	// cacheWritten records the highest cacheWriteSeq already persisted per
@@ -325,6 +380,12 @@ type Aggregator struct {
 	// cacheWriteMu, never by a.mu.
 	cacheWriteMu sync.Mutex
 	cacheWritten map[PublisherKey]uint64
+
+	// cacheOps is an optional per-aggregator filesystem seam used by the
+	// cache retry tests. A zero value selects the os-backed operations.
+	cacheOps cacheFileOps
+
+	changes changeDispatcher
 }
 
 // Config carries Aggregator construction parameters. All fields are
@@ -347,14 +408,17 @@ type Config struct {
 // than silently disable the publisher.
 func New(cfg Config) (*Aggregator, error) {
 	publishers := make(map[PublisherKey]struct{}, len(cfg.PublisherKeys))
-	state := make(map[PublisherKey]*PublisherState, len(cfg.PublisherKeys))
+	state := make(map[PublisherKey]*publisherState, len(cfg.PublisherKeys))
 	for _, k := range cfg.PublisherKeys {
 		var zero PublisherKey
 		if k == zero {
 			return nil, errors.New("publisher key is all zero")
 		}
+		if crypto.PublicKeyType(k[:]) == crypto.KeyTypeUnknown {
+			return nil, fmt.Errorf("publisher key has unknown key type prefix 0x%02x", k[0])
+		}
 		publishers[k] = struct{}{}
-		state[k] = &PublisherState{
+		state[k] = &publisherState{
 			MasterKey: k,
 			Status:    StatusUnavailable,
 		}
@@ -367,17 +431,25 @@ func New(cfg Config) (*Aggregator, error) {
 	// surfaces a real value before the first poll fires. Mirrors
 	// rippled ValidatorSite.cpp:83 (`nextRefresh = clock_type::now() +
 	// refreshInterval`).
-	initialNextRefresh := clock().Add(DefaultRefreshInterval)
+	initialNextRefresh := clock().Add(defaultRefreshInterval)
 	// Seed RefreshSeconds with the default refresh interval so the
 	// `refresh_interval_min` RPC field reports the configured cadence
 	// from boot, before any envelope-supplied override is observed.
 	// Mirrors rippled ValidatorSite.cpp:81 where Site::refreshInterval
 	// is initialised to default_refresh_interval (5 minutes) at
 	// construction and emitted unconditionally in getJson.
-	defaultRefreshSec := int(DefaultRefreshInterval / time.Second)
-	sites := make([]*SiteState, 0, len(cfg.SiteURIs))
+	defaultRefreshSec := int(defaultRefreshInterval / time.Second)
+	sites := make([]*siteInfoState, 0, len(cfg.SiteURIs))
+	seenSites := make(map[string]struct{}, len(cfg.SiteURIs))
 	for _, u := range cfg.SiteURIs {
-		sites = append(sites, &SiteState{
+		if err := validateSiteURI(u); err != nil {
+			return nil, fmt.Errorf("invalid validator site uri %q: %w", u, err)
+		}
+		if _, ok := seenSites[u]; ok {
+			continue
+		}
+		seenSites[u] = struct{}{}
+		sites = append(sites, &siteInfoState{
 			URI:            u,
 			NextRefresh:    initialNextRefresh,
 			RefreshSeconds: defaultRefreshSec,
@@ -388,7 +460,10 @@ func New(cfg Config) (*Aggregator, error) {
 		logger = slog.Default().With("component", "validator-list-aggregator")
 	}
 	threshold := cfg.Threshold
-	if threshold <= 0 && len(publishers) > 0 {
+	if threshold < 0 {
+		return nil, fmt.Errorf("threshold cannot be negative: %d", threshold)
+	}
+	if threshold == 0 && len(publishers) > 0 {
 		// Mirror rippled's default: ceil(N/2 + 1) for N >= 3, else 1.
 		// Matches config.ValidatorsConfig.EffectiveListThreshold().
 		if len(publishers) < 3 {
@@ -413,6 +488,10 @@ func New(cfg Config) (*Aggregator, error) {
 			state[key].Status = StatusRevoked
 		}
 	}
+	staticValidatorCount := cfg.StaticValidatorCount
+	if staticValidatorCount < 0 {
+		staticValidatorCount = 0
+	}
 	return &Aggregator{
 		publishers:           publishers,
 		state:                state,
@@ -420,7 +499,7 @@ func New(cfg Config) (*Aggregator, error) {
 		validatorManifests:   validatorManifests,
 		publisherManifests:   publisherManifests,
 		threshold:            threshold,
-		staticValidatorCount: cfg.StaticValidatorCount,
+		staticValidatorCount: staticValidatorCount,
 		clock:                clock,
 		logger:               logger,
 		peerSeq:              make(map[uint64]map[PublisherKey]uint32),
@@ -441,7 +520,7 @@ func (a *Aggregator) SetBroadcaster(b PeerBroadcaster) {
 
 // OnChange registers (or replaces) the callback fired when the
 // recomputed trusted UNL differs from the previously emitted one.
-// Passing nil clears the callback. Safe to call before or after Start.
+// Passing nil clears the callback. Safe to call before or after polling starts.
 func (a *Aggregator) OnChange(cb func(validators []consensus.NodeID, masterKeys [][33]byte)) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -453,9 +532,11 @@ func (a *Aggregator) SetStaticValidatorCount(count int) {
 		count = 0
 	}
 	a.mu.Lock()
+	defer a.dispatchChanges()
+	defer a.flushCacheWrites()
+	defer a.mu.Unlock()
 	a.staticValidatorCount = count
 	a.recomputeAndEmitLocked()
-	a.mu.Unlock()
 }
 
 // PublisherCount returns the number of configured publishers in the
@@ -506,53 +587,46 @@ func (a *Aggregator) IsQuorumUnavailable() bool {
 // PublisherSnapshot returns a deep copy of the per-publisher state for
 // RPC and observability. Order is sorted by publisher master key for
 // stable output. Safe to call concurrently with ingest.
-//
-// Lazily runs the Remaining → current promotion so the RPC sees a
-// timely view even when no new lists have been ingested in this
-// process tick. The promotion is purely a state shift inside the
-// publisher entry; it does not emit OnChange (Tick is the explicit
-// emit-on-time entry point).
-func (a *Aggregator) PublisherSnapshot() []PublisherState {
+func (a *Aggregator) PublisherSnapshot() []PublisherInfo {
 	a.mu.Lock()
-	defer a.flushCacheWrites()
 	defer a.mu.Unlock()
-	now := a.clock()
+	out := make([]PublisherInfo, 0, len(a.state))
 	for _, s := range a.state {
-		a.promoteRemainingLocked(s, now)
-	}
-	out := make([]PublisherState, 0, len(a.state))
-	for _, s := range a.state {
-		cp := *s
+		cp := PublisherInfo{
+			MasterKey:           s.MasterKey,
+			SigningKey:          s.SigningKey,
+			Status:              s.Status,
+			Sequence:            s.Sequence,
+			Effective:           s.Effective,
+			EffectiveSet:        s.EffectiveSet,
+			Expiration:          s.Expiration,
+			SiteURI:             s.SiteURI,
+			LastUpdate:          s.LastUpdate,
+			Version:             s.Version,
+			RawLocalManifestSet: s.RawLocalManifestSet,
+			MaxSequence:         s.MaxSequence,
+			MaxSequenceSet:      s.MaxSequenceSet,
+		}
 		if len(s.Validators) > 0 {
 			cp.Validators = make([][33]byte, len(s.Validators))
 			copy(cp.Validators, s.Validators)
 		}
-		if len(s.RawManifest) > 0 {
-			cp.RawManifest = append([]byte(nil), s.RawManifest...)
-		}
-		if len(s.RawBlob) > 0 {
-			cp.RawBlob = append([]byte(nil), s.RawBlob...)
-		}
-		if len(s.RawSignature) > 0 {
-			cp.RawSignature = append([]byte(nil), s.RawSignature...)
-		}
 		if len(s.Remaining) > 0 {
-			cp.Remaining = make(map[uint32]*PendingList, len(s.Remaining))
+			cp.Remaining = make(map[uint32]*RemainingInfo, len(s.Remaining))
 			for seq, p := range s.Remaining {
-				pcopy := *p
+				pcopy := &RemainingInfo{
+					Sequence:            p.Sequence,
+					Effective:           p.Effective,
+					EffectiveSet:        p.EffectiveSet,
+					Expiration:          p.Expiration,
+					SiteURI:             p.SiteURI,
+					Version:             p.Version,
+					RawLocalManifestSet: p.RawLocalManifestSet,
+				}
 				if len(p.Validators) > 0 {
 					pcopy.Validators = append([][33]byte(nil), p.Validators...)
 				}
-				if len(p.RawManifest) > 0 {
-					pcopy.RawManifest = append([]byte(nil), p.RawManifest...)
-				}
-				if len(p.RawBlob) > 0 {
-					pcopy.RawBlob = append([]byte(nil), p.RawBlob...)
-				}
-				if len(p.RawSignature) > 0 {
-					pcopy.RawSignature = append([]byte(nil), p.RawSignature...)
-				}
-				cp.Remaining[seq] = &pcopy
+				cp.Remaining[seq] = pcopy
 			}
 		}
 		out = append(out, cp)
@@ -563,12 +637,21 @@ func (a *Aggregator) PublisherSnapshot() []PublisherState {
 	return out
 }
 
-func (a *Aggregator) SiteSnapshot() []SiteState {
+func (a *Aggregator) SiteSnapshot() []SiteInfo {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	out := make([]SiteState, len(a.sites))
+	out := make([]SiteInfo, len(a.sites))
 	for i, s := range a.sites {
-		out[i] = *s
+		out[i] = SiteInfo{
+			URI:                s.URI,
+			LastFetched:        s.LastFetched,
+			LastSuccess:        s.LastSuccess,
+			LastError:          s.LastError,
+			LastDisposition:    s.LastDisposition,
+			LastDispositionSet: s.LastDispositionSet,
+			RefreshSeconds:     s.RefreshSeconds,
+			NextRefresh:        s.NextRefresh,
+		}
 	}
 	return out
 }
@@ -627,491 +710,30 @@ func (a *Aggregator) UpdateSiteState(uri string, lastFetched, lastSuccess time.T
 	}
 }
 
-// ApplyList ingests a single (manifest, blob, signature) triple and
-// returns the resulting disposition along with the publisher master
-// key (when extractable) and the blob's sequence (when extractable).
-// Wraps the rippled-faithful applyList algorithm: verify the publisher
-// manifest, look up its current ephemeral signing key, verify the blob
-// signature, JSON-parse the blob, then update per-publisher state and
-// trigger an OnChange if the trusted union changed.
-//
-// `manifestBytes` and `blob` carry the WIRE-FORM ascii strings as
-// received in TMValidatorList / TMValidatorListCollection (base64-
-// encoded). `signature` carries the WIRE-FORM hex string. `version`
-// is the protocol version negotiated at the message level.
-//
-// `siteURI` is recorded on the per-publisher state for RPC visibility
-// — pass "peer:<id>" for gossip-sourced lists and the URL for
-// HTTP-polled ones.
-//
-// Returns the publisher master key on every disposition where it's
-// extractable (i.e. the manifest decoded), so the caller can attribute
-// metrics / bad-data charges with publisher-level granularity even on
-// failure paths. Returns the zero PublisherKey when the manifest
-// itself could not be parsed. The sequence return is non-zero only
-// when the blob was decoded; the router uses it to record per-peer
-// publisher sequences regardless of accept/expired/pending outcome.
-func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version uint32, siteURI string) (Disposition, PublisherKey, uint32) {
-	if !isSupportedVersion(version) {
-		return UnsupportedVersion, PublisherKey{}, 0
-	}
-
-	// Decode the publisher manifest. The manifest is base64-encoded on
-	// the wire; the inner STObject is what manifest.Deserialize wants.
-	// Both failure modes mirror rippled ValidatorList.cpp:1363-1366
-	// which folds bad-manifest into Untrusted (no extractable master
-	// key, no usable trust decision) charged at feeUselessData — never
-	// at the heavier feeInvalidSignature reserved for bad cryptography
-	// over a structurally-sound list.
-	manifestRaw, err := decodeBase64Tolerant(manifestBytes)
-	if err != nil {
-		a.logger.Debug("validator list: manifest base64 decode failed", "error", err, "site", siteURI)
-		return Untrusted, PublisherKey{}, 0
-	}
-	parsed, err := manifest.Deserialize(manifestRaw)
-	if err != nil {
-		a.logger.Debug("validator list: manifest deserialize failed", "error", err, "site", siteURI)
-		return Untrusted, PublisherKey{}, 0
-	}
-	masterKey := parsed.MasterKey()
-	pubKey := PublisherKey(masterKey)
-
-	// Reject lists from publishers we don't trust. Per rippled this is
-	// a silent drop — gossip carries lists from many publishers and we
-	// shouldn't penalize peers for forwarding lists we choose not to
-	// trust ourselves.
-	a.mu.Lock()
-	_, trusted := a.publishers[pubKey]
-	a.mu.Unlock()
-	if !trusted {
-		return Untrusted, pubKey, 0
-	}
-
-	// Apply the publisher manifest to the manifest cache. This both
-	// caches the manifest for later use and gives us the current
-	// ephemeral signing key. A revoked manifest invalidates the
-	// publisher entirely.
-	//
-	// Track the cache disposition so revocation only flips publisher
-	// state when the manifest cache actually accepted the revocation.
-	// Mirrors rippled ValidatorList.cpp:1373-1378 — `removePublisherList`
-	// runs only under `revoked && result == ManifestDisposition::accepted`;
-	// a stale revocation (cache already holds a higher-sequence
-	// non-revoked manifest) returns untrusted without clearing state.
-	manifestAccepted := false
-	if a.publisherManifests != nil {
-		switch d := a.publisherManifests.ApplyManifest(parsed); d {
-		case manifest.Accepted:
-			manifestAccepted = true
-		case manifest.Stale:
-			// Already had this or a newer one — cache state is
-			// unchanged; don't let an old revocation manifest flip
-			// the publisher's status.
-		case manifest.Invalid:
-			// Rippled ValidatorList.cpp:1382-1383 returns
-			// `untrusted` strictly for `result == ManifestDisposition::invalid`.
-			// Untrusted maps to feeUselessData (light), Invalid would map
-			// to feeInvalidSignature (heavy) — using Untrusted avoids
-			// overcharging honest peers that forward a list whose manifest
-			// the cache cannot accept.
-			return Untrusted, pubKey, 0
-		case manifest.BadMasterKey, manifest.BadEphemeralKey:
-			// Cache state is unchanged for these (Manifest.cpp:436-477
-			// returns before any mutation), so `getSigningKey(masterPubKey)`
-			// below will still return the previously-cached signing key if
-			// any. Rippled's check at ValidatorList.cpp:1380-1383 gates only
-			// on `result == invalid`, NOT on badMasterKey/badEphemeralKey,
-			// so we fall through to the signing-key lookup. If the cache
-			// has no key for this master, the lookup branch a few lines
-			// below returns Untrusted; if it has one, blob verification
-			// proceeds against that cached key — matching rippled.
-		}
-	} else {
-		// Fall back to direct verification when no cache is wired
-		// (tests). The signing key in the manifest is what we'd have
-		// pulled from the cache. Mirrors rippled's invalid-manifest →
-		// untrusted mapping at ValidatorList.cpp:1382-1383.
-		if err := parsed.Verify(); err != nil {
-			return Untrusted, pubKey, 0
-		}
-		// No cache means every fresh verify is "accepted" for the
-		// purpose of the revocation gate.
-		manifestAccepted = true
-	}
-
-	if parsed.Revoked() {
-		// Rippled returns ListDisposition::untrusted on revocation
-		// (ValidatorList.cpp:1382-1383). Revocations are legitimate
-		// gossip; punishing the forwarding peer would cascade across
-		// every honest hop in the mesh. The state-clearing side effect
-		// only runs when the manifest cache actually accepted the
-		// revocation — mirrors rippled's `revoked && result == accepted`
-		// gate at ValidatorList.cpp:1373.
-		if manifestAccepted {
-			a.handleRevocation(pubKey)
-		}
-		return Untrusted, pubKey, 0
-	}
-
-	// Pull the current ephemeral signing key. With a cache: this is
-	// the freshest signing key we've ever seen for the publisher,
-	// which might be NEWER than the one in this very manifest if a
-	// later manifest arrived first via gossip. Rippled also uses
-	// publisherManifests_.getSigningKey here, which is the latest
-	// cached key, not the one in `manifestBytes`.
-	signingKey := parsed.SigningKey()
-	if a.publisherManifests != nil {
-		if k, ok := a.publisherManifests.GetSigningKey(masterKey); ok {
-			signingKey = k
-		} else {
-			// Cache says the master is unknown or revoked. If revoked
-			// we already handled above; if unknown despite the apply,
-			// treat as untrusted (no usable signing key from a trusted
-			// publisher means we cannot verify the blob; rippled's
-			// equivalent at ValidatorList.cpp:1382 is also untrusted).
-			return Untrusted, pubKey, 0
-		}
-	}
-
-	if err := verifyBlobSignature(signingKey, blob, signature); err != nil {
-		a.logger.Debug("validator list: blob signature invalid", "error", err, "publisher", hex.EncodeToString(pubKey[:]))
-		return Invalid, pubKey, 0
-	}
-
-	parsedBlob, disp, err := parseBlob(blob)
-	if err != nil {
-		a.logger.Debug("validator list: blob parse failed", "error", err, "publisher", hex.EncodeToString(pubKey[:]))
-		return disp, pubKey, 0
-	}
-
-	now := a.clock()
-	validFrom := time.Unix(rippleSecondsToUnix(parsedBlob.Effective), 0).UTC()
-	validUntil := time.Unix(rippleSecondsToUnix(parsedBlob.Expiration), 0).UTC()
-
-	a.mu.Lock()
-	defer a.flushCacheWrites()
-	defer a.mu.Unlock()
-
-	// New() pre-populates state[pubKey] for every trusted publisher and
-	// the entry is never deleted, so a missing key would be an internal
-	// invariant break — surface it loudly rather than silently re-create.
-	current := a.state[pubKey]
-
-	// Promote any pending Remaining entries that have reached their
-	// validFrom before the disposition check — mirrors rippled's lazy
-	// rotation in updateTrusted at ValidatorList.cpp:1929-1991, except
-	// driven by ingest rather than ledger close. Without this a fresh
-	// blob arriving after a queued rotation's effective time would see
-	// a stale `current.sequence` and decide pending/known_sequence on
-	// the wrong baseline.
-	a.promoteRemainingLocked(current, now)
-
-	// Determine disposition by sequence + time ordering. Mirrors the
-	// rippled state machine at ValidatorList.cpp:1394-1437. The
-	// SameSequence branch is intentionally unguarded by status —
-	// rippled returns same_sequence for every repeat of the current
-	// sequence regardless of `pubCollection.status`.
-	if parsedBlob.Sequence < current.Sequence {
-		return Stale, pubKey, parsedBlob.Sequence
-	}
-	if parsedBlob.Sequence == current.Sequence {
-		return SameSequence, pubKey, parsedBlob.Sequence
-	}
-	if validUntil.Before(now) || validUntil.Equal(now) {
-		// Expired ingest runs the SAME populate path as accepted in
-		// rippled: ValidatorList.cpp:1193-1295 — the local `accepted`
-		// boolean is true for both ListDisposition::accepted AND
-		// ListDisposition::expired, so the populate block writes
-		// publisher.list and publisher.manifests, and the call to
-		// updatePublisherList at line 1294 seeds embedded validator
-		// manifests into validatorManifests_ (line 1117-1133). The only
-		// runtime differences vs accepted are the final PublisherStatus
-		// (expired vs available) and that the trusted-set recompute
-		// skips non-available publishers (see recomputeAndEmitLocked:
-		// `s.Status != StatusAvailable` filter).
-		//
-		// We clear current.Validators after the populate so the RPC
-		// `validators` view does not surface stale keys under
-		// `available=false`. rippled keeps publisher.list populated for
-		// expired and relies on status filtering instead, but the
-		// effective trusted-set outcome is the same.
-		//
-		// removePublisherList(StatusExpired) at ValidatorList.cpp:1529-1542
-		// is invoked from updateTrusted (line 1999) when a previously-
-		// available list times out at ledger close — NOT from applyList.
-		a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version, manifestBytes, blob, signature)
-		current.Status = StatusExpired
-		current.Validators = nil
-		a.recomputeAndEmitLocked()
-		return Expired, pubKey, parsedBlob.Sequence
-	}
-	if validFrom.After(now) {
-		// Future-dated. Mirrors rippled ValidatorList.cpp:1414-1432
-		// pending-vs-known_sequence: a list is "pending" the first
-		// time it lands or whenever its sequence is the largest seen,
-		// and "known_sequence" only for re-arrivals at an already-
-		// queued sequence. The queued blob is retained so the next
-		// promoteRemainingLocked pass can rotate it into `current`.
-		return a.applyPendingLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, version, manifestBytes, blob, signature), pubKey, parsedBlob.Sequence
-	}
-
-	a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version, manifestBytes, blob, signature)
-	a.recomputeAndEmitLocked()
-	return Accepted, pubKey, parsedBlob.Sequence
-}
-
-// updateRawBytes refreshes the retained wire-form bytes, reusing the
-// existing backing arrays so the caller may keep its own slices.
-func (s *PublisherState) updateRawBytes(manifest, blob, signature []byte) {
-	s.RawManifest = append(s.RawManifest[:0], manifest...)
-	s.RawBlob = append(s.RawBlob[:0], blob...)
-	s.RawSignature = append(s.RawSignature[:0], signature...)
-}
-
-// extractValidatorKeys decodes and canonically sorts the validator
-// master keys from a parsed blob. logMsg is the debug message emitted
-// for skipped entries.
-func (a *Aggregator) extractValidatorKeys(blob *blobJSON, logMsg string) [][33]byte {
-	keys := make([][33]byte, 0, len(blob.Validators))
-	for i, v := range blob.Validators {
-		raw, err := hex.DecodeString(v.ValidationPublicKey)
-		if err != nil || !validatorKeyValid(raw) {
-			// Mirrors rippled ValidatorList.cpp:1250-1273 which logs
-			// `Invalid node identity` and silently skips the entry
-			// rather than rejecting the surrounding blob.
-			a.logger.Debug(logMsg,
-				"index", i,
-				"pubkey", v.ValidationPublicKey)
-			continue
-		}
-		var k [33]byte
-		copy(k[:], raw)
-		keys = append(keys, k)
-	}
-	sort.Slice(keys, func(i, j int) bool {
-		return string(keys[i][:]) < string(keys[j][:])
-	})
-	return keys
-}
-
-// applyAcceptedLocked materializes the parsed blob into the
-// publisher's state. Caller must hold a.mu. Does NOT emit OnChange —
-// that's done by recomputeAndEmitLocked once the caller has decided
-// the disposition warrants a trusted-set recompute.
-//
-// rawManifest / rawBlob / rawSignature are the wire-form bytes from
-// the original TMValidatorList / envelope; they are copied (not
-// referenced) so the caller may reuse its slices safely. Used later
-// by BroadcastLatest to re-emit the canonical accepted form to peers.
-func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, signingKey [33]byte, validFrom, validUntil time.Time, siteURI string, now time.Time, version uint32, rawManifest, rawBlob, rawSignature []byte) {
-	s.Sequence = blob.Sequence
-	s.Effective = validFrom
-	s.EffectiveSet = blob.EffectiveSet
-	s.Expiration = validUntil
-	s.SigningKey = signingKey
-	s.SiteURI = siteURI
-	s.LastUpdate = now
-	s.Status = StatusAvailable
-	if version > s.Version {
-		s.Version = version
-	}
-	s.updateRawBytes(rawManifest, rawBlob, rawSignature)
-
-	keys := a.extractValidatorKeys(blob, "validator list: skipping invalid validator entry")
-	s.Validators = keys
-
-	// Also seed any embedded validator manifests into the manifest
-	// cache so consensus can resolve ephemeral signing keys
-	// immediately, without waiting for the validator to gossip its
-	// own manifest. Mirrors rippled ValidatorList.cpp:1117-1133 which
-	// gates the apply on `keyListings_.count(m->masterKey)` — the
-	// embedded manifest's master key must be listed by some publisher
-	// (or by this publisher's new list, which is already incorporated
-	// above via `keys`). Manifests for unlisted validators are dropped:
-	// a malicious publisher must not be able to pollute the cache with
-	// manifests for validators they don't actually attest to.
-	if a.validatorManifests != nil {
-		listed := make(map[[33]byte]struct{}, len(keys)+8)
-		for _, k := range keys {
-			listed[k] = struct{}{}
-		}
-		for pubMaster, ps := range a.state {
-			if pubMaster == s.MasterKey {
-				continue
-			}
-			for _, k := range ps.Validators {
-				listed[k] = struct{}{}
-			}
-		}
-		for _, v := range blob.Validators {
-			if v.Manifest == "" {
-				continue
-			}
-			raw, err := decodeBase64Tolerant([]byte(v.Manifest))
-			if err != nil {
-				continue
-			}
-			parsed, err := manifest.Deserialize(raw)
-			if err != nil {
-				continue
-			}
-			masterKey := parsed.MasterKey()
-			if _, ok := listed[masterKey]; !ok {
-				a.logger.Debug("validator list: dropping embedded manifest for unlisted master",
-					"master", hex.EncodeToString(masterKey[:]))
-				continue
-			}
-			_ = a.validatorManifests.ApplyManifest(parsed)
-		}
-	}
-
-	a.writeCacheLocked(s)
-}
-
-// applyPendingLocked stores a future-dated blob in the publisher's
-// Remaining queue and returns Pending vs KnownSequence per rippled
-// ValidatorList.cpp:1414-1432:
-//
-//   - Pending: no MaxSequence yet, or sequence > MaxSequence, or
-//     sequence is unknown AND validFrom precedes the current
-//     MaxSequence entry's validFrom (out-of-order delivery).
-//   - KnownSequence: re-arrival at a sequence already queued.
-//
-// The blob is only stored on the Pending branch; KnownSequence is a
-// no-op since we already have the same sequence queued. Caller must
-// hold a.mu. Does NOT emit OnChange — promotion drives the trusted-set
-// update.
-func (a *Aggregator) applyPendingLocked(s *PublisherState, blob *blobJSON, signingKey [33]byte, validFrom, validUntil time.Time, siteURI string, version uint32, rawManifest, rawBlob, rawSignature []byte) Disposition {
-	known := false
-	if s.MaxSequenceSet {
-		if _, hit := s.Remaining[blob.Sequence]; hit {
-			known = true
-		} else if blob.Sequence <= s.MaxSequence {
-			// New sequence below max — pending only if it lands ahead
-			// of the current max-stored validFrom (out-of-order).
-			if maxEntry, ok := s.Remaining[s.MaxSequence]; !ok || !validFrom.Before(maxEntry.Effective) {
-				known = true
-			}
-		}
-	}
-	if known {
-		return KnownSequence
-	}
-
-	keys := a.extractValidatorKeys(blob, "validator list: skipping invalid validator entry in pending blob")
-
-	if s.Remaining == nil {
-		s.Remaining = make(map[uint32]*PendingList, 2)
-	}
-	s.Remaining[blob.Sequence] = &PendingList{
-		Sequence:     blob.Sequence,
-		Effective:    validFrom,
-		EffectiveSet: blob.EffectiveSet,
-		Expiration:   validUntil,
-		Validators:   keys,
-		SiteURI:      siteURI,
-		Version:      version,
-		SigningKey:   signingKey,
-		RawManifest:  append([]byte(nil), rawManifest...),
-		RawBlob:      append([]byte(nil), rawBlob...),
-		RawSignature: append([]byte(nil), rawSignature...),
-	}
-	a.writeCacheLocked(s)
-	if !s.MaxSequenceSet || blob.Sequence > s.MaxSequence {
-		s.MaxSequence = blob.Sequence
-		s.MaxSequenceSet = true
-	}
-	return Pending
-}
-
-// promoteRemainingLocked rotates ready Remaining entries (those whose
-// validFrom <= now) into the publisher's current slot, mirroring
-// rippled's updateTrusted loop at ValidatorList.cpp:1929-1991.
-// Operates on a single publisher; caller drives publisher iteration if
-// promoting for the whole set.
-//
-// Walks Remaining in ascending sequence order so a chain of stacked
-// rotations resolves to the LAST ready entry (rippled's iter/next
-// scan). Earlier entries are skipped and discarded — rippled
-// likewise erases [firstIter, std::next(iter)] after the rotation.
-//
-// Caller must hold a.mu. Does not emit OnChange — caller decides when
-// to recompute (typically immediately after the call when invoked at
-// ingest, or via Tick → recomputeAndEmitLocked on the time-driven
-// path).
-func (a *Aggregator) promoteRemainingLocked(s *PublisherState, now time.Time) {
-	if len(s.Remaining) == 0 {
-		return
-	}
-	seqs := make([]uint32, 0, len(s.Remaining))
-	for seq := range s.Remaining {
-		seqs = append(seqs, seq)
-	}
-	slices.Sort(seqs)
-
-	// Find the LAST entry that is ready to promote.
-	pickIdx := -1
-	for i, seq := range seqs {
-		p := s.Remaining[seq]
-		if !p.Effective.After(now) {
-			pickIdx = i
-			continue
-		}
-		break
-	}
-	if pickIdx < 0 {
-		return
-	}
-
-	chosen := s.Remaining[seqs[pickIdx]]
-	s.Sequence = chosen.Sequence
-	s.Effective = chosen.Effective
-	s.EffectiveSet = chosen.EffectiveSet
-	s.Expiration = chosen.Expiration
-	s.SigningKey = chosen.SigningKey
-	s.SiteURI = chosen.SiteURI
-	if chosen.Version > s.Version {
-		s.Version = chosen.Version
-	}
-	s.updateRawBytes(chosen.RawManifest, chosen.RawBlob, chosen.RawSignature)
-	s.Validators = append([][33]byte(nil), chosen.Validators...)
-	s.Status = StatusAvailable
-	// Mirrors rippled ValidatorList.cpp:1970 — if the promoted list is
-	// itself already expired, clear the validators so the next
-	// expiration sweep can downgrade the publisher cleanly.
-	if !s.Expiration.IsZero() && !s.Expiration.After(now) {
-		s.Status = StatusExpired
-		s.Validators = nil
-	}
-
-	// Erase all entries up to and including the chosen one — rippled
-	// remaining.erase(firstIter, std::next(iter)).
-	for i := 0; i <= pickIdx; i++ {
-		delete(s.Remaining, seqs[i])
-	}
-	if len(s.Remaining) == 0 {
-		s.Remaining = nil
-	}
-	a.writeCacheLocked(s)
-}
-
 // Tick performs a time-driven promotion sweep across every publisher
 // and emits OnChange if the resulting trusted union changed. Callers
 // should invoke this periodically (rippled drives it from updateTrusted
 // at every ledger close, ValidatorList.cpp:1910-1928); without an
 // external tick a pending rotation announced during a quiet period
-// would only promote on the next ApplyList / TrustedValidators call.
+// remains pending.
 //
 // Safe to call from any goroutine. Briefly takes the aggregator lock.
 func (a *Aggregator) Tick() {
 	a.mu.Lock()
-	defer a.flushCacheWrites()
-	defer a.mu.Unlock()
 	now := a.clock()
-	for _, s := range a.state {
-		a.promoteRemainingLocked(s, now)
+	promoted := make([]PublisherKey, 0, len(a.state))
+	for pubKey, s := range a.state {
+		if a.promoteRemainingLocked(s, now) {
+			promoted = append(promoted, pubKey)
+		}
 	}
 	a.recomputeAndEmitLocked()
+	a.mu.Unlock()
+	a.flushCacheWrites()
+	a.dispatchChanges()
+	for _, pubKey := range promoted {
+		a.BroadcastLatest(pubKey, 0)
+	}
 }
 
 // handleRevocation removes a publisher's contribution when its master
@@ -1120,6 +742,7 @@ func (a *Aggregator) Tick() {
 // the retained wire bytes so a revoked publisher is never rebroadcast.
 func (a *Aggregator) handleRevocation(pubKey PublisherKey) {
 	a.mu.Lock()
+	defer a.dispatchChanges()
 	defer a.flushCacheWrites()
 	defer a.mu.Unlock()
 	s, ok := a.state[pubKey]
@@ -1130,6 +753,8 @@ func (a *Aggregator) handleRevocation(pubKey PublisherKey) {
 	a.removeCacheLocked(s.MasterKey)
 	s.Validators = nil
 	s.RawManifest = nil
+	s.RawLocalManifest = nil
+	s.RawLocalManifestSet = false
 	s.RawBlob = nil
 	s.RawSignature = nil
 	s.Remaining = nil
@@ -1203,27 +828,15 @@ func (a *Aggregator) IsMasterListed(master [33]byte) bool {
 
 // recomputeAndEmitLocked walks the per-publisher state, computes the
 // union of validators present in at least `threshold` publishers' lists,
-// and invokes OnChange when either the trusted set or UNL-blocked state
-// changes.
-//
-// Caller MUST hold a.mu. The OnChange callback runs under the lock; the
-// adaptor.SetTrustedValidators path takes a different mutex so the
-// nesting is safe.
+// and queues an OnChange event when either the trusted set or UNL-blocked
+// state changes. Caller MUST hold a.mu; delivery happens after the caller
+// unlocks via dispatchChanges.
 func (a *Aggregator) recomputeAndEmitLocked() {
 	if a.threshold <= 0 || len(a.publishers) == 0 {
 		return
 	}
 
 	now := a.clock()
-	// Promote any Remaining entries whose validFrom has passed before
-	// counting — without this a rotation queued at applyPendingLocked
-	// would only feed the trusted set on the next ApplyList /
-	// TrustedValidators call, even if the caller (Tick or ingest path)
-	// invoked us specifically to refresh.
-	for _, s := range a.state {
-		a.promoteRemainingLocked(s, now)
-	}
-
 	// UNL-blocked accounting — mirrors rippled updateTrusted's per-publisher
 	// expiry pass and lock-down flag (ValidatorList.cpp:1929-2006, 2096-2101).
 	// good holds only while every configured publisher carries a live list; a
@@ -1285,7 +898,7 @@ func (a *Aggregator) recomputeAndEmitLocked() {
 	if slices.Equal(trusted, a.lastEmitted) && !blockedChanged && quorumUnavailable == previousQuorumUnavailable {
 		return
 	}
-	a.lastEmitted = trusted
+	a.lastEmitted = append(a.lastEmitted[:0], trusted...)
 
 	if a.onChange == nil {
 		return
@@ -1299,7 +912,11 @@ func (a *Aggregator) recomputeAndEmitLocked() {
 		"trusted_count", len(trusted),
 		"publisher_count", len(a.publishers),
 		"threshold", a.threshold)
-	a.onChange(nodeIDs, trusted)
+	a.changes.enqueue(changeEvent{
+		callback:   a.onChange,
+		validators: append([]consensus.NodeID(nil), nodeIDs...),
+		masterKeys: append([][33]byte(nil), trusted...),
+	})
 }
 
 // TrustedValidators returns the current effective trusted set as
@@ -1315,15 +932,7 @@ func (a *Aggregator) TrustedValidators() ([]consensus.NodeID, [][33]byte) {
 		return nil, nil
 	}
 
-	now := a.clock()
-	// Lazy-promote ready Remaining entries so the trusted set reflects
-	// rotations that became effective since the last ingest. Tick()
-	// handles the OnChange emission on the time-driven path; here we
-	// just need a fresh snapshot.
-	for _, s := range a.state {
-		a.promoteRemainingLocked(s, now)
-	}
-	counts := a.computeValidatorCountsLocked(now)
+	counts := a.computeValidatorCountsLocked(a.clock())
 
 	masters := make([][33]byte, 0, len(counts))
 	for k, c := range counts {
@@ -1341,239 +950,6 @@ func (a *Aggregator) TrustedValidators() ([]consensus.NodeID, [][33]byte) {
 	return nodeIDs, masters
 }
 
-// ApplyCollection processes a v2 collection (TMValidatorListCollection),
-// applying each blob individually with the collection's shared
-// publisher manifest. Returns the per-blob dispositions in the same
-// order as the collection's blob array, plus the publisher key once
-// the manifest decoded and the highest sequence observed across the
-// collection. The router uses the dispositions to decide whether to
-// charge the sender (any Invalid / Malformed) and whether to relay
-// (at least one Accepted), and uses the max-sequence value to update
-// the per-peer publisherListSequences entry.
-//
-// Mirrors rippled's applyLists at ValidatorList.cpp:998-1070.
-func (a *Aggregator) ApplyCollection(coll *message.ValidatorListCollection, siteURI string) ([]Disposition, PublisherKey, uint32) {
-	if coll == nil {
-		return []Disposition{Malformed}, PublisherKey{}, 0
-	}
-	if !isSupportedVersion(coll.Version) {
-		return []Disposition{UnsupportedVersion}, PublisherKey{}, 0
-	}
-	if len(coll.Blobs) == 0 {
-		return []Disposition{Malformed}, PublisherKey{}, 0
-	}
-	// Anti-abuse cap. Matches rippled ValidatorList.h:272
-	// `static constexpr std::size_t maxSupportedBlobs = 5;` enforced
-	// at ValidatorList.cpp:428 (v2 JSON path) and 472-473 (parseBlobs).
-	// A peer that sends a collection larger than this would force the
-	// aggregator to run N signature verifications; reject before any
-	// crypto work.
-	if len(coll.Blobs) > MaxSupportedBlobs {
-		return []Disposition{Malformed}, PublisherKey{}, 0
-	}
-	out := make([]Disposition, len(coll.Blobs))
-	var pubKey PublisherKey
-	var maxSeq uint32
-	for i, blob := range coll.Blobs {
-		// Per blob: prefer the embedded local manifest when present,
-		// else fall back to the collection's shared manifest. Matches
-		// rippled applyList(globalManifest, localManifest, ...) at
-		// ValidatorList.cpp:1140-1151.
-		mf := blob.Manifest
-		if !blob.HasManifest() {
-			mf = coll.Manifest
-		}
-		disp, pk, seq := a.ApplyList(mf, blob.Blob, blob.Signature, coll.Version, siteURI)
-		out[i] = disp
-		if pk != (PublisherKey{}) {
-			pubKey = pk
-		}
-		if seq > maxSeq {
-			maxSeq = seq
-		}
-	}
-	return out, pubKey, maxSeq
-}
-
 func isSupportedVersion(v uint32) bool {
-	return slices.Contains(SupportedVersions, v)
-}
-
-// RecordPeerSequence remembers that `peerID` has at least sequence
-// `seq` for `pubKey`. Called by the router after a successful ingress
-// of a TMValidatorList / TMValidatorListCollection — the peer has
-// proved possession of that sequence, so subsequent BroadcastLatest
-// passes for the same or older sequence can skip them.
-//
-// Monotonic: lower sequences are ignored. Zero `seq` is a no-op (we
-// only ever record a confirmed sequence). Mirrors rippled
-// PeerImp.cpp:2102-2110.
-func (a *Aggregator) RecordPeerSequence(peerID uint64, pubKey PublisherKey, seq uint32) {
-	if seq == 0 {
-		return
-	}
-	a.peerSeqMu.Lock()
-	defer a.peerSeqMu.Unlock()
-	m, ok := a.peerSeq[peerID]
-	if !ok {
-		m = make(map[PublisherKey]uint32)
-		a.peerSeq[peerID] = m
-	}
-	if seq > m[pubKey] {
-		m[pubKey] = seq
-	}
-}
-
-// ForgetPeer drops every per-publisher sequence record for `peerID`.
-// Called by the router from the peer-disconnect callback so the
-// per-peer map doesn't grow unbounded across the lifetime of the
-// process. Idempotent for unknown peers.
-func (a *Aggregator) ForgetPeer(peerID uint64) {
-	a.peerSeqMu.Lock()
-	defer a.peerSeqMu.Unlock()
-	delete(a.peerSeq, peerID)
-}
-
-// PeerSequence returns the highest sequence we believe `peerID` has
-// for `pubKey`, or 0 if unknown. Read-only accessor for tests and
-// observability; production code consults peerSeq via BroadcastLatest.
-func (a *Aggregator) PeerSequence(peerID uint64, pubKey PublisherKey) uint32 {
-	a.peerSeqMu.Lock()
-	defer a.peerSeqMu.Unlock()
-	if m, ok := a.peerSeq[peerID]; ok {
-		return m[pubKey]
-	}
-	return 0
-}
-
-// BroadcastLatest pushes the most recently accepted list for `pubKey`
-// to every connected peer that (a) negotiated ValidatorListPropagation
-// and (b) is known to be at a lower sequence than ours. `exceptPeer`
-// is the peer ID we just received the list from (or 0 for site-polled
-// lists) and is always skipped to avoid echoing back to the sender.
-//
-// No-op when no broadcaster is wired, when the publisher has no
-// accepted list to retain, or when the stored raw bytes are empty.
-// Mirrors rippled's ValidatorList::broadcastBlobs at
-// ValidatorList.cpp:872-937 — the per-peer publisherListSequence gate
-// + the "send the latest stored blob, not the inbound frame"
-// invariant. Per-peer state is updated after each successful send so
-// subsequent calls naturally skip the just-served peer.
-//
-// MUST NOT be called with a.mu held — the call snapshots state under
-// a.mu briefly then releases it, and may hold peerSeqMu and call into
-// the broadcaster (which writes to peer sockets) without either lock.
-func (a *Aggregator) BroadcastLatest(pubKey PublisherKey, exceptPeer uint64) {
-	a.mu.Lock()
-	bcaster := a.bcaster
-	if bcaster == nil {
-		a.mu.Unlock()
-		return
-	}
-	s, ok := a.state[pubKey]
-	if !ok || s.Sequence == 0 || s.Status == StatusRevoked ||
-		len(s.RawManifest) == 0 || len(s.RawBlob) == 0 || len(s.RawSignature) == 0 {
-		a.mu.Unlock()
-		return
-	}
-	sequence := s.Sequence
-	blobVersion := s.Version
-	if blobVersion == 0 {
-		blobVersion = 1
-	}
-	rawManifest := append([]byte(nil), s.RawManifest...)
-	rawBlob := append([]byte(nil), s.RawBlob...)
-	rawSignature := append([]byte(nil), s.RawSignature...)
-	// Snapshot the publisher's current blob plus any Remaining blobs
-	// into an ordered BroadcastBlob list so v2-capable peers always
-	// receive a TMValidatorListCollection (single-entry when no
-	// Remaining). Mirrors rippled's sendValidatorList at
-	// ValidatorList.cpp:752-757 which selects messageVersion=2 purely
-	// on the peer's ValidatorList2Propagation feature, regardless of
-	// whether the publisher has Remaining blobs, and buildBlobInfos
-	// at ValidatorList.cpp:852-857 which serialises current + remaining
-	// into a single map<sequence,…>.
-	collBlobs := make([]BroadcastBlob, 0, len(s.Remaining)+1)
-	collBlobs = append(collBlobs, BroadcastBlob{
-		Blob:      append([]byte(nil), s.RawBlob...),
-		Signature: append([]byte(nil), s.RawSignature...),
-	})
-	maxSeq := sequence
-	if len(s.Remaining) > 0 {
-		seqs := make([]uint32, 0, len(s.Remaining))
-		for seq := range s.Remaining {
-			seqs = append(seqs, seq)
-		}
-		slices.Sort(seqs)
-		for _, seq := range seqs {
-			rb := s.Remaining[seq]
-			collBlobs = append(collBlobs, BroadcastBlob{
-				Blob:      append([]byte(nil), rb.RawBlob...),
-				Signature: append([]byte(nil), rb.RawSignature...),
-			})
-			if seq > maxSeq {
-				maxSeq = seq
-			}
-		}
-	}
-	collVersion := max(blobVersion, 2)
-	logger := a.logger
-	a.mu.Unlock()
-
-	active := bcaster.ActivePeers()
-	sent := 0
-	for _, peerID := range active {
-		if peerID == exceptPeer {
-			continue
-		}
-		if !bcaster.PeerSupportsVL(peerID) {
-			continue
-		}
-		// v2-capable peer: always send the collection (single-entry
-		// when there are no Remaining blobs, multi-entry otherwise)
-		// so the wire shape matches rippled's broadcastBlobs at
-		// ValidatorList.cpp:872-937 which picks the message type
-		// purely on the peer's ValidatorList2Propagation feature.
-		if bcaster.PeerSupportsV2(peerID) {
-			if a.PeerSequence(peerID, pubKey) >= maxSeq {
-				continue
-			}
-			if err := bcaster.SendCollection(peerID, rawManifest, collBlobs, collVersion); err != nil {
-				logger.Debug("validator list collection broadcast: send failed",
-					"peer", peerID,
-					"publisher", hex.EncodeToString(pubKey[:]),
-					"max_sequence", maxSeq,
-					"error", err)
-				continue
-			}
-			a.RecordPeerSequence(peerID, pubKey, maxSeq)
-			sent++
-			continue
-		}
-		if a.PeerSequence(peerID, pubKey) >= sequence {
-			continue
-		}
-		if err := bcaster.SendList(peerID, rawManifest, rawBlob, rawSignature, blobVersion); err != nil {
-			logger.Debug("validator list broadcast: send failed",
-				"peer", peerID,
-				"publisher", hex.EncodeToString(pubKey[:]),
-				"sequence", sequence,
-				"error", err)
-			continue
-		}
-		// Even if the wire bytes happened to coincide with a frame the
-		// peer just sent us, the in-flight RecordPeerSequence call
-		// will reach the same target sequence — so updating here is
-		// idempotent.
-		a.RecordPeerSequence(peerID, pubKey, sequence)
-		sent++
-	}
-
-	if sent > 0 {
-		logger.Debug("validator list broadcast",
-			"publisher", hex.EncodeToString(pubKey[:]),
-			"sequence", sequence,
-			"remaining", len(collBlobs)-1,
-			"peers_sent", sent)
-	}
+	return v == supportedVersionV1 || v == supportedVersionV2
 }

--- a/internal/validator/list/aggregator_state_test.go
+++ b/internal/validator/list/aggregator_state_test.go
@@ -1,0 +1,184 @@
+package list
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/manifest"
+	"github.com/LeJamon/go-xrpl/protocol"
+)
+
+func TestApplyListCommitRejectsManifestStateChangedDuringVerification(t *testing.T) {
+	t.Run("revocation", func(t *testing.T) {
+		wireRaw, master, signing, masterPriv, signingPriv := stateTestManifest(t, 0x81, 0x82, 1, false)
+		wire := []byte(base64.StdEncoding.EncodeToString(wireRaw))
+		parsedInitial, err := manifest.Deserialize(wireRaw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := parsedInitial.Verify(); err != nil {
+			t.Fatal(err)
+		}
+		revocation, _, _, _, _ := stateTestManifest(t, 0x81, 0, manifest.RevokedSequence, true)
+		publisherCache := manifest.NewCache()
+		agg, err := New(Config{
+			PublisherKeys:      []PublisherKey{PublisherKey(master)},
+			Threshold:          1,
+			ValidatorManifests: manifest.NewCache(),
+			PublisherManifests: publisherCache,
+			Clock:              func() time.Time { return time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC) },
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		hookCalled := false
+		agg.beforeListCommit = func() {
+			hookCalled = true
+			parsed, err := manifest.Deserialize(revocation)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := publisherCache.ApplyManifest(parsed); got != manifest.Accepted {
+				t.Fatalf("revocation ApplyManifest: got %s", got)
+			}
+		}
+		blob, signature := stateTestList(t, signingPriv, 1, masterPriv, 0x90)
+		if err := verifyBlobSignature(signing, blob, signature); err != nil {
+			t.Fatal(err)
+		}
+		if _, d, err := parseBlob(blob); err != nil {
+			t.Fatalf("parse blob: %s %v", d, err)
+		}
+		d, _, _ := agg.ApplyList(wire, blob, signature, 1, "test://")
+		if !hookCalled {
+			t.Fatal("commit hook was not called")
+		}
+		if d != Untrusted {
+			t.Fatalf("disposition: got %s want untrusted", d)
+		}
+		snapshot := agg.PublisherSnapshot()
+		if snapshot[0].Sequence != 0 {
+			t.Fatalf("revocation race resurrected sequence %d", snapshot[0].Sequence)
+		}
+	})
+
+	t.Run("rotation", func(t *testing.T) {
+		wireRaw, master, _, masterPriv, signingPriv := stateTestManifest(t, 0x83, 0x84, 1, false)
+		wire := []byte(base64.StdEncoding.EncodeToString(wireRaw))
+		rotated, _, _, _, _ := stateTestManifest(t, 0x83, 0x85, 2, false)
+		publisherCache := manifest.NewCache()
+		agg, err := New(Config{
+			PublisherKeys:      []PublisherKey{PublisherKey(master)},
+			Threshold:          1,
+			ValidatorManifests: manifest.NewCache(),
+			PublisherManifests: publisherCache,
+			Clock:              func() time.Time { return time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC) },
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		agg.beforeListCommit = func() {
+			parsed, err := manifest.Deserialize(rotated)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := publisherCache.ApplyManifest(parsed); got != manifest.Accepted {
+				t.Fatalf("rotation ApplyManifest: got %s", got)
+			}
+		}
+		blob, signature := stateTestList(t, signingPriv, 1, masterPriv, 0x91)
+		d, _, _ := agg.ApplyList(wire, blob, signature, 1, "test://")
+		if d != Untrusted {
+			t.Fatalf("disposition: got %s want untrusted", d)
+		}
+		snapshot := agg.PublisherSnapshot()
+		if snapshot[0].Sequence != 0 {
+			t.Fatalf("rotation race committed stale sequence %d", snapshot[0].Sequence)
+		}
+	})
+}
+
+func stateTestManifest(t *testing.T, masterSeed, signingSeed byte, sequence uint32, revoked bool) ([]byte, [33]byte, [33]byte, ed25519.PrivateKey, ed25519.PrivateKey) {
+	t.Helper()
+	masterPriv := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{masterSeed}, ed25519.SeedSize))
+	master32 := masterPriv.Public().(ed25519.PublicKey)
+	var master [33]byte
+	copy(master[:], append([]byte{0xED}, master32...))
+	var signing [33]byte
+	var signingPriv ed25519.PrivateKey
+	if !revoked {
+		signingPriv = ed25519.NewKeyFromSeed(bytes.Repeat([]byte{signingSeed}, ed25519.SeedSize))
+		signing32 := signingPriv.Public().(ed25519.PublicKey)
+		copy(signing[:], append([]byte{0xED}, signing32...))
+	}
+	obj := map[string]any{
+		"PublicKey": hex.EncodeToString(master[:]),
+		"Sequence":  sequence,
+	}
+	if !revoked {
+		obj["SigningPubKey"] = hex.EncodeToString(signing[:])
+	}
+	preimage := stateTestManifestPreimage(t, obj)
+	if !revoked {
+		obj["Signature"] = hex.EncodeToString(ed25519.Sign(signingPriv, preimage))
+	}
+	obj["MasterSignature"] = hex.EncodeToString(ed25519.Sign(masterPriv, preimage))
+	encoded, err := binarycodec.Encode(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := hex.DecodeString(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw, master, signing, masterPriv, signingPriv
+}
+
+func stateTestManifestPreimage(t *testing.T, src map[string]any) []byte {
+	t.Helper()
+	filtered := make(map[string]any, len(src))
+	for key, value := range src {
+		if key != "Signature" && key != "MasterSignature" {
+			filtered[key] = value
+		}
+	}
+	encoded, err := binarycodec.Encode(filtered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := hex.DecodeString(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prefix := protocol.HashPrefixManifest()
+	return append(append([]byte(nil), prefix[:]...), body...)
+}
+
+func stateTestList(t *testing.T, signingPriv ed25519.PrivateKey, sequence uint32, _ ed25519.PrivateKey, validatorSeed byte) ([]byte, []byte) {
+	t.Helper()
+	validatorPriv := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{validatorSeed}, ed25519.SeedSize))
+	validator32 := validatorPriv.Public().(ed25519.PublicKey)
+	var validator [33]byte
+	copy(validator[:], append([]byte{0xED}, validator32...))
+	body := struct {
+		Sequence   uint32              `json:"sequence"`
+		Expiration uint32              `json:"expiration"`
+		Validators []map[string]string `json:"validators"`
+	}{
+		Sequence:   sequence,
+		Expiration: uint32(time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC).Unix() - protocol.RippleEpochUnix),
+		Validators: []map[string]string{{"validation_public_key": hex.EncodeToString(validator[:])}},
+	}
+	jsonBytes, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob := []byte(base64.StdEncoding.EncodeToString(jsonBytes))
+	return blob, []byte(hex.EncodeToString(ed25519.Sign(signingPriv, jsonBytes)))
+}

--- a/internal/validator/list/aggregator_state_test.go
+++ b/internal/validator/list/aggregator_state_test.go
@@ -37,16 +37,15 @@ func TestApplyListCommitRejectsManifestStateChangedDuringVerification(t *testing
 		if err != nil {
 			t.Fatal(err)
 		}
-		hookCalled := false
+		entered := make(chan struct{})
+		release := make(chan struct{})
 		agg.beforeListCommit = func() {
-			hookCalled = true
-			parsed, err := manifest.Deserialize(revocation)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if got := publisherCache.ApplyManifest(parsed); got != manifest.Accepted {
-				t.Fatalf("revocation ApplyManifest: got %s", got)
-			}
+			close(entered)
+			<-release
+		}
+		parsedRevocation, err := manifest.Deserialize(revocation)
+		if err != nil {
+			t.Fatal(err)
 		}
 		blob, signature := stateTestList(t, signingPriv, 1, masterPriv, 0x90)
 		if err := verifyBlobSignature(signing, blob, signature); err != nil {
@@ -55,10 +54,18 @@ func TestApplyListCommitRejectsManifestStateChangedDuringVerification(t *testing
 		if _, d, err := parseBlob(blob); err != nil {
 			t.Fatalf("parse blob: %s %v", d, err)
 		}
-		d, _, _ := agg.ApplyList(wire, blob, signature, 1, "test://")
-		if !hookCalled {
-			t.Fatal("commit hook was not called")
+		result := make(chan Disposition, 1)
+		go func() {
+			d, _, _ := agg.ApplyList(wire, blob, signature, 1, "test://")
+			result <- d
+		}()
+		<-entered
+		got := publisherCache.ApplyManifest(parsedRevocation)
+		close(release)
+		if got != manifest.Accepted {
+			t.Fatalf("revocation ApplyManifest: got %s", got)
 		}
+		d := <-result
 		if d != Untrusted {
 			t.Fatalf("disposition: got %s want untrusted", d)
 		}
@@ -83,17 +90,29 @@ func TestApplyListCommitRejectsManifestStateChangedDuringVerification(t *testing
 		if err != nil {
 			t.Fatal(err)
 		}
+		entered := make(chan struct{})
+		release := make(chan struct{})
 		agg.beforeListCommit = func() {
-			parsed, err := manifest.Deserialize(rotated)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if got := publisherCache.ApplyManifest(parsed); got != manifest.Accepted {
-				t.Fatalf("rotation ApplyManifest: got %s", got)
-			}
+			close(entered)
+			<-release
+		}
+		parsedRotation, err := manifest.Deserialize(rotated)
+		if err != nil {
+			t.Fatal(err)
 		}
 		blob, signature := stateTestList(t, signingPriv, 1, masterPriv, 0x91)
-		d, _, _ := agg.ApplyList(wire, blob, signature, 1, "test://")
+		result := make(chan Disposition, 1)
+		go func() {
+			d, _, _ := agg.ApplyList(wire, blob, signature, 1, "test://")
+			result <- d
+		}()
+		<-entered
+		got := publisherCache.ApplyManifest(parsedRotation)
+		close(release)
+		if got != manifest.Accepted {
+			t.Fatalf("rotation ApplyManifest: got %s", got)
+		}
+		d := <-result
 		if d != Untrusted {
 			t.Fatalf("disposition: got %s want untrusted", d)
 		}

--- a/internal/validator/list/aggregator_test.go
+++ b/internal/validator/list/aggregator_test.go
@@ -362,13 +362,9 @@ func TestAggregator_ApplyList_UnsupportedVersion(t *testing.T) {
 	}
 }
 
-// TestAggregator_ApplyList_BadManifest pins the rippled-faithful mapping
-// for malformed publisher manifests: rippled ValidatorList.cpp:1363-1366
-// folds both `!m` (manifest deserialize failure) and unknown-publisher
-// into ListDisposition::untrusted (charged at feeUselessData), never at
-// the heavier feeInvalidSignature. Without this test a future change
-// could regress to charging honest peers feeInvalidSignature for
-// forwarding lists from broken publishers.
+// TestAggregator_ApplyList_BadManifest pins rippled's distinction between a
+// malformed publisher manifest (Invalid) and a structurally valid manifest
+// from an unknown publisher (Untrusted).
 func TestAggregator_ApplyList_BadManifest(t *testing.T) {
 	agg, _ := list.New(list.Config{
 		PublisherKeys: []list.PublisherKey{{0xED, 1, 2, 3}},
@@ -376,8 +372,8 @@ func TestAggregator_ApplyList_BadManifest(t *testing.T) {
 		Clock:         fixedClock(),
 	})
 	d, _, _ := agg.ApplyList([]byte("!@not_base64"), []byte("blob"), []byte("00"), 1, "test://")
-	if d != list.Untrusted {
-		t.Fatalf("disposition: got %s want Untrusted", d)
+	if d != list.Invalid {
+		t.Fatalf("disposition: got %s want Invalid", d)
 	}
 }
 
@@ -472,7 +468,35 @@ func TestAggregator_ApplyCollection_ExplicitEmptyLocalManifestDoesNotFallback(t 
 		}},
 	}, "test://")
 
-	require.Equal(t, []list.Disposition{list.Malformed}, dispositions)
+	require.Equal(t, []list.Disposition{list.Invalid}, dispositions)
+}
+
+func TestAggregator_ApplyCollection_RetainsLocalManifestPresence(t *testing.T) {
+	pub := newPublisher(t, 0x0B, 0x0C)
+	validator := derivedValidatorKey(0x0D)
+	agg, err := list.New(list.Config{
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
+	})
+	require.NoError(t, err)
+	blob, signature := pub.signList(t, 1, 0, fixedClock()().Add(24*time.Hour).Unix(), [][33]byte{validator})
+	dispositions, _, maxSequence := agg.ApplyCollection(&message.ValidatorListCollection{
+		Version:  2,
+		Manifest: pub.manifestB64,
+		Blobs: []message.ValidatorBlobInfo{{
+			Manifest:  append([]byte(nil), pub.manifestB64...),
+			Blob:      blob,
+			Signature: signature,
+		}},
+	}, "test://")
+	require.Equal(t, []list.Disposition{list.Accepted}, dispositions)
+	require.Equal(t, uint32(1), maxSequence)
+	snapshot := agg.PublisherSnapshot()
+	require.Len(t, snapshot, 1)
+	require.True(t, snapshot[0].RawLocalManifestSet)
 }
 
 func deterministicKey(seed byte) (pub32 []byte, priv ed25519.PrivateKey) {
@@ -590,9 +614,15 @@ func TestAggregator_ApplyList_PendingThenKnownSequence(t *testing.T) {
 	exp := mutableNow.Add(48 * time.Hour).Unix()
 
 	blob, sig := pub.signList(t, 7, futureEff, exp, [][33]byte{v1})
-	d, _, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
+	d, _, maxSequence := agg.ApplyList(pub.manifestB64, blob, sig, 2, "test://")
 	if d != list.Pending {
 		t.Fatalf("first apply: got %s want Pending", d)
+	}
+	if maxSequence != 7 {
+		t.Fatalf("pending max sequence: got %d want 7", maxSequence)
+	}
+	if got := agg.PublisherSnapshot()[0].Version; got != 2 {
+		t.Fatalf("pending v2 did not advance raw version: got %d", got)
 	}
 	// No promotion yet → trusted set empty.
 	if _, m := agg.TrustedValidators(); len(m) != 0 {
@@ -603,9 +633,12 @@ func TestAggregator_ApplyList_PendingThenKnownSequence(t *testing.T) {
 	}
 
 	// Same sequence again — KnownSequence (re-arrival at a queued seq).
-	d, _, _ = agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
+	d, _, maxSequence = agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
 	if d != list.KnownSequence {
 		t.Fatalf("re-apply at queued sequence: got %s want KnownSequence", d)
+	}
+	if maxSequence != 7 || agg.PublisherSnapshot()[0].Version != 2 {
+		t.Fatalf("known sequence lost retained max/version: max=%d snapshot=%+v", maxSequence, agg.PublisherSnapshot()[0])
 	}
 
 	// Advance the clock past validFrom and Tick — rotation promotes
@@ -619,6 +652,105 @@ func TestAggregator_ApplyList_PendingThenKnownSequence(t *testing.T) {
 	if !agg.IsMasterListed(v1) {
 		t.Fatal("validator not reported listed after promotion tick")
 	}
+}
+
+func TestAggregatorApplyListReturnsRetainedMaxSequence(t *testing.T) {
+	pub := newPublisher(t, 0x31, 0x32)
+	validator := derivedValidatorKey(0x33)
+	now := fixedClock()()
+	agg, err := list.New(list.Config{
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	expiration := now.Add(48 * time.Hour).Unix()
+	blob5, sig5 := pub.signList(t, 5, 0, expiration, [][33]byte{validator})
+	if d, _, maxSequence := agg.ApplyList(pub.manifestB64, blob5, sig5, 1, "test://"); d != list.Accepted || maxSequence != 5 {
+		t.Fatalf("seq=5: disposition=%s max=%d", d, maxSequence)
+	}
+	blob10, sig10 := pub.signList(t, 10, now.Add(time.Hour).Unix(), expiration, [][33]byte{validator})
+	if d, _, maxSequence := agg.ApplyList(pub.manifestB64, blob10, sig10, 2, "test://"); d != list.Pending || maxSequence != 10 {
+		t.Fatalf("seq=10: disposition=%s max=%d", d, maxSequence)
+	}
+	blob7, sig7 := pub.signList(t, 7, 0, expiration, [][33]byte{validator})
+	if d, _, maxSequence := agg.ApplyList(pub.manifestB64, blob7, sig7, 1, "test://"); d != list.Accepted || maxSequence != 10 {
+		t.Fatalf("seq=7: disposition=%s max=%d, want Accepted/10", d, maxSequence)
+	}
+	if d, _, maxSequence := agg.ApplyList(pub.manifestB64, blob7, sig7, 1, "test://"); d != list.SameSequence || maxSequence != 10 {
+		t.Fatalf("seq=7 repeat: disposition=%s max=%d, want SameSequence/10", d, maxSequence)
+	}
+}
+
+func TestAggregatorApplyCollectionSelectsBestPublisher(t *testing.T) {
+	pubA := newPublisher(t, 0x41, 0x42)
+	pubB := newPublisher(t, 0x43, 0x44)
+	validator := derivedValidatorKey(0x45)
+	now := fixedClock()()
+	expiration := now.Add(24 * time.Hour).Unix()
+
+	newAggregator := func(t *testing.T) *list.Aggregator {
+		t.Helper()
+		agg, err := list.New(list.Config{
+			PublisherKeys: []list.PublisherKey{
+				list.PublisherKey(pubA.masterPub),
+				list.PublisherKey(pubB.masterPub),
+			},
+			Threshold:          1,
+			ValidatorManifests: manifest.NewCache(),
+			PublisherManifests: manifest.NewCache(),
+			Clock:              fixedClock(),
+		})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		return agg
+	}
+
+	t.Run("best disposition", func(t *testing.T) {
+		agg := newAggregator(t)
+		blobA, sigA := pubA.signList(t, 5, 0, expiration, [][33]byte{validator})
+		blobB, sigB := pubB.signList(t, 20, 0, expiration, [][33]byte{validator})
+		sigB[0] ^= 0xff
+		dispositions, pubKey, maxSequence := agg.ApplyCollection(&message.ValidatorListCollection{
+			Version:  2,
+			Manifest: pubA.manifestB64,
+			Blobs: []message.ValidatorBlobInfo{
+				{Manifest: pubA.manifestB64, Blob: blobA, Signature: sigA},
+				{Manifest: pubB.manifestB64, Blob: blobB, Signature: sigB},
+			},
+		}, "peer://")
+		if len(dispositions) != 2 || dispositions[0] != list.Accepted || dispositions[1] != list.Invalid {
+			t.Fatalf("dispositions: %v", dispositions)
+		}
+		if pubKey != list.PublisherKey(pubA.masterPub) || maxSequence != 5 {
+			t.Fatalf("result publisher/max: %x/%d", pubKey, maxSequence)
+		}
+	})
+
+	t.Run("highest sequence tie", func(t *testing.T) {
+		agg := newAggregator(t)
+		blobA, sigA := pubA.signList(t, 10, 0, expiration, [][33]byte{validator})
+		blobB, sigB := pubB.signList(t, 5, 0, expiration, [][33]byte{validator})
+		dispositions, pubKey, maxSequence := agg.ApplyCollection(&message.ValidatorListCollection{
+			Version:  2,
+			Manifest: pubA.manifestB64,
+			Blobs: []message.ValidatorBlobInfo{
+				{Manifest: pubA.manifestB64, Blob: blobA, Signature: sigA},
+				{Manifest: pubB.manifestB64, Blob: blobB, Signature: sigB},
+			},
+		}, "peer://")
+		if len(dispositions) != 2 || dispositions[0] != list.Accepted || dispositions[1] != list.Accepted {
+			t.Fatalf("dispositions: %v", dispositions)
+		}
+		if pubKey != list.PublisherKey(pubA.masterPub) || maxSequence != 10 {
+			t.Fatalf("result publisher/max: %x/%d", pubKey, maxSequence)
+		}
+	})
 }
 
 // TestAggregator_ApplyList_EffectiveSet_Sentinel pins the rippled
@@ -652,11 +784,9 @@ func TestAggregator_ApplyList_EffectiveSet_Sentinel(t *testing.T) {
 	}
 }
 
-// TestAggregator_ApplyList_Expired_ClearsValidators pins rippled
-// removePublisherList(StatusExpired) at ValidatorList.cpp:1529-1542 —
-// expiry clears the publisher's `list` so the RPC does not surface
-// stale validator keys under `available=false`.
-func TestAggregator_ApplyList_Expired_ClearsValidators(t *testing.T) {
+// Direct expired-list ingest populates the publisher list and preserves it
+// for the RPC projection even though it does not contribute to trust.
+func TestAggregator_ApplyList_Expired_PreservesValidatorsUntilTick(t *testing.T) {
 	pub := newPublisher(t, 0x01, 0x02)
 	v1 := derivedValidatorKey(0x10)
 
@@ -677,8 +807,8 @@ func TestAggregator_ApplyList_Expired_ClearsValidators(t *testing.T) {
 	if len(snap) != 1 {
 		t.Fatalf("snapshot len: %d", len(snap))
 	}
-	if len(snap[0].Validators) != 0 {
-		t.Fatalf("expired publisher must surface empty validator list; got %d", len(snap[0].Validators))
+	if len(snap[0].Validators) != 1 || snap[0].Validators[0] != v1 {
+		t.Fatalf("expired publisher list was not retained: %+v", snap[0].Validators)
 	}
 }
 
@@ -756,4 +886,245 @@ func TestAggregator_ApplyList_Expired_SeedsEmbeddedManifests(t *testing.T) {
 	if _, ok := validatorCache.GetSigningKey(pub.masterPub); ok {
 		t.Fatal("publisher manifest contaminated the validator cache")
 	}
+}
+
+func TestAggregator_PendingThenNewCurrentDoesNotRollback(t *testing.T) {
+	pub := newPublisher(t, 0x31, 0x32)
+	v2 := derivedValidatorKey(0x41)
+	v3 := derivedValidatorKey(0x42)
+	now := fixedClock()()
+	mutableNow := now
+	agg, err := list.New(list.Config{
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              func() time.Time { return mutableNow },
+	})
+	require.NoError(t, err)
+
+	pendingBlob, pendingSig := pub.signList(t, 2, now.Add(2*time.Hour).Unix(), now.Add(48*time.Hour).Unix(), [][33]byte{v2})
+	require.Equal(t, list.Pending, mustApply(t, agg, pub.manifestB64, pendingBlob, pendingSig))
+
+	currentBlob, currentSig := pub.signList(t, 3, 0, now.Add(48*time.Hour).Unix(), [][33]byte{v3})
+	require.Equal(t, list.Accepted, mustApply(t, agg, pub.manifestB64, currentBlob, currentSig))
+
+	mutableNow = now.Add(3 * time.Hour)
+	agg.Tick()
+	snapshot := agg.PublisherSnapshot()
+	require.Len(t, snapshot, 1)
+	require.Equal(t, uint32(3), snapshot[0].Sequence)
+	require.Empty(t, snapshot[0].Remaining)
+	_, masters := agg.TrustedValidators()
+	require.Equal(t, [][33]byte{v3}, masters)
+}
+
+func TestAggregator_PendingNonMonotonicEffectiveTimesArePruned(t *testing.T) {
+	pub := newPublisher(t, 0x51, 0x52)
+	v2 := derivedValidatorKey(0x61)
+	v5 := derivedValidatorKey(0x65)
+	v6 := derivedValidatorKey(0x66)
+	v7 := derivedValidatorKey(0x67)
+	v8 := derivedValidatorKey(0x68)
+	now := fixedClock()()
+	mutableNow := now
+	agg, err := list.New(list.Config{
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              func() time.Time { return mutableNow },
+	})
+	require.NoError(t, err)
+
+	baseBlob, baseSig := pub.signList(t, 2, 0, now.Add(48*time.Hour).Unix(), [][33]byte{v2})
+	require.Equal(t, list.Accepted, mustApply(t, agg, pub.manifestB64, baseBlob, baseSig))
+
+	applyFuture := func(sequence uint32, effective time.Time, validator [][33]byte) list.Disposition {
+		blob, signature := pub.signList(t, sequence, effective.Unix(), now.Add(72*time.Hour).Unix(), validator)
+		return mustApply(t, agg, pub.manifestB64, blob, signature)
+	}
+	// The later sequence 8 establishes a maxSequence entry with a later
+	// effective time, allowing sequence 5 to arrive out of order and then be
+	// discarded when sequence 6 supersedes it.
+	require.Equal(t, list.Pending, applyFuture(7, now.Add(3*time.Hour), [][33]byte{v7}))
+	require.Equal(t, list.Pending, applyFuture(8, now.Add(5*time.Hour), [][33]byte{v8}))
+	require.Equal(t, list.Pending, applyFuture(5, now.Add(3*time.Hour), [][33]byte{v5}))
+	require.Equal(t, list.Pending, applyFuture(6, now.Add(2*time.Hour), [][33]byte{v6}))
+
+	snapshot := agg.PublisherSnapshot()
+	require.Len(t, snapshot, 1)
+	_, hasFive := snapshot[0].Remaining[5]
+	require.False(t, hasFive)
+
+	mutableNow = now.Add(2*time.Hour + time.Minute)
+	agg.Tick()
+	snapshot = agg.PublisherSnapshot()
+	require.Equal(t, uint32(6), snapshot[0].Sequence)
+	_, hasSeven := snapshot[0].Remaining[7]
+	_, hasEight := snapshot[0].Remaining[8]
+	require.True(t, hasSeven)
+	require.True(t, hasEight)
+	_, masters := agg.TrustedValidators()
+	require.Equal(t, [][33]byte{v6}, masters)
+}
+
+func TestAggregator_PendingPromotionAppliesEmbeddedManifest(t *testing.T) {
+	pub := newPublisher(t, 0x71, 0x72)
+	valMaster32, valMasterPriv := deterministicKey(0x73)
+	valEph32, valEphPriv := deterministicKey(0x74)
+	var valMaster, valEph [33]byte
+	copy(valMaster[:], append([]byte{0xED}, valMaster32...))
+	copy(valEph[:], append([]byte{0xED}, valEph32...))
+	valManifest := base64.StdEncoding.EncodeToString(buildManifest(t, valMaster, valMasterPriv, valEph, valEphPriv, 1))
+
+	now := fixedClock()()
+	mutableNow := now
+	validatorCache := manifest.NewCache()
+	agg, err := list.New(list.Config{
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: validatorCache,
+		PublisherManifests: manifest.NewCache(),
+		Clock:              func() time.Time { return mutableNow },
+	})
+	require.NoError(t, err)
+
+	type entry struct {
+		ValidationPublicKey string `json:"validation_public_key"`
+		Manifest            string `json:"manifest,omitempty"`
+	}
+	body := struct {
+		Sequence   uint32  `json:"sequence"`
+		Expiration uint32  `json:"expiration"`
+		Effective  uint32  `json:"effective"`
+		Validators []entry `json:"validators"`
+	}{
+		Sequence:   4,
+		Expiration: uint32(now.Add(48*time.Hour).Unix() - protocol.RippleEpochUnix),
+		Effective:  uint32(now.Add(2*time.Hour).Unix() - protocol.RippleEpochUnix),
+		Validators: []entry{{
+			ValidationPublicKey: hex.EncodeToString(valMaster[:]),
+			Manifest:            valManifest,
+		}},
+	}
+	jsonBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+	blob := []byte(base64.StdEncoding.EncodeToString(jsonBytes))
+	signature := []byte(hex.EncodeToString(ed25519.Sign(pub.ephPriv, jsonBytes)))
+	require.Equal(t, list.Pending, mustApply(t, agg, pub.manifestB64, blob, signature))
+	if _, ok := validatorCache.GetSigningKey(valMaster); ok {
+		t.Fatal("pending embedded manifest applied before promotion")
+	}
+
+	mutableNow = now.Add(3 * time.Hour)
+	agg.Tick()
+	if _, ok := validatorCache.GetSigningKey(valMaster); !ok {
+		t.Fatal("pending embedded manifest was not applied at promotion")
+	}
+}
+
+func TestAggregatorOnChangeCallbackBoundaries(t *testing.T) {
+	newCase := func(t *testing.T, seed byte) (*list.Aggregator, *publisherFixture, []byte, []byte, [33]byte) {
+		t.Helper()
+		pub := newPublisher(t, seed, seed+1)
+		validator := derivedValidatorKey(seed + 2)
+		agg, err := list.New(list.Config{
+			PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+			Threshold:          1,
+			ValidatorManifests: manifest.NewCache(),
+			PublisherManifests: manifest.NewCache(),
+			Clock:              fixedClock(),
+		})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		blob, signature := pub.signList(t, 1, 0, fixedClock()().Add(24*time.Hour).Unix(), [][33]byte{validator})
+		return agg, pub, blob, signature, validator
+	}
+
+	t.Run("reentry", func(t *testing.T) {
+		agg, pub, blob, signature, _ := newCase(t, 0x71)
+		called := false
+		agg.OnChange(func(_ []consensus.NodeID, _ [][33]byte) {
+			called = true
+			if got := agg.PublisherCount(); got != 1 {
+				t.Errorf("PublisherCount from callback: %d", got)
+			}
+		})
+		if d, _, _ := agg.ApplyList(pub.manifestB64, blob, signature, 1, "test://"); d != list.Accepted {
+			t.Fatalf("ApplyList: %s", d)
+		}
+		if !called {
+			t.Fatal("callback was not invoked")
+		}
+	})
+
+	t.Run("slow callback does not hold aggregator lock", func(t *testing.T) {
+		agg, pub, blob, signature, _ := newCase(t, 0x74)
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		agg.OnChange(func(_ []consensus.NodeID, _ [][33]byte) {
+			close(entered)
+			<-release
+		})
+		applyDone := make(chan struct{})
+		go func() {
+			agg.ApplyList(pub.manifestB64, blob, signature, 1, "test://")
+			close(applyDone)
+		}()
+		select {
+		case <-entered:
+		case <-time.After(time.Second):
+			t.Fatal("callback did not start")
+		}
+		readDone := make(chan struct{})
+		go func() {
+			_ = agg.PublisherCount()
+			close(readDone)
+		}()
+		select {
+		case <-readDone:
+		case <-time.After(time.Second):
+			t.Fatal("callback held aggregator lock")
+		}
+		close(release)
+		select {
+		case <-applyDone:
+		case <-time.After(time.Second):
+			t.Fatal("ApplyList did not return after callback release")
+		}
+	})
+
+	t.Run("panic is contained", func(t *testing.T) {
+		agg, pub, blob, signature, _ := newCase(t, 0x77)
+		agg.OnChange(func(_ []consensus.NodeID, _ [][33]byte) { panic("test panic") })
+		if d, _, _ := agg.ApplyList(pub.manifestB64, blob, signature, 1, "test://"); d != list.Accepted {
+			t.Fatalf("ApplyList: %s", d)
+		}
+		if got := agg.PublisherSnapshot()[0].Sequence; got != 1 {
+			t.Fatalf("state not committed after callback panic: %d", got)
+		}
+	})
+
+	t.Run("payload isolation", func(t *testing.T) {
+		agg, pub, blob, signature, validator := newCase(t, 0x7a)
+		agg.OnChange(func(validators []consensus.NodeID, masters [][33]byte) {
+			validators[0][0] ^= 0xff
+			masters[0][0] ^= 0xff
+		})
+		if d, _, _ := agg.ApplyList(pub.manifestB64, blob, signature, 1, "test://"); d != list.Accepted {
+			t.Fatalf("ApplyList: %s", d)
+		}
+		_, masters := agg.TrustedValidators()
+		if len(masters) != 1 || masters[0] != validator {
+			t.Fatalf("callback mutated aggregator payload: %+v", masters)
+		}
+	})
+}
+
+func mustApply(t *testing.T, agg *list.Aggregator, publisherManifest, blob, signature []byte) list.Disposition {
+	t.Helper()
+	d, _, _ := agg.ApplyList(publisherManifest, blob, signature, 1, "test://")
+	return d
 }

--- a/internal/validator/list/aggregator_test.go
+++ b/internal/validator/list/aggregator_test.go
@@ -810,6 +810,13 @@ func TestAggregator_ApplyList_Expired_PreservesValidatorsUntilTick(t *testing.T)
 	if len(snap[0].Validators) != 1 || snap[0].Validators[0] != v1 {
 		t.Fatalf("expired publisher list was not retained: %+v", snap[0].Validators)
 	}
+	if !agg.IsMasterListed(v1) {
+		t.Fatal("directly ingested expired validator must remain listed until Tick")
+	}
+	agg.Tick()
+	if agg.IsMasterListed(v1) {
+		t.Fatal("expired validator remained listed after Tick")
+	}
 }
 
 // TestAggregator_ApplyList_Expired_SeedsEmbeddedManifests pins the
@@ -1021,6 +1028,57 @@ func TestAggregator_PendingPromotionAppliesEmbeddedManifest(t *testing.T) {
 	agg.Tick()
 	if _, ok := validatorCache.GetSigningKey(valMaster); !ok {
 		t.Fatal("pending embedded manifest was not applied at promotion")
+	}
+}
+
+func TestAggregatorExpiredPendingPromotionDoesNotApplyEmbeddedManifest(t *testing.T) {
+	pub := newPublisher(t, 0x78, 0x79)
+	valMaster32, valMasterPriv := deterministicKey(0x7a)
+	valEph32, valEphPriv := deterministicKey(0x7b)
+	var valMaster, valEph [33]byte
+	copy(valMaster[:], append([]byte{0xED}, valMaster32...))
+	copy(valEph[:], append([]byte{0xED}, valEph32...))
+	valManifest := base64.StdEncoding.EncodeToString(buildManifest(t, valMaster, valMasterPriv, valEph, valEphPriv, 1))
+
+	now := fixedClock()()
+	mutableNow := now
+	validatorCache := manifest.NewCache()
+	agg, err := list.New(list.Config{
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: validatorCache,
+		PublisherManifests: manifest.NewCache(),
+		Clock:              func() time.Time { return mutableNow },
+	})
+	require.NoError(t, err)
+	type entry struct {
+		ValidationPublicKey string `json:"validation_public_key"`
+		Manifest            string `json:"manifest,omitempty"`
+	}
+	body := struct {
+		Sequence   uint32  `json:"sequence"`
+		Expiration uint32  `json:"expiration"`
+		Effective  uint32  `json:"effective"`
+		Validators []entry `json:"validators"`
+	}{
+		Sequence:   4,
+		Expiration: uint32(now.Add(90*time.Minute).Unix() - protocol.RippleEpochUnix),
+		Effective:  uint32(now.Add(time.Hour).Unix() - protocol.RippleEpochUnix),
+		Validators: []entry{{
+			ValidationPublicKey: hex.EncodeToString(valMaster[:]),
+			Manifest:            valManifest,
+		}},
+	}
+	jsonBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+	blob := []byte(base64.StdEncoding.EncodeToString(jsonBytes))
+	signature := []byte(hex.EncodeToString(ed25519.Sign(pub.ephPriv, jsonBytes)))
+	require.Equal(t, list.Pending, mustApply(t, agg, pub.manifestB64, blob, signature))
+
+	mutableNow = now.Add(2 * time.Hour)
+	agg.Tick()
+	if _, ok := validatorCache.GetSigningKey(valMaster); ok {
+		t.Fatal("expired pending list applied its embedded validator manifest")
 	}
 }
 

--- a/internal/validator/list/blob.go
+++ b/internal/validator/list/blob.go
@@ -28,14 +28,17 @@ func validatorKeyValid(raw []byte) bool {
 // accepts. Version 1 is the original single-blob format; version 2 adds
 // the blobs_v2 collection used for forward-dated lists. Anything else
 // is treated as UnsupportedVersion.
-var SupportedVersions = []uint32{1, 2}
+const (
+	supportedVersionV1 uint32 = 1
+	supportedVersionV2 uint32 = 2
+)
 
 // MaxSupportedBlobs caps how many per-blob entries a v2 collection may
 // carry. Matches rippled ValidatorList.h:272
 // `static constexpr std::size_t maxSupportedBlobs = 5;`. A peer that
 // sends more than this is treated as Malformed before any signature
 // verification work.
-const MaxSupportedBlobs = 5
+const maxSupportedBlobs = 5
 
 // blobJSON is the schema published in vl.ripple.com-style envelopes and
 // embedded in TMValidatorList / TMValidatorListCollection messages.

--- a/internal/validator/list/body_reader.go
+++ b/internal/validator/list/body_reader.go
@@ -7,17 +7,22 @@ import (
 )
 
 const maxBodySize = 8 << 20
+const maxFileBodySize = 1 << 20
 
 // readBoundedBody consumes at most maxBodySize+1 bytes. Reading one byte over
 // the limit distinguishes an exactly full payload from an oversized one
 // without allocating an unbounded buffer.
 func readBoundedBody(r io.Reader) ([]byte, error) {
-	body, err := io.ReadAll(io.LimitReader(r, maxBodySize+1))
+	return readBoundedBodyLimit(r, maxBodySize)
+}
+
+func readBoundedBodyLimit(r io.Reader, limit int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, limit+1))
 	if err != nil {
 		return nil, err
 	}
-	if len(body) > maxBodySize {
-		return nil, fmt.Errorf("body exceeds %d bytes", maxBodySize)
+	if int64(len(body)) > limit {
+		return nil, fmt.Errorf("body exceeds %d bytes", limit)
 	}
 	return body, nil
 }
@@ -28,5 +33,5 @@ func readBoundedFile(path string) ([]byte, error) {
 		return nil, err
 	}
 	defer f.Close()
-	return readBoundedBody(f)
+	return readBoundedBodyLimit(f, maxFileBodySize)
 }

--- a/internal/validator/list/body_reader.go
+++ b/internal/validator/list/body_reader.go
@@ -1,0 +1,32 @@
+package list
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+const maxBodySize = 8 << 20
+
+// readBoundedBody consumes at most maxBodySize+1 bytes. Reading one byte over
+// the limit distinguishes an exactly full payload from an oversized one
+// without allocating an unbounded buffer.
+func readBoundedBody(r io.Reader) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, maxBodySize+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxBodySize {
+		return nil, fmt.Errorf("body exceeds %d bytes", maxBodySize)
+	}
+	return body, nil
+}
+
+func readBoundedFile(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return readBoundedBody(f)
+}

--- a/internal/validator/list/body_reader_sources_test.go
+++ b/internal/validator/list/body_reader_sources_test.go
@@ -41,7 +41,7 @@ func TestSitePollerFetchBoundedHTTPAndFileBodies(t *testing.T) {
 	}
 
 	path := filepath.Join(t.TempDir(), "list.json")
-	if err := os.WriteFile(path, bytes.Repeat([]byte{'f'}, maxBodySize+1), 0o600); err != nil {
+	if err := os.WriteFile(path, bytes.Repeat([]byte{'f'}, maxFileBodySize+1), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	poller := newPollerForLifecycleTest(t, "file://"+path)
@@ -56,7 +56,7 @@ func TestLoadCacheRejectsOversizeAndTrailingJSON(t *testing.T) {
 		name string
 		body []byte
 	}{
-		{name: "oversize", body: bytes.Repeat([]byte{'x'}, maxBodySize+1)},
+		{name: "oversize", body: bytes.Repeat([]byte{'x'}, maxFileBodySize+1)},
 		{name: "trailing json", body: append([]byte(`{"version":1,"manifest":"x"}`), []byte(" trailing")...)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/validator/list/body_reader_sources_test.go
+++ b/internal/validator/list/body_reader_sources_test.go
@@ -1,0 +1,83 @@
+package list
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSitePollerFetchBoundedHTTPAndFileBodies(t *testing.T) {
+	cases := []struct {
+		name    string
+		bodyLen int
+		wantErr bool
+	}{
+		{name: "http exact", bodyLen: maxBodySize},
+		{name: "http overflow", bodyLen: maxBodySize + 1, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := bytes.Repeat([]byte{'x'}, tc.bodyLen)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write(payload)
+			}))
+			defer server.Close()
+			poller := newPollerForLifecycleTest(t, server.URL)
+			got, err := poller.fetch(t.Context(), server.URL)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected HTTP body limit error")
+				}
+				return
+			}
+			if err != nil || len(got) != tc.bodyLen {
+				t.Fatalf("HTTP fetch: len=%d err=%v", len(got), err)
+			}
+		})
+	}
+
+	path := filepath.Join(t.TempDir(), "list.json")
+	if err := os.WriteFile(path, bytes.Repeat([]byte{'f'}, maxBodySize+1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	poller := newPollerForLifecycleTest(t, "file://"+path)
+	if _, err := poller.fetch(t.Context(), "file://"+path); err == nil {
+		t.Fatal("expected file body limit error")
+	}
+}
+
+func TestLoadCacheRejectsOversizeAndTrailingJSON(t *testing.T) {
+	key := PublisherKey{0xed, 9}
+	for _, tc := range []struct {
+		name string
+		body []byte
+	}{
+		{name: "oversize", body: bytes.Repeat([]byte{'x'}, maxBodySize+1)},
+		{name: "trailing json", body: append([]byte(`{"version":1,"manifest":"x"}`), []byte(" trailing")...)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			agg, err := New(Config{PublisherKeys: []PublisherKey{key}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := agg.SetCacheDir(dir); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(cachePathFor(dir, key), tc.body, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if got := agg.LoadCache(); got != 0 {
+				t.Fatalf("LoadCache accepted invalid body: %d", got)
+			}
+			var env envelope
+			if tc.name == "trailing json" && json.Unmarshal(tc.body, &env) == nil {
+				t.Fatal("test fixture unexpectedly accepted trailing JSON")
+			}
+		})
+	}
+}

--- a/internal/validator/list/body_reader_test.go
+++ b/internal/validator/list/body_reader_test.go
@@ -1,0 +1,35 @@
+package list
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestReadBoundedBodyExactAndOverflow(t *testing.T) {
+	cases := []struct {
+		name    string
+		bodyLen int
+		wantErr bool
+	}{
+		{name: "exact limit", bodyLen: maxBodySize},
+		{name: "one byte over", bodyLen: maxBodySize + 1, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := readBoundedBody(strings.NewReader(strings.Repeat("x", tc.bodyLen)))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected bounded-reader overflow")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("readBoundedBody: %v", err)
+			}
+			if len(body) != tc.bodyLen || !bytes.Equal(body[:1], []byte("x")) {
+				t.Fatalf("body length/content: got %d", len(body))
+			}
+		})
+	}
+}

--- a/internal/validator/list/broadcaster.go
+++ b/internal/validator/list/broadcaster.go
@@ -114,6 +114,10 @@ func (a *Aggregator) PeerSequence(peerID uint64, pubKey PublisherKey) uint32 {
 // newer than their recorded sequence, while per-blob manifests and the
 // collection-level manifest retain their distinct wire roles.
 func (a *Aggregator) BroadcastLatest(pubKey PublisherKey, exceptPeer uint64) {
+	a.broadcastLatest(pubKey, exceptPeer, 0)
+}
+
+func (a *Aggregator) broadcastLatest(pubKey PublisherKey, exceptPeer uint64, targetSequence uint32) {
 	a.mu.Lock()
 	bcaster := a.bcaster
 	if bcaster == nil {
@@ -170,6 +174,10 @@ func (a *Aggregator) BroadcastLatest(pubKey PublisherKey, exceptPeer uint64) {
 		}
 	}
 	collVersion := max(blobVersion, 2)
+	relaySequence := targetSequence
+	if relaySequence == 0 {
+		relaySequence = maxSeq
+	}
 	logger := a.logger
 	a.mu.Unlock()
 
@@ -181,7 +189,7 @@ func (a *Aggregator) BroadcastLatest(pubKey PublisherKey, exceptPeer uint64) {
 		}
 		if bcaster.PeerSupportsV2(peerID) {
 			peerSequence := a.PeerSequence(peerID, pubKey)
-			if peerSequence >= maxSeq {
+			if peerSequence >= relaySequence {
 				continue
 			}
 			peerBlobs := make([]BroadcastBlob, 0, len(entries))
@@ -201,7 +209,7 @@ func (a *Aggregator) BroadcastLatest(pubKey PublisherKey, exceptPeer uint64) {
 					"error", err)
 				continue
 			}
-			a.RecordPeerSequence(peerID, pubKey, maxSeq)
+			a.RecordPeerSequence(peerID, pubKey, relaySequence)
 			sent++
 			continue
 		}

--- a/internal/validator/list/broadcaster.go
+++ b/internal/validator/list/broadcaster.go
@@ -59,8 +59,8 @@ type PeerBroadcaster interface {
 // The aggregator constructs a slice of these from the publisher's
 // current + Remaining state for v2 broadcasts.
 type BroadcastBlob struct {
-	// Manifest is the per-blob manifest override; empty for blobs that
-	// use the collection's shared publisher manifest.
+	// A nil Manifest uses the shared publisher manifest; non-nil preserves an
+	// explicit per-blob override, including an empty one.
 	Manifest []byte
 	// Blob is the base64-encoded blob bytes as originally received.
 	Blob []byte

--- a/internal/validator/list/broadcaster.go
+++ b/internal/validator/list/broadcaster.go
@@ -1,5 +1,10 @@
 package list
 
+import (
+	"encoding/hex"
+	"slices"
+)
+
 // PeerBroadcaster is the minimal overlay+encoder surface the aggregator
 // uses to push the most recently accepted list (current + any
 // verified-but-future Remaining blobs) for a publisher out to
@@ -61,4 +66,185 @@ type BroadcastBlob struct {
 	Blob []byte
 	// Signature is the hex-encoded blob signature.
 	Signature []byte
+}
+
+type broadcastEntry struct {
+	sequence uint32
+	blob     BroadcastBlob
+}
+
+// RecordPeerSequence remembers that peerID has at least sequence seq for
+// pubKey. Lower sequences are ignored and zero is not a confirmed sequence.
+func (a *Aggregator) RecordPeerSequence(peerID uint64, pubKey PublisherKey, seq uint32) {
+	if seq == 0 {
+		return
+	}
+	a.peerSeqMu.Lock()
+	defer a.peerSeqMu.Unlock()
+	m, ok := a.peerSeq[peerID]
+	if !ok {
+		m = make(map[PublisherKey]uint32)
+		a.peerSeq[peerID] = m
+	}
+	if seq > m[pubKey] {
+		m[pubKey] = seq
+	}
+}
+
+// ForgetPeer drops every per-publisher sequence record for peerID.
+func (a *Aggregator) ForgetPeer(peerID uint64) {
+	a.peerSeqMu.Lock()
+	defer a.peerSeqMu.Unlock()
+	delete(a.peerSeq, peerID)
+}
+
+// PeerSequence returns the highest sequence known for peerID and pubKey.
+func (a *Aggregator) PeerSequence(peerID uint64, pubKey PublisherKey) uint32 {
+	a.peerSeqMu.Lock()
+	defer a.peerSeqMu.Unlock()
+	if m, ok := a.peerSeq[peerID]; ok {
+		return m[pubKey]
+	}
+	return 0
+}
+
+// BroadcastLatest pushes the most recently accepted list for pubKey to every
+// connected peer that negotiated validator-list propagation and is behind the
+// publisher's current sequence. v2 peers receive only collection entries
+// newer than their recorded sequence, while per-blob manifests and the
+// collection-level manifest retain their distinct wire roles.
+func (a *Aggregator) BroadcastLatest(pubKey PublisherKey, exceptPeer uint64) {
+	a.mu.Lock()
+	bcaster := a.bcaster
+	if bcaster == nil {
+		a.mu.Unlock()
+		return
+	}
+	s, ok := a.state[pubKey]
+	if !ok || s.Sequence == 0 || s.Status == StatusRevoked ||
+		len(s.RawManifest) == 0 || len(s.RawBlob) == 0 || len(s.RawSignature) == 0 {
+		a.mu.Unlock()
+		return
+	}
+	sequence := s.Sequence
+	blobVersion := s.Version
+	if blobVersion == 0 {
+		blobVersion = 1
+	}
+	rawManifest := cloneWireBytes(s.RawManifest)
+	listManifest := rawManifest
+	if s.RawLocalManifestSet {
+		listManifest = cloneOptionalWireBytes(s.RawLocalManifest, true)
+	}
+	rawBlob := cloneWireBytes(s.RawBlob)
+	rawSignature := cloneWireBytes(s.RawSignature)
+	entries := make([]broadcastEntry, 0, len(s.Remaining)+1)
+	entries = append(entries, broadcastEntry{
+		sequence: sequence,
+		blob: BroadcastBlob{
+			Manifest:  cloneOptionalWireBytes(s.RawLocalManifest, s.RawLocalManifestSet),
+			Blob:      cloneWireBytes(s.RawBlob),
+			Signature: cloneWireBytes(s.RawSignature),
+		},
+	})
+	maxSeq := sequence
+	if len(s.Remaining) > 0 {
+		seqs := make([]uint32, 0, len(s.Remaining))
+		for seq := range s.Remaining {
+			seqs = append(seqs, seq)
+		}
+		slices.Sort(seqs)
+		for _, seq := range seqs {
+			rb := s.Remaining[seq]
+			entries = append(entries, broadcastEntry{
+				sequence: seq,
+				blob: BroadcastBlob{
+					Manifest:  cloneOptionalWireBytes(rb.RawLocalManifest, rb.RawLocalManifestSet),
+					Blob:      cloneWireBytes(rb.RawBlob),
+					Signature: cloneWireBytes(rb.RawSignature),
+				},
+			})
+			if seq > maxSeq {
+				maxSeq = seq
+			}
+		}
+	}
+	collVersion := max(blobVersion, 2)
+	logger := a.logger
+	a.mu.Unlock()
+
+	active := bcaster.ActivePeers()
+	sent := 0
+	for _, peerID := range active {
+		if peerID == exceptPeer {
+			continue
+		}
+		if bcaster.PeerSupportsV2(peerID) {
+			peerSequence := a.PeerSequence(peerID, pubKey)
+			if peerSequence >= maxSeq {
+				continue
+			}
+			peerBlobs := make([]BroadcastBlob, 0, len(entries))
+			for _, entry := range entries {
+				if peerSequence == 0 || entry.sequence > peerSequence {
+					peerBlobs = append(peerBlobs, entry.blob)
+				}
+			}
+			if len(peerBlobs) == 0 {
+				continue
+			}
+			if err := bcaster.SendCollection(peerID, rawManifest, peerBlobs, collVersion); err != nil {
+				logger.Debug("validator list collection broadcast: send failed",
+					"peer", peerID,
+					"publisher", hex.EncodeToString(pubKey[:]),
+					"max_sequence", maxSeq,
+					"error", err)
+				continue
+			}
+			a.RecordPeerSequence(peerID, pubKey, maxSeq)
+			sent++
+			continue
+		}
+		if !bcaster.PeerSupportsVL(peerID) {
+			continue
+		}
+		if a.PeerSequence(peerID, pubKey) >= sequence {
+			continue
+		}
+		if err := bcaster.SendList(peerID, listManifest, rawBlob, rawSignature, supportedVersionV1); err != nil {
+			logger.Debug("validator list broadcast: send failed",
+				"peer", peerID,
+				"publisher", hex.EncodeToString(pubKey[:]),
+				"sequence", sequence,
+				"error", err)
+			continue
+		}
+		a.RecordPeerSequence(peerID, pubKey, sequence)
+		sent++
+	}
+
+	if sent > 0 {
+		logger.Debug("validator list broadcast",
+			"publisher", hex.EncodeToString(pubKey[:]),
+			"sequence", sequence,
+			"remaining", len(entries)-1,
+			"peers_sent", sent)
+	}
+}
+
+func cloneWireBytes(raw []byte) []byte {
+	if raw == nil {
+		return nil
+	}
+	return append(make([]byte, 0, len(raw)), raw...)
+}
+
+func cloneOptionalWireBytes(raw []byte, present bool) []byte {
+	if !present {
+		return nil
+	}
+	if raw == nil {
+		return []byte{}
+	}
+	return cloneWireBytes(raw)
 }

--- a/internal/validator/list/broadcaster_test.go
+++ b/internal/validator/list/broadcaster_test.go
@@ -346,6 +346,10 @@ func TestAggregatorTickPromotesAndBroadcastsWithoutReadSideMutation(t *testing.T
 	if d, _, _ := agg.ApplyList(pub.manifestB64, blob10, sig10, 2, "peer://"); d != list.Pending {
 		t.Fatalf("seq=10 apply: %s", d)
 	}
+	blob15, sig15 := pub.signList(t, 15, now.Add(3*time.Hour).Unix(), expiration, [][33]byte{validator})
+	if d, _, _ := agg.ApplyList(pub.manifestB64, blob15, sig15, 2, "peer://"); d != list.Pending {
+		t.Fatalf("seq=15 apply: %s", d)
+	}
 
 	clockNow = now.Add(2 * time.Hour)
 	if got := agg.PublisherSnapshot()[0].Sequence; got != 5 {
@@ -361,6 +365,9 @@ func TestAggregatorTickPromotesAndBroadcastsWithoutReadSideMutation(t *testing.T
 	agg.Tick()
 	if got := agg.PublisherSnapshot()[0].Sequence; got != 10 {
 		t.Fatalf("Tick did not promote pending list: got sequence %d", got)
+	}
+	if got := agg.PeerSequence(2, pubKey); got != 10 {
+		t.Fatalf("promotion recorded retained maximum instead of promoted sequence: got %d", got)
 	}
 	fake.mu.Lock()
 	defer fake.mu.Unlock()

--- a/internal/validator/list/broadcaster_test.go
+++ b/internal/validator/list/broadcaster_test.go
@@ -1,11 +1,13 @@
 package list_test
 
 import (
+	"bytes"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/manifest"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/LeJamon/go-xrpl/internal/validator/list"
 )
 
@@ -23,16 +25,18 @@ type fakeBroadcaster struct {
 }
 
 type sendListCall struct {
-	peerID  uint64
-	blob    []byte
-	sig     []byte
-	version uint32
+	peerID   uint64
+	manifest []byte
+	blob     []byte
+	sig      []byte
+	version  uint32
 }
 
 type sendCollectionCall struct {
-	peerID  uint64
-	blobs   []list.BroadcastBlob
-	version uint32
+	peerID   uint64
+	manifest []byte
+	blobs    []list.BroadcastBlob
+	version  uint32
 }
 
 func newFakeBroadcaster(peers []uint64, vlSupport, v2Support map[uint64]bool) *fakeBroadcaster {
@@ -57,10 +61,11 @@ func (f *fakeBroadcaster) SendList(peerID uint64, manifest, blob, signature []by
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.listCalls = append(f.listCalls, sendListCall{
-		peerID:  peerID,
-		blob:    append([]byte(nil), blob...),
-		sig:     append([]byte(nil), signature...),
-		version: version,
+		peerID:   peerID,
+		manifest: cloneBroadcastBytes(manifest),
+		blob:     append([]byte(nil), blob...),
+		sig:      append([]byte(nil), signature...),
+		version:  version,
 	})
 	return nil
 }
@@ -71,17 +76,25 @@ func (f *fakeBroadcaster) SendCollection(peerID uint64, manifest []byte, blobs [
 	cp := make([]list.BroadcastBlob, len(blobs))
 	for i, b := range blobs {
 		cp[i] = list.BroadcastBlob{
-			Manifest:  append([]byte(nil), b.Manifest...),
+			Manifest:  cloneBroadcastBytes(b.Manifest),
 			Blob:      append([]byte(nil), b.Blob...),
 			Signature: append([]byte(nil), b.Signature...),
 		}
 	}
 	f.collectionCalls = append(f.collectionCalls, sendCollectionCall{
-		peerID:  peerID,
-		blobs:   cp,
-		version: version,
+		peerID:   peerID,
+		manifest: cloneBroadcastBytes(manifest),
+		blobs:    cp,
+		version:  version,
 	})
 	return nil
+}
+
+func cloneBroadcastBytes(raw []byte) []byte {
+	if raw == nil {
+		return nil
+	}
+	return append([]byte{}, raw...)
 }
 
 // TestBroadcastLatest_V2PeerGetsCollection_NoRemaining pins M1: a
@@ -108,7 +121,7 @@ func TestBroadcastLatest_V2PeerGetsCollection_NoRemaining(t *testing.T) {
 	// Peer 100: v1-only. Peer 200: v2-capable.
 	fake := newFakeBroadcaster(
 		[]uint64{100, 200},
-		map[uint64]bool{100: true, 200: true},
+		map[uint64]bool{100: true, 200: false},
 		map[uint64]bool{100: false, 200: true},
 	)
 	agg.SetBroadcaster(fake)
@@ -137,6 +150,12 @@ func TestBroadcastLatest_V2PeerGetsCollection_NoRemaining(t *testing.T) {
 	}
 	if fake.collectionCalls[0].version < 2 {
 		t.Fatalf("collection version must be ≥ 2; got %d", fake.collectionCalls[0].version)
+	}
+	if !bytes.Equal(fake.collectionCalls[0].manifest, pub.manifestB64) {
+		t.Fatalf("collection manifest: got %q want %q", fake.collectionCalls[0].manifest, pub.manifestB64)
+	}
+	if fake.collectionCalls[0].blobs[0].Manifest != nil {
+		t.Fatalf("blob without local manifest must preserve nil presence, got %q", fake.collectionCalls[0].blobs[0].Manifest)
 	}
 }
 
@@ -183,5 +202,173 @@ func TestBroadcastLatest_V2PeerSkippedWhenAtMaxSeq(t *testing.T) {
 	}
 	if len(fake.listCalls) != 0 {
 		t.Fatalf("peer at maxSeq must not receive SendList either; got %d call(s)", len(fake.listCalls))
+	}
+}
+
+func TestBroadcastLatest_PreservesLocalManifestAndV1EffectiveManifest(t *testing.T) {
+	pub := newPublisher(t, 0x55, 0x56)
+	validator := derivedValidatorKey(0x62)
+	agg, err := list.New(list.Config{
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	fake := newFakeBroadcaster(
+		[]uint64{100, 200},
+		map[uint64]bool{100: true, 200: true},
+		map[uint64]bool{100: false, 200: true},
+	)
+	agg.SetBroadcaster(fake)
+	now := fixedClock()()
+	blob, sig := pub.signList(t, 6, 0, now.Add(24*time.Hour).Unix(), [][33]byte{validator})
+	dispositions, _, _ := agg.ApplyCollection(&message.ValidatorListCollection{
+		Version:  2,
+		Manifest: pub.manifestB64,
+		Blobs: []message.ValidatorBlobInfo{{
+			Manifest:  cloneBroadcastBytes(pub.manifestB64),
+			Blob:      blob,
+			Signature: sig,
+		}},
+	}, "peer://")
+	if len(dispositions) != 1 || dispositions[0] != list.Accepted {
+		t.Fatalf("ApplyCollection: got %v", dispositions)
+	}
+
+	agg.BroadcastLatest(list.PublisherKey(pub.masterPub), 0)
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.listCalls) != 1 || !bytes.Equal(fake.listCalls[0].manifest, pub.manifestB64) {
+		t.Fatalf("v1 must receive the local manifest override, got %+v", fake.listCalls)
+	}
+	if fake.listCalls[0].version != 1 {
+		t.Fatalf("v1 frame version: got %d want 1", fake.listCalls[0].version)
+	}
+	if len(fake.collectionCalls) != 1 {
+		t.Fatalf("v2 must receive one collection, got %d", len(fake.collectionCalls))
+	}
+	call := fake.collectionCalls[0]
+	if !bytes.Equal(call.manifest, pub.manifestB64) {
+		t.Fatalf("v2 collection manifest: got %q want %q", call.manifest, pub.manifestB64)
+	}
+	if len(call.blobs) != 1 || call.blobs[0].Manifest == nil ||
+		!bytes.Equal(call.blobs[0].Manifest, pub.manifestB64) {
+		t.Fatalf("v2 local manifest was not preserved: %+v", call.blobs)
+	}
+}
+
+func TestBroadcastLatest_V2FiltersEntriesByPeerSequence(t *testing.T) {
+	pub := newPublisher(t, 0x57, 0x58)
+	validator := derivedValidatorKey(0x63)
+	agg, err := list.New(list.Config{
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	fake := newFakeBroadcaster(
+		[]uint64{1, 2, 3},
+		map[uint64]bool{1: true, 2: true, 3: true},
+		map[uint64]bool{1: true, 2: true, 3: true},
+	)
+	agg.SetBroadcaster(fake)
+	now := fixedClock()()
+	exp := now.Add(48 * time.Hour).Unix()
+	blob5, sig5 := pub.signList(t, 5, 0, exp, [][33]byte{validator})
+	if d, _, _ := agg.ApplyList(pub.manifestB64, blob5, sig5, 1, "peer://"); d != list.Accepted {
+		t.Fatalf("seq=5 apply: %s", d)
+	}
+	blob10, sig10 := pub.signList(t, 10, now.Add(time.Hour).Unix(), exp, [][33]byte{validator})
+	if d, _, _ := agg.ApplyList(pub.manifestB64, blob10, sig10, 1, "peer://"); d != list.Pending {
+		t.Fatalf("seq=10 apply: %s", d)
+	}
+	pubKey := list.PublisherKey(pub.masterPub)
+	agg.RecordPeerSequence(1, pubKey, 5)
+	agg.RecordPeerSequence(2, pubKey, 7)
+	agg.BroadcastLatest(pubKey, 0)
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.collectionCalls) != 3 {
+		t.Fatalf("expected one collection per peer, got %d", len(fake.collectionCalls))
+	}
+	for _, call := range fake.collectionCalls {
+		switch call.peerID {
+		case 1, 2:
+			if len(call.blobs) != 1 || !bytes.Equal(call.blobs[0].Blob, blob10) {
+				t.Fatalf("peer %d should receive only seq 10, got %+v", call.peerID, call.blobs)
+			}
+		case 3:
+			if len(call.blobs) != 2 || !bytes.Equal(call.blobs[0].Blob, blob5) || !bytes.Equal(call.blobs[1].Blob, blob10) {
+				t.Fatalf("peer 3 should receive ordered seq 5,10, got %+v", call.blobs)
+			}
+		default:
+			t.Fatalf("unexpected peer %d", call.peerID)
+		}
+	}
+}
+
+func TestAggregatorTickPromotesAndBroadcastsWithoutReadSideMutation(t *testing.T) {
+	pub := newPublisher(t, 0x59, 0x5a)
+	validator := derivedValidatorKey(0x64)
+	now := fixedClock()()
+	clockNow := now
+	agg, err := list.New(list.Config{
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              func() time.Time { return clockNow },
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	fake := newFakeBroadcaster(
+		[]uint64{1, 2},
+		map[uint64]bool{1: true, 2: false},
+		map[uint64]bool{1: false, 2: true},
+	)
+	agg.SetBroadcaster(fake)
+	expiration := now.Add(48 * time.Hour).Unix()
+	blob5, sig5 := pub.signList(t, 5, 0, expiration, [][33]byte{validator})
+	if d, _, _ := agg.ApplyList(pub.manifestB64, blob5, sig5, 1, "peer://"); d != list.Accepted {
+		t.Fatalf("seq=5 apply: %s", d)
+	}
+	blob10, sig10 := pub.signList(t, 10, now.Add(time.Hour).Unix(), expiration, [][33]byte{validator})
+	if d, _, _ := agg.ApplyList(pub.manifestB64, blob10, sig10, 2, "peer://"); d != list.Pending {
+		t.Fatalf("seq=10 apply: %s", d)
+	}
+
+	clockNow = now.Add(2 * time.Hour)
+	if got := agg.PublisherSnapshot()[0].Sequence; got != 5 {
+		t.Fatalf("PublisherSnapshot promoted pending list: got sequence %d", got)
+	}
+	_, _ = agg.TrustedValidators()
+	if got := agg.PublisherSnapshot()[0].Sequence; got != 5 {
+		t.Fatalf("TrustedValidators promoted pending list: got sequence %d", got)
+	}
+
+	pubKey := list.PublisherKey(pub.masterPub)
+	agg.RecordPeerSequence(2, pubKey, 10)
+	agg.Tick()
+	if got := agg.PublisherSnapshot()[0].Sequence; got != 10 {
+		t.Fatalf("Tick did not promote pending list: got sequence %d", got)
+	}
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.listCalls) != 1 || fake.listCalls[0].peerID != 1 ||
+		fake.listCalls[0].version != 1 || !bytes.Equal(fake.listCalls[0].blob, blob10) {
+		t.Fatalf("promoted v1 broadcast: %+v", fake.listCalls)
+	}
+	if len(fake.collectionCalls) != 0 {
+		t.Fatalf("up-to-date v2 peer received promotion: %+v", fake.collectionCalls)
 	}
 }

--- a/internal/validator/list/cache.go
+++ b/internal/validator/list/cache.go
@@ -55,9 +55,6 @@ type pendingCacheWrite struct {
 	generation uint64
 }
 
-// cacheFileOps isolates the three filesystem mutations used by the cache
-// writer. The production zero value uses os, while same-package tests can
-// inject deterministic failures without relying on permissions or timing.
 type cacheFileOps struct {
 	remove    func(string) error
 	writeFile func(string, []byte, os.FileMode) error
@@ -72,7 +69,7 @@ type cacheFileOps struct {
 // rippled/src/xrpld/app/misc/detail/ValidatorList.cpp:368-396.
 //
 // Passing an empty string disables on-disk caching. Safe to call
-// before or after Start; takes a.mu briefly.
+// before or after Start.
 func (a *Aggregator) SetCacheDir(dir string) error {
 	if dir != "" {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -186,8 +183,8 @@ func (a *Aggregator) removeCacheLocked(pk PublisherKey) {
 // drain the queue, then performs the syscalls under cacheWriteMu. The
 // per-publisher seq stamp lets a superseded mutation be dropped, so two
 // concurrent flushers cannot leave a stale cache file as the winner.
-// Cheap no-op when nothing is queued. Errors are logged, not surfaced — a
-// failed cache mutations are requeued with their original sequence so a
+// Cheap no-op when nothing is queued. Errors are logged, not surfaced.
+// Failed cache mutations are requeued with their original sequence so a
 // later Tick or flush can retry them without allowing an older write to
 // overtake a newer mutation.
 func (a *Aggregator) flushCacheWrites() {

--- a/internal/validator/list/cache.go
+++ b/internal/validator/list/cache.go
@@ -25,6 +25,22 @@ const cacheRefreshIntervalMinutes = 24 * 60
 // it yields the per-publisher cache file name.
 const cacheFilePrefix = "cache."
 
+type cacheEnvelope struct {
+	Manifest       string               `json:"manifest"`
+	PublicKey      string               `json:"public_key,omitempty"`
+	Blob           *string              `json:"blob,omitempty"`
+	Signature      *string              `json:"signature,omitempty"`
+	Version        uint32               `json:"version"`
+	BlobsV2        *[]cacheEnvelopeBlob `json:"blobs_v2,omitempty"`
+	RefreshMinutes float64              `json:"refresh_interval,omitempty"`
+}
+
+type cacheEnvelopeBlob struct {
+	Manifest  *string `json:"manifest,omitempty"`
+	Blob      string  `json:"blob"`
+	Signature string  `json:"signature"`
+}
+
 // pendingCacheWrite is a marshaled cache-file mutation queued under a.mu
 // by writeCacheLocked / removeCacheLocked and flushed to disk by
 // flushCacheWrites once the lock is released, so disk latency never stalls
@@ -58,17 +74,13 @@ type cacheFileOps struct {
 // Passing an empty string disables on-disk caching. Safe to call
 // before or after Start; takes a.mu briefly.
 func (a *Aggregator) SetCacheDir(dir string) error {
-	if dir == "" {
-		a.mu.Lock()
-		a.cacheDir = ""
-		a.cacheGeneration++
-		a.pendingCacheWrites = make(map[PublisherKey]pendingCacheWrite)
-		a.mu.Unlock()
-		return nil
+	if dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create cache dir %q: %w", dir, err)
+		}
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return fmt.Errorf("create cache dir %q: %w", dir, err)
-	}
+	a.cacheWriteMu.Lock()
+	defer a.cacheWriteMu.Unlock()
 	a.mu.Lock()
 	if a.cacheDir != dir {
 		a.cacheGeneration++
@@ -97,7 +109,7 @@ func (a *Aggregator) writeCacheLocked(s *publisherState) {
 	if s == nil || s.Sequence == 0 || len(s.RawManifest) == 0 {
 		return
 	}
-	env := envelope{
+	env := cacheEnvelope{
 		Manifest:       string(s.RawManifest),
 		PublicKey:      hex.EncodeToString(s.MasterKey[:]),
 		Version:        s.Version,
@@ -110,7 +122,7 @@ func (a *Aggregator) writeCacheLocked(s *publisherState) {
 	if needsV2 {
 		// v2 shape — current + remaining, ordered by sequence ascending.
 		env.Version = 2
-		blobs := []envelopeBlob{{
+		blobs := []cacheEnvelopeBlob{{
 			Manifest:  optionalEnvelopeManifest(s.RawLocalManifest, s.RawLocalManifestSet),
 			Blob:      string(s.RawBlob),
 			Signature: string(s.RawSignature),
@@ -122,7 +134,7 @@ func (a *Aggregator) writeCacheLocked(s *publisherState) {
 		slices.Sort(seqs)
 		for _, seq := range seqs {
 			rb := s.Remaining[seq]
-			blobs = append(blobs, envelopeBlob{
+			blobs = append(blobs, cacheEnvelopeBlob{
 				Manifest:  optionalEnvelopeManifest(rb.RawLocalManifest, rb.RawLocalManifestSet),
 				Blob:      string(rb.RawBlob),
 				Signature: string(rb.RawSignature),
@@ -190,6 +202,9 @@ func (a *Aggregator) flushCacheWrites() {
 
 	a.cacheWriteMu.Lock()
 	defer a.cacheWriteMu.Unlock()
+	a.mu.Lock()
+	generation := a.cacheGeneration
+	a.mu.Unlock()
 	ops := a.cacheOps
 	if ops.remove == nil {
 		ops.remove = os.Remove
@@ -202,6 +217,9 @@ func (a *Aggregator) flushCacheWrites() {
 	}
 	failed := make(map[PublisherKey]pendingCacheWrite)
 	for pk, w := range pending {
+		if w.generation != generation {
+			continue
+		}
 		if w.seq <= a.cacheWritten[pk] {
 			continue
 		}
@@ -342,7 +360,7 @@ func (a *Aggregator) LoadCache() int {
 		uri := "file://" + path
 		applied := false
 		switch {
-		case env.Version >= 2:
+		case env.Version.Value != 1:
 			disps, _, _ := a.ApplyCollection(env.toCollection(), uri)
 			for _, d := range disps {
 				if d.ShouldRelay() {
@@ -350,12 +368,12 @@ func (a *Aggregator) LoadCache() int {
 					break
 				}
 			}
-		case env.Version == 1:
+		case env.Version.Value == 1:
 			disp, _, _ := a.ApplyList(
-				[]byte(env.Manifest),
-				[]byte(*env.Blob),
-				[]byte(*env.Signature),
-				env.Version,
+				[]byte(env.Manifest.Value),
+				[]byte(env.Blob.Value),
+				[]byte(env.Signature.Value),
+				env.Version.Value,
 				uri,
 			)
 			if disp.ShouldRelay() {

--- a/internal/validator/list/cache.go
+++ b/internal/validator/list/cache.go
@@ -33,9 +33,19 @@ const cacheFilePrefix = "cache."
 // flushCacheWrites to drop a mutation that a newer one for the same
 // publisher has already superseded on disk.
 type pendingCacheWrite struct {
-	path string
-	body []byte
-	seq  uint64
+	path       string
+	body       []byte
+	seq        uint64
+	generation uint64
+}
+
+// cacheFileOps isolates the three filesystem mutations used by the cache
+// writer. The production zero value uses os, while same-package tests can
+// inject deterministic failures without relying on permissions or timing.
+type cacheFileOps struct {
+	remove    func(string) error
+	writeFile func(string, []byte, os.FileMode) error
+	rename    func(string, string) error
 }
 
 // SetCacheDir wires the on-disk cache directory for accepted
@@ -51,6 +61,8 @@ func (a *Aggregator) SetCacheDir(dir string) error {
 	if dir == "" {
 		a.mu.Lock()
 		a.cacheDir = ""
+		a.cacheGeneration++
+		a.pendingCacheWrites = make(map[PublisherKey]pendingCacheWrite)
 		a.mu.Unlock()
 		return nil
 	}
@@ -58,6 +70,10 @@ func (a *Aggregator) SetCacheDir(dir string) error {
 		return fmt.Errorf("create cache dir %q: %w", dir, err)
 	}
 	a.mu.Lock()
+	if a.cacheDir != dir {
+		a.cacheGeneration++
+		a.pendingCacheWrites = make(map[PublisherKey]pendingCacheWrite)
+	}
 	a.cacheDir = dir
 	a.mu.Unlock()
 	return nil
@@ -74,7 +90,7 @@ func (a *Aggregator) SetCacheDir(dir string) error {
 // or the validators RPC read path. The eventual write is atomic via
 // tmp + rename. rippled likewise logs-and-ignores cache write failures
 // (ValidatorList.cpp:390-395).
-func (a *Aggregator) writeCacheLocked(s *PublisherState) {
+func (a *Aggregator) writeCacheLocked(s *publisherState) {
 	if a.cacheDir == "" {
 		return
 	}
@@ -90,13 +106,15 @@ func (a *Aggregator) writeCacheLocked(s *PublisherState) {
 	if env.Version == 0 {
 		env.Version = 1
 	}
-	if len(s.Remaining) > 0 {
+	needsV2 := s.Version >= 2 || s.RawLocalManifestSet || len(s.Remaining) > 0
+	if needsV2 {
 		// v2 shape — current + remaining, ordered by sequence ascending.
 		env.Version = 2
-		env.BlobsV2 = append(env.BlobsV2, envelopeBlob{
+		blobs := []envelopeBlob{{
+			Manifest:  optionalEnvelopeManifest(s.RawLocalManifest, s.RawLocalManifestSet),
 			Blob:      string(s.RawBlob),
 			Signature: string(s.RawSignature),
-		})
+		}}
 		seqs := make([]uint32, 0, len(s.Remaining))
 		for seq := range s.Remaining {
 			seqs = append(seqs, seq)
@@ -104,14 +122,18 @@ func (a *Aggregator) writeCacheLocked(s *PublisherState) {
 		slices.Sort(seqs)
 		for _, seq := range seqs {
 			rb := s.Remaining[seq]
-			env.BlobsV2 = append(env.BlobsV2, envelopeBlob{
+			blobs = append(blobs, envelopeBlob{
+				Manifest:  optionalEnvelopeManifest(rb.RawLocalManifest, rb.RawLocalManifestSet),
 				Blob:      string(rb.RawBlob),
 				Signature: string(rb.RawSignature),
 			})
 		}
+		env.BlobsV2 = &blobs
 	} else {
-		env.Blob = string(s.RawBlob)
-		env.Signature = string(s.RawSignature)
+		blob := string(s.RawBlob)
+		signature := string(s.RawSignature)
+		env.Blob = &blob
+		env.Signature = &signature
 	}
 	body, err := json.Marshal(env)
 	if err != nil {
@@ -122,9 +144,10 @@ func (a *Aggregator) writeCacheLocked(s *PublisherState) {
 	}
 	a.cacheWriteSeq++
 	a.pendingCacheWrites[s.MasterKey] = pendingCacheWrite{
-		path: cachePathFor(a.cacheDir, s.MasterKey),
-		body: body,
-		seq:  a.cacheWriteSeq,
+		path:       cachePathFor(a.cacheDir, s.MasterKey),
+		body:       body,
+		seq:        a.cacheWriteSeq,
+		generation: a.cacheGeneration,
 	}
 }
 
@@ -139,9 +162,10 @@ func (a *Aggregator) removeCacheLocked(pk PublisherKey) {
 	}
 	a.cacheWriteSeq++
 	a.pendingCacheWrites[pk] = pendingCacheWrite{
-		path: cachePathFor(a.cacheDir, pk),
-		body: nil,
-		seq:  a.cacheWriteSeq,
+		path:       cachePathFor(a.cacheDir, pk),
+		body:       nil,
+		seq:        a.cacheWriteSeq,
+		generation: a.cacheGeneration,
 	}
 }
 
@@ -151,7 +175,9 @@ func (a *Aggregator) removeCacheLocked(pk PublisherKey) {
 // per-publisher seq stamp lets a superseded mutation be dropped, so two
 // concurrent flushers cannot leave a stale cache file as the winner.
 // Cheap no-op when nothing is queued. Errors are logged, not surfaced — a
-// failed cache write is recoverable and self-corrects on the next list.
+// failed cache mutations are requeued with their original sequence so a
+// later Tick or flush can retry them without allowing an older write to
+// overtake a newer mutation.
 func (a *Aggregator) flushCacheWrites() {
 	a.mu.Lock()
 	if len(a.pendingCacheWrites) == 0 {
@@ -164,36 +190,91 @@ func (a *Aggregator) flushCacheWrites() {
 
 	a.cacheWriteMu.Lock()
 	defer a.cacheWriteMu.Unlock()
+	ops := a.cacheOps
+	if ops.remove == nil {
+		ops.remove = os.Remove
+	}
+	if ops.writeFile == nil {
+		ops.writeFile = os.WriteFile
+	}
+	if ops.rename == nil {
+		ops.rename = os.Rename
+	}
+	failed := make(map[PublisherKey]pendingCacheWrite)
 	for pk, w := range pending {
 		if w.seq <= a.cacheWritten[pk] {
 			continue
 		}
 		if w.body == nil {
-			if err := os.Remove(w.path); err != nil && !os.IsNotExist(err) {
-				a.logger.Debug("validator list: cache remove failed",
+			if err := ops.remove(w.path); err != nil && !os.IsNotExist(err) {
+				a.logger.Error("validator list: cache remove failed",
 					"publisher", hex.EncodeToString(pk[:]),
+					"retry", true,
 					"error", err)
+				failed[pk] = w
 				continue
 			}
 			a.cacheWritten[pk] = w.seq
 			continue
 		}
 		tmp := w.path + ".tmp"
-		if err := os.WriteFile(tmp, w.body, 0o600); err != nil {
-			a.logger.Debug("validator list: cache write failed",
+		if err := ops.writeFile(tmp, w.body, 0o600); err != nil {
+			a.logger.Error("validator list: cache write failed",
 				"publisher", hex.EncodeToString(pk[:]),
+				"retry", true,
 				"error", err)
+			if cleanupErr := ops.remove(tmp); cleanupErr != nil && !os.IsNotExist(cleanupErr) {
+				a.logger.Error("validator list: cache temporary-file cleanup failed",
+					"publisher", hex.EncodeToString(pk[:]),
+					"error", cleanupErr)
+			}
+			failed[pk] = w
 			continue
 		}
-		if err := os.Rename(tmp, w.path); err != nil {
-			a.logger.Debug("validator list: cache rename failed",
+		if err := ops.rename(tmp, w.path); err != nil {
+			a.logger.Error("validator list: cache rename failed",
 				"publisher", hex.EncodeToString(pk[:]),
+				"retry", true,
 				"error", err)
-			_ = os.Remove(tmp)
+			if cleanupErr := ops.remove(tmp); cleanupErr != nil && !os.IsNotExist(cleanupErr) {
+				a.logger.Error("validator list: cache temporary-file cleanup failed",
+					"publisher", hex.EncodeToString(pk[:]),
+					"error", cleanupErr)
+			}
+			failed[pk] = w
 			continue
 		}
 		a.cacheWritten[pk] = w.seq
 	}
+	if len(failed) == 0 {
+		return
+	}
+	// Keep cacheWriteMu held while checking cacheWritten and merging failed
+	// entries back under a.mu. This lock order prevents a concurrent flush
+	// from applying a newer mutation and then allowing an older failure to be
+	// requeued behind it.
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for pk, w := range failed {
+		if w.generation != a.cacheGeneration {
+			continue
+		}
+		if w.seq <= a.cacheWritten[pk] {
+			continue
+		}
+		if current, ok := a.pendingCacheWrites[pk]; ok && current.seq >= w.seq {
+			continue
+		}
+		a.pendingCacheWrites[pk] = w
+	}
+}
+
+func optionalEnvelopeManifest(raw []byte, present bool) *string {
+	if !present {
+		return nil
+	}
+	value := string(raw)
+	return &value
 }
 
 // LoadCache rehydrates publisher state from the on-disk cache. For
@@ -236,7 +317,7 @@ func (a *Aggregator) LoadCache() int {
 	loaded := 0
 	for _, pk := range pubs {
 		path := cachePathFor(dir, pk)
-		body, err := os.ReadFile(path)
+		body, err := readBoundedFile(path)
 		if err != nil {
 			if !os.IsNotExist(err) {
 				a.logger.Debug("validator list: cache read failed",
@@ -252,12 +333,16 @@ func (a *Aggregator) LoadCache() int {
 				"error", err)
 			continue
 		}
-		if env.Version == 0 || env.Manifest == "" {
+		if err := env.validateShape(); err != nil {
+			a.logger.Debug("validator list: invalid cache envelope",
+				"publisher", hex.EncodeToString(pk[:]),
+				"error", err)
 			continue
 		}
 		uri := "file://" + path
 		applied := false
-		if len(env.BlobsV2) > 0 {
+		switch {
+		case env.Version >= 2:
 			disps, _, _ := a.ApplyCollection(env.toCollection(), uri)
 			for _, d := range disps {
 				if d.ShouldRelay() {
@@ -265,11 +350,11 @@ func (a *Aggregator) LoadCache() int {
 					break
 				}
 			}
-		} else if env.Blob != "" && env.Signature != "" {
+		case env.Version == 1:
 			disp, _, _ := a.ApplyList(
 				[]byte(env.Manifest),
-				[]byte(env.Blob),
-				[]byte(env.Signature),
+				[]byte(*env.Blob),
+				[]byte(*env.Signature),
 				env.Version,
 				uri,
 			)

--- a/internal/validator/list/cache_failure_test.go
+++ b/internal/validator/list/cache_failure_test.go
@@ -260,7 +260,12 @@ func queueCacheWrite(t *testing.T, agg *Aggregator, path string, pk PublisherKey
 	t.Helper()
 	agg.mu.Lock()
 	agg.cacheWriteSeq++
-	agg.pendingCacheWrites[pk] = pendingCacheWrite{path: path, body: body, seq: agg.cacheWriteSeq}
+	agg.pendingCacheWrites[pk] = pendingCacheWrite{
+		path:       path,
+		body:       body,
+		seq:        agg.cacheWriteSeq,
+		generation: agg.cacheGeneration,
+	}
 	agg.mu.Unlock()
 }
 

--- a/internal/validator/list/cache_failure_test.go
+++ b/internal/validator/list/cache_failure_test.go
@@ -1,0 +1,206 @@
+package list
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestFlushCacheWrites_RetriesWriteAndObservesFailure(t *testing.T) {
+	var logs bytes.Buffer
+	agg := newCacheFailureAggregator(t, slog.New(slog.NewTextHandler(&logs, nil)))
+	path := cachePathFor(t.TempDir(), PublisherKey{0xed, 1})
+	var writes int
+	agg.cacheOps = cacheFileOps{
+		writeFile: func(name string, body []byte, mode os.FileMode) error {
+			writes++
+			if writes == 1 {
+				return errors.New("injected write failure")
+			}
+			return os.WriteFile(name, body, mode)
+		},
+	}
+	queueCacheWrite(t, agg, path, PublisherKey{0xed, 1}, []byte("first"))
+	agg.flushCacheWrites()
+	if writes != 1 {
+		t.Fatalf("write calls after failure: %d", writes)
+	}
+	if !bytes.Contains(logs.Bytes(), []byte("cache write failed")) {
+		t.Fatalf("write failure was not observable: %q", logs.String())
+	}
+	if pendingCacheCount(agg) != 1 {
+		t.Fatalf("failed write was not requeued")
+	}
+
+	agg.flushCacheWrites()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("retry did not create cache: %v", err)
+	}
+	if string(body) != "first" || pendingCacheCount(agg) != 0 {
+		t.Fatalf("retry result: body=%q pending=%d", body, pendingCacheCount(agg))
+	}
+}
+
+func TestFlushCacheWrites_RetriesRemoveAndDeletesStaleCache(t *testing.T) {
+	agg := newCacheFailureAggregator(t, nil)
+	pk := PublisherKey{0xed, 2}
+	path := cachePathFor(t.TempDir(), pk)
+	if err := os.WriteFile(path, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+	var removes int
+	agg.cacheOps = cacheFileOps{
+		remove: func(name string) error {
+			removes++
+			if removes == 1 {
+				return errors.New("injected remove failure")
+			}
+			return os.Remove(name)
+		},
+	}
+	agg.mu.Lock()
+	agg.cacheWriteSeq++
+	agg.pendingCacheWrites[pk] = pendingCacheWrite{path: path, seq: agg.cacheWriteSeq}
+	agg.mu.Unlock()
+	agg.flushCacheWrites()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stale cache disappeared after failed remove: %v", err)
+	}
+	if pendingCacheCount(agg) != 1 {
+		t.Fatalf("failed remove was not requeued")
+	}
+	agg.flushCacheWrites()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("retry did not delete stale cache, err=%v", err)
+	}
+}
+
+func TestFlushCacheWrites_RetriesRename(t *testing.T) {
+	agg := newCacheFailureAggregator(t, nil)
+	pk := PublisherKey{0xed, 3}
+	path := cachePathFor(t.TempDir(), pk)
+	var renames int
+	agg.cacheOps = cacheFileOps{
+		rename: func(old, new string) error {
+			renames++
+			if renames == 1 {
+				return errors.New("injected rename failure")
+			}
+			return os.Rename(old, new)
+		},
+	}
+	queueCacheWrite(t, agg, path, pk, []byte("rename"))
+	agg.flushCacheWrites()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("cache appeared after failed rename, err=%v", err)
+	}
+	if pendingCacheCount(agg) != 1 {
+		t.Fatalf("failed rename was not requeued")
+	}
+	agg.flushCacheWrites()
+	body, err := os.ReadFile(path)
+	if err != nil || string(body) != "rename" {
+		t.Fatalf("rename retry result: body=%q err=%v", body, err)
+	}
+}
+
+func TestFlushCacheWrites_DropsFailedOlderMutationWhenNewerQueued(t *testing.T) {
+	agg := newCacheFailureAggregator(t, nil)
+	pk := PublisherKey{0xed, 4}
+	path := cachePathFor(t.TempDir(), pk)
+	var writes int
+	agg.cacheOps = cacheFileOps{
+		writeFile: func(name string, body []byte, mode os.FileMode) error {
+			writes++
+			if writes == 1 {
+				return errors.New("injected write failure")
+			}
+			return os.WriteFile(name, body, mode)
+		},
+	}
+	queueCacheWrite(t, agg, path, pk, []byte("old"))
+	agg.flushCacheWrites()
+	if pendingCacheCount(agg) != 1 {
+		t.Fatalf("failed first mutation was not requeued")
+	}
+	// A newer revocation supersedes the failed write. The remove succeeds and
+	// the older body must never be retried or recreate the cache file.
+	agg.mu.Lock()
+	agg.cacheWriteSeq++
+	agg.pendingCacheWrites[pk] = pendingCacheWrite{path: path, seq: agg.cacheWriteSeq}
+	agg.mu.Unlock()
+	agg.flushCacheWrites()
+	if pendingCacheCount(agg) != 0 {
+		t.Fatalf("newer mutation did not supersede failed write")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("failed older write recreated cache, err=%v", err)
+	}
+}
+
+func TestSetCacheDirDisableDropsFailedMutationRetry(t *testing.T) {
+	agg := newCacheFailureAggregator(t, nil)
+	dir := t.TempDir()
+	if err := agg.SetCacheDir(dir); err != nil {
+		t.Fatalf("SetCacheDir: %v", err)
+	}
+	pk := PublisherKey{0xed, 5}
+	path := cachePathFor(dir, pk)
+	writes := 0
+	agg.cacheOps.writeFile = func(string, []byte, os.FileMode) error {
+		writes++
+		return errors.New("injected write failure")
+	}
+	agg.mu.Lock()
+	agg.cacheWriteSeq++
+	agg.pendingCacheWrites[pk] = pendingCacheWrite{
+		path:       path,
+		body:       []byte("stale"),
+		seq:        agg.cacheWriteSeq,
+		generation: agg.cacheGeneration,
+	}
+	agg.mu.Unlock()
+	agg.flushCacheWrites()
+	if pendingCacheCount(agg) != 1 {
+		t.Fatal("failed mutation was not queued for retry")
+	}
+	if err := agg.SetCacheDir(""); err != nil {
+		t.Fatalf("disable cache: %v", err)
+	}
+	agg.flushCacheWrites()
+	if writes != 1 || pendingCacheCount(agg) != 0 {
+		t.Fatalf("disabled cache retried old mutation: writes=%d pending=%d", writes, pendingCacheCount(agg))
+	}
+}
+
+func newCacheFailureAggregator(t *testing.T, logger *slog.Logger) *Aggregator {
+	t.Helper()
+	agg, err := New(Config{
+		PublisherKeys: []PublisherKey{{0xed, 1}},
+		Threshold:     1,
+		Clock:         func() time.Time { return time.Unix(1, 0) },
+		Logger:        logger,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return agg
+}
+
+func queueCacheWrite(t *testing.T, agg *Aggregator, path string, pk PublisherKey, body []byte) {
+	t.Helper()
+	agg.mu.Lock()
+	agg.cacheWriteSeq++
+	agg.pendingCacheWrites[pk] = pendingCacheWrite{path: path, body: body, seq: agg.cacheWriteSeq}
+	agg.mu.Unlock()
+}
+
+func pendingCacheCount(agg *Aggregator) int {
+	agg.mu.Lock()
+	defer agg.mu.Unlock()
+	return len(agg.pendingCacheWrites)
+}

--- a/internal/validator/list/cache_failure_test.go
+++ b/internal/validator/list/cache_failure_test.go
@@ -177,6 +177,71 @@ func TestSetCacheDirDisableDropsFailedMutationRetry(t *testing.T) {
 	}
 }
 
+func TestSetCacheDirWaitsForInflightWrite(t *testing.T) {
+	agg := newCacheFailureAggregator(t, nil)
+	dir := t.TempDir()
+	if err := agg.SetCacheDir(dir); err != nil {
+		t.Fatalf("SetCacheDir: %v", err)
+	}
+	pk := PublisherKey{0xed, 6}
+	path := cachePathFor(dir, pk)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	agg.cacheOps.writeFile = func(name string, body []byte, mode os.FileMode) error {
+		close(entered)
+		<-release
+		return os.WriteFile(name, body, mode)
+	}
+	queueCacheWrite(t, agg, path, pk, []byte("inflight"))
+	flushed := make(chan struct{})
+	go func() {
+		agg.flushCacheWrites()
+		close(flushed)
+	}()
+	<-entered
+	disabled := make(chan error, 1)
+	go func() { disabled <- agg.SetCacheDir("") }()
+	select {
+	case err := <-disabled:
+		t.Fatalf("SetCacheDir returned before in-flight write completed: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(release)
+	<-flushed
+	if err := <-disabled; err != nil {
+		t.Fatalf("disable cache: %v", err)
+	}
+}
+
+func TestFlushCacheWritesDropsStaleGenerationBeforeIO(t *testing.T) {
+	agg := newCacheFailureAggregator(t, nil)
+	dir := t.TempDir()
+	if err := agg.SetCacheDir(dir); err != nil {
+		t.Fatalf("SetCacheDir: %v", err)
+	}
+	pk := PublisherKey{0xed, 7}
+	path := cachePathFor(dir, pk)
+	writes := 0
+	agg.cacheOps.writeFile = func(string, []byte, os.FileMode) error {
+		writes++
+		return nil
+	}
+	agg.mu.Lock()
+	agg.cacheWriteSeq++
+	agg.pendingCacheWrites[pk] = pendingCacheWrite{
+		path:       path,
+		body:       []byte("stale"),
+		seq:        agg.cacheWriteSeq,
+		generation: agg.cacheGeneration,
+	}
+	agg.cacheGeneration++
+	agg.mu.Unlock()
+	agg.flushCacheWrites()
+	if writes != 0 {
+		t.Fatalf("stale generation reached disk I/O: %d writes", writes)
+	}
+}
+
 func newCacheFailureAggregator(t *testing.T, logger *slog.Logger) *Aggregator {
 	t.Helper()
 	agg, err := New(Config{

--- a/internal/validator/list/cache_test.go
+++ b/internal/validator/list/cache_test.go
@@ -333,6 +333,104 @@ func TestAggregator_Cache_V2RotationPreservesLocalManifestThroughPromotion(t *te
 	}
 }
 
+func TestAggregatorCacheRetainsPendingCollectionManifest(t *testing.T) {
+	pub := newPublisher(t, 0x52, 0x53)
+	pubKey := list.PublisherKey(pub.masterPub)
+	now := fixedClock()()
+	manifest2, signing2 := rotationManifest(t, pub, 0x54, 2)
+	dir := t.TempDir()
+	agg, err := list.New(list.Config{
+		PublisherKeys:      []list.PublisherKey{pubKey},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := agg.SetCacheDir(dir); err != nil {
+		t.Fatalf("SetCacheDir: %v", err)
+	}
+	expiration := now.Add(48 * time.Hour).Unix()
+	blob1, signature1 := pub.signList(t, 5, 0, expiration, [][33]byte{derivedValidatorKey(0x55)})
+	if disposition, _, _ := agg.ApplyList(pub.manifestB64, blob1, signature1, 1, "cache://initial"); disposition != list.Accepted {
+		t.Fatalf("initial disposition: got %s want accepted", disposition)
+	}
+	blob2, signature2 := signListWithKey(t, signing2, 10, now.Add(time.Hour).Unix(), expiration, [][33]byte{derivedValidatorKey(0x56)})
+	dispositions, _, _ := agg.ApplyCollection(&message.ValidatorListCollection{
+		Version:  2,
+		Manifest: manifest2,
+		Blobs:    []message.ValidatorBlobInfo{{Blob: blob2, Signature: signature2}},
+	}, "cache://rotation")
+	if len(dispositions) != 1 || dispositions[0] != list.Pending {
+		t.Fatalf("rotation dispositions: %v", dispositions)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "cache."+hex.EncodeToString(pub.masterPub[:])))
+	if err != nil {
+		t.Fatalf("read cache: %v", err)
+	}
+	var env struct {
+		Manifest string `json:"manifest"`
+		Blobs    []struct {
+			Manifest *string `json:"manifest"`
+		} `json:"blobs_v2"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("decode cache: %v", err)
+	}
+	if env.Manifest != string(manifest2) || len(env.Blobs) != 2 || env.Blobs[1].Manifest != nil {
+		t.Fatalf("pending collection manifest was not retained: %+v", env)
+	}
+}
+
+func TestAggregatorCacheSerializesNormalizedRemainingLists(t *testing.T) {
+	pub := newPublisher(t, 0x57, 0x58)
+	now := fixedClock()()
+	dir := t.TempDir()
+	agg, err := list.New(list.Config{
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := agg.SetCacheDir(dir); err != nil {
+		t.Fatalf("SetCacheDir: %v", err)
+	}
+	expiration := now.Add(48 * time.Hour).Unix()
+	for _, input := range []struct {
+		sequence  uint32
+		effective int64
+		want      list.Disposition
+	}{
+		{1, 0, list.Accepted},
+		{2, now.Add(time.Hour).Unix(), list.Pending},
+		{3, 0, list.Accepted},
+	} {
+		blob, signature := pub.signList(t, input.sequence, input.effective, expiration, [][33]byte{derivedValidatorKey(byte(0x60 + input.sequence))})
+		if disposition, _, _ := agg.ApplyList(pub.manifestB64, blob, signature, 1, "cache://normalize"); disposition != input.want {
+			t.Fatalf("sequence %d disposition: got %s want %s", input.sequence, disposition, input.want)
+		}
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "cache."+hex.EncodeToString(pub.masterPub[:])))
+	if err != nil {
+		t.Fatalf("read cache: %v", err)
+	}
+	var env struct {
+		Blobs []json.RawMessage `json:"blobs_v2"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("decode cache: %v", err)
+	}
+	if len(env.Blobs) != 1 {
+		t.Fatalf("cache retained superseded pending lists: %d blobs", len(env.Blobs))
+	}
+}
+
 func rotationManifest(t *testing.T, pub *publisherFixture, ephSeed byte, sequence uint32) ([]byte, ed25519.PrivateKey) {
 	t.Helper()
 	ephPub32, ephPriv := deterministicKey(ephSeed)

--- a/internal/validator/list/cache_test.go
+++ b/internal/validator/list/cache_test.go
@@ -1,6 +1,8 @@
 package list_test
 
 import (
+	"crypto/ed25519"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"os"
@@ -9,7 +11,9 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/manifest"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/LeJamon/go-xrpl/internal/validator/list"
+	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 func TestAggregator_Cache_WriteThenRoundTripLoad(t *testing.T) {
@@ -181,4 +185,184 @@ func TestAggregator_Cache_DisabledDirNoFile(t *testing.T) {
 	if len(entries) != 0 {
 		t.Fatalf("cache dir written without SetCacheDir: %d entries", len(entries))
 	}
+}
+
+func TestAggregatorLoadCacheRejectsVersionShapeMismatch(t *testing.T) {
+	pub := newPublisher(t, 0x35, 0x36)
+	validator := derivedValidatorKey(0x37)
+	blob, signature := pub.signList(t, 1, 0, fixedClock()().Add(24*time.Hour).Unix(), [][33]byte{validator})
+	tests := map[string]map[string]any{
+		"v1 with blobs_v2": {
+			"manifest": string(pub.manifestB64), "version": 1,
+			"blob": string(blob), "signature": string(signature),
+			"blobs_v2": []map[string]any{{"blob": string(blob), "signature": string(signature)}},
+		},
+		"v2 with v1 fields": {
+			"manifest": string(pub.manifestB64), "version": 2,
+			"blob": string(blob), "signature": string(signature),
+			"blobs_v2": []map[string]any{{"blob": string(blob), "signature": string(signature)}},
+		},
+	}
+	for name, env := range tests {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			agg, err := list.New(list.Config{
+				PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+				Threshold:          1,
+				ValidatorManifests: manifest.NewCache(),
+				PublisherManifests: manifest.NewCache(),
+				Clock:              fixedClock(),
+			})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			if err := agg.SetCacheDir(dir); err != nil {
+				t.Fatalf("SetCacheDir: %v", err)
+			}
+			body, err := json.Marshal(env)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			path := filepath.Join(dir, "cache."+hex.EncodeToString(pub.masterPub[:]))
+			if err := os.WriteFile(path, body, 0o600); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			if loaded := agg.LoadCache(); loaded != 0 {
+				t.Fatalf("LoadCache accepted mismatched envelope: %d", loaded)
+			}
+			if got := agg.PublisherSnapshot()[0].Sequence; got != 0 {
+				t.Fatalf("mismatched envelope mutated publisher: sequence=%d", got)
+			}
+		})
+	}
+}
+
+func TestAggregator_Cache_V2RotationPreservesLocalManifestThroughPromotion(t *testing.T) {
+	pub := newPublisher(t, 0x45, 0x46)
+	validator := derivedValidatorKey(0x51)
+	pubKey := list.PublisherKey(pub.masterPub)
+	var now = fixedClock()()
+	localM2, eph2Priv := rotationManifest(t, pub, 0x47, 2)
+
+	dir := t.TempDir()
+	src, err := list.New(list.Config{
+		PublisherKeys:      []list.PublisherKey{pubKey},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("New src: %v", err)
+	}
+	if err := src.SetCacheDir(dir); err != nil {
+		t.Fatalf("SetCacheDir src: %v", err)
+	}
+	exp := now.Add(48 * time.Hour).Unix()
+	blob1, sig1 := pub.signList(t, 5, 0, exp, [][33]byte{validator})
+	blob2, sig2 := signListWithKey(t, eph2Priv, 10, now.Add(time.Hour).Unix(), exp, [][33]byte{validator})
+	dispositions, _, maxSequence := src.ApplyCollection(&message.ValidatorListCollection{
+		Version:  2,
+		Manifest: pub.manifestB64,
+		Blobs: []message.ValidatorBlobInfo{
+			{Blob: blob1, Signature: sig1},
+			{Manifest: localM2, Blob: blob2, Signature: sig2},
+		},
+	}, "cache://src")
+	if len(dispositions) != 2 || dispositions[0] != list.Accepted || dispositions[1] != list.Pending || maxSequence != 10 {
+		t.Fatalf("ApplyCollection: got %v", dispositions)
+	}
+	path := filepath.Join(dir, "cache."+hex.EncodeToString(pub.masterPub[:]))
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read cache: %v", err)
+	}
+	var env struct {
+		Manifest string `json:"manifest"`
+		Version  uint32 `json:"version"`
+		Blobs    []struct {
+			Manifest *string `json:"manifest"`
+		} `json:"blobs_v2"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("decode cache: %v", err)
+	}
+	if env.Version != 2 || env.Manifest != string(pub.manifestB64) || len(env.Blobs) != 2 {
+		t.Fatalf("unexpected v2 envelope: %+v", env)
+	}
+	if env.Blobs[0].Manifest != nil {
+		t.Fatalf("current blob must omit local manifest: %+v", *env.Blobs[0].Manifest)
+	}
+	if env.Blobs[1].Manifest == nil || *env.Blobs[1].Manifest != string(localM2) {
+		t.Fatalf("pending local manifest lost: %+v", env.Blobs[1].Manifest)
+	}
+
+	dst, err := list.New(list.Config{
+		PublisherKeys:      []list.PublisherKey{pubKey},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("New dst: %v", err)
+	}
+	if err := dst.SetCacheDir(dir); err != nil {
+		t.Fatalf("SetCacheDir dst: %v", err)
+	}
+	if loaded := dst.LoadCache(); loaded != 1 {
+		t.Fatalf("LoadCache: got %d want 1", loaded)
+	}
+	snapshot := dst.PublisherSnapshot()
+	if len(snapshot) != 1 || snapshot[0].Sequence != 5 || snapshot[0].RawLocalManifestSet {
+		t.Fatalf("current state after hydrate: %+v", snapshot)
+	}
+	if len(snapshot[0].Remaining) != 1 {
+		t.Fatalf("pending state after hydrate: %+v", snapshot[0].Remaining)
+	}
+	pending := snapshot[0].Remaining[10]
+	if pending == nil || !pending.RawLocalManifestSet {
+		t.Fatalf("pending local manifest after hydrate: %+v", pending)
+	}
+
+	now = now.Add(2 * time.Hour)
+	dst.Tick()
+	snapshot = dst.PublisherSnapshot()
+	if snapshot[0].Sequence != 10 || !snapshot[0].RawLocalManifestSet {
+		t.Fatalf("promoted rotation lost local manifest: %+v", snapshot[0])
+	}
+}
+
+func rotationManifest(t *testing.T, pub *publisherFixture, ephSeed byte, sequence uint32) ([]byte, ed25519.PrivateKey) {
+	t.Helper()
+	ephPub32, ephPriv := deterministicKey(ephSeed)
+	var ephPub [33]byte
+	copy(ephPub[:], append([]byte{0xED}, ephPub32...))
+	raw := buildManifest(t, pub.masterPub, pub.masterPriv, ephPub, ephPriv, sequence)
+	return []byte(base64.StdEncoding.EncodeToString(raw)), ephPriv
+}
+
+func signListWithKey(t *testing.T, privateKey ed25519.PrivateKey, sequence uint32, validFromUnix, validUntilUnix int64, validatorMasters [][33]byte) ([]byte, []byte) {
+	t.Helper()
+	type entry struct {
+		ValidationPublicKey string `json:"validation_public_key"`
+	}
+	type body struct {
+		Sequence   uint32  `json:"sequence"`
+		Expiration uint32  `json:"expiration"`
+		Effective  uint32  `json:"effective,omitempty"`
+		Validators []entry `json:"validators"`
+	}
+	v := body{Sequence: sequence, Expiration: uint32(validUntilUnix - protocol.RippleEpochUnix)}
+	if validFromUnix > 0 {
+		v.Effective = uint32(validFromUnix - protocol.RippleEpochUnix)
+	}
+	for _, master := range validatorMasters {
+		v.Validators = append(v.Validators, entry{ValidationPublicKey: hex.EncodeToString(master[:])})
+	}
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("blob JSON marshal: %v", err)
+	}
+	return []byte(base64.StdEncoding.EncodeToString(raw)), []byte(hex.EncodeToString(ed25519.Sign(privateKey, raw)))
 }

--- a/internal/validator/list/change_dispatch.go
+++ b/internal/validator/list/change_dispatch.go
@@ -1,0 +1,100 @@
+package list
+
+import (
+	"log/slog"
+	"sync"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+)
+
+// changeEvent is an immutable snapshot of one trusted-set transition. The
+// callback is captured when the transition is queued so replacing a callback
+// cannot reorder or redirect an event that was already computed.
+type changeEvent struct {
+	callback   func([]consensus.NodeID, [][33]byte)
+	validators []consensus.NodeID
+	masterKeys [][33]byte
+}
+
+// changeDispatcher serializes callback delivery without holding Aggregator.mu.
+// New transitions may be queued while a callback is slow or re-enters the
+// aggregator; the active drainer picks them up in aggregator lock order.
+type changeDispatcher struct {
+	mu       sync.Mutex
+	events   []changeEvent
+	draining bool
+}
+
+func (a *Aggregator) dispatchChanges() {
+	a.changes.drain(a.logger)
+}
+
+func (a *Aggregator) dispatchChangesAsync() {
+	if !a.changes.beginDrain() {
+		return
+	}
+	go a.changes.drainOwned(a.logger)
+}
+
+func (d *changeDispatcher) enqueue(event changeEvent) {
+	if event.callback == nil {
+		return
+	}
+	event.validators = append([]consensus.NodeID(nil), event.validators...)
+	event.masterKeys = append([][33]byte(nil), event.masterKeys...)
+	d.mu.Lock()
+	d.events = append(d.events, event)
+	d.mu.Unlock()
+}
+
+func (d *changeDispatcher) drain(logger *slog.Logger) {
+	if !d.beginDrain() {
+		return
+	}
+	d.drainOwned(logger)
+}
+
+func (d *changeDispatcher) beginDrain() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.draining || len(d.events) == 0 {
+		return false
+	}
+	d.draining = true
+	return true
+}
+
+func (d *changeDispatcher) drainOwned(logger *slog.Logger) {
+	for {
+		d.mu.Lock()
+		if len(d.events) == 0 {
+			d.draining = false
+			d.mu.Unlock()
+			return
+		}
+		event := d.events[0]
+		d.events[0] = changeEvent{}
+		d.events = d.events[1:]
+		d.mu.Unlock()
+
+		invokeChange(event, logger)
+	}
+}
+
+func invokeChange(event changeEvent, logger *slog.Logger) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			if logger == nil {
+				slog.Default().Error("validator-list change callback panicked", "panic", recovered)
+				return
+			}
+			logger.Error("validator-list change callback panicked", "panic", recovered)
+		}
+	}()
+
+	// The event owns these slices. Give the callback a fresh copy so a
+	// callback cannot mutate a queued event that has not been delivered yet.
+	validators := append([]consensus.NodeID(nil), event.validators...)
+	masterKeys := append([][33]byte(nil), event.masterKeys...)
+	event.callback(validators, masterKeys)
+}

--- a/internal/validator/list/change_dispatch_test.go
+++ b/internal/validator/list/change_dispatch_test.go
@@ -33,17 +33,16 @@ func TestChangeDispatcherReentryPanicAndOrder(t *testing.T) {
 }
 
 func TestChangeDispatcherSlowCallbackDoesNotBlockAggregator(t *testing.T) {
-	var d changeDispatcher
 	agg := &Aggregator{}
 	entered := make(chan struct{})
 	release := make(chan struct{})
-	d.enqueue(changeEvent{callback: func(_ []consensus.NodeID, _ [][33]byte) {
+	agg.changes.enqueue(changeEvent{callback: func(_ []consensus.NodeID, _ [][33]byte) {
 		close(entered)
 		<-release
 	}})
 	done := make(chan struct{})
 	go func() {
-		d.drain(nil)
+		agg.dispatchChanges()
 		close(done)
 	}()
 	select {

--- a/internal/validator/list/change_dispatch_test.go
+++ b/internal/validator/list/change_dispatch_test.go
@@ -1,0 +1,92 @@
+package list
+
+import (
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+)
+
+func TestChangeDispatcherReentryPanicAndOrder(t *testing.T) {
+	var d changeDispatcher
+	var mu sync.Mutex
+	var order []int
+	var agg Aggregator
+	agg.logger = slog.Default()
+	for i := 1; i <= 3; i++ {
+		d.enqueue(changeEvent{callback: func(_ []consensus.NodeID, _ [][33]byte) {
+			if i == 1 {
+				_ = agg.PublisherCount()
+				panic("test panic")
+			}
+			mu.Lock()
+			order = append(order, i)
+			mu.Unlock()
+		}})
+	}
+	d.drain(agg.logger)
+	if got, want := order, []int{2, 3}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("callback order after panic: got %v want %v", got, want)
+	}
+}
+
+func TestChangeDispatcherSlowCallbackDoesNotBlockAggregator(t *testing.T) {
+	var d changeDispatcher
+	agg := &Aggregator{}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	d.enqueue(changeEvent{callback: func(_ []consensus.NodeID, _ [][33]byte) {
+		close(entered)
+		<-release
+	}})
+	done := make(chan struct{})
+	go func() {
+		d.drain(nil)
+		close(done)
+	}()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("callback did not start")
+	}
+	snapshotDone := make(chan struct{})
+	go func() {
+		_ = agg.PublisherCount()
+		close(snapshotDone)
+	}()
+	select {
+	case <-snapshotDone:
+	case <-time.After(time.Second):
+		t.Fatal("aggregator method blocked behind callback")
+	}
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher did not finish")
+	}
+}
+
+func TestChangeDispatcherRetainsPayloadAndClonesDelivery(t *testing.T) {
+	var d changeDispatcher
+	got := make(chan [33]byte, 1)
+	var key [33]byte
+	key[0] = 1
+	validators := []consensus.NodeID{{1}}
+	masters := [][33]byte{key}
+	d.enqueue(changeEvent{callback: func(v []consensus.NodeID, m [][33]byte) {
+		v[0][0] = 9
+		got <- m[0]
+	}, validators: validators, masterKeys: masters})
+	validators[0][0] = 8
+	masters[0][0] = 7
+	d.drain(nil)
+	if gotKey := <-got; gotKey[0] != 1 {
+		t.Fatalf("callback did not receive retained event payload: got %d", gotKey[0])
+	}
+	if validators[0][0] != 8 || masters[0][0] != 7 {
+		t.Fatal("delivery mutation escaped event ownership")
+	}
+}

--- a/internal/validator/list/config_test.go
+++ b/internal/validator/list/config_test.go
@@ -1,0 +1,59 @@
+package list
+
+import "testing"
+
+func TestNewNormalizesAndValidatesConfig(t *testing.T) {
+	key1 := PublisherKey{0xed, 1}
+	key2 := PublisherKey{0xed, 2}
+	cases := []struct {
+		name       string
+		cfg        Config
+		wantErr    bool
+		publishers int
+		sites      int
+		threshold  int
+		static     int
+	}{
+		{
+			name: "deduplicates keys and sites and defaults threshold",
+			cfg: Config{PublisherKeys: []PublisherKey{key1, key1, key2}, SiteURIs: []string{
+				"https://one.example", "https://one.example", "file:///tmp/lists.json",
+			}, StaticValidatorCount: -3},
+			publishers: 2, sites: 2, threshold: 1,
+		},
+		{
+			name: "zero threshold without publishers is valid",
+			cfg:  Config{}, threshold: 0,
+		},
+		{name: "unknown key prefix", cfg: Config{PublisherKeys: []PublisherKey{{1, 1}}}, wantErr: true},
+		{name: "negative threshold", cfg: Config{Threshold: -1}, wantErr: true},
+		{name: "threshold exceeds normalized publishers", cfg: Config{PublisherKeys: []PublisherKey{key1}, Threshold: 2}, wantErr: true},
+		{name: "invalid site URI", cfg: Config{SiteURIs: []string{"file://host/path"}}, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agg, err := New(tc.cfg)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected constructor error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			if got := agg.PublisherCount(); got != tc.publishers {
+				t.Fatalf("publishers: got %d want %d", got, tc.publishers)
+			}
+			if got := len(agg.SiteSnapshot()); got != tc.sites {
+				t.Fatalf("sites: got %d want %d", got, tc.sites)
+			}
+			if got := agg.Threshold(); got != tc.threshold {
+				t.Fatalf("threshold: got %d want %d", got, tc.threshold)
+			}
+			if agg.staticValidatorCount != tc.static {
+				t.Fatalf("static count: got %d want %d", agg.staticValidatorCount, tc.static)
+			}
+		})
+	}
+}

--- a/internal/validator/list/config_test.go
+++ b/internal/validator/list/config_test.go
@@ -15,11 +15,11 @@ func TestNewNormalizesAndValidatesConfig(t *testing.T) {
 		static     int
 	}{
 		{
-			name: "deduplicates keys and sites and defaults threshold",
+			name: "deduplicates keys, preserves sites, and defaults threshold",
 			cfg: Config{PublisherKeys: []PublisherKey{key1, key1, key2}, SiteURIs: []string{
 				"https://one.example", "https://one.example", "file:///tmp/lists.json",
 			}, StaticValidatorCount: -3},
-			publishers: 2, sites: 2, threshold: 1,
+			publishers: 2, sites: 3, threshold: 1,
 		},
 		{
 			name: "zero threshold without publishers is valid",

--- a/internal/validator/list/disposition.go
+++ b/internal/validator/list/disposition.go
@@ -29,15 +29,13 @@ package list
 // ValidatorList.cpp:973. Re-arranging this iota would silently flip the
 // relay set.
 //
-// Malformed is a go-xrpl-only summary disposition emitted exclusively
-// by the HTTP site poller for wire-level envelope failures (HTTP
-// transport error, JSON body undecodable, required envelope fields
-// absent). The aggregator itself never returns Malformed: a corrupt
-// publisher manifest folds into Untrusted (rippled
-// ValidatorList.cpp:1363-1366) and a corrupt blob envelope folds into
-// Invalid (rippled ValidatorList.cpp:1386-1392). Malformed is folded
-// back to "invalid" by the RPC adapter so external consumers see only
-// rippled-emitted labels.
+// Malformed is a go-xrpl-only summary disposition for HTTP/site or
+// collection-envelope failures (transport error, undecodable JSON, absent
+// required envelope fields, or an invalid collection shape). A malformed
+// publisher manifest is Invalid, matching rippled's deserialize failure at
+// ValidatorList.cpp:1128-1135; a structurally valid but untrusted or
+// cache-invalid manifest is Untrusted. Malformed is folded back to
+// "invalid" by the RPC adapter so external consumers see only rippled labels.
 type Disposition uint8
 
 const (
@@ -94,7 +92,7 @@ const (
 // dispositions that warrant rebroadcasting the originating frame.
 // Mirrors rippled's `disposition <= ListDisposition::known_sequence`
 // gate at ValidatorList.cpp:973.
-const MaxValidRelaySeverity = KnownSequence
+const maxValidRelaySeverity = KnownSequence
 
 // String returns a short, lowercase label suitable for logs and metrics.
 func (d Disposition) String() string {
@@ -195,5 +193,5 @@ func (d Disposition) Charge() ChargeCategory {
 // and KnownSequence all relay. Per-peer filtering (skip peers already
 // at the same sequence) is done at broadcast time, not here.
 func (d Disposition) ShouldRelay() bool {
-	return d.Severity() <= MaxValidRelaySeverity.Severity()
+	return d.Severity() <= maxValidRelaySeverity.Severity()
 }

--- a/internal/validator/list/listed_test.go
+++ b/internal/validator/list/listed_test.go
@@ -20,7 +20,7 @@ func TestAggregator_IsListed(t *testing.T) {
 
 	a := &Aggregator{
 		publishers: map[PublisherKey]struct{}{pk1: {}, pk2: {}},
-		state: map[PublisherKey]*PublisherState{
+		state: map[PublisherKey]*publisherState{
 			pk1: {MasterKey: pk1, Status: StatusUnavailable},
 			pk2: {MasterKey: pk2, Status: StatusUnavailable},
 		},

--- a/internal/validator/list/publisher_state.go
+++ b/internal/validator/list/publisher_state.go
@@ -138,7 +138,7 @@ func (a *Aggregator) applyListInternal(globalManifest, localManifest []byte, loc
 		// revocation — mirrors rippled's `revoked && result == accepted`
 		// gate at ValidatorList.cpp:1373.
 		if manifestAccepted {
-			a.handleRevocation(pubKey)
+			a.handleRevocation(pubKey, asyncDispatch)
 		}
 		return Untrusted, pubKey, 0
 	}
@@ -199,95 +199,96 @@ func (a *Aggregator) applyListInternal(globalManifest, localManifest []byte, loc
 		a.beforeListCommit()
 	}
 
-	// Manifest verification and blob parsing happen outside a.mu. Recheck
-	// the per-publisher manifest generation and signing key at the commit
-	// boundary so an older apply cannot resurrect a publisher revoked or
-	// rotated while its signature was being verified.
-	if !a.publisherCommitValidLocked(masterKey, signingKey, manifestSequence, manifestSequenceSet) {
+	commit := func() (Disposition, uint32) {
+		// Match applyLists' post-apply cleanup before evaluating the next
+		// disposition. Ready entries are deliberately not promoted here: a
+		// re-arrival at a ready pending sequence must take rippled's Accepted
+		// promotion path below, rather than becoming SameSequence.
+		a.normalizeRemainingLocked(current)
+
+		// Determine disposition by sequence + time ordering. Mirrors the
+		// rippled state machine at ValidatorList.cpp:1394-1437. The
+		// SameSequence branch is intentionally unguarded by status —
+		// rippled returns same_sequence for every repeat of the current
+		// sequence regardless of `pubCollection.status`.
+		if parsedBlob.Sequence < current.Sequence {
+			return Stale, 0
+		}
+		if parsedBlob.Sequence == current.Sequence {
+			return SameSequence, current.MaxSequence
+		}
+		expired := validUntil.Before(now) || validUntil.Equal(now)
+		if expired || !validFrom.After(now) {
+			// Expired ingest runs the SAME populate path as accepted in
+			// rippled: ValidatorList.cpp:1193-1295 — the local `accepted`
+			// boolean is true for both ListDisposition::accepted AND
+			// ListDisposition::expired, so the populate block writes
+			// publisher.list and publisher.manifests, and the call to
+			// updatePublisherList at line 1294 seeds embedded validator
+			// manifests into validatorManifests_ (line 1117-1133). The only
+			// runtime differences vs accepted are the final PublisherStatus
+			// (expired vs available) and that the trusted-set recompute
+			// skips non-available publishers (see recomputeAndEmitLocked:
+			// `s.Status != StatusAvailable` filter).
+			//
+			// removePublisherList(StatusExpired) at ValidatorList.cpp:1529-1542
+			// is invoked from updateTrusted (line 1999) when a previously-
+			// available list times out at ledger close — NOT from applyList.
+			if _, pending := current.Remaining[parsedBlob.Sequence]; pending {
+				a.promotePendingSequenceLocked(current, parsedBlob.Sequence, now)
+			} else {
+				a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version, globalManifest, localManifest, localManifestSet, blob, signature)
+				a.recordMaxSequenceLocked(current, parsedBlob.Sequence)
+			}
+			if expired {
+				current.Status = StatusExpired
+			}
+			a.normalizeRemainingLocked(current)
+			a.writeCacheLocked(current)
+			a.recomputeAndEmitLocked()
+			if expired {
+				return Expired, current.MaxSequence
+			}
+			return Accepted, current.MaxSequence
+		}
+		if validFrom.After(now) {
+			// Future-dated. Mirrors rippled ValidatorList.cpp:1414-1432
+			// pending-vs-known_sequence: a list is "pending" the first
+			// time it lands or whenever its sequence is the largest seen,
+			// and "known_sequence" only for re-arrivals at an already-
+			// queued sequence. The queued blob is retained so the next
+			// promoteRemainingLocked pass can rotate it into `current`.
+			d := a.applyPendingLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, version, globalManifest, localManifest, localManifestSet, blob, signature)
+			a.normalizeRemainingLocked(current)
+			if d == Pending {
+				a.writeCacheLocked(current)
+			}
+			return d, current.MaxSequence
+		}
+
+		a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version, globalManifest, localManifest, localManifestSet, blob, signature)
+		a.recordMaxSequenceLocked(current, parsedBlob.Sequence)
+		a.normalizeRemainingLocked(current)
+		a.writeCacheLocked(current)
+		a.recomputeAndEmitLocked()
+		return Accepted, current.MaxSequence
+	}
+
+	if a.publisherManifests == nil {
+		disp, sequence := commit()
+		return disp, pubKey, sequence
+	}
+	if !manifestSequenceSet {
 		return Untrusted, pubKey, 0
 	}
-
-	// Match applyLists' post-apply cleanup before evaluating the next
-	// disposition. Ready entries are deliberately not promoted here: a
-	// re-arrival at a ready pending sequence must take rippled's Accepted
-	// promotion path below, rather than becoming SameSequence.
-	a.normalizeRemainingLocked(current)
-
-	// Determine disposition by sequence + time ordering. Mirrors the
-	// rippled state machine at ValidatorList.cpp:1394-1437. The
-	// SameSequence branch is intentionally unguarded by status —
-	// rippled returns same_sequence for every repeat of the current
-	// sequence regardless of `pubCollection.status`.
-	if parsedBlob.Sequence < current.Sequence {
-		return Stale, pubKey, 0
+	var disposition Disposition
+	var sequence uint32
+	if !a.publisherManifests.WithCurrent(masterKey, signingKey, manifestSequence, func() {
+		disposition, sequence = commit()
+	}) {
+		return Untrusted, pubKey, 0
 	}
-	if parsedBlob.Sequence == current.Sequence {
-		return SameSequence, pubKey, current.MaxSequence
-	}
-	expired := validUntil.Before(now) || validUntil.Equal(now)
-	if expired || !validFrom.After(now) {
-		// Expired ingest runs the SAME populate path as accepted in
-		// rippled: ValidatorList.cpp:1193-1295 — the local `accepted`
-		// boolean is true for both ListDisposition::accepted AND
-		// ListDisposition::expired, so the populate block writes
-		// publisher.list and publisher.manifests, and the call to
-		// updatePublisherList at line 1294 seeds embedded validator
-		// manifests into validatorManifests_ (line 1117-1133). The only
-		// runtime differences vs accepted are the final PublisherStatus
-		// (expired vs available) and that the trusted-set recompute
-		// skips non-available publishers (see recomputeAndEmitLocked:
-		// `s.Status != StatusAvailable` filter).
-		//
-		// removePublisherList(StatusExpired) at ValidatorList.cpp:1529-1542
-		// is invoked from updateTrusted (line 1999) when a previously-
-		// available list times out at ledger close — NOT from applyList.
-		if _, pending := current.Remaining[parsedBlob.Sequence]; pending {
-			a.promotePendingSequenceLocked(current, parsedBlob.Sequence, now)
-		} else {
-			a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version, globalManifest, localManifest, localManifestSet, blob, signature)
-			a.recordMaxSequenceLocked(current, parsedBlob.Sequence)
-		}
-		if expired {
-			current.Status = StatusExpired
-		}
-		a.normalizeRemainingLocked(current)
-		a.recomputeAndEmitLocked()
-		if expired {
-			return Expired, pubKey, current.MaxSequence
-		}
-		return Accepted, pubKey, current.MaxSequence
-	}
-	if validFrom.After(now) {
-		// Future-dated. Mirrors rippled ValidatorList.cpp:1414-1432
-		// pending-vs-known_sequence: a list is "pending" the first
-		// time it lands or whenever its sequence is the largest seen,
-		// and "known_sequence" only for re-arrivals at an already-
-		// queued sequence. The queued blob is retained so the next
-		// promoteRemainingLocked pass can rotate it into `current`.
-		d := a.applyPendingLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, version, globalManifest, localManifest, localManifestSet, blob, signature)
-		a.normalizeRemainingLocked(current)
-		return d, pubKey, current.MaxSequence
-	}
-
-	a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version, globalManifest, localManifest, localManifestSet, blob, signature)
-	a.recordMaxSequenceLocked(current, parsedBlob.Sequence)
-	a.normalizeRemainingLocked(current)
-	a.recomputeAndEmitLocked()
-	return Accepted, pubKey, current.MaxSequence
-}
-
-// publisherCommitValidLocked verifies that the publisher cache state used for
-// blob verification is still current. Caller must hold a.mu.
-func (a *Aggregator) publisherCommitValidLocked(masterKey [33]byte, signingKey [33]byte, sequence uint32, sequenceSet bool) bool {
-	if a.publisherManifests == nil {
-		return true
-	}
-	currentSequence, ok := a.publisherManifests.GetSequence(masterKey)
-	if !ok || (sequenceSet && currentSequence != sequence) {
-		return false
-	}
-	currentSigningKey, ok := a.publisherManifests.GetSigningKey(masterKey)
-	return ok && currentSigningKey == signingKey && !a.publisherManifests.Revoked(masterKey)
+	return disposition, pubKey, sequence
 }
 
 // updateRawBytes refreshes the retained wire-form bytes, reusing the
@@ -357,7 +358,6 @@ func (a *Aggregator) applyAcceptedLocked(s *publisherState, blob *blobJSON, sign
 	s.Validators = keys
 	a.applyEmbeddedManifestsLocked(s, blob.Validators)
 
-	a.writeCacheLocked(s)
 }
 
 // applyEmbeddedManifestsLocked applies validator manifests from an effective
@@ -480,8 +480,8 @@ func (a *Aggregator) applyPendingLocked(s *publisherState, blob *blobJSON, signi
 	if version > s.Version {
 		s.Version = version
 	}
+	s.RawManifest = append(s.RawManifest[:0], rawManifest...)
 	a.recordMaxSequenceLocked(s, blob.Sequence)
-	a.writeCacheLocked(s)
 	return Pending
 }
 
@@ -563,16 +563,16 @@ func (a *Aggregator) promotePendingSequenceLocked(s *publisherState, sequence ui
 	s.updateRawBytes(chosen.RawManifest, chosen.RawBlob, chosen.RawSignature)
 	s.updateRawLocalManifest(chosen.RawLocalManifest, chosen.RawLocalManifestSet)
 	s.Validators = append([][33]byte(nil), chosen.Validators...)
-	a.applyEmbeddedPendingManifestsLocked(s, chosen.EmbeddedManifests)
 	s.Status = StatusAvailable
 	if !chosen.Expiration.After(now) {
 		s.Status = StatusExpired
 		s.Validators = nil
+	} else {
+		a.applyEmbeddedPendingManifestsLocked(s, chosen.EmbeddedManifests)
 	}
 	delete(s.Remaining, sequence)
 	a.recordMaxSequenceLocked(s, sequence)
 	a.normalizeRemainingLocked(s)
-	a.writeCacheLocked(s)
 }
 
 // promoteRemainingLocked rotates ready Remaining entries (those whose
@@ -590,10 +590,10 @@ func (a *Aggregator) promotePendingSequenceLocked(s *publisherState, sequence ui
 // to recompute (typically immediately after the call when invoked at
 // ingest, or via Tick → recomputeAndEmitLocked on the time-driven
 // path).
-func (a *Aggregator) promoteRemainingLocked(s *publisherState, now time.Time) bool {
+func (a *Aggregator) promoteRemainingLocked(s *publisherState, now time.Time) uint32 {
 	a.normalizeRemainingLocked(s)
 	if len(s.Remaining) == 0 {
-		return false
+		return 0
 	}
 	seqs := make([]uint32, 0, len(s.Remaining))
 	for seq := range s.Remaining {
@@ -612,7 +612,7 @@ func (a *Aggregator) promoteRemainingLocked(s *publisherState, now time.Time) bo
 		break
 	}
 	if pickIdx < 0 {
-		return false
+		return 0
 	}
 
 	chosen := s.Remaining[seqs[pickIdx]]
@@ -628,7 +628,7 @@ func (a *Aggregator) promoteRemainingLocked(s *publisherState, now time.Time) bo
 	}
 	a.normalizeRemainingLocked(s)
 	a.writeCacheLocked(s)
-	return true
+	return chosen.Sequence
 }
 
 // ApplyCollection processes a v2 collection (TMValidatorListCollection),

--- a/internal/validator/list/publisher_state.go
+++ b/internal/validator/list/publisher_state.go
@@ -10,30 +10,13 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 )
 
-// ApplyList ingests a single (manifest, blob, signature) triple and
-// returns the resulting disposition along with the publisher master
-// key (when extractable) and the blob's sequence (when extractable).
-// Wraps the rippled-faithful applyList algorithm: verify the publisher
-// manifest, look up its current ephemeral signing key, verify the blob
-// signature, JSON-parse the blob, then update per-publisher state and
-// trigger an OnChange if the trusted union changed.
+// ApplyList ingests a single (manifest, blob, signature) triple and returns
+// its disposition, publisher master key, and sequence when extractable.
 //
 // `manifestBytes` and `blob` carry the WIRE-FORM ascii strings as
 // received in TMValidatorList / TMValidatorListCollection (base64-
 // encoded). `signature` carries the WIRE-FORM hex string. `version`
 // is the protocol version negotiated at the message level.
-//
-// `siteURI` is recorded on the per-publisher state for RPC visibility
-// — pass "peer:<id>" for gossip-sourced lists and the URL for
-// HTTP-polled ones.
-//
-// Returns the publisher master key on every disposition where it's
-// extractable (i.e. the manifest decoded), so the caller can attribute
-// metrics / bad-data charges with publisher-level granularity even on
-// failure paths. Returns the zero PublisherKey when the manifest
-// itself could not be parsed. The sequence return is non-zero only
-// when the blob was decoded; the router uses it to record per-peer
-// publisher sequences regardless of accept/expired/pending outcome.
 func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version uint32, siteURI string) (Disposition, PublisherKey, uint32) {
 	return a.applyListInternal(manifestBytes, nil, false, blob, signature, version, siteURI, false)
 }
@@ -52,8 +35,6 @@ func (a *Aggregator) applyListInternal(globalManifest, localManifest []byte, loc
 		manifestBytes = localManifest
 	}
 
-	// Decode the publisher manifest. The manifest is base64-encoded on
-	// the wire; the inner STObject is what manifest.Deserialize wants.
 	manifestRaw, err := decodeBase64Tolerant(manifestBytes)
 	if err != nil {
 		a.logger.Debug("validator list: manifest base64 decode failed", "error", err, "site", siteURI)
@@ -78,11 +59,6 @@ func (a *Aggregator) applyListInternal(globalManifest, localManifest []byte, loc
 		return Untrusted, pubKey, 0
 	}
 
-	// Apply the publisher manifest to the manifest cache. This both
-	// caches the manifest for later use and gives us the current
-	// ephemeral signing key. A revoked manifest invalidates the
-	// publisher entirely.
-	//
 	// Track the cache disposition so revocation only flips publisher
 	// state when the manifest cache actually accepted the revocation.
 	// Mirrors rippled ValidatorList.cpp:1373-1378 — `removePublisherList`
@@ -97,9 +73,6 @@ func (a *Aggregator) applyListInternal(globalManifest, localManifest []byte, loc
 		case manifest.Accepted:
 			manifestAccepted = true
 		case manifest.Stale:
-			// Already had this or a newer one — cache state is
-			// unchanged; don't let an old revocation manifest flip
-			// the publisher's status.
 		case manifest.Invalid:
 			// The manifest was structurally valid, but its signatures or
 			// cache invariants were not. Rippled maps this path to
@@ -124,8 +97,6 @@ func (a *Aggregator) applyListInternal(globalManifest, localManifest []byte, loc
 		if err := parsed.Verify(); err != nil {
 			return Untrusted, pubKey, 0
 		}
-		// No cache means every fresh verify is "accepted" for the
-		// purpose of the revocation gate.
 		manifestAccepted = true
 	}
 
@@ -291,8 +262,6 @@ func (a *Aggregator) applyListInternal(globalManifest, localManifest []byte, loc
 	return disposition, pubKey, sequence
 }
 
-// updateRawBytes refreshes the retained wire-form bytes, reusing the
-// existing backing arrays so the caller may keep its own slices.
 func (s *publisherState) updateRawBytes(manifest, blob, signature []byte) {
 	s.RawManifest = append(s.RawManifest[:0], manifest...)
 	s.RawBlob = append(s.RawBlob[:0], blob...)
@@ -304,9 +273,6 @@ func (s *publisherState) updateRawLocalManifest(raw []byte, present bool) {
 	s.RawLocalManifestSet = present
 }
 
-// extractValidatorKeys decodes and canonically sorts the validator
-// master keys from a parsed blob. logMsg is the debug message emitted
-// for skipped entries.
 func (a *Aggregator) extractValidatorKeys(blob *blobJSON, logMsg string) [][33]byte {
 	keys := make([][33]byte, 0, len(blob.Validators))
 	for i, v := range blob.Validators {
@@ -330,15 +296,6 @@ func (a *Aggregator) extractValidatorKeys(blob *blobJSON, logMsg string) [][33]b
 	return keys
 }
 
-// applyAcceptedLocked materializes the parsed blob into the
-// publisher's state. Caller must hold a.mu. Does NOT emit OnChange —
-// that's done by recomputeAndEmitLocked once the caller has decided
-// the disposition warrants a trusted-set recompute.
-//
-// rawManifest / rawBlob / rawSignature are the wire-form bytes from
-// the original TMValidatorList / envelope; they are copied (not
-// referenced) so the caller may reuse its slices safely. Used later
-// by BroadcastLatest to re-emit the canonical accepted form to peers.
 func (a *Aggregator) applyAcceptedLocked(s *publisherState, blob *blobJSON, signingKey [33]byte, validFrom, validUntil time.Time, siteURI string, now time.Time, version uint32, rawManifest, rawLocalManifest []byte, rawLocalManifestSet bool, rawBlob, rawSignature []byte) {
 	s.Sequence = blob.Sequence
 	s.Effective = validFrom
@@ -444,8 +401,6 @@ func (a *Aggregator) applyPendingLocked(s *publisherState, blob *blobJSON, signi
 		if _, hit := s.Remaining[blob.Sequence]; hit {
 			known = true
 		} else if blob.Sequence <= s.MaxSequence {
-			// New sequence below max — pending only if it lands ahead
-			// of the current max-stored validFrom (out-of-order).
 			if maxEntry, ok := s.Remaining[s.MaxSequence]; !ok || !validFrom.Before(maxEntry.Effective) {
 				known = true
 			}
@@ -600,7 +555,6 @@ func (a *Aggregator) promoteRemainingLocked(s *publisherState, now time.Time) ui
 	}
 	slices.Sort(seqs)
 
-	// Find the LAST entry that is ready to promote.
 	pickIdx := -1
 	for i, seq := range seqs {
 		p := s.Remaining[seq]
@@ -631,14 +585,9 @@ func (a *Aggregator) promoteRemainingLocked(s *publisherState, now time.Time) ui
 }
 
 // ApplyCollection processes a v2 collection (TMValidatorListCollection),
-// applying each blob individually with the collection's shared
-// publisher manifest. Returns the per-blob dispositions in the same
-// order as the collection's blob array, plus the publisher key once
-// the manifest decoded and the highest sequence observed across the
-// collection. The router uses the dispositions to decide whether to
-// charge the sender (any Invalid / Malformed) and whether to relay
-// (at least one Accepted), and uses the max-sequence value to update
-// the per-peer publisherListSequences entry.
+// applying each blob individually with the collection's shared publisher
+// manifest. Results preserve blob order and include the publisher key and
+// highest observed sequence when extractable.
 //
 // Mirrors rippled's applyLists at ValidatorList.cpp:998-1070.
 func (a *Aggregator) ApplyCollection(coll *message.ValidatorListCollection, siteURI string) ([]Disposition, PublisherKey, uint32) {

--- a/internal/validator/list/publisher_state.go
+++ b/internal/validator/list/publisher_state.go
@@ -357,7 +357,6 @@ func (a *Aggregator) applyAcceptedLocked(s *publisherState, blob *blobJSON, sign
 	keys := a.extractValidatorKeys(blob, "validator list: skipping invalid validator entry")
 	s.Validators = keys
 	a.applyEmbeddedManifestsLocked(s, blob.Validators)
-
 }
 
 // applyEmbeddedManifestsLocked applies validator manifests from an effective

--- a/internal/validator/list/publisher_state.go
+++ b/internal/validator/list/publisher_state.go
@@ -164,6 +164,7 @@ func (a *Aggregator) applyListInternal(globalManifest, localManifest []byte, loc
 	// invariant break — surface it loudly rather than silently re-create.
 	current := a.state[pubKey]
 	if current == nil {
+		a.logger.Error("validator list: trusted publisher state missing", "publisher", hex.EncodeToString(pubKey[:]))
 		return Untrusted, pubKey, 0
 	}
 	if a.beforeListCommit != nil {
@@ -434,7 +435,7 @@ func (a *Aggregator) applyPendingLocked(s *publisherState, blob *blobJSON, signi
 	if version > s.Version {
 		s.Version = version
 	}
-	s.RawManifest = append(s.RawManifest[:0], rawManifest...)
+	s.RawManifest = append([]byte(nil), rawManifest...)
 	a.recordMaxSequenceLocked(s, blob.Sequence)
 	return Pending
 }

--- a/internal/validator/list/publisher_state.go
+++ b/internal/validator/list/publisher_state.go
@@ -1,0 +1,709 @@
+package list
+
+import (
+	"encoding/hex"
+	"slices"
+	"sort"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/manifest"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+)
+
+// ApplyList ingests a single (manifest, blob, signature) triple and
+// returns the resulting disposition along with the publisher master
+// key (when extractable) and the blob's sequence (when extractable).
+// Wraps the rippled-faithful applyList algorithm: verify the publisher
+// manifest, look up its current ephemeral signing key, verify the blob
+// signature, JSON-parse the blob, then update per-publisher state and
+// trigger an OnChange if the trusted union changed.
+//
+// `manifestBytes` and `blob` carry the WIRE-FORM ascii strings as
+// received in TMValidatorList / TMValidatorListCollection (base64-
+// encoded). `signature` carries the WIRE-FORM hex string. `version`
+// is the protocol version negotiated at the message level.
+//
+// `siteURI` is recorded on the per-publisher state for RPC visibility
+// — pass "peer:<id>" for gossip-sourced lists and the URL for
+// HTTP-polled ones.
+//
+// Returns the publisher master key on every disposition where it's
+// extractable (i.e. the manifest decoded), so the caller can attribute
+// metrics / bad-data charges with publisher-level granularity even on
+// failure paths. Returns the zero PublisherKey when the manifest
+// itself could not be parsed. The sequence return is non-zero only
+// when the blob was decoded; the router uses it to record per-peer
+// publisher sequences regardless of accept/expired/pending outcome.
+func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version uint32, siteURI string) (Disposition, PublisherKey, uint32) {
+	return a.applyListInternal(manifestBytes, nil, false, blob, signature, version, siteURI, false)
+}
+
+// applyListInternal is the common v1/v2 ingest path. globalManifest is the
+// collection-level publisher manifest; localManifest is an optional per-blob
+// override. localManifestSet must be true even for an explicitly empty local
+// manifest so the caller does not silently fall back to the global value.
+func (a *Aggregator) applyListInternal(globalManifest, localManifest []byte, localManifestSet bool, blob, signature []byte, version uint32, siteURI string, asyncDispatch bool) (Disposition, PublisherKey, uint32) {
+	if !isSupportedVersion(version) {
+		return UnsupportedVersion, PublisherKey{}, 0
+	}
+
+	manifestBytes := globalManifest
+	if localManifestSet {
+		manifestBytes = localManifest
+	}
+
+	// Decode the publisher manifest. The manifest is base64-encoded on
+	// the wire; the inner STObject is what manifest.Deserialize wants.
+	manifestRaw, err := decodeBase64Tolerant(manifestBytes)
+	if err != nil {
+		a.logger.Debug("validator list: manifest base64 decode failed", "error", err, "site", siteURI)
+		return Invalid, PublisherKey{}, 0
+	}
+	parsed, err := manifest.Deserialize(manifestRaw)
+	if err != nil {
+		a.logger.Debug("validator list: manifest deserialize failed", "error", err, "site", siteURI)
+		return Invalid, PublisherKey{}, 0
+	}
+	masterKey := parsed.MasterKey()
+	pubKey := PublisherKey(masterKey)
+
+	// Reject lists from publishers we don't trust. Per rippled this is
+	// a silent drop — gossip carries lists from many publishers and we
+	// shouldn't penalize peers for forwarding lists we choose not to
+	// trust ourselves.
+	a.mu.Lock()
+	_, trusted := a.publishers[pubKey]
+	a.mu.Unlock()
+	if !trusted {
+		return Untrusted, pubKey, 0
+	}
+
+	// Apply the publisher manifest to the manifest cache. This both
+	// caches the manifest for later use and gives us the current
+	// ephemeral signing key. A revoked manifest invalidates the
+	// publisher entirely.
+	//
+	// Track the cache disposition so revocation only flips publisher
+	// state when the manifest cache actually accepted the revocation.
+	// Mirrors rippled ValidatorList.cpp:1373-1378 — `removePublisherList`
+	// runs only under `revoked && result == ManifestDisposition::accepted`;
+	// a stale revocation (cache already holds a higher-sequence
+	// non-revoked manifest) returns untrusted without clearing state.
+	manifestAccepted := false
+	var manifestSequence uint32
+	manifestSequenceSet := false
+	if a.publisherManifests != nil {
+		switch d := a.publisherManifests.ApplyManifest(parsed); d {
+		case manifest.Accepted:
+			manifestAccepted = true
+		case manifest.Stale:
+			// Already had this or a newer one — cache state is
+			// unchanged; don't let an old revocation manifest flip
+			// the publisher's status.
+		case manifest.Invalid:
+			// The manifest was structurally valid, but its signatures or
+			// cache invariants were not. Rippled maps this path to
+			// ListDisposition::untrusted (ValidatorList.cpp:1360-1363).
+			return Untrusted, pubKey, 0
+		case manifest.BadMasterKey, manifest.BadEphemeralKey:
+			// Cache state is unchanged for these (Manifest.cpp:436-477
+			// returns before any mutation), so `getSigningKey(masterPubKey)`
+			// below will still return the previously-cached signing key if
+			// any. Rippled's check at ValidatorList.cpp:1380-1383 gates only
+			// on `result == invalid`, NOT on badMasterKey/badEphemeralKey,
+			// so we fall through to the signing-key lookup. If the cache
+			// has no key for this master, the lookup branch a few lines
+			// below returns Untrusted; if it has one, blob verification
+			// proceeds against that cached key — matching rippled.
+		}
+	} else {
+		// Fall back to direct verification when no cache is wired
+		// (tests). The signing key in the manifest is what we'd have
+		// pulled from the cache. Mirrors rippled's invalid-manifest →
+		// untrusted mapping at ValidatorList.cpp:1382-1383.
+		if err := parsed.Verify(); err != nil {
+			return Untrusted, pubKey, 0
+		}
+		// No cache means every fresh verify is "accepted" for the
+		// purpose of the revocation gate.
+		manifestAccepted = true
+	}
+
+	if parsed.Revoked() {
+		// Rippled returns ListDisposition::untrusted on revocation
+		// (ValidatorList.cpp:1382-1383). Revocations are legitimate
+		// gossip; punishing the forwarding peer would cascade across
+		// every honest hop in the mesh. The state-clearing side effect
+		// only runs when the manifest cache actually accepted the
+		// revocation — mirrors rippled's `revoked && result == accepted`
+		// gate at ValidatorList.cpp:1373.
+		if manifestAccepted {
+			a.handleRevocation(pubKey)
+		}
+		return Untrusted, pubKey, 0
+	}
+
+	// Pull the current ephemeral signing key. With a cache: this is
+	// the freshest signing key we've ever seen for the publisher,
+	// which might be NEWER than the one in this very manifest if a
+	// later manifest arrived first via gossip. Rippled also uses
+	// publisherManifests_.getSigningKey here, which is the latest
+	// cached key, not the one in `manifestBytes`.
+	signingKey := parsed.SigningKey()
+	if a.publisherManifests != nil {
+		if k, ok := a.publisherManifests.GetSigningKey(masterKey); ok {
+			signingKey = k
+			manifestSequence, manifestSequenceSet = a.publisherManifests.GetSequence(masterKey)
+		} else {
+			// Cache says the master is unknown or revoked. If revoked
+			// we already handled above; if unknown despite the apply,
+			// treat as untrusted (no usable signing key from a trusted
+			// publisher means we cannot verify the blob; rippled's
+			// equivalent at ValidatorList.cpp:1382 is also untrusted).
+			return Untrusted, pubKey, 0
+		}
+	}
+
+	if err := verifyBlobSignature(signingKey, blob, signature); err != nil {
+		a.logger.Debug("validator list: blob signature invalid", "error", err, "publisher", hex.EncodeToString(pubKey[:]))
+		return Invalid, pubKey, 0
+	}
+
+	parsedBlob, disp, err := parseBlob(blob)
+	if err != nil {
+		a.logger.Debug("validator list: blob parse failed", "error", err, "publisher", hex.EncodeToString(pubKey[:]))
+		return disp, pubKey, 0
+	}
+
+	now := a.clock()
+	validFrom := time.Unix(rippleSecondsToUnix(parsedBlob.Effective), 0).UTC()
+	validUntil := time.Unix(rippleSecondsToUnix(parsedBlob.Expiration), 0).UTC()
+
+	a.mu.Lock()
+	if asyncDispatch {
+		defer a.dispatchChangesAsync()
+	} else {
+		defer a.dispatchChanges()
+	}
+	defer a.flushCacheWrites()
+	defer a.mu.Unlock()
+
+	// New() pre-populates state[pubKey] for every trusted publisher and
+	// the entry is never deleted, so a missing key would be an internal
+	// invariant break — surface it loudly rather than silently re-create.
+	current := a.state[pubKey]
+	if current == nil {
+		return Untrusted, pubKey, 0
+	}
+	if a.beforeListCommit != nil {
+		a.beforeListCommit()
+	}
+
+	// Manifest verification and blob parsing happen outside a.mu. Recheck
+	// the per-publisher manifest generation and signing key at the commit
+	// boundary so an older apply cannot resurrect a publisher revoked or
+	// rotated while its signature was being verified.
+	if !a.publisherCommitValidLocked(masterKey, signingKey, manifestSequence, manifestSequenceSet) {
+		return Untrusted, pubKey, 0
+	}
+
+	// Match applyLists' post-apply cleanup before evaluating the next
+	// disposition. Ready entries are deliberately not promoted here: a
+	// re-arrival at a ready pending sequence must take rippled's Accepted
+	// promotion path below, rather than becoming SameSequence.
+	a.normalizeRemainingLocked(current)
+
+	// Determine disposition by sequence + time ordering. Mirrors the
+	// rippled state machine at ValidatorList.cpp:1394-1437. The
+	// SameSequence branch is intentionally unguarded by status —
+	// rippled returns same_sequence for every repeat of the current
+	// sequence regardless of `pubCollection.status`.
+	if parsedBlob.Sequence < current.Sequence {
+		return Stale, pubKey, 0
+	}
+	if parsedBlob.Sequence == current.Sequence {
+		return SameSequence, pubKey, current.MaxSequence
+	}
+	expired := validUntil.Before(now) || validUntil.Equal(now)
+	if expired || !validFrom.After(now) {
+		// Expired ingest runs the SAME populate path as accepted in
+		// rippled: ValidatorList.cpp:1193-1295 — the local `accepted`
+		// boolean is true for both ListDisposition::accepted AND
+		// ListDisposition::expired, so the populate block writes
+		// publisher.list and publisher.manifests, and the call to
+		// updatePublisherList at line 1294 seeds embedded validator
+		// manifests into validatorManifests_ (line 1117-1133). The only
+		// runtime differences vs accepted are the final PublisherStatus
+		// (expired vs available) and that the trusted-set recompute
+		// skips non-available publishers (see recomputeAndEmitLocked:
+		// `s.Status != StatusAvailable` filter).
+		//
+		// removePublisherList(StatusExpired) at ValidatorList.cpp:1529-1542
+		// is invoked from updateTrusted (line 1999) when a previously-
+		// available list times out at ledger close — NOT from applyList.
+		if _, pending := current.Remaining[parsedBlob.Sequence]; pending {
+			a.promotePendingSequenceLocked(current, parsedBlob.Sequence, now)
+		} else {
+			a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version, globalManifest, localManifest, localManifestSet, blob, signature)
+			a.recordMaxSequenceLocked(current, parsedBlob.Sequence)
+		}
+		if expired {
+			current.Status = StatusExpired
+		}
+		a.normalizeRemainingLocked(current)
+		a.recomputeAndEmitLocked()
+		if expired {
+			return Expired, pubKey, current.MaxSequence
+		}
+		return Accepted, pubKey, current.MaxSequence
+	}
+	if validFrom.After(now) {
+		// Future-dated. Mirrors rippled ValidatorList.cpp:1414-1432
+		// pending-vs-known_sequence: a list is "pending" the first
+		// time it lands or whenever its sequence is the largest seen,
+		// and "known_sequence" only for re-arrivals at an already-
+		// queued sequence. The queued blob is retained so the next
+		// promoteRemainingLocked pass can rotate it into `current`.
+		d := a.applyPendingLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, version, globalManifest, localManifest, localManifestSet, blob, signature)
+		a.normalizeRemainingLocked(current)
+		return d, pubKey, current.MaxSequence
+	}
+
+	a.applyAcceptedLocked(current, parsedBlob, signingKey, validFrom, validUntil, siteURI, now, version, globalManifest, localManifest, localManifestSet, blob, signature)
+	a.recordMaxSequenceLocked(current, parsedBlob.Sequence)
+	a.normalizeRemainingLocked(current)
+	a.recomputeAndEmitLocked()
+	return Accepted, pubKey, current.MaxSequence
+}
+
+// publisherCommitValidLocked verifies that the publisher cache state used for
+// blob verification is still current. Caller must hold a.mu.
+func (a *Aggregator) publisherCommitValidLocked(masterKey [33]byte, signingKey [33]byte, sequence uint32, sequenceSet bool) bool {
+	if a.publisherManifests == nil {
+		return true
+	}
+	currentSequence, ok := a.publisherManifests.GetSequence(masterKey)
+	if !ok || (sequenceSet && currentSequence != sequence) {
+		return false
+	}
+	currentSigningKey, ok := a.publisherManifests.GetSigningKey(masterKey)
+	return ok && currentSigningKey == signingKey && !a.publisherManifests.Revoked(masterKey)
+}
+
+// updateRawBytes refreshes the retained wire-form bytes, reusing the
+// existing backing arrays so the caller may keep its own slices.
+func (s *publisherState) updateRawBytes(manifest, blob, signature []byte) {
+	s.RawManifest = append(s.RawManifest[:0], manifest...)
+	s.RawBlob = append(s.RawBlob[:0], blob...)
+	s.RawSignature = append(s.RawSignature[:0], signature...)
+}
+
+func (s *publisherState) updateRawLocalManifest(raw []byte, present bool) {
+	s.RawLocalManifest = append(s.RawLocalManifest[:0], raw...)
+	s.RawLocalManifestSet = present
+}
+
+// extractValidatorKeys decodes and canonically sorts the validator
+// master keys from a parsed blob. logMsg is the debug message emitted
+// for skipped entries.
+func (a *Aggregator) extractValidatorKeys(blob *blobJSON, logMsg string) [][33]byte {
+	keys := make([][33]byte, 0, len(blob.Validators))
+	for i, v := range blob.Validators {
+		raw, err := hex.DecodeString(v.ValidationPublicKey)
+		if err != nil || !validatorKeyValid(raw) {
+			// Mirrors rippled ValidatorList.cpp:1250-1273 which logs
+			// `Invalid node identity` and silently skips the entry
+			// rather than rejecting the surrounding blob.
+			a.logger.Debug(logMsg,
+				"index", i,
+				"pubkey", v.ValidationPublicKey)
+			continue
+		}
+		var k [33]byte
+		copy(k[:], raw)
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return string(keys[i][:]) < string(keys[j][:])
+	})
+	return keys
+}
+
+// applyAcceptedLocked materializes the parsed blob into the
+// publisher's state. Caller must hold a.mu. Does NOT emit OnChange —
+// that's done by recomputeAndEmitLocked once the caller has decided
+// the disposition warrants a trusted-set recompute.
+//
+// rawManifest / rawBlob / rawSignature are the wire-form bytes from
+// the original TMValidatorList / envelope; they are copied (not
+// referenced) so the caller may reuse its slices safely. Used later
+// by BroadcastLatest to re-emit the canonical accepted form to peers.
+func (a *Aggregator) applyAcceptedLocked(s *publisherState, blob *blobJSON, signingKey [33]byte, validFrom, validUntil time.Time, siteURI string, now time.Time, version uint32, rawManifest, rawLocalManifest []byte, rawLocalManifestSet bool, rawBlob, rawSignature []byte) {
+	s.Sequence = blob.Sequence
+	s.Effective = validFrom
+	s.EffectiveSet = blob.EffectiveSet
+	s.Expiration = validUntil
+	s.SigningKey = signingKey
+	s.SiteURI = siteURI
+	s.LastUpdate = now
+	s.Status = StatusAvailable
+	if version > s.Version {
+		s.Version = version
+	}
+	s.updateRawBytes(rawManifest, rawBlob, rawSignature)
+	s.updateRawLocalManifest(rawLocalManifest, rawLocalManifestSet)
+
+	keys := a.extractValidatorKeys(blob, "validator list: skipping invalid validator entry")
+	s.Validators = keys
+	a.applyEmbeddedManifestsLocked(s, blob.Validators)
+
+	a.writeCacheLocked(s)
+}
+
+// applyEmbeddedManifestsLocked applies validator manifests from an effective
+// blob after checking that their master keys occur in at least one live list.
+// Caller must hold a.mu.
+func (a *Aggregator) applyEmbeddedManifestsLocked(s *publisherState, entries []blobEntryJS) {
+	if a.validatorManifests == nil {
+		return
+	}
+	listed := make(map[[33]byte]struct{}, len(s.Validators)+8)
+	for _, k := range s.Validators {
+		listed[k] = struct{}{}
+	}
+	for pubMaster, ps := range a.state {
+		if pubMaster == s.MasterKey {
+			continue
+		}
+		for _, k := range ps.Validators {
+			listed[k] = struct{}{}
+		}
+	}
+	for _, v := range entries {
+		if v.Manifest == "" {
+			continue
+		}
+		raw, err := decodeBase64Tolerant([]byte(v.Manifest))
+		if err != nil {
+			continue
+		}
+		a.applyEmbeddedManifestRawLocked(listed, raw)
+	}
+}
+
+func (a *Aggregator) applyEmbeddedManifestRawLocked(listed map[[33]byte]struct{}, raw []byte) {
+	parsed, err := manifest.Deserialize(raw)
+	if err != nil {
+		return
+	}
+	masterKey := parsed.MasterKey()
+	if _, ok := listed[masterKey]; !ok {
+		a.logger.Debug("validator list: dropping embedded manifest for unlisted master",
+			"master", hex.EncodeToString(masterKey[:]))
+		return
+	}
+	_ = a.validatorManifests.ApplyManifest(parsed)
+}
+
+func (a *Aggregator) applyEmbeddedPendingManifestsLocked(s *publisherState, entries []pendingEmbeddedManifest) {
+	if len(entries) == 0 || a.validatorManifests == nil {
+		return
+	}
+	listed := make(map[[33]byte]struct{}, len(s.Validators)+8)
+	for _, k := range s.Validators {
+		listed[k] = struct{}{}
+	}
+	for pubMaster, ps := range a.state {
+		if pubMaster == s.MasterKey {
+			continue
+		}
+		for _, k := range ps.Validators {
+			listed[k] = struct{}{}
+		}
+	}
+	for _, entry := range entries {
+		a.applyEmbeddedManifestRawLocked(listed, entry.Raw)
+	}
+}
+
+// applyPendingLocked stores a future-dated blob in the publisher's
+// Remaining queue and returns Pending vs KnownSequence per rippled
+// ValidatorList.cpp:1414-1432:
+//
+//   - Pending: no MaxSequence yet, or sequence > MaxSequence, or
+//     sequence is unknown AND validFrom precedes the current
+//     MaxSequence entry's validFrom (out-of-order delivery).
+//   - KnownSequence: re-arrival at a sequence already queued.
+//
+// The blob is only stored on the Pending branch; KnownSequence is a
+// no-op since we already have the same sequence queued. Caller must
+// hold a.mu. Does NOT emit OnChange — promotion drives the trusted-set
+// update.
+func (a *Aggregator) applyPendingLocked(s *publisherState, blob *blobJSON, signingKey [33]byte, validFrom, validUntil time.Time, siteURI string, version uint32, rawManifest, rawLocalManifest []byte, rawLocalManifestSet bool, rawBlob, rawSignature []byte) Disposition {
+	known := false
+	if s.MaxSequenceSet {
+		if _, hit := s.Remaining[blob.Sequence]; hit {
+			known = true
+		} else if blob.Sequence <= s.MaxSequence {
+			// New sequence below max — pending only if it lands ahead
+			// of the current max-stored validFrom (out-of-order).
+			if maxEntry, ok := s.Remaining[s.MaxSequence]; !ok || !validFrom.Before(maxEntry.Effective) {
+				known = true
+			}
+		}
+	}
+	if known {
+		return KnownSequence
+	}
+
+	keys := a.extractValidatorKeys(blob, "validator list: skipping invalid validator entry in pending blob")
+
+	if s.Remaining == nil {
+		s.Remaining = make(map[uint32]*pendingList, 2)
+	}
+	s.Remaining[blob.Sequence] = &pendingList{
+		Sequence:            blob.Sequence,
+		Effective:           validFrom,
+		EffectiveSet:        blob.EffectiveSet,
+		Expiration:          validUntil,
+		Validators:          keys,
+		SiteURI:             siteURI,
+		Version:             version,
+		SigningKey:          signingKey,
+		RawManifest:         append([]byte(nil), rawManifest...),
+		RawLocalManifest:    append([]byte(nil), rawLocalManifest...),
+		RawLocalManifestSet: rawLocalManifestSet,
+		RawBlob:             append([]byte(nil), rawBlob...),
+		RawSignature:        append([]byte(nil), rawSignature...),
+		EmbeddedManifests:   a.pendingEmbeddedManifests(blob),
+	}
+	if version > s.Version {
+		s.Version = version
+	}
+	a.recordMaxSequenceLocked(s, blob.Sequence)
+	a.writeCacheLocked(s)
+	return Pending
+}
+
+func (a *Aggregator) pendingEmbeddedManifests(blob *blobJSON) []pendingEmbeddedManifest {
+	var out []pendingEmbeddedManifest
+	for _, entry := range blob.Validators {
+		if entry.Manifest == "" {
+			continue
+		}
+		raw, err := decodeBase64Tolerant([]byte(entry.Manifest))
+		if err != nil {
+			continue
+		}
+		if _, err := manifest.Deserialize(raw); err != nil {
+			continue
+		}
+		out = append(out, pendingEmbeddedManifest{Raw: append([]byte(nil), raw...)})
+	}
+	return out
+}
+
+func (a *Aggregator) recordMaxSequenceLocked(s *publisherState, sequence uint32) {
+	if !s.MaxSequenceSet || sequence > s.MaxSequence {
+		s.MaxSequence = sequence
+		s.MaxSequenceSet = true
+	}
+}
+
+// normalizeRemainingLocked mirrors the cleanup at ValidatorList.cpp:1022-
+// 1037. Remaining is ordered by sequence, but only entries whose effective
+// times are strictly increasing can remain relevant. Caller must hold a.mu.
+func (a *Aggregator) normalizeRemainingLocked(s *publisherState) {
+	if s == nil || len(s.Remaining) == 0 {
+		return
+	}
+	seqs := make([]uint32, 0, len(s.Remaining))
+	for sequence := range s.Remaining {
+		seqs = append(seqs, sequence)
+	}
+	slices.Sort(seqs)
+	for i, sequence := range seqs {
+		if sequence <= s.Sequence {
+			delete(s.Remaining, sequence)
+			continue
+		}
+		nextIndex := i + 1
+		if nextIndex < len(seqs) {
+			next := s.Remaining[seqs[nextIndex]]
+			current := s.Remaining[sequence]
+			if next != nil && current != nil && !next.Effective.After(current.Effective) {
+				delete(s.Remaining, sequence)
+			}
+		}
+	}
+	if len(s.Remaining) == 0 {
+		s.Remaining = nil
+	}
+}
+
+// promotePendingSequenceLocked handles the applyList race where a queued
+// sequence has become effective before the time-driven promotion sweep.
+// Caller must hold a.mu and must have confirmed that sequence is in
+// Remaining and greater than the current sequence.
+func (a *Aggregator) promotePendingSequenceLocked(s *publisherState, sequence uint32, now time.Time) {
+	chosen := s.Remaining[sequence]
+	if chosen == nil || sequence <= s.Sequence {
+		return
+	}
+	s.Sequence = chosen.Sequence
+	s.Effective = chosen.Effective
+	s.EffectiveSet = chosen.EffectiveSet
+	s.Expiration = chosen.Expiration
+	s.SigningKey = chosen.SigningKey
+	s.SiteURI = chosen.SiteURI
+	s.LastUpdate = now
+	if chosen.Version > s.Version {
+		s.Version = chosen.Version
+	}
+	s.updateRawBytes(chosen.RawManifest, chosen.RawBlob, chosen.RawSignature)
+	s.updateRawLocalManifest(chosen.RawLocalManifest, chosen.RawLocalManifestSet)
+	s.Validators = append([][33]byte(nil), chosen.Validators...)
+	a.applyEmbeddedPendingManifestsLocked(s, chosen.EmbeddedManifests)
+	s.Status = StatusAvailable
+	if !chosen.Expiration.After(now) {
+		s.Status = StatusExpired
+		s.Validators = nil
+	}
+	delete(s.Remaining, sequence)
+	a.recordMaxSequenceLocked(s, sequence)
+	a.normalizeRemainingLocked(s)
+	a.writeCacheLocked(s)
+}
+
+// promoteRemainingLocked rotates ready Remaining entries (those whose
+// validFrom <= now) into the publisher's current slot, mirroring
+// rippled's updateTrusted loop at ValidatorList.cpp:1929-1991.
+// Operates on a single publisher; caller drives publisher iteration if
+// promoting for the whole set.
+//
+// Walks Remaining in ascending sequence order so a chain of stacked
+// rotations resolves to the LAST ready entry (rippled's iter/next
+// scan). Earlier entries are skipped and discarded — rippled
+// likewise erases [firstIter, std::next(iter)] after the rotation.
+//
+// Caller must hold a.mu. Does not emit OnChange — caller decides when
+// to recompute (typically immediately after the call when invoked at
+// ingest, or via Tick → recomputeAndEmitLocked on the time-driven
+// path).
+func (a *Aggregator) promoteRemainingLocked(s *publisherState, now time.Time) bool {
+	a.normalizeRemainingLocked(s)
+	if len(s.Remaining) == 0 {
+		return false
+	}
+	seqs := make([]uint32, 0, len(s.Remaining))
+	for seq := range s.Remaining {
+		seqs = append(seqs, seq)
+	}
+	slices.Sort(seqs)
+
+	// Find the LAST entry that is ready to promote.
+	pickIdx := -1
+	for i, seq := range seqs {
+		p := s.Remaining[seq]
+		if !p.Effective.After(now) {
+			pickIdx = i
+			continue
+		}
+		break
+	}
+	if pickIdx < 0 {
+		return false
+	}
+
+	chosen := s.Remaining[seqs[pickIdx]]
+	a.promotePendingSequenceLocked(s, chosen.Sequence, now)
+
+	// Erase all entries up to and including the chosen one — rippled
+	// remaining.erase(firstIter, std::next(iter)).
+	for i := 0; i <= pickIdx; i++ {
+		delete(s.Remaining, seqs[i])
+	}
+	if len(s.Remaining) == 0 {
+		s.Remaining = nil
+	}
+	a.normalizeRemainingLocked(s)
+	a.writeCacheLocked(s)
+	return true
+}
+
+// ApplyCollection processes a v2 collection (TMValidatorListCollection),
+// applying each blob individually with the collection's shared
+// publisher manifest. Returns the per-blob dispositions in the same
+// order as the collection's blob array, plus the publisher key once
+// the manifest decoded and the highest sequence observed across the
+// collection. The router uses the dispositions to decide whether to
+// charge the sender (any Invalid / Malformed) and whether to relay
+// (at least one Accepted), and uses the max-sequence value to update
+// the per-peer publisherListSequences entry.
+//
+// Mirrors rippled's applyLists at ValidatorList.cpp:998-1070.
+func (a *Aggregator) ApplyCollection(coll *message.ValidatorListCollection, siteURI string) ([]Disposition, PublisherKey, uint32) {
+	return a.applyCollection(coll, siteURI, false)
+}
+
+func (a *Aggregator) applyCollectionFromSite(coll *message.ValidatorListCollection, siteURI string) ([]Disposition, PublisherKey, uint32) {
+	return a.applyCollection(coll, siteURI, true)
+}
+
+func (a *Aggregator) applyCollection(coll *message.ValidatorListCollection, siteURI string, asyncDispatch bool) ([]Disposition, PublisherKey, uint32) {
+	if coll == nil {
+		return []Disposition{Malformed}, PublisherKey{}, 0
+	}
+	if !isSupportedVersion(coll.Version) {
+		return []Disposition{UnsupportedVersion}, PublisherKey{}, 0
+	}
+	if len(coll.Blobs) == 0 {
+		return []Disposition{Malformed}, PublisherKey{}, 0
+	}
+	// Anti-abuse cap. Matches rippled ValidatorList.h:272
+	// `static constexpr std::size_t maxSupportedBlobs = 5;` enforced
+	// at ValidatorList.cpp:428 (v2 JSON path) and 472-473 (parseBlobs).
+	// A peer that sends a collection larger than this would force the
+	// aggregator to run N signature verifications; reject before any
+	// crypto work.
+	if len(coll.Blobs) > maxSupportedBlobs {
+		return []Disposition{Malformed}, PublisherKey{}, 0
+	}
+	out := make([]Disposition, len(coll.Blobs))
+	var resultKey PublisherKey
+	var resultSequence uint32
+	var resultDisposition Disposition
+	resultSet := false
+	for i, blob := range coll.Blobs {
+		// Per blob: prefer the embedded local manifest when present,
+		// else fall back to the collection's shared manifest. Matches
+		// rippled applyList(globalManifest, localManifest, ...) at
+		// ValidatorList.cpp:1140-1151.
+		disp, pk, sequence := a.applyListInternal(
+			coll.Manifest,
+			blob.Manifest,
+			blob.HasManifest(),
+			blob.Blob,
+			blob.Signature,
+			coll.Version,
+			siteURI,
+			asyncDispatch,
+		)
+		out[i] = disp
+		if !resultSet || disp.Severity() < resultDisposition.Severity() ||
+			(disp == resultDisposition && sequence > resultSequence) {
+			resultDisposition = disp
+			resultKey = pk
+			resultSequence = sequence
+			resultSet = true
+		}
+	}
+	if resultKey != (PublisherKey{}) {
+		a.mu.Lock()
+		if state := a.state[resultKey]; state != nil && state.MaxSequenceSet {
+			resultSequence = state.MaxSequence
+		}
+		a.mu.Unlock()
+	}
+	return out, resultKey, resultSequence
+}

--- a/internal/validator/list/rpc_adapter.go
+++ b/internal/validator/list/rpc_adapter.go
@@ -191,12 +191,6 @@ func (r *RPCReader) ListedValidators() []rpctypes.ListedValidator {
 	seen := make(map[[33]byte]struct{})
 	var out []rpctypes.ListedValidator
 	for _, p := range r.agg.PublisherSnapshot() {
-		// rippled's keyListings_ only counts keys from currently-applied
-		// (available) publisher lists; expired / unavailable lists are
-		// decremented out. Mirror that by skipping non-available publishers.
-		if p.Status != StatusAvailable {
-			continue
-		}
 		for _, mk := range p.Validators {
 			if _, dup := seen[mk]; dup {
 				continue

--- a/internal/validator/list/rpc_adapter_test.go
+++ b/internal/validator/list/rpc_adapter_test.go
@@ -1,0 +1,58 @@
+package list
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRPCReaderPublisherProjectionStates(t *testing.T) {
+	key := PublisherKey{0xed, 1}
+	agg, err := New(Config{PublisherKeys: []PublisherKey{key}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	cases := []struct {
+		name       string
+		status     PublisherStatus
+		pending    bool
+		available  bool
+		remainingN int
+	}{
+		{name: "unavailable", status: StatusUnavailable},
+		{name: "available", status: StatusAvailable, available: true},
+		{name: "expired", status: StatusExpired},
+		{name: "revoked", status: StatusRevoked},
+		{name: "pending", status: StatusUnavailable, pending: true, remainingN: 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agg.mu.Lock()
+			state := agg.state[key]
+			*state = publisherState{MasterKey: key, Status: tc.status}
+			if tc.pending {
+				state.Remaining = map[uint32]*pendingList{9: {
+					Sequence: 9, Effective: time.Now().Add(time.Hour), EffectiveSet: true,
+				}}
+			}
+			agg.mu.Unlock()
+
+			got := NewRPCReader(agg).Publishers()
+			if len(got) != 1 || got[0].Available != tc.available || got[0].Status != tc.status.String() {
+				t.Fatalf("projection: got %+v", got)
+			}
+			if len(got[0].Remaining) != tc.remainingN {
+				t.Fatalf("remaining: got %d want %d", len(got[0].Remaining), tc.remainingN)
+			}
+		})
+	}
+}
+
+func TestRPCReaderNilIsSafe(t *testing.T) {
+	var reader *RPCReader
+	if reader.HasConfiguredPublishers() || reader.PublisherCount() != 0 || reader.Threshold() != 0 || reader.IsUNLBlocked() {
+		t.Fatal("nil reader returned configured state")
+	}
+	if reader.Publishers() != nil || reader.Sites() != nil || reader.TrustedMasterKeys() != nil || reader.ListedValidators() != nil {
+		t.Fatal("nil reader returned non-empty projection")
+	}
+}

--- a/internal/validator/list/site_poller.go
+++ b/internal/validator/list/site_poller.go
@@ -5,11 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -20,30 +18,30 @@ import (
 // DefaultRefreshInterval matches rippled's
 // ValidatorSite::default_refresh_interval — 5 minutes between polls of
 // a configured publisher URL.
-const DefaultRefreshInterval = 5 * time.Minute
+const defaultRefreshInterval = 5 * time.Minute
 
 // DefaultMinRefresh is the floor applied to a publisher-supplied
 // refresh interval. One minute matches rippled's clamp at
 // ValidatorSite.cpp:486.
-const DefaultMinRefresh = 1 * time.Minute
+const defaultMinRefresh = 1 * time.Minute
 
 // DefaultMaxRefresh is the ceiling applied to a publisher-supplied
 // refresh interval. 24 hours matches rippled.
-const DefaultMaxRefresh = 24 * time.Hour
+const defaultMaxRefresh = 24 * time.Hour
 
 // DefaultRequestTimeout caps a single HTTP fetch attempt. Mirrors
 // rippled's ValidatorSite constructor default at
 // rippled/src/xrpld/app/misc/ValidatorSite.h:142-145
 // (`std::chrono::seconds timeout = std::chrono::seconds{20}`).
-const DefaultRequestTimeout = 20 * time.Second
+const defaultRequestTimeout = 20 * time.Second
 
 // MaxRedirects caps the number of HTTP redirects followed during a
 // single fetch. Matches rippled ValidatorSite.cpp:36 `max_redirects = 3`.
-const MaxRedirects = 3
+const maxRedirects = 3
 
 // ErrorRetryInterval is the cadence used to retry a failed fetch.
 // Mirrors rippled's error_retry_interval at ValidatorSite.cpp:35.
-const ErrorRetryInterval = 30 * time.Second
+const errorRetryInterval = 30 * time.Second
 
 // missingFieldsMessage mirrors rippled's exception text from
 // ValidatorSite.cpp::parseJsonResponse ("Missing fields in JSON
@@ -63,20 +61,20 @@ const missingFieldsMessage = "Missing fields in JSON response"
 // by the cache file name and the refresh cadence is driven by the site
 // poller. Fields beyond these are tolerated and ignored on read.
 type envelope struct {
-	Manifest       string         `json:"manifest"`
-	PublicKey      string         `json:"public_key,omitempty"`
-	Blob           string         `json:"blob,omitempty"`
-	Signature      string         `json:"signature,omitempty"`
-	Version        uint32         `json:"version"`
-	BlobsV2        []envelopeBlob `json:"blobs_v2,omitempty"`
-	RefreshMinutes float64        `json:"refresh_interval,omitempty"`
+	Manifest       string          `json:"manifest"`
+	PublicKey      string          `json:"public_key,omitempty"`
+	Blob           *string         `json:"blob,omitempty"`
+	Signature      *string         `json:"signature,omitempty"`
+	Version        uint32          `json:"version"`
+	BlobsV2        *[]envelopeBlob `json:"blobs_v2,omitempty"`
+	RefreshMinutes float64         `json:"refresh_interval,omitempty"`
 }
 
 // envelopeBlob is a v2 collection entry inside the envelope.
 type envelopeBlob struct {
-	Manifest  string `json:"manifest,omitempty"`
-	Blob      string `json:"blob"`
-	Signature string `json:"signature"`
+	Manifest  *string `json:"manifest,omitempty"`
+	Blob      string  `json:"blob"`
+	Signature string  `json:"signature"`
 }
 
 // toCollection builds the v2 collection view of the envelope for the
@@ -88,14 +86,44 @@ func (e *envelope) toCollection() *message.ValidatorListCollection {
 		Version:  e.Version,
 		Manifest: []byte(e.Manifest),
 	}
-	for _, b := range e.BlobsV2 {
+	if e.BlobsV2 == nil {
+		return coll
+	}
+	for _, b := range *e.BlobsV2 {
+		var localManifest []byte
+		if b.Manifest != nil {
+			// Allocate even for an explicitly empty string: message
+			// ValidatorBlobInfo uses nil-vs-present to distinguish an
+			// omitted override from an explicit empty override.
+			localManifest = make([]byte, len(*b.Manifest))
+			copy(localManifest, *b.Manifest)
+		}
 		coll.Blobs = append(coll.Blobs, message.ValidatorBlobInfo{
-			Manifest:  []byte(b.Manifest),
+			Manifest:  localManifest,
 			Blob:      []byte(b.Blob),
 			Signature: []byte(b.Signature),
 		})
 	}
 	return coll
+}
+
+func (e *envelope) validateShape() error {
+	if e.Version == 0 || e.Manifest == "" {
+		return errors.New(missingFieldsMessage)
+	}
+	switch {
+	case e.Version == 1:
+		if e.Blob == nil || e.Signature == nil || *e.Blob == "" || *e.Signature == "" || e.BlobsV2 != nil {
+			return errors.New(missingFieldsMessage)
+		}
+	case e.Version >= 2:
+		if e.BlobsV2 == nil || len(*e.BlobsV2) == 0 || e.Blob != nil || e.Signature != nil {
+			return errors.New(missingFieldsMessage)
+		}
+	default:
+		return errors.New(missingFieldsMessage)
+	}
+	return nil
 }
 
 // siteState tracks the per-URL scheduling cursor inside the poller.
@@ -120,11 +148,14 @@ type SitePoller struct {
 	logger     *slog.Logger
 	interval   time.Duration
 
-	mu      sync.Mutex
-	started bool
-	sites   []*siteState
-	wg      sync.WaitGroup
-	stop    chan struct{}
+	mu         sync.Mutex
+	sites      []*siteState
+	generation *pollGeneration
+}
+
+type pollGeneration struct {
+	cancel context.CancelFunc
+	done   chan struct{}
 }
 
 // NewSitePoller constructs a poller for the given URLs. Each URL is
@@ -143,20 +174,25 @@ func NewSitePoller(uris []string, agg *Aggregator, logger *slog.Logger) (*SitePo
 		logger = slog.Default().With("component", "validator-list-site-poller")
 	}
 	sites := make([]*siteState, 0, len(uris))
+	seen := make(map[string]struct{}, len(uris))
 	for _, u := range uris {
 		if err := validateSiteURI(u); err != nil {
 			return nil, fmt.Errorf("invalid validator site uri %q: %w", u, err)
 		}
-		sites = append(sites, &siteState{uri: u, interval: DefaultRefreshInterval})
+		if _, ok := seen[u]; ok {
+			continue
+		}
+		seen[u] = struct{}{}
+		sites = append(sites, &siteState{uri: u, interval: defaultRefreshInterval})
 	}
 	p := &SitePoller{
 		aggregator: agg,
 		logger:     logger,
-		interval:   DefaultRefreshInterval,
+		interval:   defaultRefreshInterval,
 		sites:      sites,
 	}
 	p.client = &http.Client{
-		Timeout:       DefaultRequestTimeout,
+		Timeout:       defaultRequestTimeout,
 		CheckRedirect: checkRedirect,
 	}
 	return p, nil
@@ -196,15 +232,15 @@ func validateSiteURI(uri string) error {
 }
 
 // checkRedirect is the redirect policy applied to every HTTP fetch.
-// Caps the chain at MaxRedirects and rejects any redirect target whose
+// Caps the chain at maxRedirects and rejects any redirect target whose
 // scheme is not http/https — mirrors rippled's processRedirect at
 // rippled/src/xrpld/app/misc/detail/ValidatorSite.cpp:511-531. Without
 // the scheme gate an attacker controlling the publisher hostname (or
 // any intermediate redirect target) could send the fetcher at a
 // `file:///etc/passwd` URL and read arbitrary local files.
 func checkRedirect(req *http.Request, via []*http.Request) error {
-	if len(via) >= MaxRedirects {
-		return fmt.Errorf("max redirects (%d) exceeded", MaxRedirects)
+	if len(via) >= maxRedirects {
+		return fmt.Errorf("max redirects (%d) exceeded", maxRedirects)
 	}
 	scheme := strings.ToLower(req.URL.Scheme)
 	if scheme != "http" && scheme != "https" {
@@ -218,6 +254,11 @@ func checkRedirect(req *http.Request, via []*http.Request) error {
 // callers rarely override. MUST be called before Start.
 func (p *SitePoller) SetInterval(d time.Duration) {
 	if d <= 0 {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.generation != nil {
 		return
 	}
 	p.interval = d
@@ -234,11 +275,17 @@ func (p *SitePoller) SetHTTPClient(c *http.Client) {
 	if c == nil {
 		return
 	}
-	c.CheckRedirect = checkRedirect
-	if c.Timeout == 0 {
-		c.Timeout = DefaultRequestTimeout
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.generation != nil {
+		return
 	}
-	p.client = c
+	clone := *c
+	clone.CheckRedirect = checkRedirect
+	if clone.Timeout <= 0 || clone.Timeout > defaultRequestTimeout {
+		clone.Timeout = defaultRequestTimeout
+	}
+	p.client = &clone
 }
 
 // Start launches the polling goroutine. The goroutine drives all
@@ -257,20 +304,25 @@ func (p *SitePoller) SetHTTPClient(c *http.Client) {
 // rearms after stop (ValidatorSite.cpp:171-172, :198); each run owns a fresh
 // stop channel created here.
 func (p *SitePoller) Start(ctx context.Context) {
-	if len(p.sites) == 0 {
-		return
-	}
 	p.mu.Lock()
-	if p.started {
+	if len(p.sites) == 0 || p.generation != nil {
 		p.mu.Unlock()
 		return
 	}
-	p.started = true
-	p.stop = make(chan struct{})
-	stop := p.stop
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	generation := &pollGeneration{cancel: cancel, done: make(chan struct{})}
+	p.generation = generation
+	for _, site := range p.sites {
+		site.nextRefresh = time.Time{}
+	}
 	p.mu.Unlock()
-	p.wg.Add(1)
-	go p.runLoop(ctx, stop)
+	go func() {
+		defer cancel()
+		p.runLoop(runCtx, generation)
+	}()
 }
 
 // Stop signals the polling goroutine to exit and blocks until it has.
@@ -278,15 +330,14 @@ func (p *SitePoller) Start(ctx context.Context) {
 // polling on a fresh stop channel.
 func (p *SitePoller) Stop() {
 	p.mu.Lock()
-	if !p.started {
+	generation := p.generation
+	if generation == nil {
 		p.mu.Unlock()
 		return
 	}
-	p.started = false
-	stop := p.stop
 	p.mu.Unlock()
-	close(stop)
-	p.wg.Wait()
+	generation.cancel()
+	<-generation.done
 }
 
 // runLoop drives the timer pattern: pick the site with the smallest
@@ -294,8 +345,15 @@ func (p *SitePoller) Stop() {
 // repeat. The single-goroutine design matches rippled's setTimer and
 // avoids parallel BroadcastLatest races when two sites simultaneously
 // deliver the same publisher's list.
-func (p *SitePoller) runLoop(ctx context.Context, stop chan struct{}) {
-	defer p.wg.Done()
+func (p *SitePoller) runLoop(ctx context.Context, generation *pollGeneration) {
+	defer func() {
+		p.mu.Lock()
+		if p.generation == generation {
+			p.generation = nil
+			close(generation.done)
+		}
+		p.mu.Unlock()
+	}()
 
 	timer := time.NewTimer(0)
 	defer timer.Stop()
@@ -318,8 +376,6 @@ func (p *SitePoller) runLoop(ctx context.Context, stop chan struct{}) {
 
 		select {
 		case <-ctx.Done():
-			return
-		case <-stop:
 			return
 		case <-timer.C:
 		}
@@ -377,7 +433,7 @@ func (p *SitePoller) fetchSite(ctx context.Context, s *siteState) {
 	// envelope level for both v1 and v2 — see ValidatorList::parseBlobs
 	// and ValidatorSite.cpp:391-410. The literal "Missing fields in
 	// JSON response" message is the rippled-faithful error text.
-	if env.Version == 0 || env.Manifest == "" {
+	if err := env.validateShape(); err != nil {
 		p.recordFailure(s, false, missingFieldsMessage, missingFieldsMessage, "uri", uri)
 		return
 	}
@@ -392,23 +448,18 @@ func (p *SitePoller) fetchSite(ctx context.Context, s *siteState) {
 	var pubKey PublisherKey
 	switch {
 	case env.Version >= 2:
-		if len(env.BlobsV2) == 0 {
-			p.recordFailure(s, false, missingFieldsMessage, missingFieldsMessage, "uri", uri, "version", env.Version)
-			return
-		}
-		dispList, pubKey, _ = p.aggregator.ApplyCollection(env.toCollection(), uri)
+		dispList, pubKey, _ = p.aggregator.applyCollectionFromSite(env.toCollection(), uri)
 		disp = bestDisposition(dispList)
 	case env.Version == 1:
-		if env.Blob == "" || env.Signature == "" {
-			p.recordFailure(s, false, missingFieldsMessage, missingFieldsMessage, "uri", uri)
-			return
-		}
-		disp, pubKey, _ = p.aggregator.ApplyList(
+		disp, pubKey, _ = p.aggregator.applyListInternal(
 			[]byte(env.Manifest),
-			[]byte(env.Blob),
-			[]byte(env.Signature),
+			nil,
+			false,
+			[]byte(*env.Blob),
+			[]byte(*env.Signature),
 			env.Version,
 			uri,
+			true,
 		)
 	default:
 		p.recordFailure(s, false, missingFieldsMessage, missingFieldsMessage, "uri", uri, "version", env.Version)
@@ -434,10 +485,10 @@ func (p *SitePoller) fetchSite(ctx context.Context, s *siteState) {
 	refreshSec := 0
 	if refreshMin := int(env.RefreshMinutes); refreshMin > 0 {
 		d := time.Duration(refreshMin) * time.Minute
-		if d < DefaultMinRefresh {
-			d = DefaultMinRefresh
-		} else if d > DefaultMaxRefresh {
-			d = DefaultMaxRefresh
+		if d < defaultMinRefresh {
+			d = defaultMinRefresh
+		} else if d > defaultMaxRefresh {
+			d = defaultMaxRefresh
 		}
 		chosenInterval = d
 		refreshSec = int(d / time.Second)
@@ -482,7 +533,7 @@ func (p *SitePoller) recordFailure(s *siteState, retry bool, lastErr, logMsg str
 	p.mu.Lock()
 	nextAt := now.Add(s.interval)
 	if retry {
-		nextAt = now.Add(ErrorRetryInterval)
+		nextAt = now.Add(errorRetryInterval)
 	}
 	s.nextRefresh = nextAt
 	p.mu.Unlock()
@@ -511,12 +562,11 @@ func (p *SitePoller) fetch(ctx context.Context, uri string) ([]byte, error) {
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			return nil, fmt.Errorf("HTTP %d %s", resp.StatusCode, resp.Status)
 		}
-		const maxBody = 8 << 20
-		return io.ReadAll(io.LimitReader(resp.Body, maxBody))
+		return readBoundedBody(resp.Body)
 	case "file":
 		// Host already rejected at construction (see validateSiteURI);
 		// Path already guaranteed non-empty.
-		return os.ReadFile(parsed.Path)
+		return readBoundedFile(parsed.Path)
 	default:
 		return nil, fmt.Errorf("unsupported URI scheme %q", parsed.Scheme)
 	}

--- a/internal/validator/list/site_poller.go
+++ b/internal/validator/list/site_poller.go
@@ -113,7 +113,7 @@ func (v *envelopeUint32) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	var value int64
-	if err := json.Unmarshal(data, &value); err != nil || value < -2147483648 || value > 2147483647 {
+	if err := json.Unmarshal(data, &value); err != nil || value < 0 || value > 2147483647 {
 		return nil
 	}
 	v.Value = uint32(value)

--- a/internal/validator/list/site_poller.go
+++ b/internal/validator/list/site_poller.go
@@ -50,18 +50,6 @@ const errorRetryInterval = 30 * time.Second
 const missingFieldsMessage = "Missing fields in JSON response"
 const missingFieldsStatusMessage = "missing fields"
 
-// envelope is the JSON shape published at vl.* publisher URLs (and the
-// equivalent file:// payloads), and the on-disk cache format the
-// aggregator writes. Its field names and types match rippled's
-// buildFileData layout (ValidatorList.cpp:304-366) so a cache file is
-// schema-compatible with rippled; field order is not significant because
-// the file is only ever read back via JSON unmarshal, never compared
-// byte-for-byte.
-//
-// public_key and refresh_interval are emitted for that schema
-// compatibility but are not consumed on read: the publisher is identified
-// by the cache file name and the refresh cadence is driven by the site
-// poller. Fields beyond these are tolerated and ignored on read.
 type envelope struct {
 	Object         bool            `json:"-"`
 	Manifest       envelopeString  `json:"manifest"`

--- a/internal/validator/list/site_poller.go
+++ b/internal/validator/list/site_poller.go
@@ -1,6 +1,7 @@
 package list
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -47,6 +48,7 @@ const errorRetryInterval = 30 * time.Second
 // ValidatorSite.cpp::parseJsonResponse ("Missing fields in JSON
 // response") so external monitors keyed on the literal string match.
 const missingFieldsMessage = "Missing fields in JSON response"
+const missingFieldsStatusMessage = "missing fields"
 
 // envelope is the JSON shape published at vl.* publisher URLs (and the
 // equivalent file:// payloads), and the on-disk cache format the
@@ -61,20 +63,106 @@ const missingFieldsMessage = "Missing fields in JSON response"
 // by the cache file name and the refresh cadence is driven by the site
 // poller. Fields beyond these are tolerated and ignored on read.
 type envelope struct {
-	Manifest       string          `json:"manifest"`
-	PublicKey      string          `json:"public_key,omitempty"`
-	Blob           *string         `json:"blob,omitempty"`
-	Signature      *string         `json:"signature,omitempty"`
-	Version        uint32          `json:"version"`
-	BlobsV2        *[]envelopeBlob `json:"blobs_v2,omitempty"`
-	RefreshMinutes float64         `json:"refresh_interval,omitempty"`
+	Object         bool            `json:"-"`
+	Manifest       envelopeString  `json:"manifest"`
+	PublicKey      json.RawMessage `json:"public_key,omitempty"`
+	Blob           envelopeString  `json:"blob"`
+	Signature      envelopeString  `json:"signature"`
+	Version        envelopeUint32  `json:"version"`
+	BlobsV2        envelopeBlobs   `json:"blobs_v2"`
+	RefreshMinutes envelopeNumber  `json:"refresh_interval,omitempty"`
+}
+
+func (e *envelope) UnmarshalJSON(data []byte) error {
+	if trimmed := bytes.TrimSpace(data); len(trimmed) == 0 || trimmed[0] != '{' {
+		*e = envelope{}
+		return nil
+	}
+	type envelopeFields envelope
+	var decoded envelopeFields
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*e = envelope(decoded)
+	e.Object = true
+	return nil
 }
 
 // envelopeBlob is a v2 collection entry inside the envelope.
 type envelopeBlob struct {
-	Manifest  *string `json:"manifest,omitempty"`
-	Blob      string  `json:"blob"`
-	Signature string  `json:"signature"`
+	Manifest  envelopeString `json:"manifest"`
+	Blob      envelopeString `json:"blob"`
+	Signature envelopeString `json:"signature"`
+}
+
+type envelopeString struct {
+	Value   string
+	Present bool
+	Valid   bool
+}
+
+func (s *envelopeString) UnmarshalJSON(data []byte) error {
+	*s = envelopeString{Present: true}
+	if string(data) == "null" {
+		return nil
+	}
+	if err := json.Unmarshal(data, &s.Value); err != nil {
+		return nil
+	}
+	s.Valid = true
+	return nil
+}
+
+type envelopeUint32 struct {
+	Value   uint32
+	Present bool
+	Valid   bool
+}
+
+func (v *envelopeUint32) UnmarshalJSON(data []byte) error {
+	*v = envelopeUint32{Present: true}
+	if string(data) == "null" {
+		return nil
+	}
+	var value int64
+	if err := json.Unmarshal(data, &value); err != nil || value < -2147483648 || value > 2147483647 {
+		return nil
+	}
+	v.Value = uint32(value)
+	v.Valid = true
+	return nil
+}
+
+type envelopeBlobs struct {
+	Values  []envelopeBlob
+	Present bool
+	Valid   bool
+}
+
+type envelopeNumber struct {
+	Value float64
+	Valid bool
+}
+
+func (n *envelopeNumber) UnmarshalJSON(data []byte) error {
+	*n = envelopeNumber{}
+	if err := json.Unmarshal(data, &n.Value); err != nil {
+		return nil
+	}
+	n.Valid = true
+	return nil
+}
+
+func (b *envelopeBlobs) UnmarshalJSON(data []byte) error {
+	*b = envelopeBlobs{Present: true}
+	if string(data) == "null" {
+		return nil
+	}
+	if err := json.Unmarshal(data, &b.Values); err != nil {
+		return nil
+	}
+	b.Valid = true
+	return nil
 }
 
 // toCollection builds the v2 collection view of the envelope for the
@@ -83,45 +171,50 @@ type envelopeBlob struct {
 // shared manifest otherwise.
 func (e *envelope) toCollection() *message.ValidatorListCollection {
 	coll := &message.ValidatorListCollection{
-		Version:  e.Version,
-		Manifest: []byte(e.Manifest),
+		Version:  e.Version.Value,
+		Manifest: []byte(e.Manifest.Value),
 	}
-	if e.BlobsV2 == nil {
+	if !e.BlobsV2.Present {
 		return coll
 	}
-	for _, b := range *e.BlobsV2 {
+	for _, b := range e.BlobsV2.Values {
 		var localManifest []byte
-		if b.Manifest != nil {
+		if b.Manifest.Present {
 			// Allocate even for an explicitly empty string: message
 			// ValidatorBlobInfo uses nil-vs-present to distinguish an
 			// omitted override from an explicit empty override.
-			localManifest = make([]byte, len(*b.Manifest))
-			copy(localManifest, *b.Manifest)
+			localManifest = make([]byte, len(b.Manifest.Value))
+			copy(localManifest, b.Manifest.Value)
 		}
 		coll.Blobs = append(coll.Blobs, message.ValidatorBlobInfo{
 			Manifest:  localManifest,
-			Blob:      []byte(b.Blob),
-			Signature: []byte(b.Signature),
+			Blob:      []byte(b.Blob.Value),
+			Signature: []byte(b.Signature.Value),
 		})
 	}
 	return coll
 }
 
 func (e *envelope) validateShape() error {
-	if e.Version == 0 || e.Manifest == "" {
+	if !e.Object || !e.Version.Present || !e.Version.Valid || !e.Manifest.Present || !e.Manifest.Valid {
 		return errors.New(missingFieldsMessage)
 	}
-	switch {
-	case e.Version == 1:
-		if e.Blob == nil || e.Signature == nil || *e.Blob == "" || *e.Signature == "" || e.BlobsV2 != nil {
+	if e.Version.Value == 1 {
+		if !e.Blob.Present || !e.Blob.Valid || !e.Signature.Present || !e.Signature.Valid || e.BlobsV2.Present {
 			return errors.New(missingFieldsMessage)
 		}
-	case e.Version >= 2:
-		if e.BlobsV2 == nil || len(*e.BlobsV2) == 0 || e.Blob != nil || e.Signature != nil {
-			return errors.New(missingFieldsMessage)
-		}
-	default:
+		return nil
+	}
+	if !e.BlobsV2.Present || !e.BlobsV2.Valid || len(e.BlobsV2.Values) == 0 || len(e.BlobsV2.Values) > 5 || e.Blob.Present || e.Signature.Present {
 		return errors.New(missingFieldsMessage)
+	}
+	for _, blob := range e.BlobsV2.Values {
+		if !blob.Blob.Present || !blob.Blob.Valid || !blob.Signature.Present || !blob.Signature.Valid {
+			return errors.New(missingFieldsMessage)
+		}
+		if blob.Manifest.Present && !blob.Manifest.Valid {
+			return errors.New(missingFieldsMessage)
+		}
 	}
 	return nil
 }
@@ -130,6 +223,7 @@ func (e *envelope) validateShape() error {
 // Mirrors the fields rippled's `setTimer` consults to pick the next
 // site to fetch (ValidatorSite.cpp:213-228).
 type siteState struct {
+	occurrence  int
 	uri         string
 	interval    time.Duration
 	nextRefresh time.Time
@@ -174,16 +268,13 @@ func NewSitePoller(uris []string, agg *Aggregator, logger *slog.Logger) (*SitePo
 		logger = slog.Default().With("component", "validator-list-site-poller")
 	}
 	sites := make([]*siteState, 0, len(uris))
-	seen := make(map[string]struct{}, len(uris))
+	occurrences := make(map[string]int, len(uris))
 	for _, u := range uris {
 		if err := validateSiteURI(u); err != nil {
 			return nil, fmt.Errorf("invalid validator site uri %q: %w", u, err)
 		}
-		if _, ok := seen[u]; ok {
-			continue
-		}
-		seen[u] = struct{}{}
-		sites = append(sites, &siteState{uri: u, interval: defaultRefreshInterval})
+		sites = append(sites, &siteState{occurrence: occurrences[u], uri: u, interval: defaultRefreshInterval})
+		occurrences[u]++
 	}
 	p := &SitePoller{
 		aggregator: agg,
@@ -414,7 +505,7 @@ func (p *SitePoller) fetchSite(ctx context.Context, s *siteState) {
 	// where nextRefresh is set before makeRequest. Without this the
 	// validator_list_sites RPC reports a stale, already-past
 	// next_refresh_time for the duration of an in-flight fetch.
-	p.aggregator.SetNextRefresh(uri, time.Now().UTC().Add(s.interval))
+	p.aggregator.setNextRefreshOccurrence(uri, s.occurrence, time.Now().UTC().Add(s.interval))
 
 	body, err := p.fetch(ctx, uri)
 	if err != nil {
@@ -424,8 +515,7 @@ func (p *SitePoller) fetchSite(ctx context.Context, s *siteState) {
 
 	var env envelope
 	if jsonErr := json.Unmarshal(body, &env); jsonErr != nil {
-		msg := fmt.Sprintf("envelope JSON decode: %v", jsonErr)
-		p.recordFailure(s, false, msg, msg, "uri", uri)
+		p.recordFailure(s, false, "bad json", "validator list site JSON decode failed", "uri", uri, "error", jsonErr)
 		return
 	}
 
@@ -434,7 +524,7 @@ func (p *SitePoller) fetchSite(ctx context.Context, s *siteState) {
 	// and ValidatorSite.cpp:391-410. The literal "Missing fields in
 	// JSON response" message is the rippled-faithful error text.
 	if err := env.validateShape(); err != nil {
-		p.recordFailure(s, false, missingFieldsMessage, missingFieldsMessage, "uri", uri)
+		p.recordFailure(s, false, missingFieldsStatusMessage, missingFieldsMessage, "uri", uri)
 		return
 	}
 
@@ -447,23 +537,20 @@ func (p *SitePoller) fetchSite(ctx context.Context, s *siteState) {
 	var dispList []Disposition
 	var pubKey PublisherKey
 	switch {
-	case env.Version >= 2:
+	case env.Version.Value != 1:
 		dispList, pubKey, _ = p.aggregator.applyCollectionFromSite(env.toCollection(), uri)
 		disp = bestDisposition(dispList)
-	case env.Version == 1:
+	case env.Version.Value == 1:
 		disp, pubKey, _ = p.aggregator.applyListInternal(
-			[]byte(env.Manifest),
+			[]byte(env.Manifest.Value),
 			nil,
 			false,
-			[]byte(*env.Blob),
-			[]byte(*env.Signature),
-			env.Version,
+			[]byte(env.Blob.Value),
+			[]byte(env.Signature.Value),
+			env.Version.Value,
 			uri,
 			true,
 		)
-	default:
-		p.recordFailure(s, false, missingFieldsMessage, missingFieldsMessage, "uri", uri, "version", env.Version)
-		return
 	}
 
 	// Capture time AFTER apply completes — mirrors rippled
@@ -483,7 +570,7 @@ func (p *SitePoller) fetchSite(ctx context.Context, s *siteState) {
 	// (ValidatorSite.cpp:484-489).
 	chosenInterval := p.interval
 	refreshSec := 0
-	if refreshMin := int(env.RefreshMinutes); refreshMin > 0 {
+	if refreshMin := int(env.RefreshMinutes.Value); env.RefreshMinutes.Valid && refreshMin > 0 {
 		d := time.Duration(refreshMin) * time.Minute
 		if d < defaultMinRefresh {
 			d = defaultMinRefresh
@@ -494,20 +581,14 @@ func (p *SitePoller) fetchSite(ctx context.Context, s *siteState) {
 		refreshSec = int(d / time.Second)
 	}
 
-	// rippled emits an empty `last_refresh_message` whenever the parse
-	// succeeded — the disposition itself carries the outcome
-	// (ValidatorSite.cpp:430). Stash the disposition string in the
-	// message only for dispositions that indicate the apply rejected
-	// the list (anything not ShouldRelay-eligible).
+	// A successfully parsed response has an empty status message even
+	// when semantic validation rejects the list.
 	lastSuccess := time.Time{}
-	lastErr := ""
 	if disp.ShouldRelay() {
 		lastSuccess = applyTime
-	} else {
-		lastErr = "disposition=" + disp.String()
 	}
 	nextAt := applyTime.Add(chosenInterval)
-	p.aggregator.UpdateSiteState(uri, applyTime, lastSuccess, lastErr, disp, refreshSec, nextAt)
+	p.aggregator.updateSiteStateOccurrence(uri, s.occurrence, applyTime, lastSuccess, "", disp, refreshSec, nextAt)
 
 	p.mu.Lock()
 	s.interval = chosenInterval
@@ -537,7 +618,7 @@ func (p *SitePoller) recordFailure(s *siteState, retry bool, lastErr, logMsg str
 	}
 	s.nextRefresh = nextAt
 	p.mu.Unlock()
-	p.aggregator.UpdateSiteState(s.uri, now, time.Time{}, lastErr, Malformed, 0, nextAt)
+	p.aggregator.updateSiteStateOccurrence(s.uri, s.occurrence, now, time.Time{}, lastErr, Malformed, 0, nextAt)
 }
 
 // fetch retrieves the raw envelope body from the given URI. Scheme

--- a/internal/validator/list/site_poller_lifecycle_test.go
+++ b/internal/validator/list/site_poller_lifecycle_test.go
@@ -2,6 +2,7 @@ package list
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -9,6 +10,39 @@ import (
 	"testing"
 	"time"
 )
+
+func TestEnvelopeValidateShapePreservesPresenceAndType(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		ok   bool
+	}{
+		{"v1 present empty", `{"manifest":"","blob":"","signature":"","version":1}`, true},
+		{"v1 missing blob", `{"manifest":"","signature":"","version":1}`, false},
+		{"v2 present empty", `{"manifest":"","version":2,"blobs_v2":[{"blob":"","signature":""}]}`, true},
+		{"v2 missing signature", `{"manifest":"","version":2,"blobs_v2":[{"blob":""}]}`, false},
+		{"v2 null manifest override", `{"manifest":"","version":2,"blobs_v2":[{"manifest":null,"blob":"","signature":""}]}`, false},
+		{"unknown version uses v2 shape", `{"manifest":"","version":0,"blobs_v2":[{"blob":"","signature":""}]}`, true},
+		{"missing version", `{"manifest":"","blobs_v2":[{"blob":"","signature":""}]}`, false},
+		{"non-object root", `[]`, false},
+		{"version outside signed range", `{"manifest":"","version":2147483648,"blobs_v2":[{"blob":"","signature":""}]}`, false},
+		{"wrong manifest type", `{"manifest":7,"blob":"","signature":"","version":1}`, false},
+		{"duplicate manifest ends invalid", `{"manifest":"","manifest":null,"blob":"","signature":"","version":1}`, false},
+		{"irrelevant field types", `{"manifest":"","blob":"","signature":"","version":1,"public_key":7,"refresh_interval":"later"}`, true},
+		{"more than five blobs", `{"manifest":"","version":2,"blobs_v2":[{"blob":"","signature":""},{"blob":"","signature":""},{"blob":"","signature":""},{"blob":"","signature":""},{"blob":"","signature":""},{"blob":"","signature":""}]}`, false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var env envelope
+			if err := json.Unmarshal([]byte(test.body), &env); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if got := env.validateShape() == nil; got != test.ok {
+				t.Fatalf("validateShape success = %v, want %v", got, test.ok)
+			}
+		})
+	}
+}
 
 func mustURLForTest(t *testing.T, raw string) *url.URL {
 	t.Helper()

--- a/internal/validator/list/site_poller_lifecycle_test.go
+++ b/internal/validator/list/site_poller_lifecycle_test.go
@@ -1,0 +1,97 @@
+package list
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func mustURLForTest(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	return u
+}
+
+func newPollerForLifecycleTest(t *testing.T, uri string) *SitePoller {
+	t.Helper()
+	agg, err := New(Config{PublisherKeys: []PublisherKey{{0xed, 1}}, SiteURIs: []string{uri}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	poller, err := NewSitePoller([]string{uri}, agg, nil)
+	if err != nil {
+		t.Fatalf("NewSitePoller: %v", err)
+	}
+	return poller
+}
+
+func TestSitePollerClonesHTTPClientAndClampsTimeout(t *testing.T) {
+	poller := newPollerForLifecycleTest(t, "https://example.com/list")
+	caller := &http.Client{Timeout: time.Hour}
+	poller.SetHTTPClient(caller)
+	if caller.Timeout != time.Hour {
+		t.Fatal("SetHTTPClient mutated caller client")
+	}
+	if poller.client == caller || poller.client.Timeout != defaultRequestTimeout {
+		t.Fatalf("client clone/timeout: same=%v timeout=%v", poller.client == caller, poller.client.Timeout)
+	}
+	if err := poller.client.CheckRedirect(&http.Request{URL: mustURLForTest(t, "file:///tmp/x")}, nil); err == nil {
+		t.Fatal("redirect policy allowed non-http scheme")
+	}
+	short := &http.Client{Timeout: time.Second}
+	poller = newPollerForLifecycleTest(t, "https://example.com/list")
+	poller.SetHTTPClient(short)
+	if poller.client.Timeout != time.Second || short.CheckRedirect != nil {
+		t.Fatal("short timeout or caller redirect policy was not preserved/isolated")
+	}
+}
+
+func TestSitePollerCanceledContextCanRestart(t *testing.T) {
+	var served atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		served.Add(1)
+		_, _ = w.Write([]byte(`{"version":1,"manifest":"bad","blob":"bad","signature":"bad"}`))
+	}))
+	defer server.Close()
+	poller := newPollerForLifecycleTest(t, server.URL)
+	poller.SetInterval(time.Millisecond)
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	poller.Start(canceled)
+	poller.Stop()
+	poller.Start(context.Background())
+	defer poller.Stop()
+	deadline := time.Now().Add(time.Second)
+	for served.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if served.Load() == 0 {
+		t.Fatal("poller did not restart after canceled generation")
+	}
+}
+
+func TestSitePollerConcurrentStartStop(t *testing.T) {
+	poller := newPollerForLifecycleTest(t, "file:///definitely/missing")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 50; i++ {
+			poller.Start(ctx)
+		}
+		close(done)
+	}()
+	for i := 0; i < 50; i++ {
+		poller.Stop()
+		poller.Start(ctx)
+	}
+	<-done
+	poller.Stop()
+}

--- a/internal/validator/list/site_poller_lifecycle_test.go
+++ b/internal/validator/list/site_poller_lifecycle_test.go
@@ -25,6 +25,7 @@ func TestEnvelopeValidateShapePreservesPresenceAndType(t *testing.T) {
 		{"unknown version uses v2 shape", `{"manifest":"","version":0,"blobs_v2":[{"blob":"","signature":""}]}`, true},
 		{"missing version", `{"manifest":"","blobs_v2":[{"blob":"","signature":""}]}`, false},
 		{"non-object root", `[]`, false},
+		{"negative version", `{"manifest":"","version":-1,"blobs_v2":[{"blob":"","signature":""}]}`, false},
 		{"version outside signed range", `{"manifest":"","version":2147483648,"blobs_v2":[{"blob":"","signature":""}]}`, false},
 		{"wrong manifest type", `{"manifest":7,"blob":"","signature":"","version":1}`, false},
 		{"duplicate manifest ends invalid", `{"manifest":"","manifest":null,"blob":"","signature":"","version":1}`, false},

--- a/internal/validator/list/site_poller_test.go
+++ b/internal/validator/list/site_poller_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/manifest"
 	"github.com/LeJamon/go-xrpl/internal/validator/list"
 )
@@ -261,5 +262,40 @@ func TestSitePoller_RestartAfterStop(t *testing.T) {
 	case <-served:
 	case <-time.After(3 * time.Second):
 		t.Fatal("Start after Stop did not resume polling")
+	}
+}
+
+func TestSitePoller_OnChangeMayStopPoller(t *testing.T) {
+	pub := newPublisher(t, 0x69, 0x6a)
+	body := validV1Envelope(t, pub, [][33]byte{derivedValidatorKey(0x74)})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+	agg, err := list.New(list.Config{
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		SiteURIs:           []string{srv.URL},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	poller, err := list.NewSitePoller([]string{srv.URL}, agg, nil)
+	if err != nil {
+		t.Fatalf("NewSitePoller: %v", err)
+	}
+	poller.SetInterval(time.Hour)
+	stopped := make(chan struct{})
+	agg.OnChange(func(_ []consensus.NodeID, _ [][33]byte) {
+		poller.Stop()
+		close(stopped)
+	})
+	poller.Start(t.Context())
+	select {
+	case <-stopped:
+	case <-time.After(3 * time.Second):
+		t.Fatal("OnChange -> Stop deadlocked")
 	}
 }

--- a/internal/validator/list/site_poller_test.go
+++ b/internal/validator/list/site_poller_test.go
@@ -1,6 +1,7 @@
 package list_test
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -297,5 +298,53 @@ func TestSitePoller_OnChangeMayStopPoller(t *testing.T) {
 	case <-stopped:
 	case <-time.After(3 * time.Second):
 		t.Fatal("OnChange -> Stop deadlocked")
+	}
+}
+
+func TestSitePoller_RevocationOnChangeMayStopPoller(t *testing.T) {
+	pub := newPublisher(t, 0x75, 0x76)
+	blob, signature := pub.signList(t, 1, 0, time.Now().Add(24*time.Hour).Unix(), [][33]byte{derivedValidatorKey(0x77)})
+	revocation := buildRevocation(t, pub.masterPub, pub.masterPriv)
+	body, err := json.Marshal(map[string]any{
+		"manifest":  base64.StdEncoding.EncodeToString(revocation),
+		"blob":      "",
+		"signature": "",
+		"version":   1,
+	})
+	if err != nil {
+		t.Fatalf("marshal revocation envelope: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+	agg, err := list.New(list.Config{
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		SiteURIs:           []string{srv.URL},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if disposition, _, _ := agg.ApplyList(pub.manifestB64, blob, signature, 1, "test://initial"); disposition != list.Accepted {
+		t.Fatalf("initial disposition: got %s want accepted", disposition)
+	}
+	poller, err := list.NewSitePoller([]string{srv.URL}, agg, nil)
+	if err != nil {
+		t.Fatalf("NewSitePoller: %v", err)
+	}
+	poller.SetInterval(time.Hour)
+	stopped := make(chan struct{})
+	agg.OnChange(func(_ []consensus.NodeID, _ [][33]byte) {
+		poller.Stop()
+		close(stopped)
+	})
+	poller.Start(t.Context())
+	select {
+	case <-stopped:
+	case <-time.After(3 * time.Second):
+		t.Fatal("revocation OnChange -> Stop deadlocked")
 	}
 }

--- a/internal/validator/list/unl_blocked_test.go
+++ b/internal/validator/list/unl_blocked_test.go
@@ -20,14 +20,14 @@ func TestAggregator_IsUNLBlocked(t *testing.T) {
 	newAgg := func(now *time.Time, pubs ...PublisherKey) *Aggregator {
 		a := &Aggregator{
 			publishers: map[PublisherKey]struct{}{},
-			state:      map[PublisherKey]*PublisherState{},
+			state:      map[PublisherKey]*publisherState{},
 			threshold:  1,
 			clock:      func() time.Time { return *now },
 			logger:     slog.Default(),
 		}
 		for _, p := range pubs {
 			a.publishers[p] = struct{}{}
-			a.state[p] = &PublisherState{MasterKey: p, Status: StatusUnavailable}
+			a.state[p] = &publisherState{MasterKey: p, Status: StatusUnavailable}
 		}
 		return a
 	}
@@ -75,7 +75,7 @@ func TestAggregator_IsUNLBlocked(t *testing.T) {
 		now := time.Unix(1000, 0)
 		a := newAgg(&now, pk1)
 		a.staticValidatorCount = 1
-		a.state[pk1] = &PublisherState{
+		a.state[pk1] = &publisherState{
 			MasterKey:  pk1,
 			Status:     StatusAvailable,
 			Validators: val,
@@ -285,7 +285,7 @@ func TestAggregator_UNLBlockChangeEmitsWithoutTrustChange(t *testing.T) {
 	validator := [][33]byte{{9}}
 	a := &Aggregator{
 		publishers: map[PublisherKey]struct{}{pk1: {}, pk2: {}},
-		state: map[PublisherKey]*PublisherState{
+		state: map[PublisherKey]*publisherState{
 			pk1: {MasterKey: pk1, Status: StatusAvailable, Validators: validator, Expiration: now.Add(2 * time.Hour)},
 			pk2: {MasterKey: pk2, Status: StatusAvailable, Validators: validator, Expiration: now.Add(time.Hour)},
 		},


### PR DESCRIPTION
## Summary

- prevent publisher sequence rollback and preserve publisher/validator rotation manifests across pending state, relay, cache, restart, and promotion
- close revocation/apply, callback, cache retry, poller lifecycle, body-bound, configuration, and mutable-API gaps
- match rippled collection selection and relay semantics, including v1/v2 feature handling and protocol-sized collection splitting

## Test plan

- [x] `go test -timeout 120s ./internal/validator/list ./internal/consensus/adaptor ./internal/node ./internal/rpc/... -count=1`
- [x] `go test -race -timeout 180s ./internal/validator/list ./internal/consensus/adaptor -count=1`
- [x] `go test -timeout 240s -count=10 -shuffle=on ./internal/validator/list`
- [x] `go test -timeout 300s ./... -count=1`
- [x] `just build-all`
- [x] `just vet`
- [x] `golangci-lint run`
- [x] `just lint`
- [x] `git diff --check`

Fixes #1511


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Validator-list collections can be split into smaller messages for reliable delivery.
  - Broadcasting supports current and legacy protocol versions while sending only needed updates.
  - Validator-list processing supports rotations, embedded manifests, sequence tracking, and publisher metadata.
  - Site polling and local cache handling support safer versioned data and recovery from failed updates.

- **Bug Fixes**
  - Improved handling of malformed manifests, expired lists, revoked publishers, duplicate data, and oversized inputs.
  - Prevented stale or untrusted validator information from being committed.
  - Improved callback, caching, and polling reliability without blocking normal operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->