### PR TITLE
fix: restore Delegate V1_1 lifecycle parity

### DIFF
--- a/internal/testing/accountdelete/delegate_cleanup_test.go
+++ b/internal/testing/accountdelete/delegate_cleanup_test.go
@@ -1,0 +1,162 @@
+package accountdelete_test
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/ticket"
+	delegatetx "github.com/LeJamon/go-xrpl/internal/tx/delegate"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func setDelegate(t *testing.T, env *jtx.TestEnv, owner, authorized *jtx.Account) {
+	t.Helper()
+	ds := delegatetx.NewDelegateSet(owner.Address)
+	ds.Authorize = authorized.Address
+	ds.Permissions = append(ds.Permissions, delegatetx.NewPermission("Payment"))
+	jtx.RequireTxSuccess(t, env.Submit(ds))
+}
+
+func directoryContains(t *testing.T, env *jtx.TestEnv, owner [20]byte, item [32]byte) bool {
+	t.Helper()
+	found := false
+	require.NoError(t, state.DirForEach(env.Ledger(), keylet.OwnerDir(owner), func(key [32]byte) error {
+		if key == item {
+			found = true
+		}
+		return nil
+	}))
+	return found
+}
+
+func TestAccountDelete_CleansDelegateWhenDeletingDelegator(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("PermissionDelegationV1_1")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	carol := jtx.NewAccount("carol")
+	env.Fund(alice, bob, carol)
+	env.Close()
+
+	setDelegate(t, env, alice, bob)
+	env.Close()
+	delegateKey := keylet.Delegate(alice.ID, bob.ID)
+	require.True(t, directoryContains(t, env, bob.ID, delegateKey.Key))
+
+	env.IncLedgerSeqForAccDel(alice)
+	jtx.RequireTxSuccess(t, env.Submit(newAccountDelete(alice, carol)))
+	env.Close()
+
+	jtx.RequireAccountNotExists(t, env, alice)
+	require.False(t, env.LedgerEntryExists(delegateKey))
+	require.False(t, directoryContains(t, env, bob.ID, delegateKey.Key))
+}
+
+func TestAccountDelete_CleansDelegateWhenDeletingDelegatee(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("PermissionDelegationV1_1")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	carol := jtx.NewAccount("carol")
+	env.FundAmount(alice, uint64(jtx.XRP(100_000)))
+	env.Fund(bob, carol)
+	env.Close()
+
+	jtx.RequireTxSuccess(t, env.Submit(ticket.TicketCreate(alice, 32).Build()))
+	setDelegate(t, env, alice, bob)
+	env.Close()
+	delegateKey := keylet.Delegate(alice.ID, bob.ID)
+	data, err := env.LedgerEntry(delegateKey)
+	require.NoError(t, err)
+	entry, err := state.ParseDelegate(data)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), entry.OwnerNode)
+	require.Zero(t, entry.DestinationNode)
+
+	env.IncLedgerSeqForAccDel(bob)
+	jtx.RequireTxSuccess(t, env.Submit(newAccountDelete(bob, carol)))
+	env.Close()
+
+	jtx.RequireAccountNotExists(t, env, bob)
+	require.False(t, env.LedgerEntryExists(delegateKey))
+	require.False(t, directoryContains(t, env, alice.ID, delegateKey.Key))
+	require.Equal(t, uint32(32), env.OwnerCount(alice))
+}
+
+func TestAccountDelete_CleansMultipleInboundDelegates(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("PermissionDelegationV1_1")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	carol := jtx.NewAccount("carol")
+	destination := jtx.NewAccount("destination")
+	env.Fund(alice, bob, carol, destination)
+	env.Close()
+
+	setDelegate(t, env, alice, bob)
+	setDelegate(t, env, carol, bob)
+	env.Close()
+
+	env.IncLedgerSeqForAccDel(bob)
+	jtx.RequireTxSuccess(t, env.Submit(newAccountDelete(bob, destination)))
+	env.Close()
+
+	for _, owner := range []*jtx.Account{alice, carol} {
+		delegateKey := keylet.Delegate(owner.ID, bob.ID)
+		require.False(t, env.LedgerEntryExists(delegateKey))
+		require.False(t, directoryContains(t, env, owner.ID, delegateKey.Key))
+		require.Zero(t, env.OwnerCount(owner))
+	}
+}
+
+func TestAccountDelete_DelegateCleanupFailureIsAtomic(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("PermissionDelegationV1_1")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	carol := jtx.NewAccount("carol")
+	env.Fund(alice, bob, carol)
+	env.Close()
+
+	setDelegate(t, env, alice, bob)
+	env.Close()
+	delegateKey := keylet.Delegate(alice.ID, bob.ID)
+	destinationDirKey := keylet.OwnerDir(bob.ID)
+	destinationData, err := env.LedgerEntry(destinationDirKey)
+	require.NoError(t, err)
+	destinationDir, err := state.ParseDirectoryNode(destinationData)
+	require.NoError(t, err)
+	destinationDir.Indexes = nil
+	destinationData, err = state.SerializeDirectoryNode(destinationDir, false)
+	require.NoError(t, err)
+	require.NoError(t, env.Ledger().Update(destinationDirKey, destinationData))
+	env.IncLedgerSeqForAccDel(alice)
+
+	stateHash, err := env.Ledger().StateMapHash()
+	require.NoError(t, err)
+	delegateBefore, err := env.LedgerEntry(delegateKey)
+	require.NoError(t, err)
+	ownerDirBefore, err := env.LedgerEntry(keylet.OwnerDir(alice.ID))
+	require.NoError(t, err)
+	balanceBefore := env.Balance(alice)
+	sequenceBefore := env.Seq(alice)
+
+	result := env.Submit(newAccountDelete(alice, carol))
+	jtx.RequireTxFail(t, result, jtx.TefBAD_LEDGER)
+	require.Nil(t, result.Metadata)
+
+	afterHash, err := env.Ledger().StateMapHash()
+	require.NoError(t, err)
+	require.Equal(t, stateHash, afterHash)
+	require.Equal(t, balanceBefore, env.Balance(alice))
+	require.Equal(t, sequenceBefore, env.Seq(alice))
+	require.True(t, env.LedgerEntryExists(keylet.Account(alice.ID)))
+	delegateAfter, err := env.LedgerEntry(delegateKey)
+	require.NoError(t, err)
+	require.Equal(t, delegateBefore, delegateAfter)
+	ownerDirAfter, err := env.LedgerEntry(keylet.OwnerDir(alice.ID))
+	require.NoError(t, err)
+	require.Equal(t, ownerDirBefore, ownerDirAfter)
+}

--- a/internal/testing/batch/batch_test.go
+++ b/internal/testing/batch/batch_test.go
@@ -1377,7 +1377,7 @@ func TestBadOuterFee(t *testing.T) {
 // =============================================================================
 // Test 12: testBatchDelegate
 // Reference: rippled Batch_test.cpp testBatchDelegate()
-// Skipped: Requires Delegate transaction type which is not yet implemented
+// Delegation coverage for Batch outer and inner transactions.
 // =============================================================================
 
 func TestBatchDelegate(t *testing.T) {

--- a/internal/testing/batch/batch_test.go
+++ b/internal/testing/batch/batch_test.go
@@ -1377,7 +1377,6 @@ func TestBadOuterFee(t *testing.T) {
 // =============================================================================
 // Test 12: testBatchDelegate
 // Reference: rippled Batch_test.cpp testBatchDelegate()
-// Delegation coverage for Batch outer and inner transactions.
 // =============================================================================
 
 func TestBatchDelegate(t *testing.T) {

--- a/internal/testing/delegate/delegate_test.go
+++ b/internal/testing/delegate/delegate_test.go
@@ -1,7 +1,5 @@
 // Package delegate_test contains behaviour tests for delegated transactions and
-// the PermissionDelegationV1_1 amendment. Ported from rippled's Delegate_test.cpp;
-// the granular-permission base behaviour is additionally covered by the
-// app/Delegate conformance fixtures (rippled 2.6.2, which predates the amendment).
+// the PermissionDelegationV1_1 amendment.
 //
 // PermissionDelegationV1_1 replaces the removed PermissionDelegation +
 // fixDelegateV1_1 amendments, folding the delegatability restrictions in
@@ -27,9 +25,7 @@ func grantPermissions(env *jtx.TestEnv, owner, delegate *jtx.Account, perms ...s
 	ds := delegatetx.NewDelegateSet(owner.Address)
 	ds.Authorize = delegate.Address
 	for _, p := range perms {
-		ds.Permissions = append(ds.Permissions, delegatetx.Permission{
-			Permission: delegatetx.PermissionData{PermissionValue: p},
-		})
+		ds.Permissions = append(ds.Permissions, delegatetx.NewPermission(p))
 	}
 	return env.SubmitSignedWith(ds, owner)
 }
@@ -59,10 +55,15 @@ func TestDelegate_FeatureDisabled(t *testing.T) {
 			}
 			gw := jtx.NewAccount("gw")
 			alice := jtx.NewAccount("alice")
-			env.Fund(gw, alice)
+			bob := jtx.NewAccount("bob")
+			env.Fund(gw, alice, bob)
 			env.Close()
 
 			require.Equal(t, want, grantPermissions(env, gw, alice, "Payment").Code)
+			if enabled {
+				env.Close()
+			}
+			require.Equal(t, want, payDelegated(env, gw, alice, bob, tx.NewXRPAmount(1_000_000)).Code)
 		})
 	}
 }
@@ -184,6 +185,7 @@ func TestDelegate_PaymentGranularMintBurn(t *testing.T) {
 	require.Equal(t, "tesSUCCESS", grantPermissions(env, gw, bob, "PaymentBurn").Code)
 	env.Close()
 	require.Equal(t, "terNO_DELEGATE_PERMISSION", payDelegated(env, gw, bob, alice, usd50).Code)
+	require.Zero(t, env.BalanceIOU(alice, "USD", gw))
 	env.Close()
 
 	// PaymentMint granted: gw mints USD to alice on behalf via bob.
@@ -191,6 +193,7 @@ func TestDelegate_PaymentGranularMintBurn(t *testing.T) {
 	env.Close()
 	require.Equal(t, "tesSUCCESS", payDelegated(env, gw, bob, alice, usd50).Code)
 	env.Close()
+	require.Equal(t, float64(50), env.BalanceIOU(alice, "USD", gw))
 
 	// XRP is never a mint or burn.
 	require.Equal(t, "terNO_DELEGATE_PERMISSION",
@@ -219,6 +222,8 @@ func TestDelegate_PaymentBurn(t *testing.T) {
 	env.Close()
 	require.Equal(t, "tesSUCCESS",
 		payDelegated(env, alice, bob, gw, tx.NewIssuedAmountFromFloat64(30, "USD", gw.Address)).Code)
+	env.Close()
+	require.Equal(t, float64(70), env.BalanceIOU(alice, "USD", gw))
 }
 
 // TestDelegate_PaymentCrossCurrency covers the restriction that a delegate
@@ -270,6 +275,9 @@ func TestDelegate_PaymentMPT(t *testing.T) {
 	mint := paymenttx.NewPayment(gw.Address, alice.Address, m.MPTAmount(50))
 	mint.GetCommon().Delegate = bob.Address
 	require.Equal(t, "tesSUCCESS", env.SubmitSignedWith(mint, bob).Code)
+	env.Close()
+	m.RequireMPTokenAmount(alice, 50)
+	require.Equal(t, uint64(50), m.IssuanceOutstandingAmount())
 }
 
 // TestDelegate_LendingNotDelegatable covers the 3.2.0 change making the

--- a/internal/testing/delegate/failure_test.go
+++ b/internal/testing/delegate/failure_test.go
@@ -1,0 +1,79 @@
+package delegate_test
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDelegate_DeleteRejectsCorruptDirectoryAtomically(t *testing.T) {
+	for _, corruptOwner := range []bool{true, false} {
+		name := "destination link"
+		if corruptOwner {
+			name = "owner link"
+		}
+		t.Run(name, func(t *testing.T) {
+			env := jtx.NewTestEnv(t)
+			env.EnableFeature("PermissionDelegationV1_1")
+			alice := jtx.NewAccount("alice")
+			bob := jtx.NewAccount("bob")
+			env.Fund(alice, bob)
+			env.Close()
+
+			require.Equal(t, "tesSUCCESS", grantPermissions(env, alice, bob, "Payment").Code)
+			env.Close()
+
+			delegateKey := keylet.Delegate(alice.ID, bob.ID)
+			delegateBefore, err := env.LedgerEntry(delegateKey)
+			require.NoError(t, err)
+			ownerDirKey := keylet.OwnerDir(alice.ID)
+			destinationDirKey := keylet.OwnerDir(bob.ID)
+			corruptKey := destinationDirKey
+			if corruptOwner {
+				corruptKey = ownerDirKey
+			}
+			corruptData, err := env.LedgerEntry(corruptKey)
+			require.NoError(t, err)
+			directory, err := state.ParseDirectoryNode(corruptData)
+			require.NoError(t, err)
+			directory.Indexes = nil
+			corruptData, err = state.SerializeDirectoryNode(directory, false)
+			require.NoError(t, err)
+			require.NoError(t, env.Ledger().Update(corruptKey, corruptData))
+
+			ownerBefore, err := env.LedgerEntry(ownerDirKey)
+			require.NoError(t, err)
+			destinationBefore, err := env.LedgerEntry(destinationDirKey)
+			require.NoError(t, err)
+			stateHash, err := env.Ledger().StateMapHash()
+			require.NoError(t, err)
+			balanceBefore := env.Balance(alice)
+			sequenceBefore := env.Seq(alice)
+			ownerCountBefore := env.OwnerCount(alice)
+
+			result := grantPermissions(env, alice, bob)
+			jtx.RequireTxFail(t, result, jtx.TefBAD_LEDGER)
+			require.Nil(t, result.Metadata)
+
+			afterHash, err := env.Ledger().StateMapHash()
+			require.NoError(t, err)
+			require.Equal(t, stateHash, afterHash)
+			require.Equal(t, balanceBefore, env.Balance(alice))
+			require.Equal(t, sequenceBefore, env.Seq(alice))
+			require.Equal(t, ownerCountBefore, env.OwnerCount(alice))
+
+			delegateAfter, err := env.LedgerEntry(delegateKey)
+			require.NoError(t, err)
+			require.Equal(t, delegateBefore, delegateAfter)
+			ownerAfter, err := env.LedgerEntry(ownerDirKey)
+			require.NoError(t, err)
+			require.Equal(t, ownerBefore, ownerAfter)
+			destinationAfter, err := env.LedgerEntry(destinationDirKey)
+			require.NoError(t, err)
+			require.Equal(t, destinationBefore, destinationAfter)
+		})
+	}
+}

--- a/internal/testing/delegate/granular_test.go
+++ b/internal/testing/delegate/granular_test.go
@@ -1,0 +1,81 @@
+package delegate_test
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	accountset "github.com/LeJamon/go-xrpl/internal/testing/accountset"
+	mpttester "github.com/LeJamon/go-xrpl/internal/testing/mpt"
+	trustset "github.com/LeJamon/go-xrpl/internal/testing/trustset"
+	mpttx "github.com/LeJamon/go-xrpl/internal/tx/mpt"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDelegate_TrustlineAuthorizeGranularEffect(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("PermissionDelegationV1_1")
+	gw := jtx.NewAccount("gw")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	env.Fund(gw, alice, bob)
+	env.EnableRequireAuth(gw)
+	env.Close()
+
+	env.Trust(alice, gw.IOU("USD", 1000))
+	env.Close()
+	require.Equal(t, "tesSUCCESS", grantPermissions(env, gw, bob, "TrustlineAuthorize").Code)
+	env.Close()
+
+	trust := trustset.TrustLine(gw, "USD", alice, "0").SetAuth().BuildTrustSet()
+	trust.Delegate = bob.Address
+	jtx.RequireTxSuccess(t, env.SubmitSignedWith(trust, bob))
+	env.Close()
+
+	data, err := env.LedgerEntry(keylet.Line(gw.ID, alice.ID, "USD"))
+	require.NoError(t, err)
+	line, err := state.ParseRippleState(data)
+	require.NoError(t, err)
+	require.NotZero(t, line.Flags&(state.LsfLowAuth|state.LsfHighAuth))
+}
+
+func TestDelegate_AccountDomainGranularEffect(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("PermissionDelegationV1_1")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	env.Fund(alice, bob)
+	env.Close()
+
+	require.Equal(t, "tesSUCCESS", grantPermissions(env, alice, bob, "AccountDomainSet").Code)
+	env.Close()
+
+	set := accountset.AccountSet(alice).Domain("6578616D706C652E636F6D").BuildAccountSet()
+	set.Delegate = bob.Address
+	jtx.RequireTxSuccess(t, env.SubmitSignedWith(set, bob))
+	env.Close()
+	require.Equal(t, "example.com", env.AccountInfo(alice).Domain)
+}
+
+func TestDelegate_MPTokenIssuanceLockGranularEffect(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("PermissionDelegationV1_1")
+	issuer := jtx.NewAccount("issuer")
+	bob := jtx.NewAccount("bob")
+	m := mpttester.NewMPTTester(t, env, issuer, mpttester.MPTInit{Holders: []*jtx.Account{bob}})
+	env.Close()
+	m.Create(mpttester.CreateOpts{Flags: mpttx.MPTokenIssuanceCreateFlagCanLock})
+	env.Close()
+
+	require.Equal(t, "tesSUCCESS", grantPermissions(env, issuer, bob, "MPTokenIssuanceLock").Code)
+	env.Close()
+
+	set := mpttx.NewMPTokenIssuanceSet(issuer.Address, m.IssuanceID())
+	set.SetFlags(mpttx.MPTokenIssuanceSetFlagLock)
+	set.Delegate = bob.Address
+	jtx.RequireTxSuccess(t, env.SubmitSignedWith(set, bob))
+	env.Close()
+	m.CheckIssuanceFlags(entry.LsfMPTCanLock | entry.LsfMPTLocked)
+}

--- a/internal/testing/delegate/lifecycle_test.go
+++ b/internal/testing/delegate/lifecycle_test.go
@@ -1,0 +1,149 @@
+package delegate_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	delegatetx "github.com/LeJamon/go-xrpl/internal/tx/delegate"
+	paymenttx "github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func ownerDirectoryContains(t *testing.T, env *jtx.TestEnv, owner [20]byte, item [32]byte) bool {
+	t.Helper()
+	found := false
+	require.NoError(t, state.DirForEach(env.Ledger(), keylet.OwnerDir(owner), func(key [32]byte) error {
+		if key == item {
+			found = true
+		}
+		return nil
+	}))
+	return found
+}
+
+func TestDelegate_LedgerLifecycle(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("PermissionDelegationV1_1")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	env.Fund(alice, bob)
+	env.Close()
+
+	delegateKey := keylet.Delegate(alice.ID, bob.ID)
+	require.Equal(t, "tesSUCCESS", grantPermissions(env, alice, bob, "Payment", "TrustSet").Code)
+	env.Close()
+
+	data, err := env.LedgerEntry(delegateKey)
+	require.NoError(t, err)
+	entry, err := state.ParseDelegate(data)
+	require.NoError(t, err)
+	require.Equal(t, alice.ID, entry.Account)
+	require.Equal(t, bob.ID, entry.Authorize)
+	require.Equal(t, []uint32{state.LookupPermissionValue("Payment"), state.LookupPermissionValue("TrustSet")}, entry.Permissions)
+	require.True(t, entry.HasDestinationNode)
+	require.True(t, ownerDirectoryContains(t, env, alice.ID, delegateKey.Key))
+	require.True(t, ownerDirectoryContains(t, env, bob.ID, delegateKey.Key))
+	require.Equal(t, uint32(1), env.OwnerCount(alice))
+	require.Zero(t, env.OwnerCount(bob))
+
+	ownerNode := entry.OwnerNode
+	destinationNode := entry.DestinationNode
+	require.Equal(t, "tesSUCCESS", grantPermissions(env, alice, bob, "TrustSet").Code)
+	env.Close()
+
+	data, err = env.LedgerEntry(delegateKey)
+	require.NoError(t, err)
+	entry, err = state.ParseDelegate(data)
+	require.NoError(t, err)
+	require.Equal(t, []uint32{state.LookupPermissionValue("TrustSet")}, entry.Permissions)
+	require.Equal(t, ownerNode, entry.OwnerNode)
+	require.Equal(t, destinationNode, entry.DestinationNode)
+	require.Equal(t, uint32(1), env.OwnerCount(alice))
+
+	deleteTx := delegatetx.NewDelegateSet(alice.Address)
+	deleteTx.Authorize = bob.Address
+	require.Equal(t, "tesSUCCESS", env.SubmitSignedWith(deleteTx, alice).Code)
+	blob, err := tx.SerializeTransaction(deleteTx)
+	require.NoError(t, err)
+	roundTripped, err := tx.ParseFromBinary(blob)
+	require.NoError(t, err)
+	require.NotNil(t, roundTripped.(*delegatetx.DelegateSet).Permissions)
+	require.Empty(t, roundTripped.(*delegatetx.DelegateSet).Permissions)
+	env.Close()
+
+	require.False(t, env.LedgerEntryExists(delegateKey))
+	require.False(t, ownerDirectoryContains(t, env, alice.ID, delegateKey.Key))
+	require.False(t, ownerDirectoryContains(t, env, bob.ID, delegateKey.Key))
+	require.Zero(t, env.OwnerCount(alice))
+	require.Zero(t, env.OwnerCount(bob))
+}
+
+func TestDelegate_OrdinaryPaymentEffectsAndFeePayer(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("PermissionDelegationV1_1")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	carol := jtx.NewAccount("carol")
+	env.Fund(alice, bob, carol)
+	env.Close()
+
+	require.Equal(t, "tesSUCCESS", grantPermissions(env, alice, bob, "Payment").Code)
+	env.Close()
+
+	aliceBalance := env.Balance(alice)
+	bobBalance := env.Balance(bob)
+	carolBalance := env.Balance(carol)
+	aliceSequence := env.Seq(alice)
+	bobSequence := env.Seq(bob)
+	amount := int64(1_000_000)
+
+	payment := paymenttx.NewPayment(alice.Address, carol.Address, tx.NewXRPAmount(amount))
+	payment.Delegate = bob.Address
+	result := env.SubmitSignedWith(payment, bob)
+	jtx.RequireTxSuccess(t, result)
+	fee, err := strconv.ParseUint(payment.Fee, 10, 64)
+	require.NoError(t, err)
+
+	require.Equal(t, aliceBalance-uint64(amount), env.Balance(alice))
+	require.Equal(t, bobBalance-fee, env.Balance(bob))
+	require.Equal(t, carolBalance+uint64(amount), env.Balance(carol))
+	require.Equal(t, aliceSequence+1, env.Seq(alice))
+	require.Equal(t, bobSequence, env.Seq(bob))
+}
+
+func TestDelegate_DeniedPaymentIsAtomic(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("PermissionDelegationV1_1")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	carol := jtx.NewAccount("carol")
+	env.Fund(alice, bob, carol)
+	env.Close()
+
+	require.Equal(t, "tesSUCCESS", grantPermissions(env, alice, bob, "TrustSet").Code)
+	env.Close()
+
+	stateHash, err := env.Ledger().StateMapHash()
+	require.NoError(t, err)
+	aliceBalance := env.Balance(alice)
+	bobBalance := env.Balance(bob)
+	carolBalance := env.Balance(carol)
+	aliceSequence := env.Seq(alice)
+	bobSequence := env.Seq(bob)
+
+	result := payDelegated(env, alice, bob, carol, tx.NewXRPAmount(1_000_000))
+	jtx.RequireTxFail(t, result, "terNO_DELEGATE_PERMISSION")
+
+	afterHash, err := env.Ledger().StateMapHash()
+	require.NoError(t, err)
+	require.Equal(t, stateHash, afterHash)
+	require.Equal(t, aliceBalance, env.Balance(alice))
+	require.Equal(t, bobBalance, env.Balance(bob))
+	require.Equal(t, carolBalance, env.Balance(carol))
+	require.Equal(t, aliceSequence, env.Seq(alice))
+	require.Equal(t, bobSequence, env.Seq(bob))
+}

--- a/internal/testing/delegate/precedence_test.go
+++ b/internal/testing/delegate/precedence_test.go
@@ -7,17 +7,18 @@ package delegate_test
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	delegatetx "github.com/LeJamon/go-xrpl/internal/tx/delegate"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/stretchr/testify/require"
 )
 
-// TestDelegateSet_FlagsMaskPrecedence pins DelegateSet finding-1: DelegateSet
-// has no getFlagsMask override, so any non-universal flag bit is temINVALID_FLAG
+// TestDelegateSet_FlagsMaskPrecedence verifies that any non-universal flag bit is temINVALID_FLAG
 // at preflight0 — before the (would-be-malformed) self-authorize check and every
 // ledger-state TER.
 func TestDelegateSet_FlagsMaskPrecedence(t *testing.T) {
@@ -30,15 +31,92 @@ func TestDelegateSet_FlagsMaskPrecedence(t *testing.T) {
 
 	ds := delegatetx.NewDelegateSet(gw.Address)
 	ds.Authorize = alice.Address
-	ds.Permissions = []delegatetx.Permission{
-		{Permission: delegatetx.PermissionData{PermissionValue: "Payment"}},
-	}
+	ds.Permissions = []delegatetx.Permission{delegatetx.NewPermission("Payment")}
 	ds.GetCommon().SetFlags(0x00000001) // non-universal bit
 	jtx.RequireTxFail(t, env.SubmitSignedWith(ds, gw), "temINVALID_FLAG")
 }
 
-// TestDelegateSet_UnknownGranularNotDelegatable pins DelegateSet finding-3: a
-// value in the granular range (>= 65536) that is NOT a registered granular
+func TestDelegateSet_EmptyPermissionsPresenceRoundTrips(t *testing.T) {
+	gw := jtx.NewAccount("gw")
+	alice := jtx.NewAccount("alice")
+
+	ds := delegatetx.NewDelegateSet(gw.Address)
+	ds.Authorize = alice.Address
+	ds.Fee = "10"
+	seq := uint32(1)
+	ds.Sequence = &seq
+	ds.SigningPubKey = ""
+
+	jsonBytes, err := txcore.ToJSON(ds)
+	require.NoError(t, err)
+	var jsonMap map[string]any
+	require.NoError(t, json.Unmarshal(jsonBytes, &jsonMap))
+	permissions, present := jsonMap["Permissions"]
+	require.True(t, present)
+	require.Empty(t, permissions)
+
+	blob, err := txcore.SerializeTransaction(ds)
+	require.NoError(t, err)
+	parsed, err := txcore.ParseFromBinary(blob)
+	require.NoError(t, err)
+	roundTripped := parsed.(*delegatetx.DelegateSet)
+	require.NotNil(t, roundTripped.Permissions)
+	require.Empty(t, roundTripped.Permissions)
+}
+
+func TestDelegateSet_MissingPermissionsIsMalformed(t *testing.T) {
+	gw := jtx.NewAccount("gw")
+	alice := jtx.NewAccount("alice")
+	raw := []byte(`{"Account":"` + gw.Address + `","Authorize":"` + alice.Address + `","TransactionType":"DelegateSet"}`)
+
+	parsed, err := txcore.FromJSON(raw)
+	require.NoError(t, err)
+	ds := parsed.(*delegatetx.DelegateSet)
+	require.Nil(t, ds.Permissions)
+
+	err = ds.Validate()
+	require.Error(t, err)
+	resultErr, ok := ter.AsResultError(err)
+	require.True(t, ok)
+	require.Equal(t, ter.TemMALFORMED, resultErr.Code)
+
+	ds.Fee = "10"
+	sequence := uint32(1)
+	ds.Sequence = &sequence
+	blob, err := txcore.SerializeTransaction(ds)
+	require.NoError(t, err)
+	_, err = txcore.ParseFromBinary(blob)
+	require.ErrorContains(t, err, "Permissions")
+}
+
+func TestDelegateSet_DuplicateResolvedPermissionIsMalformed(t *testing.T) {
+	tests := []struct {
+		name        string
+		permissions []string
+	}{
+		{name: "transaction alias", permissions: []string{"Payment", "1"}},
+		{name: "granular alias", permissions: []string{"TrustlineAuthorize", "65537"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds := delegatetx.NewDelegateSet(jtx.NewAccount("gw").Address)
+			ds.Authorize = jtx.NewAccount("alice").Address
+			for _, permission := range tt.permissions {
+				ds.Permissions = append(ds.Permissions, delegatetx.NewPermission(permission))
+			}
+
+			err := ds.Validate()
+			require.Error(t, err)
+			resultErr, ok := ter.AsResultError(err)
+			require.True(t, ok)
+			require.Equal(t, ter.TemMALFORMED, resultErr.Code)
+		})
+	}
+}
+
+// TestDelegateSet_UnknownGranularNotDelegatable verifies that a value in the
+// granular range (>= 65536) that is not a registered granular
 // permission is not delegatable. The check runs in preflight and rejects with
 // temMALFORMED (rippled isDelegable falls through getGranularName to the
 // tx-type path).
@@ -52,14 +130,12 @@ func TestDelegateSet_UnknownGranularNotDelegatable(t *testing.T) {
 
 	ds := delegatetx.NewDelegateSet(gw.Address)
 	ds.Authorize = alice.Address
-	ds.Permissions = []delegatetx.Permission{
-		{Permission: delegatetx.PermissionData{PermissionValue: "70000"}}, // unknown, >= 65536
-	}
+	ds.Permissions = []delegatetx.Permission{delegatetx.NewPermission("70000")}
 	jtx.RequireTxFail(t, env.SubmitSignedWith(ds, gw), "temMALFORMED")
 }
 
-// TestDelegateSet_UnknownPermissionValueRoundTrips pins DelegateSet finding-2:
-// sfPermissionValue is a plain UINT32, so a value with no registered name must
+// TestDelegateSet_UnknownPermissionValueRoundTrips verifies that a permission
+// value with no registered name must
 // still decode. A binary blob carrying value 60000 round-trips through the
 // string-typed field as its decimal form rather than failing to parse.
 func TestDelegateSet_UnknownPermissionValueRoundTrips(t *testing.T) {
@@ -72,9 +148,7 @@ func TestDelegateSet_UnknownPermissionValueRoundTrips(t *testing.T) {
 	seq := uint32(1)
 	ds.GetCommon().Sequence = &seq
 	ds.GetCommon().SigningPubKey = ""
-	ds.Permissions = []delegatetx.Permission{
-		{Permission: delegatetx.PermissionData{PermissionValue: "60000"}},
-	}
+	ds.Permissions = []delegatetx.Permission{delegatetx.NewPermission("60000")}
 
 	flat, err := ds.Flatten()
 	require.NoError(t, err)

--- a/internal/testing/delegate/validation_test.go
+++ b/internal/testing/delegate/validation_test.go
@@ -1,0 +1,87 @@
+package delegate_test
+
+import (
+	"strconv"
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	delegatetx "github.com/LeJamon/go-xrpl/internal/tx/delegate"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDelegateSet_PermissionCountBoundary(t *testing.T) {
+	permissions := []string{
+		"Payment", "EscrowCreate", "EscrowFinish", "EscrowCancel", "OfferCreate",
+		"OfferCancel", "TicketCreate", "PaymentChannelCreate", "PaymentChannelFund",
+		"PaymentChannelClaim", "CheckCreate",
+	}
+
+	for _, count := range []int{10, 11} {
+		t.Run(strconv.Itoa(count), func(t *testing.T) {
+			ds := delegatetx.NewDelegateSet(jtx.NewAccount("alice").Address)
+			ds.Authorize = jtx.NewAccount("bob").Address
+			for _, permission := range permissions[:count] {
+				ds.Permissions = append(ds.Permissions, delegatetx.NewPermission(permission))
+			}
+
+			err := ds.Validate()
+			if count == 10 {
+				require.NoError(t, err)
+				return
+			}
+			resultErr, ok := ter.AsResultError(err)
+			require.True(t, ok)
+			require.Equal(t, ter.TemARRAY_TOO_LARGE, resultErr.Code)
+		})
+	}
+}
+
+func TestDelegateSet_AuthorizeValidation(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("PermissionDelegationV1_1")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	env.Fund(alice)
+	env.Close()
+
+	require.Equal(t, "temMALFORMED", grantPermissions(env, alice, alice, "Payment").Code)
+	require.Equal(t, "tecNO_TARGET", grantPermissions(env, alice, bob, "Payment").Code)
+}
+
+func TestDelegateSet_ReserveFailureDoesNotCreateObject(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("PermissionDelegationV1_1")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	env.FundAmountNoRipple(alice, env.ReserveBase()+env.ReserveIncrement()-1)
+	env.Fund(bob)
+	env.Close()
+
+	delegateKey := keylet.Delegate(alice.ID, bob.ID)
+	result := grantPermissions(env, alice, bob, "Payment")
+	jtx.RequireTxFail(t, result, jtx.TecINSUFFICIENT_RESERVE)
+	require.False(t, env.LedgerEntryExists(delegateKey))
+	require.Zero(t, env.OwnerCount(alice))
+
+	env.Pay(alice, env.BaseFee()+1)
+	env.Close()
+	jtx.RequireTxSuccess(t, grantPermissions(env, alice, bob, "Payment"))
+	require.True(t, env.LedgerEntryExists(delegateKey))
+}
+
+func TestDelegateSet_PermissionIntroducingAmendment(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("PermissionDelegationV1_1")
+	env.DisableFeature("Clawback")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	env.Fund(alice, bob)
+	env.Close()
+
+	require.Equal(t, "temMALFORMED", grantPermissions(env, alice, bob, "Clawback").Code)
+	env.EnableFeature("Clawback")
+	env.Close()
+	require.Equal(t, "tesSUCCESS", grantPermissions(env, alice, bob, "Clawback").Code)
+}

--- a/internal/testing/env_trust.go
+++ b/internal/testing/env_trust.go
@@ -348,11 +348,7 @@ func (e *TestEnv) SetDelegate(owner, authorized *Account, permissions []string) 
 	ds := delegate.NewDelegateSet(owner.Address)
 	ds.Authorize = authorized.Address
 	for _, perm := range permissions {
-		ds.Permissions = append(ds.Permissions, delegate.Permission{
-			Permission: delegate.PermissionData{
-				PermissionValue: perm,
-			},
-		})
+		ds.Permissions = append(ds.Permissions, delegate.NewPermission(perm))
 	}
 
 	result := e.Submit(ds)

--- a/internal/tx/account/account_delete.go
+++ b/internal/tx/account/account_delete.go
@@ -5,6 +5,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/credential"
+	"github.com/LeJamon/go-xrpl/internal/tx/delegate"
 	"github.com/LeJamon/go-xrpl/internal/tx/oracle"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -386,19 +387,8 @@ func deleteSignerList(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data 
 	return ter.TesSUCCESS
 }
 
-func deleteDelegate(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) ter.Result {
-	dd, err := state.ParseDelegate(data)
-	if err != nil {
-		return ter.TefBAD_LEDGER
-	}
-	if !removeFromDir(ctx, ownerDirKey, dd.OwnerNode, ik.Key, false) {
-		return ter.TefBAD_LEDGER
-	}
-	if err := ctx.View.Erase(ik); err != nil {
-		return ter.TefBAD_LEDGER
-	}
-	decrementOwnerCount(ctx)
-	return ter.TesSUCCESS
+func deleteDelegate(ctx *tx.ApplyContext, _ keylet.Keylet, ik keylet.Keylet, data []byte) ter.Result {
+	return delegate.DeleteDelegate(ctx, ik, data)
 }
 
 // deleteCredential and deleteOracle delegate to helpers that own their full

--- a/internal/tx/delegate/delegate_set.go
+++ b/internal/tx/delegate/delegate_set.go
@@ -68,10 +68,17 @@ type PermissionData struct {
 	PermissionValue string `json:"PermissionValue,omitempty"`
 }
 
+// NewPermission creates a DelegateSet permission from its protocol name or
+// decimal numeric value.
+func NewPermission(permissionValue string) Permission {
+	return Permission{Permission: PermissionData{PermissionValue: permissionValue}}
+}
+
 // NewDelegateSet creates a new DelegateSet transaction
 func NewDelegateSet(account string) *DelegateSet {
 	return &DelegateSet{
-		BaseTx: *tx.NewBaseTx(tx.TypeDelegateSet, account),
+		BaseTx:      *tx.NewBaseTx(tx.TypeDelegateSet, account),
+		Permissions: make([]Permission, 0),
 	}
 }
 
@@ -93,6 +100,10 @@ func (d *DelegateSet) Validate() error {
 		return err
 	}
 
+	if d.Permissions == nil {
+		return ter.Errorf(ter.TemMALFORMED, "Permissions is required")
+	}
+
 	// Check permissions array size.
 	// Reference: rippled DelegateSet.cpp preflight() — permissions.size() > permissionMaxSize
 	if len(d.Permissions) > permissionMaxSize {
@@ -107,16 +118,14 @@ func (d *DelegateSet) Validate() error {
 
 	// Check for duplicate permission values.
 	// Reference: rippled DelegateSet.cpp preflight() — permissionSet.insert check
-	seen := make(map[string]bool)
+	seen := make(map[uint32]struct{}, len(d.Permissions))
 	for _, p := range d.Permissions {
-		pv := p.Permission.PermissionValue
-		if pv == "" {
-			continue
+		name := p.Permission.PermissionValue
+		value := state.LookupPermissionValue(name)
+		if _, exists := seen[value]; exists {
+			return ter.Errorf(ter.TemMALFORMED, "duplicate permission value %q", name)
 		}
-		if seen[pv] {
-			return ter.Errorf(ter.TemMALFORMED, "duplicate permission value %q", pv)
-		}
-		seen[pv] = true
+		seen[value] = struct{}{}
 	}
 
 	return nil
@@ -134,7 +143,7 @@ func (d *DelegateSet) Flatten() (map[string]any, error) {
 		m["Authorize"] = d.Authorize
 	}
 
-	if len(d.Permissions) > 0 {
+	if d.Permissions != nil {
 		permsArray := make([]map[string]any, len(d.Permissions))
 		for i, p := range d.Permissions {
 			// Convert the string permission name to its numeric value
@@ -217,7 +226,7 @@ func (d *DelegateSet) Apply(ctx *tx.ApplyContext) ter.Result {
 	if delegateExists {
 		// Empty permissions -- delete the delegate entry.
 		if len(permValues) == 0 {
-			return deleteDelegate(ctx, delegateKey, ctx.AccountID)
+			return DeleteDelegate(ctx, delegateKey, existingData)
 		}
 
 		// Update the existing delegate with new permissions, preserving the
@@ -281,37 +290,54 @@ func (d *DelegateSet) Apply(ctx *tx.ApplyContext) ter.Result {
 	return ter.TesSUCCESS
 }
 
-// deleteDelegate removes an existing delegate entry from the ledger.
-// Reference: rippled DelegateSet.cpp deleteDelegate()
-func deleteDelegate(ctx *tx.ApplyContext, delegateKey keylet.Keylet, account [20]byte) ter.Result {
-	// Read the existing entry to get OwnerNode
-	existingData, err := ctx.View.Read(delegateKey)
-	if err != nil || existingData == nil {
-		return ter.TefINTERNAL
-	}
-
+// DeleteDelegate removes a Delegate entry, both directory links, and the
+// delegator's owner count.
+func DeleteDelegate(ctx *tx.ApplyContext, delegateKey keylet.Keylet, existingData []byte) ter.Result {
 	existingEntry, parseErr := state.ParseDelegate(existingData)
 	if parseErr != nil {
-		return ter.TefINTERNAL
+		return ter.TefBAD_LEDGER
 	}
 
-	// Remove from the delegating account's owner directory.
-	state.DirRemove(ctx.View, keylet.OwnerDir(account), existingEntry.OwnerNode, delegateKey.Key, false)
+	removed, err := state.DirRemove(ctx.View, keylet.OwnerDir(existingEntry.Account), existingEntry.OwnerNode, delegateKey.Key, false)
+	if err != nil || removed == nil || !removed.Success {
+		return ter.TefBAD_LEDGER
+	}
 
-	// Remove from the authorized account's owner directory, if linked there.
 	if existingEntry.HasDestinationNode {
-		state.DirRemove(ctx.View, keylet.OwnerDir(existingEntry.Authorize), existingEntry.DestinationNode, delegateKey.Key, false)
+		removed, err = state.DirRemove(ctx.View, keylet.OwnerDir(existingEntry.Authorize), existingEntry.DestinationNode, delegateKey.Key, false)
+		if err != nil || removed == nil || !removed.Success {
+			return ter.TefBAD_LEDGER
+		}
 	}
 
-	// Erase the delegate entry
+	if existingEntry.Account == ctx.AccountID {
+		if ctx.Account.OwnerCount > 0 {
+			ctx.Account.OwnerCount--
+		}
+	} else {
+		accountKey := keylet.Account(existingEntry.Account)
+		accountData, err := ctx.View.Read(accountKey)
+		if err != nil || accountData == nil {
+			return ter.TecINTERNAL
+		}
+		account, err := state.ParseAccountRoot(accountData)
+		if err != nil {
+			return ter.TefINTERNAL
+		}
+		if account.OwnerCount > 0 {
+			account.OwnerCount--
+		}
+		accountData, err = state.SerializeAccountRoot(account)
+		if err != nil {
+			return ter.TefINTERNAL
+		}
+		if err := ctx.View.Update(accountKey, accountData); err != nil {
+			return ter.TefINTERNAL
+		}
+	}
+
 	if err := ctx.View.Erase(delegateKey); err != nil {
-		ctx.Log.Error("delegate set: unable to delete delegate from owner")
 		return ter.TefINTERNAL
-	}
-
-	// Only the delegating account's owner count was incremented on creation.
-	if ctx.Account.OwnerCount > 0 {
-		ctx.Account.OwnerCount--
 	}
 
 	return ter.TesSUCCESS

--- a/internal/tx/delegate/delegate_set.go
+++ b/internal/tx/delegate/delegate_set.go
@@ -68,8 +68,6 @@ type PermissionData struct {
 	PermissionValue string `json:"PermissionValue,omitempty"`
 }
 
-// NewPermission creates a DelegateSet permission from its protocol name or
-// decimal numeric value.
 func NewPermission(permissionValue string) Permission {
 	return Permission{Permission: PermissionData{PermissionValue: permissionValue}}
 }

--- a/internal/tx/delegate/registry_test.go
+++ b/internal/tx/delegate/registry_test.go
@@ -1,0 +1,123 @@
+package delegate_test
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/all"
+	delegatetx "github.com/LeJamon/go-xrpl/internal/tx/delegate"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDelegateSet_RegistrationAndAmendment(t *testing.T) {
+	all.RegisterAll()
+
+	transaction, err := tx.NewFromType(tx.TypeDelegateSet)
+	require.NoError(t, err)
+	require.IsType(t, &delegatetx.DelegateSet{}, transaction)
+	require.Equal(t, [][32]byte{amendment.FeaturePermissionDelegationV1_1}, transaction.RequiredAmendments())
+}
+
+func TestDelegateSet_EveryRegisteredTypeHasDelegationDecision(t *testing.T) {
+	all.RegisterAll()
+	expected := map[tx.Type]bool{
+		tx.TypePayment:                      true,
+		tx.TypeEscrowCreate:                 true,
+		tx.TypeEscrowFinish:                 true,
+		tx.TypeAccountSet:                   false,
+		tx.TypeEscrowCancel:                 true,
+		tx.TypeRegularKeySet:                false,
+		tx.TypeOfferCreate:                  true,
+		tx.TypeOfferCancel:                  true,
+		tx.TypeTicketCreate:                 true,
+		tx.TypeSignerListSet:                false,
+		tx.TypePaymentChannelCreate:         true,
+		tx.TypePaymentChannelFund:           true,
+		tx.TypePaymentChannelClaim:          true,
+		tx.TypeCheckCreate:                  true,
+		tx.TypeCheckCash:                    true,
+		tx.TypeCheckCancel:                  true,
+		tx.TypeDepositPreauth:               true,
+		tx.TypeTrustSet:                     true,
+		tx.TypeAccountDelete:                false,
+		tx.TypeNFTokenMint:                  true,
+		tx.TypeNFTokenBurn:                  true,
+		tx.TypeNFTokenCreateOffer:           true,
+		tx.TypeNFTokenCancelOffer:           true,
+		tx.TypeNFTokenAcceptOffer:           true,
+		tx.TypeClawback:                     true,
+		tx.TypeAMMClawback:                  true,
+		tx.TypeAMMCreate:                    true,
+		tx.TypeAMMDeposit:                   true,
+		tx.TypeAMMWithdraw:                  true,
+		tx.TypeAMMVote:                      true,
+		tx.TypeAMMBid:                       true,
+		tx.TypeAMMDelete:                    true,
+		tx.TypeXChainCreateClaimID:          true,
+		tx.TypeXChainCommit:                 true,
+		tx.TypeXChainClaim:                  true,
+		tx.TypeXChainAccountCreateCommit:    true,
+		tx.TypeXChainAddClaimAttestation:    true,
+		tx.TypeXChainAddAccountCreateAttest: true,
+		tx.TypeXChainModifyBridge:           true,
+		tx.TypeXChainCreateBridge:           true,
+		tx.TypeDIDSet:                       true,
+		tx.TypeDIDDelete:                    true,
+		tx.TypeOracleSet:                    true,
+		tx.TypeOracleDelete:                 true,
+		tx.TypeLedgerStateFix:               true,
+		tx.TypeMPTokenIssuanceCreate:        true,
+		tx.TypeMPTokenIssuanceDestroy:       true,
+		tx.TypeMPTokenIssuanceSet:           true,
+		tx.TypeMPTokenAuthorize:             true,
+		tx.TypeCredentialCreate:             true,
+		tx.TypeCredentialAccept:             true,
+		tx.TypeCredentialDelete:             true,
+		tx.TypeNFTokenModify:                true,
+		tx.TypePermissionedDomainSet:        true,
+		tx.TypePermissionedDomainDelete:     true,
+		tx.TypeDelegateSet:                  false,
+		tx.TypeVaultCreate:                  false,
+		tx.TypeVaultSet:                     false,
+		tx.TypeVaultDelete:                  false,
+		tx.TypeVaultDeposit:                 false,
+		tx.TypeVaultWithdraw:                false,
+		tx.TypeVaultClawback:                false,
+		tx.TypeBatch:                        false,
+		tx.TypeLoanBrokerSet:                false,
+		tx.TypeLoanBrokerDelete:             false,
+		tx.TypeLoanBrokerCoverDeposit:       false,
+		tx.TypeLoanBrokerCoverWithdraw:      false,
+		tx.TypeLoanBrokerCoverClawback:      false,
+		tx.TypeLoanSet:                      false,
+		tx.TypeLoanDelete:                   false,
+		tx.TypeLoanManage:                   false,
+		tx.TypeLoanPay:                      false,
+		tx.TypeAmendment:                    false,
+		tx.TypeFee:                          false,
+		tx.TypeUNLModify:                    false,
+	}
+
+	registered := tx.SupportedTypes()
+	require.Len(t, registered, len(expected))
+	features := amendment.AllFeatures()
+	enabled := make([][32]byte, len(features))
+	for i, feature := range features {
+		enabled[i] = feature.ID
+	}
+	rules := amendment.NewRules(enabled)
+	for _, transactionType := range registered {
+		wantDelegatable, decided := expected[transactionType]
+		require.Truef(t, decided, "transaction %s needs an explicit delegation decision", transactionType)
+
+		ds := delegatetx.NewDelegateSet("")
+		ds.Permissions = append(ds.Permissions, delegatetx.NewPermission(transactionType.String()))
+		err := ds.PreflightRules(rules)
+		if wantDelegatable {
+			require.NoErrorf(t, err, "transaction %s", transactionType)
+		} else {
+			require.Errorf(t, err, "transaction %s", transactionType)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- preserve the required present-empty `Permissions` array through JSON, signing, and binary serialization while rejecting an absent field
- validate duplicate permissions by their resolved `uint32` value and guard every registered transaction's delegation decision and introducing amendment
- share Delegate deletion with AccountDelete so both directory links and the delegator owner count are updated atomically
- replace return-code-only coverage with exact lifecycle, fee/sequence, balance, granular-effect, corruption rollback, reserve, amendment, and registry assertions

## Oracle parity

The production behavior and error results were checked against the pinned rippled v3.2.0 DelegateSet and AccountDelete implementations. The stale rippled 2.6.2 Delegate recordings remain excluded because they predate `PermissionDelegationV1_1`; the new tests exercise the current amendment directly. Exhaustive bad-secret/multisign field permutations and repeated granular flag combinations remain in the shared signing and transaction-specific suites, while this change adds the Delegate-boundary and exact ledger-effect coverage they lacked.

## Verification

- `go test ./internal/testing/delegate -count=20`
- `go test -race -covermode=atomic -coverpkg=./internal/testing/delegate,./internal/tx/delegate/... ./internal/testing/delegate` (80.9%)
- `go test -race -covermode=atomic -coverpkg=./internal/tx/account,./internal/tx/delegate ./internal/testing/accountdelete` (58.0%)
- focused Delegate, AccountDelete, and transaction package tests
- `just test-tx`
- `just test-integration`
- `just vet`
- focused `golangci-lint run`
- `just lint`
- `just build-all`
- `git diff --check origin/main...HEAD`

Fixes #1505


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader delegated-permission support for trustline authorization, account-domain updates, and MPToken issuance locking.
  * Improved delegate permission validation, serialization, registration, and lifecycle handling.
  * Added safer cleanup of delegation data during account deletion.

* **Bug Fixes**
  * Ensured failed delegation operations and cleanup roll back atomically without changing ledger state.
  * Improved validation for duplicate, missing, unsupported, and unauthorized permissions.

* **Tests**
  * Expanded coverage for delegate payments, fees, sequences, balances, directories, account deletion, and transaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->