### PR TITLE
depositpreauth: preserve field presence and complete lifecycle coverage

### DIFF
--- a/internal/ledger/state/signer_list.go
+++ b/internal/ledger/state/signer_list.go
@@ -246,20 +246,23 @@ func ParseDepositPreauth(data []byte) (*DepositPreauthEntry, error) {
 		return nil, fmt.Errorf("failed to decode DepositPreauth: decoder has type %T", decoded)
 	}
 
-	entry := &DepositPreauthEntry{}
-	var err error
-	if wire.Account != "" {
-		entry.Account, err = DecodeAccountID(wire.Account)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode DepositPreauth: invalid Account: %w", err)
-		}
+	if wire.Account == "" {
+		return nil, fmt.Errorf("failed to decode DepositPreauth: missing Account")
 	}
-	if wire.OwnerNode != "" {
-		entry.OwnerNode, err = strconv.ParseUint(wire.OwnerNode, 16, 64)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode DepositPreauth: invalid OwnerNode: %w", err)
-		}
+	if wire.OwnerNode == "" {
+		return nil, fmt.Errorf("failed to decode DepositPreauth: missing OwnerNode")
 	}
 
-	return entry, nil
+	parsed := &DepositPreauthEntry{}
+	var err error
+	parsed.Account, err = DecodeAccountID(wire.Account)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode DepositPreauth: invalid Account: %w", err)
+	}
+	parsed.OwnerNode, err = strconv.ParseUint(wire.OwnerNode, 16, 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode DepositPreauth: invalid OwnerNode: %w", err)
+	}
+
+	return parsed, nil
 }

--- a/internal/testing/accountdelete/accountdelete_test.go
+++ b/internal/testing/accountdelete/accountdelete_test.go
@@ -360,12 +360,12 @@ func TestAccountDelete_CredentialExpiry(t *testing.T) {
 
 		expiration := env.NowRipple() + 20
 		jtx.RequireTxSuccess(t, env.Submit(
-			credential.CredentialCreate(carol, john, credType).Expiration(expiration).Build()))
+			credential.CredentialCreateText(carol, john, credType).Expiration(expiration).Build()))
 		env.Close()
-		jtx.RequireTxSuccess(t, env.Submit(credential.CredentialAccept(john, carol, credType).Build()))
+		jtx.RequireTxSuccess(t, env.Submit(credential.CredentialAcceptText(john, carol, credType).Build()))
 		env.Close()
 
-		credIdx := depositpreauth.CredentialIndex(john, carol, credType)
+		credIdx := depositpreauth.CredentialIndexHex(john, carol, credType)
 		credK := keylet.Credential(john.ID, carol.ID, []byte(credType))
 
 		// Advancing 256 ledgers also moves time far past the expiration.
@@ -394,12 +394,12 @@ func TestAccountDelete_CredentialExpiry(t *testing.T) {
 		// Far enough out to stay in the future across the 256-ledger advance.
 		expiration := env.NowRipple() + 20000
 		jtx.RequireTxSuccess(t, env.Submit(
-			credential.CredentialCreate(carol, john, credType).Expiration(expiration).Build()))
+			credential.CredentialCreateText(carol, john, credType).Expiration(expiration).Build()))
 		env.Close()
-		jtx.RequireTxSuccess(t, env.Submit(credential.CredentialAccept(john, carol, credType).Build()))
+		jtx.RequireTxSuccess(t, env.Submit(credential.CredentialAcceptText(john, carol, credType).Build()))
 		env.Close()
 
-		credIdx := depositpreauth.CredentialIndex(john, carol, credType)
+		credIdx := depositpreauth.CredentialIndexHex(john, carol, credType)
 		credK := keylet.Credential(john.ID, carol.ID, []byte(credType))
 
 		// Alice requires deposit authorization, satisfied via the credential,
@@ -407,7 +407,7 @@ func TestAccountDelete_CredentialExpiry(t *testing.T) {
 		env.EnableDepositAuth(alice)
 		env.Close()
 		jtx.RequireTxSuccess(t, env.Submit(depositpreauth.AuthCredentials(alice, []depositpreauth.AuthorizeCredentials{
-			{Issuer: carol, CredType: credType},
+			{Issuer: carol, CredTypeText: credType},
 		}).Build()))
 		env.Close()
 

--- a/internal/testing/assertions.go
+++ b/internal/testing/assertions.go
@@ -353,6 +353,25 @@ func RequireLedgerEntryNotExists(t testing.TB, env *TestEnv, key keylet.Keylet) 
 		"Expected ledger entry to NOT exist at keylet %v", key)
 }
 
+func RequireOwnerDirectoryContains(
+	t testing.TB,
+	env *TestEnv,
+	owner *Account,
+	target [32]byte,
+	want bool,
+) {
+	t.Helper()
+	found := false
+	err := state.DirForEach(env.Ledger(), keylet.OwnerDir(owner.ID), func(item [32]byte) error {
+		if item == target {
+			found = true
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, want, found, "owner directory membership mismatch for %s", owner.Name)
+}
+
 // RequireTicketCount asserts that an account has the expected number of tickets.
 // This iterates the owner directory and counts entries of type Ticket (0x0054),
 // matching rippled's owner_count<ltTICKET> behavior.

--- a/internal/testing/credential/builder.go
+++ b/internal/testing/credential/builder.go
@@ -90,6 +90,7 @@ func (b *CredentialCreateBuilder) Build() *credential.CredentialCreate {
 		if !b.uriIsHex {
 			c.URI = hex.EncodeToString([]byte(b.uri))
 		}
+		c.Common.SetPresentFields(map[string]bool{"URI": true})
 	}
 	if b.expiration != nil {
 		c.Expiration = b.expiration

--- a/internal/testing/credential/builder.go
+++ b/internal/testing/credential/builder.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
-	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/credential"
 )
 
@@ -15,19 +14,27 @@ type CredentialCreateBuilder struct {
 	subject        *jtx.Account
 	credentialType string
 	uri            string
+	uriIsHex       bool
+	uriSet         bool
 	expiration     *uint32
 	fee            uint64
 	sequence       *uint32
 	flags          uint32
 }
 
-// CredentialCreate creates a new CredentialCreateBuilder.
-// The account (issuer) creates a credential for the subject.
-func CredentialCreate(account, subject *jtx.Account, credentialType string) *CredentialCreateBuilder {
+func CredentialCreateText(account, subject *jtx.Account, credentialType string) *CredentialCreateBuilder {
+	return CredentialCreateBytes(account, subject, []byte(credentialType))
+}
+
+func CredentialCreateBytes(account, subject *jtx.Account, credentialType []byte) *CredentialCreateBuilder {
+	return CredentialCreateHex(account, subject, hex.EncodeToString(credentialType))
+}
+
+func CredentialCreateHex(account, subject *jtx.Account, credentialTypeHex string) *CredentialCreateBuilder {
 	return &CredentialCreateBuilder{
 		account:        account,
 		subject:        subject,
-		credentialType: credentialType,
+		credentialType: credentialTypeHex,
 		fee:            10, // Default fee: 10 drops
 	}
 }
@@ -36,12 +43,16 @@ func CredentialCreate(account, subject *jtx.Account, credentialType string) *Cre
 // The URI will be hex-encoded when building the transaction.
 func (b *CredentialCreateBuilder) URI(uri string) *CredentialCreateBuilder {
 	b.uri = uri
+	b.uriIsHex = false
+	b.uriSet = true
 	return b
 }
 
 // URIHex sets the URI from an already hex-encoded string.
 func (b *CredentialCreateBuilder) URIHex(uriHex string) *CredentialCreateBuilder {
 	b.uri = uriHex
+	b.uriIsHex = true
+	b.uriSet = true
 	return b
 }
 
@@ -70,21 +81,14 @@ func (b *CredentialCreateBuilder) Flags(flags uint32) *CredentialCreateBuilder {
 }
 
 // Build constructs the CredentialCreate transaction.
-func (b *CredentialCreateBuilder) Build() tx.Transaction {
-	// Hex-encode the credential type if not already hex
-	credType := b.credentialType
-	if !isHexEncoded(credType) {
-		credType = hex.EncodeToString([]byte(credType))
-	}
-
-	c := credential.NewCredentialCreate(b.account.Address, b.subject.Address, credType)
+func (b *CredentialCreateBuilder) Build() *credential.CredentialCreate {
+	c := credential.NewCredentialCreate(b.account.Address, b.subject.Address, b.credentialType)
 	c.Fee = fmt.Sprintf("%d", b.fee)
 
-	if b.uri != "" {
-		if !isHexEncoded(b.uri) {
+	if b.uriSet {
+		c.URI = b.uri
+		if !b.uriIsHex {
 			c.URI = hex.EncodeToString([]byte(b.uri))
-		} else {
-			c.URI = b.uri
 		}
 	}
 	if b.expiration != nil {
@@ -100,11 +104,6 @@ func (b *CredentialCreateBuilder) Build() tx.Transaction {
 	return c
 }
 
-// BuildCredentialCreate is a convenience method that returns the concrete *credential.CredentialCreate type.
-func (b *CredentialCreateBuilder) BuildCredentialCreate() *credential.CredentialCreate {
-	return b.Build().(*credential.CredentialCreate)
-}
-
 // CredentialAcceptBuilder provides a fluent interface for building CredentialAccept transactions.
 type CredentialAcceptBuilder struct {
 	account        *jtx.Account
@@ -115,13 +114,19 @@ type CredentialAcceptBuilder struct {
 	flags          uint32
 }
 
-// CredentialAccept creates a new CredentialAcceptBuilder.
-// The account (subject) accepts a credential issued by the issuer.
-func CredentialAccept(account, issuer *jtx.Account, credentialType string) *CredentialAcceptBuilder {
+func CredentialAcceptText(account, issuer *jtx.Account, credentialType string) *CredentialAcceptBuilder {
+	return CredentialAcceptBytes(account, issuer, []byte(credentialType))
+}
+
+func CredentialAcceptBytes(account, issuer *jtx.Account, credentialType []byte) *CredentialAcceptBuilder {
+	return CredentialAcceptHex(account, issuer, hex.EncodeToString(credentialType))
+}
+
+func CredentialAcceptHex(account, issuer *jtx.Account, credentialTypeHex string) *CredentialAcceptBuilder {
 	return &CredentialAcceptBuilder{
 		account:        account,
 		issuer:         issuer,
-		credentialType: credentialType,
+		credentialType: credentialTypeHex,
 		fee:            10, // Default fee: 10 drops
 	}
 }
@@ -145,14 +150,8 @@ func (b *CredentialAcceptBuilder) Flags(flags uint32) *CredentialAcceptBuilder {
 }
 
 // Build constructs the CredentialAccept transaction.
-func (b *CredentialAcceptBuilder) Build() tx.Transaction {
-	// Hex-encode the credential type if not already hex
-	credType := b.credentialType
-	if !isHexEncoded(credType) {
-		credType = hex.EncodeToString([]byte(credType))
-	}
-
-	c := credential.NewCredentialAccept(b.account.Address, b.issuer.Address, credType)
+func (b *CredentialAcceptBuilder) Build() *credential.CredentialAccept {
+	c := credential.NewCredentialAccept(b.account.Address, b.issuer.Address, b.credentialType)
 	c.Fee = fmt.Sprintf("%d", b.fee)
 
 	if b.sequence != nil {
@@ -163,11 +162,6 @@ func (b *CredentialAcceptBuilder) Build() tx.Transaction {
 	}
 
 	return c
-}
-
-// BuildCredentialAccept is a convenience method that returns the concrete *credential.CredentialAccept type.
-func (b *CredentialAcceptBuilder) BuildCredentialAccept() *credential.CredentialAccept {
-	return b.Build().(*credential.CredentialAccept)
 }
 
 // CredentialDeleteBuilder provides a fluent interface for building CredentialDelete transactions.
@@ -181,14 +175,20 @@ type CredentialDeleteBuilder struct {
 	flags          uint32
 }
 
-// CredentialDelete creates a new CredentialDeleteBuilder.
-// The account submits the delete. Subject and issuer identify the credential.
-func CredentialDelete(account, subject, issuer *jtx.Account, credentialType string) *CredentialDeleteBuilder {
+func CredentialDeleteText(account, subject, issuer *jtx.Account, credentialType string) *CredentialDeleteBuilder {
+	return CredentialDeleteBytes(account, subject, issuer, []byte(credentialType))
+}
+
+func CredentialDeleteBytes(account, subject, issuer *jtx.Account, credentialType []byte) *CredentialDeleteBuilder {
+	return CredentialDeleteHex(account, subject, issuer, hex.EncodeToString(credentialType))
+}
+
+func CredentialDeleteHex(account, subject, issuer *jtx.Account, credentialTypeHex string) *CredentialDeleteBuilder {
 	return &CredentialDeleteBuilder{
 		account:        account,
 		subject:        subject,
 		issuer:         issuer,
-		credentialType: credentialType,
+		credentialType: credentialTypeHex,
 		fee:            10, // Default fee: 10 drops
 	}
 }
@@ -212,14 +212,8 @@ func (b *CredentialDeleteBuilder) Flags(flags uint32) *CredentialDeleteBuilder {
 }
 
 // Build constructs the CredentialDelete transaction.
-func (b *CredentialDeleteBuilder) Build() tx.Transaction {
-	// Hex-encode the credential type if not already hex
-	credType := b.credentialType
-	if !isHexEncoded(credType) {
-		credType = hex.EncodeToString([]byte(credType))
-	}
-
-	c := credential.NewCredentialDelete(b.account.Address, credType)
+func (b *CredentialDeleteBuilder) Build() *credential.CredentialDelete {
+	c := credential.NewCredentialDelete(b.account.Address, b.credentialType)
 	c.Fee = fmt.Sprintf("%d", b.fee)
 
 	if b.subject != nil {
@@ -236,23 +230,4 @@ func (b *CredentialDeleteBuilder) Build() tx.Transaction {
 	}
 
 	return c
-}
-
-// BuildCredentialDelete is a convenience method that returns the concrete *credential.CredentialDelete type.
-func (b *CredentialDeleteBuilder) BuildCredentialDelete() *credential.CredentialDelete {
-	return b.Build().(*credential.CredentialDelete)
-}
-
-// isHexEncoded checks if a string appears to be hex-encoded.
-// Returns true if the string has even length and contains only hex characters.
-func isHexEncoded(s string) bool {
-	if len(s)%2 != 0 {
-		return false
-	}
-	for _, c := range s {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
-			return false
-		}
-	}
-	return len(s) > 0
 }

--- a/internal/testing/credential/builder_representation_test.go
+++ b/internal/testing/credential/builder_representation_test.go
@@ -18,6 +18,18 @@ func TestCredentialTypeBuildersUseExplicitRepresentations(t *testing.T) {
 	wire := CredentialCreateHex(issuer, subject, "DeAdBeEf").Build()
 	require.Equal(t, "DeAdBeEf", wire.CredentialType)
 
+	omittedURI := CredentialCreateText(issuer, subject, "credential").Build()
+	require.False(t, omittedURI.HasField("URI"))
+
+	for _, emptyURI := range []*CredentialCreateBuilder{
+		CredentialCreateText(issuer, subject, "credential").URI(""),
+		CredentialCreateText(issuer, subject, "credential").URIHex(""),
+	} {
+		built := emptyURI.Build()
+		require.True(t, built.HasField("URI"))
+		require.Error(t, built.Validate())
+	}
+
 	require.Error(t, CredentialCreateHex(issuer, subject, "abc").Build().Validate())
 	require.Error(t, CredentialCreateHex(issuer, subject, "not-hex").Build().Validate())
 	require.Error(t, CredentialCreateText(issuer, subject, "").Build().Validate())

--- a/internal/testing/credential/builder_representation_test.go
+++ b/internal/testing/credential/builder_representation_test.go
@@ -1,0 +1,26 @@
+package credential
+
+import (
+	"strings"
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCredentialTypeBuildersUseExplicitRepresentations(t *testing.T) {
+	issuer := jtx.NewAccount("issuer")
+	subject := jtx.NewAccount("subject")
+
+	text := CredentialCreateText(issuer, subject, "deadbeef").Build()
+	require.Equal(t, "6465616462656566", text.CredentialType)
+
+	wire := CredentialCreateHex(issuer, subject, "DeAdBeEf").Build()
+	require.Equal(t, "DeAdBeEf", wire.CredentialType)
+
+	require.Error(t, CredentialCreateHex(issuer, subject, "abc").Build().Validate())
+	require.Error(t, CredentialCreateHex(issuer, subject, "not-hex").Build().Validate())
+	require.Error(t, CredentialCreateText(issuer, subject, "").Build().Validate())
+	require.NoError(t, CredentialCreateText(issuer, subject, strings.Repeat("x", 64)).Build().Validate())
+	require.Error(t, CredentialCreateText(issuer, subject, strings.Repeat("x", 65)).Build().Validate())
+}

--- a/internal/testing/credential/credential_create_meta_test.go
+++ b/internal/testing/credential/credential_create_meta_test.go
@@ -23,7 +23,7 @@ func TestCredentialCreate_Meta_NewFields(t *testing.T) {
 	env.Close()
 
 	const credTypeHex = "6162636465" // "abcde"
-	res := env.Submit(credential.CredentialCreate(alice, bob, credTypeHex).Build())
+	res := env.Submit(credential.CredentialCreateHex(alice, bob, credTypeHex).Build())
 	jtx.RequireTxSuccess(t, res)
 	require.NotNil(t, res.Metadata)
 

--- a/internal/testing/credential/credential_delete_audit_test.go
+++ b/internal/testing/credential/credential_delete_audit_test.go
@@ -77,7 +77,7 @@ func TestCredentialAccept_ExpiredRemovesFromBothDirectories(t *testing.T) {
 
 	// Issuer creates a credential for subject with a short expiration.
 	now := env.NowRipple()
-	r := env.Submit(credential.CredentialCreate(issuer, subject, credType).
+	r := env.Submit(credential.CredentialCreateText(issuer, subject, credType).
 		Expiration(now + 20).Build())
 	jtx.RequireTxSuccess(t, r)
 	env.Close()
@@ -95,7 +95,7 @@ func TestCredentialAccept_ExpiredRemovesFromBothDirectories(t *testing.T) {
 		env.Close()
 	}
 
-	r = env.Submit(credential.CredentialAccept(subject, issuer, credType).Build())
+	r = env.Submit(credential.CredentialAcceptText(subject, issuer, credType).Build())
 	jtx.RequireTxClaimed(t, r, jtx.TecEXPIRED)
 	env.Close()
 
@@ -124,10 +124,10 @@ func TestCredentialDelete_ViaDeleteSLE_AcceptedBySubject(t *testing.T) {
 
 	credKey := jtx.CredentialKeylet(subject, issuer, credType)
 
-	r := env.Submit(credential.CredentialCreate(issuer, subject, credType).Build())
+	r := env.Submit(credential.CredentialCreateText(issuer, subject, credType).Build())
 	jtx.RequireTxSuccess(t, r)
 	env.Close()
-	r = env.Submit(credential.CredentialAccept(subject, issuer, credType).Build())
+	r = env.Submit(credential.CredentialAcceptText(subject, issuer, credType).Build())
 	jtx.RequireTxSuccess(t, r)
 	env.Close()
 
@@ -138,7 +138,7 @@ func TestCredentialDelete_ViaDeleteSLE_AcceptedBySubject(t *testing.T) {
 	require.True(t, dirContains(t, env, subject, credKey))
 
 	// Subject (the owner) deletes the credential.
-	r = env.Submit(credential.CredentialDelete(subject, subject, issuer, credType).Build())
+	r = env.Submit(credential.CredentialDeleteText(subject, subject, issuer, credType).Build())
 	jtx.RequireTxSuccess(t, r)
 	env.Close()
 
@@ -166,7 +166,7 @@ func TestCredentialDelete_ViaDeleteSLE_UnacceptedByIssuer(t *testing.T) {
 
 	credKey := jtx.CredentialKeylet(subject, issuer, credType)
 
-	r := env.Submit(credential.CredentialCreate(issuer, subject, credType).Build())
+	r := env.Submit(credential.CredentialCreateText(issuer, subject, credType).Build())
 	jtx.RequireTxSuccess(t, r)
 	env.Close()
 
@@ -177,7 +177,7 @@ func TestCredentialDelete_ViaDeleteSLE_UnacceptedByIssuer(t *testing.T) {
 	require.True(t, dirContains(t, env, subject, credKey))
 
 	// Issuer (the owner) deletes the un-accepted credential.
-	r = env.Submit(credential.CredentialDelete(issuer, subject, issuer, credType).Build())
+	r = env.Submit(credential.CredentialDeleteText(issuer, subject, issuer, credType).Build())
 	jtx.RequireTxSuccess(t, r)
 	env.Close()
 
@@ -224,7 +224,7 @@ func TestCredentialCreate_ReserveUsesActualFee(t *testing.T) {
 	}
 	require.GreaterOrEqual(t, env.Balance(issuer), reserve, "issuer must hold at least the reserve")
 
-	r := env.Submit(credential.CredentialCreate(issuer, subject, credType).
+	r := env.Submit(credential.CredentialCreateText(issuer, subject, credType).
 		Fee(bigFee).Build())
 	jtx.RequireTxSuccess(t, r)
 	env.Close()

--- a/internal/testing/credential/credential_subjectnode_test.go
+++ b/internal/testing/credential/credential_subjectnode_test.go
@@ -18,7 +18,7 @@ func TestCredentialCreate_SelfIssued_OmitsSubjectNode(t *testing.T) {
 	env.Close()
 
 	credType := "abcde"
-	r := env.Submit(credential.CredentialCreate(alice, alice, credType).Build())
+	r := env.Submit(credential.CredentialCreateText(alice, alice, credType).Build())
 	jtx.RequireTxSuccess(t, r)
 
 	key := keylet.Credential(alice.ID, alice.ID, []byte(credType))
@@ -41,7 +41,7 @@ func TestCredentialCreate_CrossAccount_EmitsZeroSubjectNode(t *testing.T) {
 	env.Close()
 
 	credType := "abcde"
-	r := env.Submit(credential.CredentialCreate(issuer, subject, credType).Build())
+	r := env.Submit(credential.CredentialCreateText(issuer, subject, credType).Build())
 	jtx.RequireTxSuccess(t, r)
 
 	key := keylet.Credential(subject.ID, issuer.ID, []byte(credType))

--- a/internal/testing/credential/credential_test.go
+++ b/internal/testing/credential/credential_test.go
@@ -37,7 +37,7 @@ func TestSuccessful(t *testing.T) {
 
 	// Test: Create credential for subject
 	t.Run("CreateForSubject", func(t *testing.T) {
-		tx := credential.CredentialCreate(issuer, subject, credType).URI(uri).Build()
+		tx := credential.CredentialCreateText(issuer, subject, credType).URI(uri).Build()
 		result := env.Submit(tx)
 		if !result.Success {
 			t.Fatalf("Expected success, got %s: %s", result.Code, result.Message)
@@ -60,7 +60,7 @@ func TestSuccessful(t *testing.T) {
 
 	// Test: Accept credential
 	t.Run("AcceptCredential", func(t *testing.T) {
-		tx := credential.CredentialAccept(subject, issuer, credType).Build()
+		tx := credential.CredentialAcceptText(subject, issuer, credType).Build()
 		result := env.Submit(tx)
 		if !result.Success {
 			t.Fatalf("Expected success, got %s: %s", result.Code, result.Message)
@@ -83,7 +83,7 @@ func TestSuccessful(t *testing.T) {
 
 	// Test: Delete credential by subject
 	t.Run("DeleteCredential", func(t *testing.T) {
-		tx := credential.CredentialDelete(subject, subject, issuer, credType).Build()
+		tx := credential.CredentialDeleteText(subject, subject, issuer, credType).Build()
 		result := env.Submit(tx)
 		if !result.Success {
 			t.Fatalf("Expected success, got %s: %s", result.Code, result.Message)
@@ -121,7 +121,7 @@ func TestCreateForSelf(t *testing.T) {
 
 	// Test: Create credential for self (issuer == subject)
 	t.Run("CreateForSelf", func(t *testing.T) {
-		tx := credential.CredentialCreate(issuer, issuer, credType).URI(uri).Build()
+		tx := credential.CredentialCreateText(issuer, issuer, credType).URI(uri).Build()
 		result := env.Submit(tx)
 		if !result.Success {
 			t.Fatalf("Expected success, got %s: %s", result.Code, result.Message)
@@ -141,7 +141,7 @@ func TestCreateForSelf(t *testing.T) {
 
 	// Test: Delete self-issued credential
 	t.Run("DeleteSelfCredential", func(t *testing.T) {
-		tx := credential.CredentialDelete(issuer, issuer, issuer, credType).Build()
+		tx := credential.CredentialDeleteText(issuer, issuer, issuer, credType).Build()
 		result := env.Submit(tx)
 		if !result.Success {
 			t.Fatalf("Expected success, got %s: %s", result.Code, result.Message)
@@ -176,7 +176,7 @@ func TestCredentialsDelete(t *testing.T) {
 		ct := "delother"
 		// Create credential with near-future expiration
 		now := env.NowRipple()
-		tx := credential.CredentialCreate(issuer, subject, ct).
+		tx := credential.CredentialCreateText(issuer, subject, ct).
 			Expiration(now + 20).Build()
 		result := env.Submit(tx)
 		if !result.Success {
@@ -190,7 +190,7 @@ func TestCredentialsDelete(t *testing.T) {
 		env.Close()
 
 		// Other account can delete expired credentials
-		deleteTx := credential.CredentialDelete(other, subject, issuer, ct).Build()
+		deleteTx := credential.CredentialDeleteText(other, subject, issuer, ct).Build()
 		result = env.Submit(deleteTx)
 		if !result.Success {
 			t.Errorf("Expected success, got %s: %s", result.Code, result.Message)
@@ -213,14 +213,14 @@ func TestCredentialsDelete(t *testing.T) {
 	// Reference: rippled testCredentialsDelete "Delete by subject"
 	t.Run("DeleteBySubject", func(t *testing.T) {
 		ct := "delsubj"
-		createTx := credential.CredentialCreate(issuer, subject, ct).Build()
+		createTx := credential.CredentialCreateText(issuer, subject, ct).Build()
 		result := env.Submit(createTx)
 		if !result.Success {
 			t.Fatalf("Create expected success, got %s", result.Code)
 		}
 		env.Close()
 
-		deleteTx := credential.CredentialDelete(subject, subject, issuer, ct).Build()
+		deleteTx := credential.CredentialDeleteText(subject, subject, issuer, ct).Build()
 		result = env.Submit(deleteTx)
 		if !result.Success {
 			t.Errorf("Expected success, got %s: %s", result.Code, result.Message)
@@ -242,14 +242,14 @@ func TestCredentialsDelete(t *testing.T) {
 	// Reference: rippled testCredentialsDelete "Delete by issuer"
 	t.Run("DeleteByIssuer", func(t *testing.T) {
 		ct := "deliss"
-		createTx := credential.CredentialCreate(issuer, subject, ct).Build()
+		createTx := credential.CredentialCreateText(issuer, subject, ct).Build()
 		result := env.Submit(createTx)
 		if !result.Success {
 			t.Fatalf("Create expected success, got %s", result.Code)
 		}
 		env.Close()
 
-		deleteTx := credential.CredentialDelete(issuer, subject, issuer, ct).Build()
+		deleteTx := credential.CredentialDeleteText(issuer, subject, issuer, ct).Build()
 		result = env.Submit(deleteTx)
 		if !result.Success {
 			t.Errorf("Expected success, got %s: %s", result.Code, result.Message)
@@ -274,7 +274,7 @@ func TestCredentialsDelete(t *testing.T) {
 	// resets owner counts. Go's AccountDelete does not cascade-delete directory entries.
 	t.Run("DeleteIssuerBeforeAccept", func(t *testing.T) {
 		ct := "delibacc"
-		createTx := credential.CredentialCreate(issuer, subject, ct).Build()
+		createTx := credential.CredentialCreateText(issuer, subject, ct).Build()
 		result := env.Submit(createTx)
 		if !result.Success {
 			t.Fatalf("Create expected success, got %s", result.Code)
@@ -310,14 +310,14 @@ func TestCredentialsDelete(t *testing.T) {
 	// Rippled cascade-deletes the credential (now owned by subject) and resets subject's owner count.
 	t.Run("DeleteIssuerAfterAccept", func(t *testing.T) {
 		ct := "deliaaft"
-		createTx := credential.CredentialCreate(issuer, subject, ct).Build()
+		createTx := credential.CredentialCreateText(issuer, subject, ct).Build()
 		result := env.Submit(createTx)
 		if !result.Success {
 			t.Fatalf("Create expected success, got %s", result.Code)
 		}
 		env.Close()
 
-		acceptTx := credential.CredentialAccept(subject, issuer, ct).Build()
+		acceptTx := credential.CredentialAcceptText(subject, issuer, ct).Build()
 		result = env.Submit(acceptTx)
 		if !result.Success {
 			t.Fatalf("Accept expected success, got %s: %s", result.Code, result.Message)
@@ -352,7 +352,7 @@ func TestCredentialsDelete(t *testing.T) {
 	// Rippled cascade-deletes the credential and resets issuer's owner count.
 	t.Run("DeleteSubjectBeforeAccept", func(t *testing.T) {
 		ct := "delsbfr"
-		createTx := credential.CredentialCreate(issuer, subject, ct).Build()
+		createTx := credential.CredentialCreateText(issuer, subject, ct).Build()
 		result := env.Submit(createTx)
 		if !result.Success {
 			t.Fatalf("Create expected success, got %s", result.Code)
@@ -387,14 +387,14 @@ func TestCredentialsDelete(t *testing.T) {
 	// Rippled cascade-deletes the credential (now owned by subject) and resets issuer's owner count.
 	t.Run("DeleteSubjectAfterAccept", func(t *testing.T) {
 		ct := "delsaft"
-		createTx := credential.CredentialCreate(issuer, subject, ct).Build()
+		createTx := credential.CredentialCreateText(issuer, subject, ct).Build()
 		result := env.Submit(createTx)
 		if !result.Success {
 			t.Fatalf("Create expected success, got %s", result.Code)
 		}
 		env.Close()
 
-		acceptTx := credential.CredentialAccept(subject, issuer, ct).Build()
+		acceptTx := credential.CredentialAcceptText(subject, issuer, ct).Build()
 		result = env.Submit(acceptTx)
 		if !result.Success {
 			t.Fatalf("Accept expected success, got %s: %s", result.Code, result.Message)
@@ -467,7 +467,7 @@ func TestCreateFailed(t *testing.T) {
 
 	// Reference: rippled "Credentials fail, empty credentialType param."
 	t.Run("EmptyCredentialType", func(t *testing.T) {
-		tx := credential.CredentialCreate(issuer, subject, "").Build()
+		tx := credential.CredentialCreateText(issuer, subject, "").Build()
 		result := env.Submit(tx)
 		jtx.RequireTxFail(t, result, jtx.TemMALFORMED)
 	})
@@ -475,7 +475,7 @@ func TestCreateFailed(t *testing.T) {
 	// Reference: rippled "Credentials fail, credentialType length > maxCredentialTypeLength."
 	t.Run("CredentialTypeTooLong", func(t *testing.T) {
 		longCredType := strings.Repeat("a", 65)
-		tx := credential.CredentialCreate(issuer, subject, longCredType).Build()
+		tx := credential.CredentialCreateText(issuer, subject, longCredType).Build()
 		result := env.Submit(tx)
 		jtx.RequireTxFail(t, result, jtx.TemMALFORMED)
 	})
@@ -483,7 +483,7 @@ func TestCreateFailed(t *testing.T) {
 	// Reference: rippled "Credentials fail, URI length > 256."
 	t.Run("URITooLong", func(t *testing.T) {
 		longURI := strings.Repeat("a", 257)
-		tx := credential.CredentialCreate(issuer, subject, credType).URI(longURI).Build()
+		tx := credential.CredentialCreateText(issuer, subject, credType).URI(longURI).Build()
 		result := env.Submit(tx)
 		jtx.RequireTxFail(t, result, jtx.TemMALFORMED)
 	})
@@ -516,7 +516,7 @@ func TestCreateFailed(t *testing.T) {
 	// Reference: rippled "Credentials fail, expiration in the past."
 	t.Run("ExpirationInPast", func(t *testing.T) {
 		now := env.NowRipple()
-		tx := credential.CredentialCreate(issuer, subject, credType).
+		tx := credential.CredentialCreateText(issuer, subject, credType).
 			Expiration(now - 1).Build()
 		result := env.Submit(tx)
 		jtx.RequireTxClaimed(t, result, jtx.TecEXPIRED)
@@ -537,7 +537,7 @@ func TestCreateFailed(t *testing.T) {
 	// Reference: rippled "Credentials fail, duplicate."
 	t.Run("Duplicate", func(t *testing.T) {
 		// First create should succeed
-		tx1 := credential.CredentialCreate(issuer, subject, credType).Build()
+		tx1 := credential.CredentialCreateText(issuer, subject, credType).Build()
 		result1 := env.Submit(tx1)
 		if !result1.Success {
 			t.Fatalf("First create expected success, got %s", result1.Code)
@@ -545,7 +545,7 @@ func TestCreateFailed(t *testing.T) {
 		env.Close()
 
 		// Second create should fail with tecDUPLICATE
-		tx2 := credential.CredentialCreate(issuer, subject, credType).Build()
+		tx2 := credential.CredentialCreateText(issuer, subject, credType).Build()
 		result2 := env.Submit(tx2)
 		jtx.RequireTxClaimed(t, result2, jtx.TecDUPLICATE)
 		env.Close()
@@ -557,7 +557,7 @@ func TestCreateFailed(t *testing.T) {
 		}
 
 		// Cleanup
-		deleteTx := credential.CredentialDelete(issuer, subject, issuer, credType).Build()
+		deleteTx := credential.CredentialDeleteText(issuer, subject, issuer, credType).Build()
 		env.Submit(deleteTx)
 		env.Close()
 	})
@@ -566,7 +566,7 @@ func TestCreateFailed(t *testing.T) {
 	t.Run("SubjectDoesNotExist", func(t *testing.T) {
 		nonExistent := jtx.NewAccount("nonexistent")
 		// Do NOT fund nonExistent — it should not exist in the ledger
-		tx := credential.CredentialCreate(issuer, nonExistent, credType).Build()
+		tx := credential.CredentialCreateText(issuer, nonExistent, credType).Build()
 		result := env.Submit(tx)
 		jtx.RequireTxClaimed(t, result, jtx.TecNO_TARGET)
 		env.Close()
@@ -575,7 +575,7 @@ func TestCreateFailed(t *testing.T) {
 	// Test: Invalid flags
 	// Reference: rippled testFlags with fixInvalidTxFlags enabled
 	t.Run("InvalidFlags", func(t *testing.T) {
-		tx := credential.CredentialCreate(issuer, subject, credType).Flags(0x00010000).Build()
+		tx := credential.CredentialCreateText(issuer, subject, credType).Flags(0x00010000).Build()
 		result := env.Submit(tx)
 		jtx.RequireTxFail(t, result, jtx.TemINVALID_FLAG)
 	})
@@ -598,7 +598,7 @@ func TestCreateReserve(t *testing.T) {
 	env.Close()
 
 	// Create should fail with insufficient reserve
-	tx := credential.CredentialCreate(issuer, subject, credType).Build()
+	tx := credential.CredentialCreateText(issuer, subject, credType).Build()
 	result := env.Submit(tx)
 	jtx.RequireTxClaimed(t, result, jtx.TecINSUFFICIENT_RESERVE)
 	env.Close()
@@ -618,7 +618,7 @@ func TestAcceptFailed(t *testing.T) {
 
 	// Reference: rippled "CredentialsAccept fail, Credential doesn't exist."
 	t.Run("CredentialNotExist", func(t *testing.T) {
-		tx := credential.CredentialAccept(subject, issuer, credType).Build()
+		tx := credential.CredentialAcceptText(subject, issuer, credType).Build()
 		result := env.Submit(tx)
 		jtx.RequireTxClaimed(t, result, jtx.TecNO_ENTRY)
 		env.Close()
@@ -635,14 +635,14 @@ func TestAcceptFailed(t *testing.T) {
 
 	// Reference: rippled "CredentialsAccept fail, invalid credentialType param."
 	t.Run("EmptyCredentialType", func(t *testing.T) {
-		tx := credential.CredentialAccept(subject, issuer, "").Build()
+		tx := credential.CredentialAcceptText(subject, issuer, "").Build()
 		result := env.Submit(tx)
 		jtx.RequireTxFail(t, result, jtx.TemMALFORMED)
 	})
 
 	// Test: Invalid flags
 	t.Run("InvalidFlags", func(t *testing.T) {
-		tx := credential.CredentialAccept(subject, issuer, credType).Flags(0x00010000).Build()
+		tx := credential.CredentialAcceptText(subject, issuer, credType).Flags(0x00010000).Build()
 		result := env.Submit(tx)
 		jtx.RequireTxFail(t, result, jtx.TemINVALID_FLAG)
 	})
@@ -660,11 +660,11 @@ func TestAcceptFailed(t *testing.T) {
 	// Reference: rippled "CredentialsAccept fail, lsfAccepted already set."
 	t.Run("AlreadyAccepted", func(t *testing.T) {
 		// Create and accept
-		createTx := credential.CredentialCreate(issuer, subject, credType).Build()
+		createTx := credential.CredentialCreateText(issuer, subject, credType).Build()
 		env.Submit(createTx)
 		env.Close()
 
-		acceptTx := credential.CredentialAccept(subject, issuer, credType).Build()
+		acceptTx := credential.CredentialAcceptText(subject, issuer, credType).Build()
 		result1 := env.Submit(acceptTx)
 		if !result1.Success {
 			t.Fatalf("First accept expected success, got %s", result1.Code)
@@ -672,7 +672,7 @@ func TestAcceptFailed(t *testing.T) {
 		env.Close()
 
 		// Try to accept again - should fail with tecDUPLICATE
-		acceptTx2 := credential.CredentialAccept(subject, issuer, credType).Build()
+		acceptTx2 := credential.CredentialAcceptText(subject, issuer, credType).Build()
 		result2 := env.Submit(acceptTx2)
 		jtx.RequireTxClaimed(t, result2, jtx.TecDUPLICATE)
 		env.Close()
@@ -684,7 +684,7 @@ func TestAcceptFailed(t *testing.T) {
 		}
 
 		// Cleanup
-		deleteTx := credential.CredentialDelete(subject, subject, issuer, credType).Build()
+		deleteTx := credential.CredentialDeleteText(subject, subject, issuer, credType).Build()
 		env.Submit(deleteTx)
 		env.Close()
 	})
@@ -698,7 +698,7 @@ func TestAcceptFailed(t *testing.T) {
 		// In rippled, setting expiration to parentCloseTime and then closing one ledger
 		// makes the credential expired on the next operation.
 		now := env.NowRipple()
-		tx := credential.CredentialCreate(issuer, subject, credType2).
+		tx := credential.CredentialCreateText(issuer, subject, credType2).
 			Expiration(now).Build()
 		result := env.Submit(tx)
 		if !result.Success {
@@ -708,7 +708,7 @@ func TestAcceptFailed(t *testing.T) {
 		env.Close()
 
 		// Credentials are now expired
-		acceptTx := credential.CredentialAccept(subject, issuer, credType2).Build()
+		acceptTx := credential.CredentialAcceptText(subject, issuer, credType2).Build()
 		result = env.Submit(acceptTx)
 		jtx.RequireTxClaimed(t, result, jtx.TecEXPIRED)
 		env.Close()
@@ -731,7 +731,7 @@ func TestAcceptFailed(t *testing.T) {
 	// should fail. In rippled this returns tecNO_ISSUER.
 	t.Run("IssuerDoesNotExist", func(t *testing.T) {
 		ct := "noiss"
-		createTx := credential.CredentialCreate(issuer, subject, ct).Build()
+		createTx := credential.CredentialCreateText(issuer, subject, ct).Build()
 		result := env.Submit(createTx)
 		if !result.Success {
 			t.Fatalf("Create expected success, got %s", result.Code)
@@ -749,7 +749,7 @@ func TestAcceptFailed(t *testing.T) {
 		env.Close()
 
 		// Try to accept — issuer no longer exists
-		acceptTx := credential.CredentialAccept(subject, issuer, ct).Build()
+		acceptTx := credential.CredentialAcceptText(subject, issuer, ct).Build()
 		result = env.Submit(acceptTx)
 		jtx.RequireTxClaimed(t, result, jtx.TecNO_ISSUER)
 		env.Close()
@@ -784,7 +784,7 @@ func TestAcceptReserve(t *testing.T) {
 	env.Close()
 
 	// Create credential should succeed (issuer has reserve)
-	createTx := credential.CredentialCreate(issuer, subject, credType).Build()
+	createTx := credential.CredentialCreateText(issuer, subject, credType).Build()
 	result := env.Submit(createTx)
 	if !result.Success {
 		t.Fatalf("Create expected success, got %s", result.Code)
@@ -792,7 +792,7 @@ func TestAcceptReserve(t *testing.T) {
 	env.Close()
 
 	// Accept should fail - subject doesn't have reserve
-	acceptTx := credential.CredentialAccept(subject, issuer, credType).Build()
+	acceptTx := credential.CredentialAcceptText(subject, issuer, credType).Build()
 	result = env.Submit(acceptTx)
 	jtx.RequireTxClaimed(t, result, jtx.TecINSUFFICIENT_RESERVE)
 	env.Close()
@@ -804,7 +804,7 @@ func TestAcceptReserve(t *testing.T) {
 	}
 
 	// Cleanup by issuer
-	deleteTx := credential.CredentialDelete(issuer, subject, issuer, credType).Build()
+	deleteTx := credential.CredentialDeleteText(issuer, subject, issuer, credType).Build()
 	env.Submit(deleteTx)
 	env.Close()
 }
@@ -824,7 +824,7 @@ func TestDeleteFailed(t *testing.T) {
 
 	// Reference: rippled "CredentialsDelete fail, no Credentials."
 	t.Run("CredentialNotExist", func(t *testing.T) {
-		tx := credential.CredentialDelete(subject, subject, issuer, credType).Build()
+		tx := credential.CredentialDeleteText(subject, subject, issuer, credType).Build()
 		result := env.Submit(tx)
 		jtx.RequireTxClaimed(t, result, jtx.TecNO_ENTRY)
 		env.Close()
@@ -856,14 +856,14 @@ func TestDeleteFailed(t *testing.T) {
 
 	// Reference: rippled "CredentialsDelete fail, invalid credentialType param."
 	t.Run("EmptyCredentialType", func(t *testing.T) {
-		tx := credential.CredentialDelete(subject, subject, issuer, "").Build()
+		tx := credential.CredentialDeleteText(subject, subject, issuer, "").Build()
 		result := env.Submit(tx)
 		jtx.RequireTxFail(t, result, jtx.TemMALFORMED)
 	})
 
 	// Test: Invalid flags
 	t.Run("InvalidFlags", func(t *testing.T) {
-		tx := credential.CredentialDelete(subject, subject, issuer, credType).Flags(0x00010000).Build()
+		tx := credential.CredentialDeleteText(subject, subject, issuer, credType).Flags(0x00010000).Build()
 		result := env.Submit(tx)
 		jtx.RequireTxFail(t, result, jtx.TemINVALID_FLAG)
 	})
@@ -873,12 +873,12 @@ func TestDeleteFailed(t *testing.T) {
 		credType2 := "fghij"
 
 		// Create credential without expiration
-		createTx := credential.CredentialCreate(issuer, subject, credType2).Build()
+		createTx := credential.CredentialCreateText(issuer, subject, credType2).Build()
 		env.Submit(createTx)
 		env.Close()
 
 		// Other account tries to delete - should fail
-		deleteTx := credential.CredentialDelete(other, subject, issuer, credType2).Build()
+		deleteTx := credential.CredentialDeleteText(other, subject, issuer, credType2).Build()
 		result := env.Submit(deleteTx)
 		jtx.RequireTxClaimed(t, result, jtx.TecNO_PERMISSION)
 		env.Close()
@@ -890,7 +890,7 @@ func TestDeleteFailed(t *testing.T) {
 		}
 
 		// Cleanup by issuer
-		cleanupTx := credential.CredentialDelete(issuer, subject, issuer, credType2).Build()
+		cleanupTx := credential.CredentialDeleteText(issuer, subject, issuer, credType2).Build()
 		env.Submit(cleanupTx)
 		env.Close()
 	})
@@ -900,7 +900,7 @@ func TestDeleteFailed(t *testing.T) {
 	t.Run("TimeNotExpiredYet", func(t *testing.T) {
 		now := env.NowRipple()
 		// Create credential with expiration far in the future
-		tx := credential.CredentialCreate(issuer, subject, credType).
+		tx := credential.CredentialCreateText(issuer, subject, credType).
 			Expiration(now + 1000).Build()
 		result := env.Submit(tx)
 		if !result.Success {
@@ -909,7 +909,7 @@ func TestDeleteFailed(t *testing.T) {
 		env.Close()
 
 		// Other account can't delete credentials that are not yet expired
-		deleteTx := credential.CredentialDelete(other, subject, issuer, credType).Build()
+		deleteTx := credential.CredentialDeleteText(other, subject, issuer, credType).Build()
 		result = env.Submit(deleteTx)
 		jtx.RequireTxClaimed(t, result, jtx.TecNO_PERMISSION)
 		env.Close()
@@ -921,7 +921,7 @@ func TestDeleteFailed(t *testing.T) {
 		}
 
 		// Cleanup by issuer
-		cleanupTx := credential.CredentialDelete(issuer, subject, issuer, credType).Build()
+		cleanupTx := credential.CredentialDeleteText(issuer, subject, issuer, credType).Build()
 		env.Submit(cleanupTx)
 		env.Close()
 	})
@@ -965,7 +965,7 @@ func TestDeleteBySubject(t *testing.T) {
 	env.Close()
 
 	// Create credential
-	createTx := credential.CredentialCreate(issuer, subject, credType).Build()
+	createTx := credential.CredentialCreateText(issuer, subject, credType).Build()
 	result := env.Submit(createTx)
 	if !result.Success {
 		t.Fatalf("Create expected success, got %s", result.Code)
@@ -973,7 +973,7 @@ func TestDeleteBySubject(t *testing.T) {
 	env.Close()
 
 	// Subject can delete (even before accepting)
-	deleteTx := credential.CredentialDelete(subject, subject, issuer, credType).Build()
+	deleteTx := credential.CredentialDeleteText(subject, subject, issuer, credType).Build()
 	result = env.Submit(deleteTx)
 	if !result.Success {
 		t.Errorf("Expected success, got %s: %s", result.Code, result.Message)
@@ -1006,7 +1006,7 @@ func TestDeleteByIssuer(t *testing.T) {
 	env.Close()
 
 	// Create credential
-	createTx := credential.CredentialCreate(issuer, subject, credType).Build()
+	createTx := credential.CredentialCreateText(issuer, subject, credType).Build()
 	result := env.Submit(createTx)
 	if !result.Success {
 		t.Fatalf("Create expected success, got %s", result.Code)
@@ -1014,7 +1014,7 @@ func TestDeleteByIssuer(t *testing.T) {
 	env.Close()
 
 	// Issuer can delete
-	deleteTx := credential.CredentialDelete(issuer, subject, issuer, credType).Build()
+	deleteTx := credential.CredentialDeleteText(issuer, subject, issuer, credType).Build()
 	result = env.Submit(deleteTx)
 	if !result.Success {
 		t.Errorf("Expected success, got %s: %s", result.Code, result.Message)
@@ -1046,7 +1046,7 @@ func TestCredentialTypeLimits(t *testing.T) {
 	// Test: CredentialType at exactly 64 bytes should succeed
 	t.Run("CredentialTypeAtLimit", func(t *testing.T) {
 		credType64 := strings.Repeat("a", 64)
-		tx := credential.CredentialCreate(issuer, subject, credType64).Build()
+		tx := credential.CredentialCreateText(issuer, subject, credType64).Build()
 		result := env.Submit(tx)
 		if !result.Success {
 			t.Errorf("Expected success with 64-byte CredentialType, got %s", result.Code)
@@ -1054,7 +1054,7 @@ func TestCredentialTypeLimits(t *testing.T) {
 		env.Close()
 
 		// Cleanup
-		deleteTx := credential.CredentialDelete(issuer, subject, issuer, credType64).Build()
+		deleteTx := credential.CredentialDeleteText(issuer, subject, issuer, credType64).Build()
 		env.Submit(deleteTx)
 		env.Close()
 	})
@@ -1063,7 +1063,7 @@ func TestCredentialTypeLimits(t *testing.T) {
 	t.Run("URIAtLimit", func(t *testing.T) {
 		credType := "testcred"
 		uri256 := strings.Repeat("b", 256)
-		tx := credential.CredentialCreate(issuer, subject, credType).URI(uri256).Build()
+		tx := credential.CredentialCreateText(issuer, subject, credType).URI(uri256).Build()
 		result := env.Submit(tx)
 		if !result.Success {
 			t.Errorf("Expected success with 256-byte URI, got %s", result.Code)
@@ -1071,7 +1071,7 @@ func TestCredentialTypeLimits(t *testing.T) {
 		env.Close()
 
 		// Cleanup
-		deleteTx := credential.CredentialDelete(issuer, subject, issuer, credType).Build()
+		deleteTx := credential.CredentialDeleteText(issuer, subject, issuer, credType).Build()
 		env.Submit(deleteTx)
 		env.Close()
 	})
@@ -1095,19 +1095,19 @@ func TestEnabled(t *testing.T) {
 
 	// Without the featureCredentials amendment, all credential transactions should fail
 	t.Run("CreateDisabled", func(t *testing.T) {
-		tx := credential.CredentialCreate(issuer, subject, credType).Build()
+		tx := credential.CredentialCreateText(issuer, subject, credType).Build()
 		result := env.Submit(tx)
 		jtx.RequireTxFail(t, result, jtx.TemDISABLED)
 	})
 
 	t.Run("AcceptDisabled", func(t *testing.T) {
-		tx := credential.CredentialAccept(subject, issuer, credType).Build()
+		tx := credential.CredentialAcceptText(subject, issuer, credType).Build()
 		result := env.Submit(tx)
 		jtx.RequireTxFail(t, result, jtx.TemDISABLED)
 	})
 
 	t.Run("DeleteDisabled", func(t *testing.T) {
-		tx := credential.CredentialDelete(subject, subject, issuer, credType).Build()
+		tx := credential.CredentialDeleteText(subject, subject, issuer, credType).Build()
 		result := env.Submit(tx)
 		jtx.RequireTxFail(t, result, jtx.TemDISABLED)
 	})
@@ -1126,7 +1126,7 @@ func TestMultipleCredentials(t *testing.T) {
 
 	// Create multiple credentials
 	for _, ct := range credTypes {
-		tx := credential.CredentialCreate(issuer, subject, ct).Build()
+		tx := credential.CredentialCreateText(issuer, subject, ct).Build()
 		result := env.Submit(tx)
 		if !result.Success {
 			t.Fatalf("Create %s expected success, got %s", ct, result.Code)
@@ -1141,7 +1141,7 @@ func TestMultipleCredentials(t *testing.T) {
 
 	// Accept all
 	for _, ct := range credTypes {
-		tx := credential.CredentialAccept(subject, issuer, ct).Build()
+		tx := credential.CredentialAcceptText(subject, issuer, ct).Build()
 		result := env.Submit(tx)
 		if !result.Success {
 			t.Fatalf("Accept %s expected success, got %s", ct, result.Code)
@@ -1159,7 +1159,7 @@ func TestMultipleCredentials(t *testing.T) {
 
 	// Delete all
 	for _, ct := range credTypes {
-		tx := credential.CredentialDelete(subject, subject, issuer, ct).Build()
+		tx := credential.CredentialDeleteText(subject, subject, issuer, ct).Build()
 		result := env.Submit(tx)
 		if !result.Success {
 			t.Fatalf("Delete %s expected success, got %s", ct, result.Code)

--- a/internal/testing/credential/credential_test.go
+++ b/internal/testing/credential/credential_test.go
@@ -489,28 +489,10 @@ func TestCreateFailed(t *testing.T) {
 	})
 
 	// Reference: rippled "Credentials fail, URI empty."
-	// An explicitly present but zero-length URI should fail with temMALFORMED.
 	t.Run("EmptyURI", func(t *testing.T) {
-		// Construct directly to set a present-but-empty URI field
-		credTypeHex := hex.EncodeToString([]byte(credType))
-		cc := credtx.NewCredentialCreate(issuer.Address, subject.Address, credTypeHex)
-		cc.Fee = "10"
-		// Set URI to a valid hex string that decodes to empty bytes
-		// The builder's URIHex("") results in no URI field; we need an explicitly empty VL.
-		// In rippled, credentials::uri("") sets the field to an empty blob.
-		// In Go, an empty string URI is treated as absent. We need to test the
-		// case where the URI hex is set but decodes to zero-length.
-		// Setting URI to "" won't trigger the check since omitempty skips it.
-		// This matches the Go behavior where absent URI is valid.
-		// When URI field IS present but empty, it should fail.
-		cc.URI = "00" // A 1-byte URI is valid, but truly empty ("") is absent
-		// For the actual empty-URI case, we need the hex to decode to empty
-		// The Go validation checks: len(decoded) == 0 → ErrCredentialURIEmpty
-		// But cc.URI = "" would skip the check due to `if c.URI != ""`
-		// This is a difference from rippled where the field can be present-but-empty.
-		// Test what we can: a present but 0-decoded URI
-		t.Log("Go treats empty URI string as absent (not present), which is valid. " +
-			"Rippled can have a present-but-empty VL field which fails with temMALFORMED.")
+		tx := credential.CredentialCreateText(issuer, subject, credType).URI("").Build()
+		result := env.Submit(tx)
+		jtx.RequireTxFail(t, result, jtx.TemMALFORMED)
 	})
 
 	// Reference: rippled "Credentials fail, expiration in the past."

--- a/internal/testing/credential/precedence_test.go
+++ b/internal/testing/credential/precedence_test.go
@@ -25,7 +25,7 @@ func TestPrecedence_CredentialCreateFlagBeforeField(t *testing.T) {
 	env.Close()
 
 	// Empty CredentialType is temMALFORMED in Validate; the invalid flag must win.
-	create := credentialtest.CredentialCreate(issuer, subject, "").
+	create := credentialtest.CredentialCreateText(issuer, subject, "").
 		Flags(0x00000001).
 		Build()
 	jtx.RequireTxFail(t, env.Submit(create), jtx.TemINVALID_FLAG)
@@ -39,7 +39,7 @@ func TestPrecedence_CredentialAcceptFlagBeforeField(t *testing.T) {
 	env.Close()
 
 	// Empty CredentialType is temMALFORMED in Validate; the invalid flag must win.
-	accept := credentialtest.CredentialAccept(subject, issuer, "").
+	accept := credentialtest.CredentialAcceptText(subject, issuer, "").
 		Flags(0x00000001).
 		Build()
 	jtx.RequireTxFail(t, env.Submit(accept), jtx.TemINVALID_FLAG)
@@ -53,7 +53,7 @@ func TestPrecedence_CredentialDeleteFlagBeforeField(t *testing.T) {
 
 	// Neither Subject nor Issuer present is temMALFORMED in Validate; the invalid
 	// flag must win.
-	del := credentialtest.CredentialDelete(sender, nil, nil, "credType").
+	del := credentialtest.CredentialDeleteText(sender, nil, nil, "credType").
 		Flags(0x00000001).
 		Build()
 	jtx.RequireTxFail(t, env.Submit(del), jtx.TemINVALID_FLAG)

--- a/internal/testing/depositpreauth/builder.go
+++ b/internal/testing/depositpreauth/builder.go
@@ -10,54 +10,103 @@ import (
 	"fmt"
 
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
-	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/depositpreauth"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
-// AuthorizeCredentials describes a single credential requirement for
-// credential-based deposit preauthorization.
-// Reference: rippled jtx::deposit::AuthorizeCredentials
 type AuthorizeCredentials struct {
-	Issuer   *jtx.Account
-	CredType string // raw credential type (will be hex-encoded if needed)
+	Issuer       *jtx.Account
+	CredTypeText string
+	CredTypeHex  *string
 }
 
-// -----------------------------------------------------------------------
-// AuthBuilder – builds DepositPreauth with Authorize field set.
-// Reference: rippled deposit::auth(account, auth)
-// -----------------------------------------------------------------------
-
-// AuthBuilder provides a fluent interface for building a DepositPreauth
-// transaction that authorizes an account.
-type AuthBuilder struct {
-	owner      *jtx.Account
-	authorized *jtx.Account
-	fee        uint64
-	sequence   *uint32
-	flags      *uint32
-	ticketSeq  *uint32
+func AuthorizeCredentialText(issuer *jtx.Account, credentialType string) AuthorizeCredentials {
+	return AuthorizeCredentials{Issuer: issuer, CredTypeText: credentialType}
 }
 
-// Auth creates a new AuthBuilder for deposit preauthorization.
-func Auth(owner, authorized *jtx.Account) *AuthBuilder {
-	return &AuthBuilder{
-		owner:      owner,
-		authorized: authorized,
-		fee:        10,
+func AuthorizeCredentialBytes(issuer *jtx.Account, credentialType []byte) AuthorizeCredentials {
+	return AuthorizeCredentialText(issuer, string(append([]byte(nil), credentialType...)))
+}
+
+func AuthorizeCredentialHex(issuer *jtx.Account, credentialTypeHex string) (AuthorizeCredentials, error) {
+	if _, err := hex.DecodeString(credentialTypeHex); err != nil {
+		return AuthorizeCredentials{}, fmt.Errorf("invalid credential type hex: %w", err)
 	}
+	encoded := credentialTypeHex
+	return AuthorizeCredentials{Issuer: issuer, CredTypeHex: &encoded}, nil
 }
 
-func (b *AuthBuilder) Fee(f uint64) *AuthBuilder         { b.fee = f; return b }
-func (b *AuthBuilder) Sequence(seq uint32) *AuthBuilder  { b.sequence = &seq; return b }
-func (b *AuthBuilder) Flags(flags uint32) *AuthBuilder   { b.flags = &flags; return b }
-func (b *AuthBuilder) TicketSeq(seq uint32) *AuthBuilder { b.ticketSeq = &seq; return b }
+type builderKind uint8
 
-// Build constructs the DepositPreauth transaction.
-func (b *AuthBuilder) Build() tx.Transaction {
+const (
+	authorizeAccount builderKind = iota
+	unauthorizeAccount
+	authorizeCredentials
+	unauthorizeCredentials
+)
+
+type Builder struct {
+	kind        builderKind
+	owner       *jtx.Account
+	account     *jtx.Account
+	credentials []AuthorizeCredentials
+	fee         uint64
+	sequence    *uint32
+	flags       *uint32
+	ticketSeq   *uint32
+}
+
+func Auth(owner, authorized *jtx.Account) *Builder {
+	return &Builder{kind: authorizeAccount, owner: owner, account: authorized, fee: 10}
+}
+
+func Unauth(owner, unauthorized *jtx.Account) *Builder {
+	return &Builder{kind: unauthorizeAccount, owner: owner, account: unauthorized, fee: 10}
+}
+
+func AuthCredentials(owner *jtx.Account, credentials []AuthorizeCredentials) *Builder {
+	return &Builder{kind: authorizeCredentials, owner: owner, credentials: credentials, fee: 10}
+}
+
+func UnauthCredentials(owner *jtx.Account, credentials []AuthorizeCredentials) *Builder {
+	return &Builder{kind: unauthorizeCredentials, owner: owner, credentials: credentials, fee: 10}
+}
+
+func (b *Builder) Fee(f uint64) *Builder {
+	b.fee = f
+	return b
+}
+
+func (b *Builder) Sequence(sequence uint32) *Builder {
+	b.sequence = &sequence
+	return b
+}
+
+func (b *Builder) Flags(flags uint32) *Builder {
+	b.flags = &flags
+	return b
+}
+
+func (b *Builder) TicketSeq(ticketSequence uint32) *Builder {
+	b.ticketSeq = &ticketSequence
+	return b
+}
+
+func (b *Builder) Build() *depositpreauth.DepositPreauth {
 	dp := depositpreauth.NewDepositPreauth(b.owner.Address)
-	dp.SetAuthorize(b.authorized.Address)
 	dp.Fee = fmt.Sprintf("%d", b.fee)
+
+	switch b.kind {
+	case authorizeAccount:
+		dp.SetAuthorize(b.account.Address)
+	case unauthorizeAccount:
+		dp.SetUnauthorize(b.account.Address)
+	case authorizeCredentials:
+		dp.AuthorizeCredentials = credentialWrappers(b.credentials)
+	case unauthorizeCredentials:
+		dp.UnauthorizeCredentials = credentialWrappers(b.credentials)
+	}
+
 	if b.sequence != nil {
 		dp.SetSequence(*b.sequence)
 	}
@@ -72,205 +121,22 @@ func (b *AuthBuilder) Build() tx.Transaction {
 	return dp
 }
 
-// BuildDepositPreauth returns the concrete *depositpreauth.DepositPreauth type.
-func (b *AuthBuilder) BuildDepositPreauth() *depositpreauth.DepositPreauth {
-	return b.Build().(*depositpreauth.DepositPreauth)
-}
-
-// -----------------------------------------------------------------------
-// UnauthBuilder – builds DepositPreauth with Unauthorize field set.
-// Reference: rippled deposit::unauth(account, unauth)
-// -----------------------------------------------------------------------
-
-// UnauthBuilder provides a fluent interface for building a DepositPreauth
-// transaction that removes authorization for an account.
-type UnauthBuilder struct {
-	owner        *jtx.Account
-	unauthorized *jtx.Account
-	fee          uint64
-	sequence     *uint32
-	flags        *uint32
-	ticketSeq    *uint32
-}
-
-// Unauth creates a new UnauthBuilder for removing deposit preauthorization.
-func Unauth(owner, unauthorized *jtx.Account) *UnauthBuilder {
-	return &UnauthBuilder{
-		owner:        owner,
-		unauthorized: unauthorized,
-		fee:          10,
-	}
-}
-
-func (b *UnauthBuilder) Fee(f uint64) *UnauthBuilder         { b.fee = f; return b }
-func (b *UnauthBuilder) Sequence(seq uint32) *UnauthBuilder  { b.sequence = &seq; return b }
-func (b *UnauthBuilder) Flags(flags uint32) *UnauthBuilder   { b.flags = &flags; return b }
-func (b *UnauthBuilder) TicketSeq(seq uint32) *UnauthBuilder { b.ticketSeq = &seq; return b }
-
-// Build constructs the DepositPreauth (unauthorize) transaction.
-func (b *UnauthBuilder) Build() tx.Transaction {
-	dp := depositpreauth.NewDepositPreauth(b.owner.Address)
-	dp.SetUnauthorize(b.unauthorized.Address)
-	dp.Fee = fmt.Sprintf("%d", b.fee)
-	if b.sequence != nil {
-		dp.SetSequence(*b.sequence)
-	}
-	if b.flags != nil {
-		dp.SetFlags(*b.flags)
-	}
-	if b.ticketSeq != nil {
-		zero := uint32(0)
-		dp.Sequence = &zero
-		dp.TicketSequence = b.ticketSeq
-	}
-	return dp
-}
-
-// BuildDepositPreauth returns the concrete *depositpreauth.DepositPreauth type.
-func (b *UnauthBuilder) BuildDepositPreauth() *depositpreauth.DepositPreauth {
-	return b.Build().(*depositpreauth.DepositPreauth)
-}
-
-// -----------------------------------------------------------------------
-// AuthCredentialsBuilder – builds DepositPreauth with AuthorizeCredentials.
-// Reference: rippled deposit::authCredentials(account, credentials)
-// -----------------------------------------------------------------------
-
-// AuthCredentialsBuilder provides a fluent interface for building a
-// DepositPreauth transaction that authorizes deposits using credentials.
-type AuthCredentialsBuilder struct {
-	owner       *jtx.Account
-	credentials []AuthorizeCredentials
-	fee         uint64
-	sequence    *uint32
-	flags       *uint32
-}
-
-// AuthCredentials creates a new AuthCredentialsBuilder.
-func AuthCredentials(owner *jtx.Account, credentials []AuthorizeCredentials) *AuthCredentialsBuilder {
-	return &AuthCredentialsBuilder{
-		owner:       owner,
-		credentials: credentials,
-		fee:         10,
-	}
-}
-
-func (b *AuthCredentialsBuilder) Fee(f uint64) *AuthCredentialsBuilder { b.fee = f; return b }
-func (b *AuthCredentialsBuilder) Sequence(seq uint32) *AuthCredentialsBuilder {
-	b.sequence = &seq
-	return b
-}
-func (b *AuthCredentialsBuilder) Flags(flags uint32) *AuthCredentialsBuilder {
-	b.flags = &flags
-	return b
-}
-
-// Build constructs the DepositPreauth transaction with AuthorizeCredentials.
-func (b *AuthCredentialsBuilder) Build() tx.Transaction {
-	dp := depositpreauth.NewDepositPreauth(b.owner.Address)
-	dp.Fee = fmt.Sprintf("%d", b.fee)
-
-	wrappers := make([]depositpreauth.CredentialWrapper, len(b.credentials))
-	for i, c := range b.credentials {
-		credType := c.CredType
-		if !isHexEncoded(credType) {
-			credType = hex.EncodeToString([]byte(credType))
+func credentialWrappers(credentials []AuthorizeCredentials) []depositpreauth.CredentialWrapper {
+	wrapper := make([]depositpreauth.CredentialWrapper, len(credentials))
+	for i, credential := range credentials {
+		credentialType := hex.EncodeToString([]byte(credential.CredTypeText))
+		if credential.CredTypeHex != nil {
+			credentialType = *credential.CredTypeHex
 		}
-		wrappers[i] = depositpreauth.CredentialWrapper{
+		wrapper[i] = depositpreauth.CredentialWrapper{
 			Credential: depositpreauth.CredentialSpec{
-				Issuer:         c.Issuer.Address,
-				CredentialType: credType,
+				Issuer:         credential.Issuer.Address,
+				CredentialType: credentialType,
 			},
 		}
 	}
-	dp.AuthorizeCredentials = wrappers
-
-	if b.sequence != nil {
-		dp.SetSequence(*b.sequence)
-	}
-	if b.flags != nil {
-		dp.SetFlags(*b.flags)
-	}
-	return dp
+	return wrapper
 }
-
-// BuildDepositPreauth returns the concrete *depositpreauth.DepositPreauth type.
-func (b *AuthCredentialsBuilder) BuildDepositPreauth() *depositpreauth.DepositPreauth {
-	return b.Build().(*depositpreauth.DepositPreauth)
-}
-
-// -----------------------------------------------------------------------
-// UnauthCredentialsBuilder – builds DepositPreauth with UnauthorizeCredentials.
-// Reference: rippled deposit::unauthCredentials(account, credentials)
-// -----------------------------------------------------------------------
-
-// UnauthCredentialsBuilder provides a fluent interface for building a
-// DepositPreauth transaction that removes credential-based authorization.
-type UnauthCredentialsBuilder struct {
-	owner       *jtx.Account
-	credentials []AuthorizeCredentials
-	fee         uint64
-	sequence    *uint32
-	flags       *uint32
-}
-
-// UnauthCredentials creates a new UnauthCredentialsBuilder.
-func UnauthCredentials(owner *jtx.Account, credentials []AuthorizeCredentials) *UnauthCredentialsBuilder {
-	return &UnauthCredentialsBuilder{
-		owner:       owner,
-		credentials: credentials,
-		fee:         10,
-	}
-}
-
-func (b *UnauthCredentialsBuilder) Fee(f uint64) *UnauthCredentialsBuilder { b.fee = f; return b }
-func (b *UnauthCredentialsBuilder) Sequence(seq uint32) *UnauthCredentialsBuilder {
-	b.sequence = &seq
-	return b
-}
-func (b *UnauthCredentialsBuilder) Flags(flags uint32) *UnauthCredentialsBuilder {
-	b.flags = &flags
-	return b
-}
-
-// Build constructs the DepositPreauth transaction with UnauthorizeCredentials.
-func (b *UnauthCredentialsBuilder) Build() tx.Transaction {
-	dp := depositpreauth.NewDepositPreauth(b.owner.Address)
-	dp.Fee = fmt.Sprintf("%d", b.fee)
-
-	wrappers := make([]depositpreauth.CredentialWrapper, len(b.credentials))
-	for i, c := range b.credentials {
-		credType := c.CredType
-		if !isHexEncoded(credType) {
-			credType = hex.EncodeToString([]byte(credType))
-		}
-		wrappers[i] = depositpreauth.CredentialWrapper{
-			Credential: depositpreauth.CredentialSpec{
-				Issuer:         c.Issuer.Address,
-				CredentialType: credType,
-			},
-		}
-	}
-	dp.UnauthorizeCredentials = wrappers
-
-	if b.sequence != nil {
-		dp.SetSequence(*b.sequence)
-	}
-	if b.flags != nil {
-		dp.SetFlags(*b.flags)
-	}
-	return dp
-}
-
-// BuildDepositPreauth returns the concrete *depositpreauth.DepositPreauth type.
-func (b *UnauthCredentialsBuilder) BuildDepositPreauth() *depositpreauth.DepositPreauth {
-	return b.Build().(*depositpreauth.DepositPreauth)
-}
-
-// -----------------------------------------------------------------------
-// RawDepositPreauthBuilder – builds a raw DepositPreauth transaction
-// allowing arbitrary field combinations for negative testing.
-// -----------------------------------------------------------------------
 
 // RawBuilder provides direct access to all DepositPreauth fields for
 // constructing invalid transactions for negative testing.
@@ -300,38 +166,11 @@ func (b *RawBuilder) UnauthorizeCredentials(c []depositpreauth.CredentialWrapper
 // Build returns the DepositPreauth transaction.
 func (b *RawBuilder) Build() *depositpreauth.DepositPreauth { return b.dp }
 
-// -----------------------------------------------------------------------
-// Helpers
-// -----------------------------------------------------------------------
+func CredentialIndexHex(subject, issuer *jtx.Account, credentialType string) string {
+	return CredentialBytesIndexHex(subject, issuer, []byte(credentialType))
+}
 
-// CredentialIndex computes the ledger entry hash for a credential.
-// This matches rippled's credentials::ledgerEntry index.
-func CredentialIndex(subject, issuer *jtx.Account, credType string) string {
-	rawCredType := credType
-	if isHexEncoded(credType) {
-		decoded, err := hex.DecodeString(credType)
-		if err == nil {
-			rawCredType = string(decoded)
-		}
-	}
-	k := keylet.Credential(subject.ID, issuer.ID, []byte(rawCredType))
+func CredentialBytesIndexHex(subject, issuer *jtx.Account, credentialType []byte) string {
+	k := keylet.Credential(subject.ID, issuer.ID, credentialType)
 	return fmt.Sprintf("%X", k.Key)
-}
-
-// DepositPreauthKeylet returns the keylet for a basic (account-based) deposit preauth.
-func DepositPreauthKeylet(owner, authorized *jtx.Account) keylet.Keylet {
-	return keylet.DepositPreauth(owner.ID, authorized.ID)
-}
-
-// isHexEncoded checks if a string appears to be hex-encoded.
-func isHexEncoded(s string) bool {
-	if len(s)%2 != 0 || len(s) == 0 {
-		return false
-	}
-	for _, c := range s {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/testing/depositpreauth/builder_representation_test.go
+++ b/internal/testing/depositpreauth/builder_representation_test.go
@@ -1,0 +1,59 @@
+package depositpreauth
+
+import (
+	"strings"
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCredentialTypeBuildersUseExplicitRepresentations(t *testing.T) {
+	owner := jtx.NewAccount("owner")
+	issuer := jtx.NewAccount("issuer")
+
+	text := AuthCredentials(owner, []AuthorizeCredentials{
+		AuthorizeCredentialText(issuer, "deadbeef"),
+	}).Build()
+	require.Equal(t, "6465616462656566", text.AuthorizeCredentials[0].Credential.CredentialType)
+
+	wireCredential, err := AuthorizeCredentialHex(issuer, "DeAdBeEf")
+	require.NoError(t, err)
+	wire := AuthCredentials(owner, []AuthorizeCredentials{wireCredential}).Build()
+	require.Equal(t, "DeAdBeEf", wire.AuthorizeCredentials[0].Credential.CredentialType)
+
+	_, err = AuthorizeCredentialHex(issuer, "abc")
+	require.Error(t, err)
+	_, err = AuthorizeCredentialHex(issuer, "not-hex")
+	require.Error(t, err)
+
+	require.Error(t, AuthCredentials(owner, []AuthorizeCredentials{
+		AuthorizeCredentialText(issuer, ""),
+	}).Build().Validate())
+	require.NoError(t, AuthCredentials(owner, []AuthorizeCredentials{
+		AuthorizeCredentialText(issuer, strings.Repeat("x", 64)),
+	}).Build().Validate())
+	require.Error(t, AuthCredentials(owner, []AuthorizeCredentials{
+		AuthorizeCredentialText(issuer, strings.Repeat("x", 65)),
+	}).Build().Validate())
+}
+
+func TestAllDepositPreauthBuildersSupportTickets(t *testing.T) {
+	owner := jtx.NewAccount("owner")
+	target := jtx.NewAccount("target")
+	credential := AuthorizeCredentialText(target, "credential")
+
+	transactions := []*Builder{
+		Auth(owner, target),
+		Unauth(owner, target),
+		AuthCredentials(owner, []AuthorizeCredentials{credential}),
+		UnauthCredentials(owner, []AuthorizeCredentials{credential}),
+	}
+	for _, builder := range transactions {
+		txn := builder.TicketSeq(123).Build()
+		require.NotNil(t, txn.Sequence)
+		require.Zero(t, *txn.Sequence)
+		require.NotNil(t, txn.TicketSequence)
+		require.Equal(t, uint32(123), *txn.TicketSequence)
+	}
+}

--- a/internal/testing/depositpreauth/depositauth_test.go
+++ b/internal/testing/depositpreauth/depositauth_test.go
@@ -7,23 +7,14 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/accountset"
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	accounttx "github.com/LeJamon/go-xrpl/internal/tx/account"
 	paymentPkg "github.com/LeJamon/go-xrpl/internal/tx/payment"
 	"github.com/stretchr/testify/require"
 )
-
-// hasDepositAuth returns true if the account has lsfDepositAuth set.
-// Reference: rippled hasDepositAuth()
-func hasDepositAuth(t *testing.T, env *jtx.TestEnv, acc *jtx.Account) bool {
-	t.Helper()
-	info := env.AccountInfo(acc)
-	if info == nil {
-		return false
-	}
-	return (info.Flags & state.LsfDepositAuth) == state.LsfDepositAuth
-}
 
 // reserve returns the account reserve for the given owner count.
 // Reference: rippled reserve(env, count)
@@ -46,13 +37,11 @@ func TestDepositAuth_Enable(t *testing.T) {
 
 	env.EnableDepositAuth(alice)
 	env.Close()
-	require.True(t, hasDepositAuth(t, env, alice),
-		"DepositAuth flag should be set")
+	jtx.RequireFlagSet(t, env, alice, state.LsfDepositAuth)
 
 	env.DisableDepositAuth(alice)
 	env.Close()
-	require.False(t, hasDepositAuth(t, env, alice),
-		"DepositAuth flag should be cleared")
+	jtx.RequireFlagNotSet(t, env, alice, state.LsfDepositAuth)
 }
 
 // --------------------------------------------------------------------------
@@ -85,10 +74,11 @@ func TestDepositAuth_PayIOU(t *testing.T) {
 	result = env.Submit(payment.PayIssued(gw, alice, usd150).Build())
 	jtx.RequireTxSuccess(t, result)
 
-	// carol creates an offer: sell USD(100) for XRP(100)
+	// carol creates an offer: sell XRP(100) for USD(100)
 	usd100Offer := tx.NewIssuedAmountFromFloat64(100, "USD", gw.Address)
 	xrp100Offer := tx.NewXRPAmount(jtx.XRP(100))
-	env.CreateOffer(carol, usd100Offer, xrp100Offer)
+	result = env.CreateOffer(carol, xrp100Offer, usd100Offer)
+	jtx.RequireTxSuccess(t, result)
 	env.Close()
 
 	// alice pays bob some USD to set up initial balance
@@ -100,11 +90,11 @@ func TestDepositAuth_PayIOU(t *testing.T) {
 	// bob enables DepositAuth
 	env.EnableDepositAuth(bob)
 	env.Close()
-	require.True(t, hasDepositAuth(t, env, bob))
+	jtx.RequireFlagSet(t, env, bob, state.LsfDepositAuth)
 
 	// --- failedIouPayments closure ---
 	failedIouPayments := func() {
-		require.True(t, hasDepositAuth(t, env, bob))
+		jtx.RequireFlagSet(t, env, bob, state.LsfDepositAuth)
 
 		bobXRP := env.Balance(bob)
 		bobUSD := env.BalanceIOU(bob, "USD", gw)
@@ -149,15 +139,9 @@ func TestDepositAuth_PayIOU(t *testing.T) {
 	failedIouPayments()
 
 	// Test when bob has XRP balance == 0.
-	env.Noop(bob)
+	env.NoopWithFee(bob, reserve(env, 0))
 	env.Close()
-
-	// After noop at base-reserve fee, bob should have 0 XRP.
-	// (Noop uses baseFee, but we need to drain to 0.)
-	// Use a noop with exact remaining balance as fee.
-	// Actually the Noop helper uses baseFee. To get bob to 0, we need a custom fee.
-	// rippled: env(noop(bob), fee(reserve(env, 0)));
-	// For now just verify the IOU payments still fail.
+	require.Zero(t, env.Balance(bob))
 	failedIouPayments()
 
 	// bob clears DepositAuth and payments succeed again.
@@ -167,10 +151,20 @@ func TestDepositAuth_PayIOU(t *testing.T) {
 
 	env.DisableDepositAuth(bob)
 	env.Close()
+	jtx.RequireFlagNotSet(t, env, bob, state.LsfDepositAuth)
 
+	bobUSD := env.BalanceIOU(bob, "USD", gw)
 	result = env.Submit(payment.PayIssued(alice, bob, usd50).Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
+	require.InDelta(t, bobUSD+50, env.BalanceIOU(bob, "USD", gw), 1e-10)
+
+	bobXRP := env.Balance(bob)
+	usd1 := tx.NewIssuedAmountFromFloat64(1, "USD", gw.Address)
+	result = env.Submit(payment.Pay(alice, bob, 1).SendMax(usd1).Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+	require.Equal(t, bobXRP+1, env.Balance(bob))
 }
 
 // --------------------------------------------------------------------------
@@ -180,6 +174,7 @@ func TestDepositAuth_PayIOU(t *testing.T) {
 
 func TestDepositAuth_PayXRP(t *testing.T) {
 	env := jtx.NewTestEnv(t)
+	env.EnableOpenLedgerReplay()
 
 	alice := jtx.NewAccount("alice")
 	bob := jtx.NewAccount("bob")
@@ -191,10 +186,6 @@ func TestDepositAuth_PayXRP(t *testing.T) {
 	env.Close()
 
 	// bob enables DepositAuth
-	env.Submit(
-		payment.Pay(bob, bob, 0).Fee(baseFee).Build(), // placeholder; use AccountSet
-	)
-	// Actually use the env helper:
 	env.EnableDepositAuth(bob)
 	env.Close()
 
@@ -263,16 +254,38 @@ func TestDepositAuth_PayXRP(t *testing.T) {
 	require.Equal(t, uint64(0), env.Balance(bob))
 
 	// bob should not be able to clear lsfDepositAuth (terINSUF_FEE_B).
+	bobSeq := env.Seq(bob)
+	clearDepositAuth := accountset.AccountSet(bob).
+		ClearFlag(accounttx.AccountSetFlagDepositAuth).
+		Fee(baseFee).
+		Build()
+	result = env.Submit(clearDepositAuth)
+	require.Equal(t, "terINSUF_FEE_B", result.Code)
+	env.Close()
+	require.Zero(t, env.Balance(bob))
+	require.Equal(t, bobSeq, env.Seq(bob))
+	jtx.RequireFlagSet(t, env, bob, state.LsfDepositAuth)
 
 	// Pay bob 1 drop – should succeed when balance is at or below reserve.
 	result = env.Submit(payment.Pay(alice, bob, 1).Build())
-	// Result depends on bob's exact balance. If above reserve, tecNO_PERMISSION.
-	// If at/below, tesSUCCESS.
+	jtx.RequireTxSuccess(t, result)
 	env.Close()
+	require.Equal(t, uint64(1), env.Balance(bob))
+	require.Equal(t, bobSeq, env.Seq(bob))
+	jtx.RequireFlagSet(t, env, bob, state.LsfDepositAuth)
 
-	// Since bob no longer has lsfDepositAuth set (after clearing), any payment succeeds.
-	// This part requires exact balance manipulation which is hard without custom fee support.
-	// The core logic is tested above with the reserve-boundary checks.
+	// Funding the remaining fee causes the held AccountSet to retry and clear the flag.
+	result = env.Submit(payment.Pay(alice, bob, baseFee-1).Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+	require.Zero(t, env.Balance(bob))
+	require.Equal(t, bobSeq+1, env.Seq(bob))
+	jtx.RequireFlagNotSet(t, env, bob, state.LsfDepositAuth)
+
+	result = env.Submit(payment.Pay(alice, bob, reserve(env, 0)+1).Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+	require.Equal(t, reserve(env, 0)+1, env.Balance(bob))
 }
 
 // --------------------------------------------------------------------------
@@ -303,24 +316,37 @@ func TestDepositAuth_NoRipple(t *testing.T) {
 		if noRipplePrev {
 			aliceTrust = aliceTrust.NoRipple()
 		}
-		env.Submit(aliceTrust.Build())
+		result := env.Submit(aliceTrust.Build())
+		jtx.RequireTxSuccess(t, result)
 
 		// gw1 trusts bob["USD"] with optional noRipple
 		bobTrust := trustset.TrustLine(gw1, "USD", bob, "10")
 		if noRippleNext {
 			bobTrust = bobTrust.NoRipple()
 		}
-		env.Submit(bobTrust.Build())
+		result = env.Submit(bobTrust.Build())
+		jtx.RequireTxSuccess(t, result)
 
-		env.Submit(trustset.TrustLine(alice, "USD", gw1, "10").Build())
-		env.Submit(trustset.TrustLine(bob, "USD", gw1, "10").Build())
+		result = env.Submit(trustset.TrustLine(alice, "USD", gw1, "10").Build())
+		jtx.RequireTxSuccess(t, result)
+		result = env.Submit(trustset.TrustLine(bob, "USD", gw1, "10").Build())
+		jtx.RequireTxSuccess(t, result)
 
 		usd10 := tx.NewIssuedAmountFromFloat64(10, "USD", gw1.Address)
-		env.Submit(payment.PayIssued(gw1, alice, usd10).Build())
+		result = env.Submit(payment.PayIssued(gw1, alice, usd10).Build())
+		jtx.RequireTxSuccess(t, result)
 
 		if withDepositAuth {
 			env.EnableDepositAuth(gw1)
 		}
+		env.Close()
+		if withDepositAuth {
+			jtx.RequireFlagSet(t, env, gw1, state.LsfDepositAuth)
+		} else {
+			jtx.RequireFlagNotSet(t, env, gw1, state.LsfDepositAuth)
+		}
+		require.InDelta(t, 10, env.BalanceIOU(alice, "USD", gw1), 1e-10)
+		require.Zero(t, env.BalanceIOU(bob, "USD", gw1))
 
 		// Expected result: tecPATH_DRY if both noRipple flags are set, tesSUCCESS otherwise.
 		expectedCode := "tesSUCCESS"
@@ -330,12 +356,20 @@ func TestDepositAuth_NoRipple(t *testing.T) {
 
 		// Use explicit path through gw1 (matching rippled: path(gw1))
 		gw1Path := [][]paymentPkg.PathStep{{{Account: gw1.Address}}}
-		result := env.Submit(
+		result = env.Submit(
 			payment.PayIssued(alice, bob, usd10).Paths(gw1Path).Build(),
 		)
 		require.Equal(t, expectedCode, result.Code,
 			"noRipplePrev=%v noRippleNext=%v withDepositAuth=%v",
 			noRipplePrev, noRippleNext, withDepositAuth)
+		env.Close()
+		if expectedCode == "tesSUCCESS" {
+			require.Zero(t, env.BalanceIOU(alice, "USD", gw1))
+			require.InDelta(t, 10, env.BalanceIOU(bob, "USD", gw1), 1e-10)
+		} else {
+			require.InDelta(t, 10, env.BalanceIOU(alice, "USD", gw1), 1e-10)
+			require.Zero(t, env.BalanceIOU(bob, "USD", gw1))
+		}
 	}
 
 	testNonIssuer := func(t *testing.T, noRipplePrev, noRippleNext, withDepositAuth bool) {
@@ -350,20 +384,31 @@ func TestDepositAuth_NoRipple(t *testing.T) {
 		if noRipplePrev {
 			usd1Trust = usd1Trust.NoRipple()
 		}
-		env.Submit(usd1Trust.Build())
+		result := env.Submit(usd1Trust.Build())
+		jtx.RequireTxSuccess(t, result)
 
 		usd2Trust := trustset.TrustLine(alice, "USD", gw2, "10")
 		if noRippleNext {
 			usd2Trust = usd2Trust.NoRipple()
 		}
-		env.Submit(usd2Trust.Build())
+		result = env.Submit(usd2Trust.Build())
+		jtx.RequireTxSuccess(t, result)
 
 		usd2_10 := tx.NewIssuedAmountFromFloat64(10, "USD", gw2.Address)
-		env.Submit(payment.PayIssued(gw2, alice, usd2_10).Build())
+		result = env.Submit(payment.PayIssued(gw2, alice, usd2_10).Build())
+		jtx.RequireTxSuccess(t, result)
 
 		if withDepositAuth {
 			env.EnableDepositAuth(alice)
 		}
+		env.Close()
+		if withDepositAuth {
+			jtx.RequireFlagSet(t, env, alice, state.LsfDepositAuth)
+		} else {
+			jtx.RequireFlagNotSet(t, env, alice, state.LsfDepositAuth)
+		}
+		require.Zero(t, env.BalanceIOU(alice, "USD", gw1))
+		require.InDelta(t, 10, env.BalanceIOU(alice, "USD", gw2), 1e-10)
 
 		expectedCode := "tesSUCCESS"
 		if noRippleNext && noRipplePrev {
@@ -374,7 +419,7 @@ func TestDepositAuth_NoRipple(t *testing.T) {
 		usd2_10_pay := tx.NewIssuedAmountFromFloat64(10, "USD", gw2.Address)
 		// Use explicit path through alice (matching rippled: path(alice), sendmax(USD1(10)))
 		alicePath := [][]paymentPkg.PathStep{{{Account: alice.Address}}}
-		result := env.Submit(
+		result = env.Submit(
 			payment.PayIssued(gw1, gw2, usd2_10_pay).
 				SendMax(usd1_10).
 				Paths(alicePath).
@@ -383,6 +428,14 @@ func TestDepositAuth_NoRipple(t *testing.T) {
 		require.Equal(t, expectedCode, result.Code,
 			"noRipplePrev=%v noRippleNext=%v withDepositAuth=%v",
 			noRipplePrev, noRippleNext, withDepositAuth)
+		env.Close()
+		if expectedCode == "tesSUCCESS" {
+			require.InDelta(t, 10, env.BalanceIOU(alice, "USD", gw1), 1e-10)
+			require.Zero(t, env.BalanceIOU(alice, "USD", gw2))
+		} else {
+			require.Zero(t, env.BalanceIOU(alice, "USD", gw1))
+			require.InDelta(t, 10, env.BalanceIOU(alice, "USD", gw2), 1e-10)
+		}
 	}
 
 	// Test every combination of noRipplePrev, noRippleNext, and withDepositAuth.

--- a/internal/testing/depositpreauth/depositauth_test.go
+++ b/internal/testing/depositpreauth/depositauth_test.go
@@ -74,7 +74,6 @@ func TestDepositAuth_PayIOU(t *testing.T) {
 	result = env.Submit(payment.PayIssued(gw, alice, usd150).Build())
 	jtx.RequireTxSuccess(t, result)
 
-	// carol creates an offer: sell XRP(100) for USD(100)
 	usd100Offer := tx.NewIssuedAmountFromFloat64(100, "USD", gw.Address)
 	xrp100Offer := tx.NewXRPAmount(jtx.XRP(100))
 	result = env.CreateOffer(carol, xrp100Offer, usd100Offer)

--- a/internal/testing/depositpreauth/depositpreauth_test.go
+++ b/internal/testing/depositpreauth/depositpreauth_test.go
@@ -1275,6 +1275,7 @@ func TestDepositPreauth_SortingCredentials(t *testing.T) {
 			CredTypeText: credTypes[i],
 		}
 	}
+	credentials[1].Issuer = credentials[0].Issuer
 	expectedCredentials := append([]dp.AuthorizeCredentials(nil), credentials...)
 	sort.Slice(expectedCredentials, func(i, j int) bool {
 		if cmp := bytes.Compare(expectedCredentials[i].Issuer.ID[:], expectedCredentials[j].Issuer.ID[:]); cmp != 0 {

--- a/internal/testing/depositpreauth/depositpreauth_test.go
+++ b/internal/testing/depositpreauth/depositpreauth_test.go
@@ -3,19 +3,23 @@
 package depositpreauth_test
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
+	"sort"
 	"testing"
-	"time"
 
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/testing/credential"
 	dp "github.com/LeJamon/go-xrpl/internal/testing/depositpreauth"
+	"github.com/LeJamon/go-xrpl/internal/testing/escrow"
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/depositpreauth"
 	paymentPkg "github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/keylet"
+	ledgerentry "github.com/LeJamon/go-xrpl/ledger/entry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -181,25 +185,53 @@ func TestDepositPreauth_Invalid(t *testing.T) {
 		env.Close()
 	})
 
-	// alice successfully authorizes becky.
-	t.Run("SuccessfulAuth", func(t *testing.T) {
-		jtx.RequireOwnerCount(t, env, alice, 0)
-		jtx.RequireOwnerCount(t, env, becky, 0)
+	t.Run("AuthorizationLifecycle", func(t *testing.T) {
+		lifecycleEnv := jtx.NewTestEnv(t)
+		lifecycleEnv.FundAmount(alice, uint64(jtx.XRP(10000)))
+		lifecycleEnv.FundAmount(becky, uint64(jtx.XRP(10000)))
+		lifecycleEnv.Close()
+		preauthKey := keylet.DepositPreauth(alice.ID, becky.ID)
+		initialBalance := lifecycleEnv.Balance(alice)
 
-		result := env.Submit(dp.Auth(alice, becky).Build())
+		jtx.RequireOwnerCount(t, lifecycleEnv, alice, 0)
+		result := lifecycleEnv.Submit(dp.Auth(alice, becky).Build())
 		jtx.RequireTxSuccess(t, result)
-		env.Close()
-		jtx.RequireOwnerCount(t, env, alice, 1)
-		jtx.RequireOwnerCount(t, env, becky, 0)
-	})
+		lifecycleEnv.Close()
+		jtx.RequireLedgerEntryExists(t, lifecycleEnv, preauthKey)
+		jtx.RequireOwnerDirectoryContains(t, lifecycleEnv, alice, preauthKey.Key, true)
+		jtx.RequireOwnerCount(t, lifecycleEnv, alice, 1)
+		data, err := lifecycleEnv.LedgerEntry(preauthKey)
+		require.NoError(t, err)
+		stored := &ledgerentry.DepositPreauth{}
+		require.NoError(t, stored.Decode(data))
+		require.Equal(t, alice.Address, stored.Account)
+		require.Equal(t, becky.Address, stored.Authorize)
+		require.Equal(t, "0", stored.OwnerNode)
+		require.Equal(t, initialBalance-lifecycleEnv.BaseFee(), lifecycleEnv.Balance(alice))
+		availableAfterCreate := lifecycleEnv.Balance(alice) - reserve(lifecycleEnv, 1)
 
-	// Duplicate authorization.
-	t.Run("DuplicateAuth", func(t *testing.T) {
-		result := env.Submit(dp.Auth(alice, becky).Build())
+		result = lifecycleEnv.Submit(dp.Auth(alice, becky).Build())
 		require.Equal(t, "tecDUPLICATE", result.Code)
-		env.Close()
-		jtx.RequireOwnerCount(t, env, alice, 1)
-		jtx.RequireOwnerCount(t, env, becky, 0)
+		lifecycleEnv.Close()
+		jtx.RequireLedgerEntryExists(t, lifecycleEnv, preauthKey)
+		jtx.RequireOwnerCount(t, lifecycleEnv, alice, 1)
+
+		result = lifecycleEnv.Submit(dp.Unauth(alice, becky).Build())
+		jtx.RequireTxSuccess(t, result)
+		lifecycleEnv.Close()
+		jtx.RequireLedgerEntryNotExists(t, lifecycleEnv, preauthKey)
+		jtx.RequireOwnerDirectoryContains(t, lifecycleEnv, alice, preauthKey.Key, false)
+		jtx.RequireOwnerCount(t, lifecycleEnv, alice, 0)
+		require.Equal(t, initialBalance-3*lifecycleEnv.BaseFee(), lifecycleEnv.Balance(alice))
+		require.Equal(t,
+			availableAfterCreate+lifecycleEnv.ReserveIncrement()-2*lifecycleEnv.BaseFee(),
+			lifecycleEnv.Balance(alice)-reserve(lifecycleEnv, 0),
+		)
+
+		result = lifecycleEnv.Submit(dp.Unauth(alice, becky).Build())
+		require.Equal(t, "tecNO_ENTRY", result.Code)
+		lifecycleEnv.Close()
+		jtx.RequireOwnerCount(t, lifecycleEnv, alice, 0)
 	})
 
 	// Insufficient reserve.
@@ -233,30 +265,12 @@ func TestDepositPreauth_Invalid(t *testing.T) {
 		env.Close()
 		jtx.RequireOwnerCount(t, env, carol, 1)
 		jtx.RequireOwnerCount(t, env, becky, 0)
-		jtx.RequireOwnerCount(t, env, alice, 1)
+		jtx.RequireOwnerCount(t, env, alice, 0)
 	})
 
 	// Remove non-existent authorization.
 	t.Run("RemoveNonExistent", func(t *testing.T) {
 		result := env.Submit(dp.Unauth(alice, carol).Build())
-		require.Equal(t, "tecNO_ENTRY", result.Code)
-		env.Close()
-		jtx.RequireOwnerCount(t, env, alice, 1)
-		jtx.RequireOwnerCount(t, env, becky, 0)
-	})
-
-	// Successfully remove authorization.
-	t.Run("SuccessfulUnauth", func(t *testing.T) {
-		result := env.Submit(dp.Unauth(alice, becky).Build())
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-		jtx.RequireOwnerCount(t, env, alice, 0)
-		jtx.RequireOwnerCount(t, env, becky, 0)
-	})
-
-	// Remove again — should fail.
-	t.Run("RemoveAgain", func(t *testing.T) {
-		result := env.Submit(dp.Unauth(alice, becky).Build())
 		require.Equal(t, "tecNO_ENTRY", result.Code)
 		env.Close()
 		jtx.RequireOwnerCount(t, env, alice, 0)
@@ -398,24 +412,24 @@ func testPayment(t *testing.T, supportsCredentials bool) {
 
 		// becky sets up credential-based preauth.
 		result = env.Submit(dp.AuthCredentials(becky, []dp.AuthorizeCredentials{
-			{Issuer: carol, CredType: credType},
+			{Issuer: carol, CredTypeText: credType},
 		}).Build())
 		require.Equal(t, expectDP, result.Code)
 		env.Close()
 
 		// carol creates credential for gw (subject=gw, issuer=carol).
-		result = env.Submit(credential.CredentialCreate(carol, gw, credType).Build())
+		result = env.Submit(credential.CredentialCreateText(carol, gw, credType).Build())
 		require.Equal(t, expectCredentials, result.Code)
 		env.Close()
 		// gw accepts the credential from carol.
-		result = env.Submit(credential.CredentialAccept(gw, carol, credType).Build())
+		result = env.Submit(credential.CredentialAcceptText(gw, carol, credType).Build())
 		require.Equal(t, expectCredentials, result.Code)
 		env.Close()
 
 		// Compute credential index (subject=gw, issuer=carol).
 		var credIdx string
 		if supportsCredentials {
-			credIdx = dp.CredentialIndex(gw, carol, credType)
+			credIdx = dp.CredentialIndexHex(gw, carol, credType)
 		} else {
 			credIdx = "48004829F915654A81B11C4AB8218D96FED67F209B58328A72314FB6EA288BE4"
 		}
@@ -578,7 +592,7 @@ func TestDepositPreauth_CredentialsPayment(t *testing.T) {
 
 		// Setup credential-based DepositPreauth fails — amendment not supported.
 		result := env.Submit(dp.AuthCredentials(bob, []dp.AuthorizeCredentials{
-			{Issuer: issuer, CredType: credType},
+			{Issuer: issuer, CredTypeText: credType},
 		}).Build())
 		require.Equal(t, "temDISABLED", result.Code)
 		env.Close()
@@ -610,12 +624,12 @@ func TestDepositPreauth_CredentialsPayment(t *testing.T) {
 		env.Close()
 
 		// Issuer creates credential for Alice, Alice hasn't accepted yet.
-		result := env.Submit(credential.CredentialCreate(issuer, alice, credType).Build())
+		result := env.Submit(credential.CredentialCreateText(issuer, alice, credType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
 		// Get the credential index.
-		credIdx := dp.CredentialIndex(alice, issuer, credType)
+		credIdx := dp.CredentialIndexHex(alice, issuer, credType)
 
 		// Bob requires preauthorization.
 		env.EnableDepositAuth(bob)
@@ -623,7 +637,7 @@ func TestDepositPreauth_CredentialsPayment(t *testing.T) {
 
 		// Bob accepts payments from accounts with credentials signed by 'issuer'.
 		result = env.Submit(dp.AuthCredentials(bob, []dp.AuthorizeCredentials{
-			{Issuer: issuer, CredType: credType},
+			{Issuer: issuer, CredTypeText: credType},
 		}).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -647,7 +661,7 @@ func TestDepositPreauth_CredentialsPayment(t *testing.T) {
 		env.Close()
 
 		// Alice accepts the credentials.
-		result = env.Submit(credential.CredentialAccept(alice, issuer, credType).Build())
+		result = env.Submit(credential.CredentialAcceptText(alice, issuer, credType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
@@ -693,14 +707,14 @@ func TestDepositPreauth_CredentialsPayment(t *testing.T) {
 		env.Close()
 
 		// Issuer creates credential for alice, then alice accepts.
-		result := env.Submit(credential.CredentialCreate(issuer, alice, credType).Build())
+		result := env.Submit(credential.CredentialCreateText(issuer, alice, credType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
-		result = env.Submit(credential.CredentialAccept(alice, issuer, credType).Build())
+		result = env.Submit(credential.CredentialAcceptText(alice, issuer, credType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		credIdx := dp.CredentialIndex(alice, issuer, credType)
+		credIdx := dp.CredentialIndexHex(alice, issuer, credType)
 
 		// Success: destination didn't enable preauthorization, so valid credentials won't fail.
 		result = env.Submit(
@@ -724,14 +738,14 @@ func TestDepositPreauth_CredentialsPayment(t *testing.T) {
 
 		// Bob tries to setup DepositPreauth with duplicates — not allowed.
 		result = env.Submit(dp.AuthCredentials(bob, []dp.AuthorizeCredentials{
-			{Issuer: issuer, CredType: credType},
-			{Issuer: issuer, CredType: credType},
+			{Issuer: issuer, CredTypeText: credType},
+			{Issuer: issuer, CredTypeText: credType},
 		}).Build())
 		require.Equal(t, "temMALFORMED", result.Code)
 
 		// Bob sets up DepositPreauth correctly.
 		result = env.Submit(dp.AuthCredentials(bob, []dp.AuthorizeCredentials{
-			{Issuer: issuer, CredType: credType},
+			{Issuer: issuer, CredTypeText: credType},
 		}).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -755,14 +769,14 @@ func TestDepositPreauth_CredentialsPayment(t *testing.T) {
 
 		// Create another valid credential for alice with different type.
 		credType2 := "fghij"
-		result = env.Submit(credential.CredentialCreate(issuer, alice, credType2).Build())
+		result = env.Submit(credential.CredentialCreateText(issuer, alice, credType2).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
-		result = env.Submit(credential.CredentialAccept(alice, issuer, credType2).Build())
+		result = env.Submit(credential.CredentialAcceptText(alice, issuer, credType2).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		credIdx2 := dp.CredentialIndex(alice, issuer, credType2)
+		credIdx2 := dp.CredentialIndexHex(alice, issuer, credType2)
 
 		// Alice can't pay with invalid set of valid credentials (wrong combination).
 		result = env.Submit(
@@ -898,7 +912,7 @@ func TestDepositPreauth_CredentialsCreation(t *testing.T) {
 	// Empty credential type.
 	t.Run("EmptyCredType", func(t *testing.T) {
 		result := env.Submit(dp.AuthCredentials(bob, []dp.AuthorizeCredentials{
-			{Issuer: issuer, CredType: ""},
+			{Issuer: issuer, CredTypeText: ""},
 		}).Build())
 		require.Equal(t, "temMALFORMED", result.Code)
 	})
@@ -914,7 +928,7 @@ func TestDepositPreauth_CredentialsCreation(t *testing.T) {
 
 		creds := make([]dp.AuthorizeCredentials, 9)
 		for i, acc := range accounts {
-			creds[i] = dp.AuthorizeCredentials{Issuer: acc, CredType: credType}
+			creds[i] = dp.AuthorizeCredentials{Issuer: acc, CredTypeText: credType}
 		}
 		result := env.Submit(dp.AuthCredentials(bob, creds).Build())
 		require.Equal(t, "temARRAY_TOO_LARGE", result.Code)
@@ -924,7 +938,7 @@ func TestDepositPreauth_CredentialsCreation(t *testing.T) {
 	t.Run("NonExistingIssuer", func(t *testing.T) {
 		rick := jtx.NewAccount("rick")
 		result := env.Submit(dp.AuthCredentials(bob, []dp.AuthorizeCredentials{
-			{Issuer: rick, CredType: credType},
+			{Issuer: rick, CredTypeText: credType},
 		}).Build())
 		require.Equal(t, "tecNO_ISSUER", result.Code)
 		env.Close()
@@ -937,7 +951,7 @@ func TestDepositPreauth_CredentialsCreation(t *testing.T) {
 		env.Close()
 
 		result := env.Submit(dp.AuthCredentials(john, []dp.AuthorizeCredentials{
-			{Issuer: issuer, CredType: credType},
+			{Issuer: issuer, CredTypeText: credType},
 		}).Build())
 		require.Equal(t, "tecINSUFFICIENT_RESERVE", result.Code)
 	})
@@ -945,33 +959,52 @@ func TestDepositPreauth_CredentialsCreation(t *testing.T) {
 	// No deposit object exists for unauthorize.
 	t.Run("NoEntryForUnauth", func(t *testing.T) {
 		result := env.Submit(dp.UnauthCredentials(bob, []dp.AuthorizeCredentials{
-			{Issuer: issuer, CredType: credType},
+			{Issuer: issuer, CredTypeText: credType},
 		}).Build())
 		require.Equal(t, "tecNO_ENTRY", result.Code)
 	})
 
-	// Create DepositPreauth object with credentials.
-	t.Run("CreateCredentialPreauth", func(t *testing.T) {
+	t.Run("CredentialAuthorizationLifecycle", func(t *testing.T) {
+		preauthKey := keylet.DepositPreauthCredentials(bob.ID, []keylet.CredentialPair{{
+			Issuer: issuer.ID, CredentialType: []byte(credType),
+		}})
+		jtx.RequireOwnerCount(t, env, bob, 0)
 		result := env.Submit(dp.AuthCredentials(bob, []dp.AuthorizeCredentials{
-			{Issuer: issuer, CredType: credType},
+			{Issuer: issuer, CredTypeText: credType},
 		}).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
+		jtx.RequireLedgerEntryExists(t, env, preauthKey)
+		jtx.RequireOwnerDirectoryContains(t, env, bob, preauthKey.Key, true)
+		jtx.RequireOwnerCount(t, env, bob, 1)
+		data, err := env.LedgerEntry(preauthKey)
+		require.NoError(t, err)
+		stored := &ledgerentry.DepositPreauth{}
+		require.NoError(t, stored.Decode(data))
+		require.Equal(t, bob.Address, stored.Account)
+		require.Equal(t, "0", stored.OwnerNode)
+		require.Equal(t, []any{map[string]any{
+			"Credential": map[string]any{
+				"Issuer": issuer.Address, "CredentialType": hex.EncodeToString([]byte(credType)),
+			},
+		}}, stored.AuthorizeCredentials)
 
-		// Can't create duplicate.
 		result = env.Submit(dp.AuthCredentials(bob, []dp.AuthorizeCredentials{
-			{Issuer: issuer, CredType: credType},
+			{Issuer: issuer, CredTypeText: credType},
 		}).Build())
 		require.Equal(t, "tecDUPLICATE", result.Code)
-	})
+		env.Close()
+		jtx.RequireLedgerEntryExists(t, env, preauthKey)
+		jtx.RequireOwnerCount(t, env, bob, 1)
 
-	// Delete DepositPreauth object with credentials.
-	t.Run("DeleteCredentialPreauth", func(t *testing.T) {
-		result := env.Submit(dp.UnauthCredentials(bob, []dp.AuthorizeCredentials{
-			{Issuer: issuer, CredType: credType},
+		result = env.Submit(dp.UnauthCredentials(bob, []dp.AuthorizeCredentials{
+			{Issuer: issuer, CredTypeText: credType},
 		}).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
+		jtx.RequireLedgerEntryNotExists(t, env, preauthKey)
+		jtx.RequireOwnerDirectoryContains(t, env, bob, preauthKey.Key, false)
+		jtx.RequireOwnerCount(t, env, bob, 0)
 	})
 }
 
@@ -1003,7 +1036,7 @@ func TestDepositPreauth_ExpiredCreds(t *testing.T) {
 		now := env.NowRipple()
 		expiration := now + 60
 		result := env.Submit(
-			credential.CredentialCreate(issuer, alice, credType).
+			credential.CredentialCreateText(issuer, alice, credType).
 				Expiration(expiration).
 				Build(),
 		)
@@ -1011,28 +1044,28 @@ func TestDepositPreauth_ExpiredCreds(t *testing.T) {
 		env.Close()
 
 		// Alice accepts credentials.
-		result = env.Submit(credential.CredentialAccept(alice, issuer, credType).Build())
+		result = env.Submit(credential.CredentialAcceptText(alice, issuer, credType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
 		// Issuer creates non-expiring credential for alice (expiration far in the future).
 		now = env.NowRipple()
 		result = env.Submit(
-			credential.CredentialCreate(issuer, alice, credType2).
+			credential.CredentialCreateText(issuer, alice, credType2).
 				Expiration(now + 1000).
 				Build(),
 		)
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
-		result = env.Submit(credential.CredentialAccept(alice, issuer, credType2).Build())
+		result = env.Submit(credential.CredentialAcceptText(alice, issuer, credType2).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
 		jtx.RequireOwnerCount(t, env, issuer, 0)
 		jtx.RequireOwnerCount(t, env, alice, 2)
 
-		credIdx := dp.CredentialIndex(alice, issuer, credType)
-		credIdx2 := dp.CredentialIndex(alice, issuer, credType2)
+		credIdx := dp.CredentialIndexHex(alice, issuer, credType)
+		credIdx2 := dp.CredentialIndexHex(alice, issuer, credType2)
 
 		// Bob requires preauthorization.
 		env.EnableDepositAuth(bob)
@@ -1040,8 +1073,8 @@ func TestDepositPreauth_ExpiredCreds(t *testing.T) {
 
 		// Bob sets up credential-based preauth for both credential types.
 		result = env.Submit(dp.AuthCredentials(bob, []dp.AuthorizeCredentials{
-			{Issuer: issuer, CredType: credType},
-			{Issuer: issuer, CredType: credType2},
+			{Issuer: issuer, CredTypeText: credType},
+			{Issuer: issuer, CredTypeText: credType2},
 		}).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -1081,17 +1114,17 @@ func TestDepositPreauth_ExpiredCreds(t *testing.T) {
 		// Additional test: issuer creates credential for gw with short expiration.
 		now = env.NowRipple()
 		result = env.Submit(
-			credential.CredentialCreate(issuer, gw, credType).
+			credential.CredentialCreateText(issuer, gw, credType).
 				Expiration(now + 40).
 				Build(),
 		)
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
-		result = env.Submit(credential.CredentialAccept(gw, issuer, credType).Build())
+		result = env.Submit(credential.CredentialAcceptText(gw, issuer, credType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		gwCredIdx := dp.CredentialIndex(gw, issuer, credType)
+		gwCredIdx := dp.CredentialIndexHex(gw, issuer, credType)
 
 		jtx.RequireOwnerCount(t, env, issuer, 0)
 		jtx.RequireOwnerCount(t, env, gw, 1)
@@ -1133,7 +1166,7 @@ func TestDepositPreauth_ExpiredCreds(t *testing.T) {
 		// Issuer creates credential for zelda with short expiration.
 		now := env.NowRipple()
 		result := env.Submit(
-			credential.CredentialCreate(issuer, zelda, credType).
+			credential.CredentialCreateText(issuer, zelda, credType).
 				Expiration(now + 50).
 				Build(),
 		)
@@ -1141,11 +1174,11 @@ func TestDepositPreauth_ExpiredCreds(t *testing.T) {
 		env.Close()
 
 		// Zelda accepts credentials.
-		result = env.Submit(credential.CredentialAccept(zelda, issuer, credType).Build())
+		result = env.Submit(credential.CredentialAcceptText(zelda, issuer, credType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		credIdx := dp.CredentialIndex(zelda, issuer, credType)
+		credIdx := dp.CredentialIndexHex(zelda, issuer, credType)
 
 		// Bob requires preauthorization.
 		env.EnableDepositAuth(bob)
@@ -1153,44 +1186,59 @@ func TestDepositPreauth_ExpiredCreds(t *testing.T) {
 
 		// Bob sets up credential-based preauth.
 		result = env.Submit(dp.AuthCredentials(bob, []dp.AuthorizeCredentials{
-			{Issuer: issuer, CredType: credType},
+			{Issuer: issuer, CredTypeText: credType},
 		}).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// Create escrow from alice to bob.
-		// Note: This test requires escrow support. The escrow is created with
-		// a finish time 1 second in the future so zelda can try to finish it
-		// with credentials.
 		aliceSeq := env.Seq(alice)
-		finishTime := env.Now().Add(1 * time.Second)
-		_ = aliceSeq
-		_ = finishTime
-		// TODO: Integrate with escrow builder when available.
-		// For now, test the credential validation logic directly.
-
-		// zelda can't finish escrow with empty credentials.
-		// env(escrow::finish(zelda, alice, seq), credentials::ids({}), ter(temMALFORMED))
-
-		// zelda can't finish with invalid credentials.
-		// invalidIdx := "0E0B04ED60588A758B67E21FBBE95AC5A63598BA951761DC0EC9C08D7E01E034"
-		// env(escrow::finish(zelda, alice, seq), credentials::ids({invalidIdx}), ter(tecBAD_CREDENTIALS))
-
-		// Advance time past expiration.
-		env.AdvanceTime(60 * time.Second)
+		escrowKey := keylet.Escrow(alice.ID, aliceSeq)
+		bobBalance := env.Balance(bob)
+		result = env.Submit(
+			escrow.EscrowCreate(alice, bob, jtx.XRP(1000)).
+				FinishAfter(env.NowRipple() + 1).
+				Build(),
+		)
+		jtx.RequireTxSuccess(t, result)
 		env.Close()
+		require.True(t, env.LedgerEntryExists(escrowKey))
+		jtx.RequireOwnerCount(t, env, alice, 1)
+		require.Equal(t, bobBalance, env.Balance(bob))
+
+		result = env.Submit(
+			escrow.EscrowFinish(zelda, alice, aliceSeq).
+				CredentialIDs([]string{}).
+				Build(),
+		)
+		require.Equal(t, "temMALFORMED", result.Code)
+		env.Close()
+		require.True(t, env.LedgerEntryExists(escrowKey))
+
+		invalidIdx := "0E0B04ED60588A758B67E21FBBE95AC5A63598BA951761DC0EC9C08D7E01E034"
+		result = env.Submit(
+			escrow.EscrowFinish(zelda, alice, aliceSeq).
+				CredentialIDs([]string{invalidIdx}).
+				Build(),
+		)
+		require.Equal(t, "tecBAD_CREDENTIALS", result.Code)
+		env.Close()
+		require.True(t, env.LedgerEntryExists(escrowKey))
+
+		result = env.Submit(
+			escrow.EscrowFinish(zelda, alice, aliceSeq).
+				CredentialIDs([]string{credIdx}).
+				Fee(1500).
+				Build(),
+		)
+		require.Equal(t, "tecEXPIRED", result.Code)
 		env.Close()
 
-		// zelda's credentials are now expired. Using them should return tecEXPIRED
-		// and the expired credentials should be deleted.
-		_ = credIdx
-
-		// Verify expired credentials were deleted.
 		zeldaCredKey := jtx.CredentialKeylet(zelda, issuer, credType)
-		// After the escrow finish attempt with expired creds, the credential should be deleted.
-		// Since we can't fully test escrow here, at least verify the credential still exists
-		// (it will be deleted when a transaction attempts to use it after expiration).
-		_ = zeldaCredKey
+		require.False(t, env.LedgerEntryExists(zeldaCredKey))
+		require.True(t, env.LedgerEntryExists(escrowKey))
+		jtx.RequireOwnerCount(t, env, zelda, 0)
+		jtx.RequireOwnerCount(t, env, alice, 1)
+		require.Equal(t, bobBalance, env.Balance(bob))
 	})
 }
 
@@ -1223,17 +1271,28 @@ func TestDepositPreauth_SortingCredentials(t *testing.T) {
 	credentials := make([]dp.AuthorizeCredentials, 8)
 	for i := range credentials {
 		credentials[i] = dp.AuthorizeCredentials{
-			Issuer:   issuers[i],
-			CredType: credTypes[i],
+			Issuer:       issuers[i],
+			CredTypeText: credTypes[i],
 		}
 	}
+	expectedCredentials := append([]dp.AuthorizeCredentials(nil), credentials...)
+	sort.Slice(expectedCredentials, func(i, j int) bool {
+		if cmp := bytes.Compare(expectedCredentials[i].Issuer.ID[:], expectedCredentials[j].Issuer.ID[:]); cmp != 0 {
+			return cmp < 0
+		}
+		return expectedCredentials[i].CredTypeText < expectedCredentials[j].CredTypeText
+	})
+	credentialPairs := make([]keylet.CredentialPair, len(credentials))
+	for i, credential := range credentials {
+		credentialPairs[i] = keylet.CredentialPair{
+			Issuer:         credential.Issuer.ID,
+			CredentialType: []byte(credential.CredTypeText),
+		}
+	}
+	preauthKey := keylet.DepositPreauthCredentials(stock.ID, credentialPairs)
 
 	// Sorting in ledger object: credentials should be sorted regardless of input order.
 	t.Run("SortingInObject", func(t *testing.T) {
-		// Shuffle and create, verify sorted in ledger.
-		// Since we can't easily read the ledger entry's AuthorizeCredentials field
-		// in Go (unlike rippled's ledger_entry RPC), we verify that creation and
-		// deletion work correctly regardless of input order.
 		for i := range 10 {
 			// Rotate the credentials array to get different orderings.
 			rotated := make([]dp.AuthorizeCredentials, len(credentials))
@@ -1247,10 +1306,31 @@ func TestDepositPreauth_SortingCredentials(t *testing.T) {
 			jtx.RequireTxSuccess(t, result)
 			env.Close()
 
-			// Delete with original order should also work (sorted internally).
-			result = env.Submit(dp.UnauthCredentials(stock, rotated).Build())
+			data, err := env.LedgerEntry(preauthKey)
+			require.NoError(t, err)
+			stored := &ledgerentry.DepositPreauth{}
+			require.NoError(t, stored.Decode(data))
+			require.Len(t, stored.AuthorizeCredentials, len(expectedCredentials))
+			for index, value := range stored.AuthorizeCredentials {
+				wrapper, ok := value.(map[string]any)
+				require.True(t, ok)
+				credential, ok := wrapper["Credential"].(map[string]any)
+				require.True(t, ok)
+				require.Equal(t, expectedCredentials[index].Issuer.Address, credential["Issuer"])
+				require.Equal(t,
+					hex.EncodeToString([]byte(expectedCredentials[index].CredTypeText)),
+					credential["CredentialType"],
+				)
+			}
+
+			deleteOrder := make([]dp.AuthorizeCredentials, len(credentials))
+			for j := range deleteOrder {
+				deleteOrder[j] = credentials[(len(credentials)-1-j+i)%len(credentials)]
+			}
+			result = env.Submit(dp.UnauthCredentials(stock, deleteOrder).Build())
 			jtx.RequireTxSuccess(t, result)
 			env.Close()
+			require.False(t, env.LedgerEntryExists(preauthKey))
 		}
 	})
 
@@ -1272,6 +1352,11 @@ func TestDepositPreauth_SortingCredentials(t *testing.T) {
 			result := env.Submit(dp.AuthCredentials(stock, rotated).Build())
 			require.Equal(t, "tecDUPLICATE", result.Code)
 		}
+
+		result = env.Submit(dp.UnauthCredentials(stock, credentials).Build())
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		require.False(t, env.LedgerEntryExists(preauthKey))
 	})
 
 	// Duplicate credentials in DepositPreauth params.
@@ -1294,14 +1379,14 @@ func TestDepositPreauth_SortingCredentials(t *testing.T) {
 		// Create credentials for alice and save their hashes.
 		credentialIDs := make([]string, len(credentials))
 		for i, c := range credentials {
-			result := env.Submit(credential.CredentialCreate(c.Issuer, alice, c.CredType).Build())
+			result := env.Submit(credential.CredentialCreateText(c.Issuer, alice, c.CredTypeText).Build())
 			jtx.RequireTxSuccess(t, result)
 			env.Close()
-			result = env.Submit(credential.CredentialAccept(alice, c.Issuer, c.CredType).Build())
+			result = env.Submit(credential.CredentialAcceptText(alice, c.Issuer, c.CredTypeText).Build())
 			jtx.RequireTxSuccess(t, result)
 			env.Close()
 
-			credentialIDs[i] = dp.CredentialIndex(alice, c.Issuer, c.CredType)
+			credentialIDs[i] = dp.CredentialIndexHex(alice, c.Issuer, c.CredTypeText)
 		}
 
 		// Check duplicates in payment params.

--- a/internal/testing/depositpreauth/precedence_test.go
+++ b/internal/testing/depositpreauth/precedence_test.go
@@ -7,6 +7,7 @@ import (
 	dp "github.com/LeJamon/go-xrpl/internal/testing/depositpreauth"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/depositpreauth"
+	"github.com/LeJamon/go-xrpl/keylet"
 )
 
 // TestDepositPreauth_Precedence_FullyCanonicalSigAllowed pins finding #1: a
@@ -24,7 +25,7 @@ func TestDepositPreauth_Precedence_FullyCanonicalSigAllowed(t *testing.T) {
 
 	result := env.Submit(dp.Auth(alice, becky).Flags(tx.TfFullyCanonicalSig).Build())
 	jtx.RequireTxSuccess(t, result)
-	jtx.RequireLedgerEntryExists(t, env, dp.DepositPreauthKeylet(alice, becky))
+	jtx.RequireLedgerEntryExists(t, env, keylet.DepositPreauth(alice.ID, becky.ID))
 }
 
 // TestDepositPreauth_Precedence_EmptyCredentialsDisabledAmendment pins finding #6:

--- a/internal/testing/depositpreauth/verify_deposit_preauth_test.go
+++ b/internal/testing/depositpreauth/verify_deposit_preauth_test.go
@@ -39,17 +39,17 @@ func TestDepositAuth_ExpiredCredentialsReserveExemption(t *testing.T) {
 	// Issuer creates a soon-to-expire credential for alice; alice accepts.
 	expiration := env.NowRipple() + 50
 	result := env.Submit(
-		credential.CredentialCreate(issuer, alice, credType).
+		credential.CredentialCreateText(issuer, alice, credType).
 			Expiration(expiration).
 			Build(),
 	)
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
-	result = env.Submit(credential.CredentialAccept(alice, issuer, credType).Build())
+	result = env.Submit(credential.CredentialAcceptText(alice, issuer, credType).Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
 
-	credIdx := dp.CredentialIndex(alice, issuer, credType)
+	credIdx := dp.CredentialIndexHex(alice, issuer, credType)
 	credKey := jtx.CredentialKeylet(alice, issuer, credType)
 
 	// Bring bob's XRP balance down to exactly the base reserve.
@@ -130,17 +130,17 @@ func TestPayment_ExpiredCredentialsNoDepositAuthDestination(t *testing.T) {
 	// Issuer creates a soon-to-expire credential for alice; alice accepts.
 	expiration := env.NowRipple() + 50
 	result = env.Submit(
-		credential.CredentialCreate(issuer, alice, credType).
+		credential.CredentialCreateText(issuer, alice, credType).
 			Expiration(expiration).
 			Build(),
 	)
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
-	result = env.Submit(credential.CredentialAccept(alice, issuer, credType).Build())
+	result = env.Submit(credential.CredentialAcceptText(alice, issuer, credType).Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
 
-	credIdx := dp.CredentialIndex(alice, issuer, credType)
+	credIdx := dp.CredentialIndexHex(alice, issuer, credType)
 	credKey := jtx.CredentialKeylet(alice, issuer, credType)
 
 	// Let the credential expire.
@@ -192,17 +192,17 @@ func TestMPTPayment_CanTransferCheckedBeforeDepositPreauth(t *testing.T) {
 	// Issuer creates a soon-to-expire credential for bob; bob accepts.
 	expiration := env.NowRipple() + 50
 	result := env.Submit(
-		credential.CredentialCreate(issuer, bob, credType).
+		credential.CredentialCreateText(issuer, bob, credType).
 			Expiration(expiration).
 			Build(),
 	)
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
-	result = env.Submit(credential.CredentialAccept(bob, issuer, credType).Build())
+	result = env.Submit(credential.CredentialAcceptText(bob, issuer, credType).Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
 
-	credIdx := dp.CredentialIndex(bob, issuer, credType)
+	credIdx := dp.CredentialIndexHex(bob, issuer, credType)
 	credKey := jtx.CredentialKeylet(bob, issuer, credType)
 
 	// Let the credential expire.

--- a/internal/testing/escrow/escrow_test.go
+++ b/internal/testing/escrow/escrow_test.go
@@ -2046,11 +2046,11 @@ func TestEscrow_Credentials(t *testing.T) {
 		credType := "abcde"
 
 		// Create credential: zelda issues to carol
-		result := env.Submit(credential.CredentialCreate(zelda, carol, credType).Build())
+		result := env.Submit(credential.CredentialCreateText(zelda, carol, credType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		credIdx := dp.CredentialIndex(carol, zelda, credType)
+		credIdx := dp.CredentialIndexHex(carol, zelda, credType)
 
 		seq := env.Seq(alice)
 		result = env.Submit(
@@ -2073,7 +2073,7 @@ func TestEscrow_Credentials(t *testing.T) {
 		env.Close()
 
 		// Accept the credential
-		result = env.Submit(credential.CredentialAccept(carol, zelda, credType).Build())
+		result = env.Submit(credential.CredentialAcceptText(carol, zelda, credType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
@@ -2094,7 +2094,7 @@ func TestEscrow_Credentials(t *testing.T) {
 		// Bob authorizes credentials from zelda with this credType
 		result = env.Submit(
 			dp.AuthCredentials(bob, []dp.AuthorizeCredentials{
-				{Issuer: zelda, CredType: credType},
+				{Issuer: zelda, CredTypeText: credType},
 			}).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -2123,14 +2123,14 @@ func TestEscrow_Credentials(t *testing.T) {
 
 		credType := "abcde"
 
-		result := env.Submit(credential.CredentialCreate(zelda, carol, credType).Build())
+		result := env.Submit(credential.CredentialCreateText(zelda, carol, credType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
-		result = env.Submit(credential.CredentialAccept(carol, zelda, credType).Build())
+		result = env.Submit(credential.CredentialAcceptText(carol, zelda, credType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		credIdx := dp.CredentialIndex(carol, zelda, credType)
+		credIdx := dp.CredentialIndexHex(carol, zelda, credType)
 
 		seq := env.Seq(alice)
 		result = env.Submit(
@@ -2156,14 +2156,14 @@ func TestEscrow_Credentials(t *testing.T) {
 
 		// Test: use any valid credentials if account == dst
 		credType2 := "fghijk"
-		result = env.Submit(credential.CredentialCreate(zelda, bob, credType2).Build())
+		result = env.Submit(credential.CredentialCreateText(zelda, bob, credType2).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
-		result = env.Submit(credential.CredentialAccept(bob, zelda, credType2).Build())
+		result = env.Submit(credential.CredentialAcceptText(bob, zelda, credType2).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		credIdxBob := dp.CredentialIndex(bob, zelda, credType2)
+		credIdxBob := dp.CredentialIndexHex(bob, zelda, credType2)
 
 		seq2 := env.Seq(alice)
 		result = env.Submit(
@@ -2178,7 +2178,7 @@ func TestEscrow_Credentials(t *testing.T) {
 		env.Close()
 		result = env.Submit(
 			dp.AuthCredentials(bob, []dp.AuthorizeCredentials{
-				{Issuer: zelda, CredType: credType},
+				{Issuer: zelda, CredTypeText: credType},
 			}).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()

--- a/internal/testing/paychan/paychan_test.go
+++ b/internal/testing/paychan/paychan_test.go
@@ -1158,13 +1158,13 @@ func TestPayChan_DepositAuthCreds(t *testing.T) {
 		// Create credentials with expiration
 		{
 			expTime := ToRippleTime(env.Now()) + 100
-			result := env.Submit(credential.CredentialCreate(carol, alice, credType).
+			result := env.Submit(credential.CredentialCreateText(carol, alice, credType).
 				Expiration(expTime).Build())
 			jtx.RequireTxSuccess(t, result)
 			env.Close()
 		}
 
-		credIdx := depositpreauth.CredentialIndex(alice, carol, credType)
+		credIdx := depositpreauth.CredentialIndexHex(alice, carol, credType)
 
 		// Bob requires preauthorization
 		env.EnableDepositAuth(bob)
@@ -1177,7 +1177,7 @@ func TestPayChan_DepositAuthCreds(t *testing.T) {
 		env.Close()
 
 		// Accept credentials
-		result = env.Submit(credential.CredentialAccept(alice, carol, credType).Build())
+		result = env.Submit(credential.CredentialAcceptText(alice, carol, credType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
@@ -1189,7 +1189,7 @@ func TestPayChan_DepositAuthCreds(t *testing.T) {
 
 		// Setup deposit authorization with credentials
 		result = env.Submit(depositpreauth.AuthCredentials(bob, []depositpreauth.AuthorizeCredentials{
-			{Issuer: carol, CredType: credType},
+			{Issuer: carol, CredTypeText: credType},
 		}).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -1228,15 +1228,15 @@ func TestPayChan_DepositAuthCreds(t *testing.T) {
 
 		// Create credentials once more (without expiration)
 		{
-			result := env.Submit(credential.CredentialCreate(carol, alice, credType).Build())
+			result := env.Submit(credential.CredentialCreateText(carol, alice, credType).Build())
 			jtx.RequireTxSuccess(t, result)
 			env.Close()
 
-			result = env.Submit(credential.CredentialAccept(alice, carol, credType).Build())
+			result = env.Submit(credential.CredentialAcceptText(alice, carol, credType).Build())
 			jtx.RequireTxSuccess(t, result)
 			env.Close()
 
-			credIdx2 := depositpreauth.CredentialIndex(alice, carol, credType)
+			credIdx2 := depositpreauth.CredentialIndexHex(alice, carol, credType)
 
 			// Success
 			result = env.Submit(ChannelClaim(alice, chanIDHex).
@@ -1274,15 +1274,15 @@ func TestPayChan_DepositAuthCreds(t *testing.T) {
 		delta := xrp(500)
 
 		// Create and accept credentials
-		result = env.Submit(credential.CredentialCreate(carol, alice, credType).Build())
+		result = env.Submit(credential.CredentialCreateText(carol, alice, credType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		result = env.Submit(credential.CredentialAccept(alice, carol, credType).Build())
+		result = env.Submit(credential.CredentialAcceptText(alice, carol, credType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		credIdx := depositpreauth.CredentialIndex(alice, carol, credType)
+		credIdx := depositpreauth.CredentialIndexHex(alice, carol, credType)
 
 		// Succeed, lsfDepositAuth is not set
 		result = env.Submit(ChannelClaim(alice, chanIDHex).
@@ -1826,19 +1826,19 @@ func TestPayChan_CredentialExpirySemantics(t *testing.T) {
 
 	expiration := ToRippleTime(env.Now()) + 1000
 	jtx.RequireTxSuccess(t, env.Submit(
-		credential.CredentialCreate(carol, alice, credType).Expiration(expiration).Build()))
+		credential.CredentialCreateText(carol, alice, credType).Expiration(expiration).Build()))
 	env.Close()
-	jtx.RequireTxSuccess(t, env.Submit(credential.CredentialAccept(alice, carol, credType).Build()))
+	jtx.RequireTxSuccess(t, env.Submit(credential.CredentialAcceptText(alice, carol, credType).Build()))
 	env.Close()
 
-	credIdx := depositpreauth.CredentialIndex(alice, carol, credType)
+	credIdx := depositpreauth.CredentialIndexHex(alice, carol, credType)
 	credK := keylet.Credential(alice.ID, carol.ID, []byte(credType))
 
 	// Bob requires deposit authorization, satisfied via the credential.
 	env.EnableDepositAuth(bob)
 	env.Close()
 	jtx.RequireTxSuccess(t, env.Submit(depositpreauth.AuthCredentials(bob, []depositpreauth.AuthorizeCredentials{
-		{Issuer: carol, CredType: credType},
+		{Issuer: carol, CredTypeText: credType},
 	}).Build()))
 	env.Close()
 
@@ -1895,12 +1895,12 @@ func TestPayChan_ExpiredCredentialWithoutBalanceClaim(t *testing.T) {
 
 	expiration := ToRippleTime(env.Now()) + 20
 	jtx.RequireTxSuccess(t, env.Submit(
-		credential.CredentialCreate(carol, alice, credType).Expiration(expiration).Build()))
+		credential.CredentialCreateText(carol, alice, credType).Expiration(expiration).Build()))
 	env.Close()
-	jtx.RequireTxSuccess(t, env.Submit(credential.CredentialAccept(alice, carol, credType).Build()))
+	jtx.RequireTxSuccess(t, env.Submit(credential.CredentialAcceptText(alice, carol, credType).Build()))
 	env.Close()
 
-	credIdx := depositpreauth.CredentialIndex(alice, carol, credType)
+	credIdx := depositpreauth.CredentialIndexHex(alice, carol, credType)
 	credK := keylet.Credential(alice.ID, carol.ID, []byte(credType))
 
 	// Advance well past the credential expiration.

--- a/internal/testing/payment/depositauth_test.go
+++ b/internal/testing/payment/depositauth_test.go
@@ -624,12 +624,12 @@ func TestDepositPreauth_Credentials(t *testing.T) {
 	env.Close()
 
 	// issuer creates credential for alice, alice hasn't accepted yet.
-	result := env.Submit(credential.CredentialCreate(issuer, alice, credType).Build())
+	result := env.Submit(credential.CredentialCreateText(issuer, alice, credType).Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
 
 	// Get the credential index.
-	credIdx := dp.CredentialIndex(alice, issuer, credType)
+	credIdx := dp.CredentialIndexHex(alice, issuer, credType)
 
 	// bob requires preauthorization.
 	env.EnableDepositAuth(bob)
@@ -637,7 +637,7 @@ func TestDepositPreauth_Credentials(t *testing.T) {
 
 	// bob accepts payments from accounts with credentials signed by 'issuer'.
 	result = env.Submit(dp.AuthCredentials(bob, []dp.AuthorizeCredentials{
-		{Issuer: issuer, CredType: credType},
+		{Issuer: issuer, CredTypeText: credType},
 	}).Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
@@ -663,7 +663,7 @@ func TestDepositPreauth_Credentials(t *testing.T) {
 	env.Close()
 
 	// alice accepts the credentials.
-	result = env.Submit(credential.CredentialAccept(alice, issuer, credType).Build())
+	result = env.Submit(credential.CredentialAcceptText(alice, issuer, credType).Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
 
@@ -718,14 +718,14 @@ func TestDepositPreauth_Credentials(t *testing.T) {
 		env2.Close()
 
 		// issuer creates credential for alice, alice accepts.
-		result := env2.Submit(credential.CredentialCreate(issuer2, alice2, credType).Build())
+		result := env2.Submit(credential.CredentialCreateText(issuer2, alice2, credType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env2.Close()
-		result = env2.Submit(credential.CredentialAccept(alice2, issuer2, credType).Build())
+		result = env2.Submit(credential.CredentialAcceptText(alice2, issuer2, credType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env2.Close()
 
-		credIdx := dp.CredentialIndex(alice2, issuer2, credType)
+		credIdx := dp.CredentialIndexHex(alice2, issuer2, credType)
 
 		// Success: destination didn't enable preauthorization, so valid
 		// credentials won't fail.
@@ -750,14 +750,14 @@ func TestDepositPreauth_Credentials(t *testing.T) {
 
 		// bob tries to set up DepositPreauth with duplicates - not allowed.
 		result = env2.Submit(dp.AuthCredentials(bob2, []dp.AuthorizeCredentials{
-			{Issuer: issuer2, CredType: credType},
-			{Issuer: issuer2, CredType: credType},
+			{Issuer: issuer2, CredTypeText: credType},
+			{Issuer: issuer2, CredTypeText: credType},
 		}).Build())
 		require.Equal(t, "temMALFORMED", result.Code)
 
 		// bob sets up DepositPreauth correctly.
 		result = env2.Submit(dp.AuthCredentials(bob2, []dp.AuthorizeCredentials{
-			{Issuer: issuer2, CredType: credType},
+			{Issuer: issuer2, CredTypeText: credType},
 		}).Build())
 		jtx.RequireTxSuccess(t, result)
 		env2.Close()
@@ -781,14 +781,14 @@ func TestDepositPreauth_Credentials(t *testing.T) {
 
 		// Create another valid credential for alice with different type.
 		credType2 := "fghij"
-		result = env2.Submit(credential.CredentialCreate(issuer2, alice2, credType2).Build())
+		result = env2.Submit(credential.CredentialCreateText(issuer2, alice2, credType2).Build())
 		jtx.RequireTxSuccess(t, result)
 		env2.Close()
-		result = env2.Submit(credential.CredentialAccept(alice2, issuer2, credType2).Build())
+		result = env2.Submit(credential.CredentialAcceptText(alice2, issuer2, credType2).Build())
 		jtx.RequireTxSuccess(t, result)
 		env2.Close()
 
-		credIdx2 := dp.CredentialIndex(alice2, issuer2, credType2)
+		credIdx2 := dp.CredentialIndexHex(alice2, issuer2, credType2)
 
 		// alice can't pay with invalid set of valid credentials (wrong combination).
 		result = env2.Submit(
@@ -843,7 +843,7 @@ func TestDepositPreauth_ExpiredCredentials(t *testing.T) {
 	now := env.NowRipple()
 	expiration := now + 60
 	result := env.Submit(
-		credential.CredentialCreate(issuer, alice, credType).
+		credential.CredentialCreateText(issuer, alice, credType).
 			Expiration(expiration).
 			Build(),
 	)
@@ -851,28 +851,28 @@ func TestDepositPreauth_ExpiredCredentials(t *testing.T) {
 	env.Close()
 
 	// alice accepts the credential.
-	result = env.Submit(credential.CredentialAccept(alice, issuer, credType).Build())
+	result = env.Submit(credential.CredentialAcceptText(alice, issuer, credType).Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
 
 	// issuer creates a second credential for alice with long expiration.
 	now = env.NowRipple()
 	result = env.Submit(
-		credential.CredentialCreate(issuer, alice, credType2).
+		credential.CredentialCreateText(issuer, alice, credType2).
 			Expiration(now + 1000).
 			Build(),
 	)
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
-	result = env.Submit(credential.CredentialAccept(alice, issuer, credType2).Build())
+	result = env.Submit(credential.CredentialAcceptText(alice, issuer, credType2).Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
 
 	jtx.RequireOwnerCount(t, env, issuer, 0)
 	jtx.RequireOwnerCount(t, env, alice, 2)
 
-	credIdx := dp.CredentialIndex(alice, issuer, credType)
-	credIdx2 := dp.CredentialIndex(alice, issuer, credType2)
+	credIdx := dp.CredentialIndexHex(alice, issuer, credType)
+	credIdx2 := dp.CredentialIndexHex(alice, issuer, credType2)
 
 	// bob requires preauthorization.
 	env.EnableDepositAuth(bob)
@@ -880,8 +880,8 @@ func TestDepositPreauth_ExpiredCredentials(t *testing.T) {
 
 	// bob sets up credential-based preauth for both credential types.
 	result = env.Submit(dp.AuthCredentials(bob, []dp.AuthorizeCredentials{
-		{Issuer: issuer, CredType: credType},
-		{Issuer: issuer, CredType: credType2},
+		{Issuer: issuer, CredTypeText: credType},
+		{Issuer: issuer, CredTypeText: credType2},
 	}).Build())
 	jtx.RequireTxSuccess(t, result)
 	env.Close()

--- a/internal/testing/permissioneddex/env_helper.go
+++ b/internal/testing/permissioneddex/env_helper.go
@@ -87,12 +87,12 @@ func SetupPermissionedDEX(t *testing.T, env *jtx.TestEnv) *PermissionedDEXEnv {
 	// Issue and accept credentials for alice, bob, carol, gw
 	members := []*jtx.Account{alice, bob, carol, gw}
 	for _, member := range members {
-		result = env.Submit(cred.CredentialCreate(domainOwner, member, credType).Build())
+		result = env.Submit(cred.CredentialCreateHex(domainOwner, member, credType).Build())
 		if !result.Success {
 			t.Fatalf("SetupPermissionedDEX: credential create for %s: %s %s", member.Name, result.Code, result.Message)
 		}
 		env.Close()
-		result = env.Submit(cred.CredentialAccept(member, domainOwner, credType).Build())
+		result = env.Submit(cred.CredentialAcceptHex(member, domainOwner, credType).Build())
 		if !result.Success {
 			t.Fatalf("SetupPermissionedDEX: credential accept for %s: %s %s", member.Name, result.Code, result.Message)
 		}

--- a/internal/testing/permissioneddex/permissioned_dex_test.go
+++ b/internal/testing/permissioneddex/permissioned_dex_test.go
@@ -219,7 +219,7 @@ func TestPermissionedDEX_OfferCreate(t *testing.T) {
 		env.Close()
 
 		// domainOwner issues credential for devin
-		result = env.Submit(cred.CredentialCreate(dex.DomainOwner, devin, dex.CredType).Build())
+		result = env.Submit(cred.CredentialCreateHex(dex.DomainOwner, devin, dex.CredType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
@@ -232,7 +232,7 @@ func TestPermissionedDEX_OfferCreate(t *testing.T) {
 		env.Close()
 
 		// devin accepts credential
-		result = env.Submit(cred.CredentialAccept(devin, dex.DomainOwner, dex.CredType).Build())
+		result = env.Submit(cred.CredentialAcceptHex(devin, dex.DomainOwner, dex.CredType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
@@ -261,13 +261,13 @@ func TestPermissionedDEX_OfferCreate(t *testing.T) {
 		// Issue credential with 20s expiry
 		expiration := env.NowRipple() + 20
 		result := env.Submit(
-			cred.CredentialCreate(dex.DomainOwner, devin, dex.CredType).
+			cred.CredentialCreateHex(dex.DomainOwner, devin, dex.CredType).
 				Expiration(expiration).Build(),
 		)
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		result = env.Submit(cred.CredentialAccept(devin, dex.DomainOwner, dex.CredType).Build())
+		result = env.Submit(cred.CredentialAcceptHex(devin, dex.DomainOwner, dex.CredType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
@@ -315,7 +315,7 @@ func TestPermissionedDEX_OfferCreate(t *testing.T) {
 
 		// remove gw from domain
 		result := env.Submit(
-			cred.CredentialDelete(dex.DomainOwner, dex.GW, dex.DomainOwner, dex.CredType).Build(),
+			cred.CredentialDeleteHex(dex.DomainOwner, dex.GW, dex.DomainOwner, dex.CredType).Build(),
 		)
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -338,7 +338,7 @@ func TestPermissionedDEX_OfferCreate(t *testing.T) {
 
 		// remove gw from domain
 		result := env.Submit(
-			cred.CredentialDelete(dex.DomainOwner, dex.GW, dex.DomainOwner, dex.CredType).Build(),
+			cred.CredentialDeleteHex(dex.DomainOwner, dex.GW, dex.DomainOwner, dex.CredType).Build(),
 		)
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -506,7 +506,7 @@ func TestPermissionedDEX_Payment(t *testing.T) {
 		env.Close()
 
 		// Issue credential for devin
-		result = env.Submit(cred.CredentialCreate(dex.DomainOwner, devin, dex.CredType).Build())
+		result = env.Submit(cred.CredentialCreateHex(dex.DomainOwner, devin, dex.CredType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
@@ -521,7 +521,7 @@ func TestPermissionedDEX_Payment(t *testing.T) {
 		env.Close()
 
 		// devin accepts credential
-		result = env.Submit(cred.CredentialAccept(devin, dex.DomainOwner, dex.CredType).Build())
+		result = env.Submit(cred.CredentialAcceptHex(devin, dex.DomainOwner, dex.CredType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
@@ -567,7 +567,7 @@ func TestPermissionedDEX_Payment(t *testing.T) {
 		env.Close()
 
 		// Issue credential for devin
-		result = env.Submit(cred.CredentialCreate(dex.DomainOwner, devin, dex.CredType).Build())
+		result = env.Submit(cred.CredentialCreateHex(dex.DomainOwner, devin, dex.CredType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
@@ -581,7 +581,7 @@ func TestPermissionedDEX_Payment(t *testing.T) {
 		jtx.RequireTxClaimed(t, result, "tecNO_PERMISSION")
 		env.Close()
 
-		result = env.Submit(cred.CredentialAccept(devin, dex.DomainOwner, dex.CredType).Build())
+		result = env.Submit(cred.CredentialAcceptHex(devin, dex.DomainOwner, dex.CredType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
@@ -815,10 +815,10 @@ func TestPermissionedDEX_BookStep(t *testing.T) {
 		badDomainID := keylet.PermissionedDomain(badDomainOwner.ID, badDomainSeq).Key
 
 		// devin gets credential for bad domain
-		result = env.Submit(cred.CredentialCreate(badDomainOwner, devin, badCredType).Build())
+		result = env.Submit(cred.CredentialCreateHex(badDomainOwner, devin, badCredType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
-		result = env.Submit(cred.CredentialAccept(devin, badDomainOwner, badCredType).Build())
+		result = env.Submit(cred.CredentialAcceptHex(devin, badDomainOwner, badCredType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
@@ -884,12 +884,12 @@ func TestPermissionedDEX_BookStep(t *testing.T) {
 		// first payment instead of 3 (which would exceed the 20s expiration).
 		expiration := env.NowRipple() + 20
 		result := env.Submit(
-			cred.CredentialCreate(dex.DomainOwner, devin, dex.CredType).
+			cred.CredentialCreateHex(dex.DomainOwner, devin, dex.CredType).
 				Expiration(expiration).Build(),
 		)
 		jtx.RequireTxSuccess(t, result)
 
-		result = env.Submit(cred.CredentialAccept(devin, dex.DomainOwner, dex.CredType).Build())
+		result = env.Submit(cred.CredentialAcceptHex(devin, dex.DomainOwner, dex.CredType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
@@ -957,7 +957,7 @@ func TestPermissionedDEX_BookStep(t *testing.T) {
 
 		// Remove bob's credential
 		result = env.Submit(
-			cred.CredentialDelete(dex.DomainOwner, dex.Bob, dex.DomainOwner, dex.CredType).Build(),
+			cred.CredentialDeleteHex(dex.DomainOwner, dex.Bob, dex.DomainOwner, dex.CredType).Build(),
 		)
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
@@ -993,11 +993,11 @@ func TestPermissionedDEX_BookStep(t *testing.T) {
 		env.Close()
 
 		// domain owner issues credential for devin
-		result = env.Submit(cred.CredentialCreate(dex.DomainOwner, devin, dex.CredType).Build())
+		result = env.Submit(cred.CredentialCreateHex(dex.DomainOwner, devin, dex.CredType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		result = env.Submit(cred.CredentialAccept(devin, dex.DomainOwner, dex.CredType).Build())
+		result = env.Submit(cred.CredentialAcceptHex(devin, dex.DomainOwner, dex.CredType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
@@ -1030,7 +1030,7 @@ func TestPermissionedDEX_Rippling(t *testing.T) {
 
 	// Remove bob from domain
 	result = env.Submit(
-		cred.CredentialDelete(dex.DomainOwner, dex.Bob, dex.DomainOwner, dex.CredType).Build(),
+		cred.CredentialDeleteHex(dex.DomainOwner, dex.Bob, dex.DomainOwner, dex.CredType).Build(),
 	)
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
@@ -1098,7 +1098,7 @@ func TestPermissionedDEX_OfferTokenIssuerInDomain(t *testing.T) {
 
 	// Remove gateway from domain
 	result = env.Submit(
-		cred.CredentialDelete(dex.DomainOwner, dex.GW, dex.DomainOwner, dex.CredType).Build(),
+		cred.CredentialDeleteHex(dex.DomainOwner, dex.GW, dex.DomainOwner, dex.CredType).Build(),
 	)
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
@@ -1155,7 +1155,7 @@ func TestPermissionedDEX_RemoveUnfundedOffer(t *testing.T) {
 
 	// Remove alice from domain - her offer becomes unfunded
 	result = env.Submit(
-		cred.CredentialDelete(dex.DomainOwner, dex.Alice, dex.DomainOwner, dex.CredType).Build(),
+		cred.CredentialDeleteHex(dex.DomainOwner, dex.Alice, dex.DomainOwner, dex.CredType).Build(),
 	)
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
@@ -1499,10 +1499,10 @@ func TestPermissionedDEX_HybridBookStep(t *testing.T) {
 
 		badDomainIDKey := keylet.PermissionedDomain(badDomainOwner.ID, badDomainSeq).Key
 
-		result = env.Submit(cred.CredentialCreate(badDomainOwner, devin, badCredType).Build())
+		result = env.Submit(cred.CredentialCreateHex(badDomainOwner, devin, badCredType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
-		result = env.Submit(cred.CredentialAccept(devin, badDomainOwner, badCredType).Build())
+		result = env.Submit(cred.CredentialAcceptHex(devin, badDomainOwner, badCredType).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
@@ -1671,7 +1671,7 @@ func TestPermissionedDEX_HybridInvalidOffer(t *testing.T) {
 
 	// Remove bob from domain
 	result = env.Submit(
-		cred.CredentialDelete(dex.DomainOwner, dex.Bob, dex.DomainOwner, dex.CredType).Build(),
+		cred.CredentialDeleteHex(dex.DomainOwner, dex.Bob, dex.DomainOwner, dex.CredType).Build(),
 	)
 	jtx.RequireTxSuccess(t, result)
 	env.Close()

--- a/internal/testing/vault/vault_deposit_test.go
+++ b/internal/testing/vault/vault_deposit_test.go
@@ -111,25 +111,25 @@ func TestVaultDeposit_PrivateDomainAuthorizationAndExpiredCleanup(t *testing.T) 
 	jtx.RequireTxClaimed(t, env.Submit(deposit()), jtx.TecNO_AUTH)
 
 	jtx.RequireTxSuccess(t, env.Submit(
-		credentialtest.CredentialCreate(validIssuer, depositor, credentialType).Build(),
+		credentialtest.CredentialCreateText(validIssuer, depositor, credentialType).Build(),
 	))
 	jtx.RequireTxSuccess(t, env.Submit(
-		credentialtest.CredentialAccept(depositor, validIssuer, credentialType).Build(),
+		credentialtest.CredentialAcceptText(depositor, validIssuer, credentialType).Build(),
 	))
 	jtx.RequireTxSuccess(t, env.Submit(deposit()))
 
 	jtx.RequireTxSuccess(t, env.Submit(
-		credentialtest.CredentialDelete(validIssuer, depositor, validIssuer, credentialType).Build(),
+		credentialtest.CredentialDeleteText(validIssuer, depositor, validIssuer, credentialType).Build(),
 	))
 
 	const expiration uint32 = 2_000_000_000
 	jtx.RequireTxSuccess(t, env.Submit(
-		credentialtest.CredentialCreate(expiredIssuer, depositor, credentialType).
+		credentialtest.CredentialCreateText(expiredIssuer, depositor, credentialType).
 			Expiration(expiration).
 			Build(),
 	))
 	jtx.RequireTxSuccess(t, env.Submit(
-		credentialtest.CredentialAccept(depositor, expiredIssuer, credentialType).Build(),
+		credentialtest.CredentialAcceptText(depositor, expiredIssuer, credentialType).Build(),
 	))
 	expiredKey := jtx.CredentialKeylet(depositor, expiredIssuer, credentialType)
 	if !env.LedgerEntryExists(expiredKey) {

--- a/internal/tx/depositpreauth/depositpreauth.go
+++ b/internal/tx/depositpreauth/depositpreauth.go
@@ -307,10 +307,18 @@ func (d *DepositPreauth) Preclaim(view tx.LedgerView, config tx.EngineConfig) te
 		if derr != nil {
 			return ter.TemINVALID
 		}
-		if exists, _ := view.Exists(keylet.Account(authorizedID)); !exists {
+		exists, err := view.Exists(keylet.Account(authorizedID))
+		if err != nil {
+			return ter.TefEXCEPTION
+		}
+		if !exists {
 			return ter.TecNO_TARGET
 		}
-		if exists, _ := view.Exists(keylet.DepositPreauth(accountID, authorizedID)); exists {
+		exists, err = view.Exists(keylet.DepositPreauth(accountID, authorizedID))
+		if err != nil {
+			return ter.TefEXCEPTION
+		}
+		if exists {
 			return ter.TecDUPLICATE
 		}
 	case d.Unauthorize != "":
@@ -318,7 +326,11 @@ func (d *DepositPreauth) Preclaim(view tx.LedgerView, config tx.EngineConfig) te
 		if derr != nil {
 			return ter.TemINVALID
 		}
-		if exists, _ := view.Exists(keylet.DepositPreauth(accountID, unauthorizedID)); !exists {
+		exists, err := view.Exists(keylet.DepositPreauth(accountID, unauthorizedID))
+		if err != nil {
+			return ter.TefEXCEPTION
+		}
+		if !exists {
 			return ter.TecNO_ENTRY
 		}
 	case len(d.AuthorizeCredentials) > 0:
@@ -327,11 +339,19 @@ func (d *DepositPreauth) Preclaim(view tx.LedgerView, config tx.EngineConfig) te
 			return ter.TefINTERNAL
 		}
 		for _, p := range sorted {
-			if exists, _ := view.Exists(keylet.Account(p.issuer)); !exists {
+			exists, err := view.Exists(keylet.Account(p.issuer))
+			if err != nil {
+				return ter.TefEXCEPTION
+			}
+			if !exists {
 				return ter.TecNO_ISSUER
 			}
 		}
-		if exists, _ := view.Exists(keylet.DepositPreauthCredentials(accountID, toKeyletPairs(sorted))); exists {
+		exists, err := view.Exists(keylet.DepositPreauthCredentials(accountID, toKeyletPairs(sorted)))
+		if err != nil {
+			return ter.TefEXCEPTION
+		}
+		if exists {
 			return ter.TecDUPLICATE
 		}
 	case len(d.UnauthorizeCredentials) > 0:
@@ -339,7 +359,11 @@ func (d *DepositPreauth) Preclaim(view tx.LedgerView, config tx.EngineConfig) te
 		if sorted == nil {
 			return ter.TefINTERNAL
 		}
-		if exists, _ := view.Exists(keylet.DepositPreauthCredentials(accountID, toKeyletPairs(sorted))); !exists {
+		exists, err := view.Exists(keylet.DepositPreauthCredentials(accountID, toKeyletPairs(sorted)))
+		if err != nil {
+			return ter.TefEXCEPTION
+		}
+		if !exists {
 			return ter.TecNO_ENTRY
 		}
 	}
@@ -411,7 +435,7 @@ func (d *DepositPreauth) applyAuthorize(ctx *tx.ApplyContext) ter.Result {
 		return ter.TefINTERNAL
 	}
 
-	ctx.Account.OwnerCount++
+	ctx.Account.OwnerCount = tx.ConfineOwnerCount(ctx.Account.OwnerCount, 1)
 	return ter.TesSUCCESS
 }
 
@@ -481,7 +505,7 @@ func (d *DepositPreauth) applyAuthorizeCredentials(ctx *tx.ApplyContext) ter.Res
 		return ter.TefINTERNAL
 	}
 
-	ctx.Account.OwnerCount++
+	ctx.Account.OwnerCount = tx.ConfineOwnerCount(ctx.Account.OwnerCount, 1)
 	return ter.TesSUCCESS
 }
 

--- a/internal/tx/depositpreauth/depositpreauth.go
+++ b/internal/tx/depositpreauth/depositpreauth.go
@@ -3,6 +3,7 @@ package depositpreauth
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"sort"
 
 	"github.com/LeJamon/go-xrpl/amendment"
@@ -82,7 +83,7 @@ func (d *DepositPreauth) RequiredAmendments() [][32]byte {
 // checkExtraFeatures, before preflight1's common checks and before the
 // temARRAY_EMPTY body check.
 func (d *DepositPreauth) CheckExtraFeatures(rules *amendment.Rules) error {
-	if (d.AuthorizeCredentials != nil || d.UnauthorizeCredentials != nil) &&
+	if (d.hasAuthorizeCredentials() || d.hasUnauthorizeCredentials()) &&
 		!rules.Enabled(amendment.FeatureCredentials) {
 		return ter.Errorf(ter.TemDISABLED, "credentials require the Credentials amendment")
 	}
@@ -105,12 +106,11 @@ func (d *DepositPreauth) Validate() error {
 	}
 
 	// Count which fields are present.
-	// Use nil check (not len>0) because an empty non-nil array means the field
-	// IS present, just empty — which is still a presence for mutual exclusivity.
+	// Empty arrays are still present for mutual exclusivity.
 	hasAuth := d.Authorize != ""
 	hasUnauth := d.Unauthorize != ""
-	hasAuthCreds := d.AuthorizeCredentials != nil
-	hasUnauthCreds := d.UnauthorizeCredentials != nil
+	hasAuthCreds := d.hasAuthorizeCredentials()
+	hasUnauthCreds := d.hasUnauthorizeCredentials()
 
 	authPresent := boolToInt(hasAuth) + boolToInt(hasUnauth)
 	authCredPresent := boolToInt(hasAuthCreds) + boolToInt(hasUnauthCreds)
@@ -198,7 +198,25 @@ func checkCredentialArray(creds []CredentialWrapper) error {
 }
 
 func (d *DepositPreauth) Flatten() (map[string]any, error) {
-	return tx.ReflectFlatten(d)
+	fields, err := tx.ReflectFlatten(d)
+	if err != nil {
+		return nil, err
+	}
+	if len(d.AuthorizeCredentials) == 0 && d.hasAuthorizeCredentials() {
+		fields["AuthorizeCredentials"] = []map[string]any{}
+	}
+	if len(d.UnauthorizeCredentials) == 0 && d.hasUnauthorizeCredentials() {
+		fields["UnauthorizeCredentials"] = []map[string]any{}
+	}
+	return fields, nil
+}
+
+func (d *DepositPreauth) hasAuthorizeCredentials() bool {
+	return d.AuthorizeCredentials != nil || d.Common.HasField("AuthorizeCredentials")
+}
+
+func (d *DepositPreauth) hasUnauthorizeCredentials() bool {
+	return d.UnauthorizeCredentials != nil || d.Common.HasField("UnauthorizeCredentials")
 }
 
 // SetAuthorize sets the account to authorize
@@ -375,8 +393,10 @@ func (d *DepositPreauth) applyAuthorize(ctx *tx.ApplyContext) ter.Result {
 		dir.Owner = ctx.AccountID
 	})
 	if err != nil {
-		ctx.Log.Error("deposit preauth authorize: directory full", "error", err)
-		return ter.TecDIR_FULL
+		if errors.Is(err, state.ErrDirFull) {
+			return ter.TecDIR_FULL
+		}
+		return ctx.Internal("DepositPreauth.Authorize.DirInsert", err)
 	}
 
 	// --- doApply: create and insert preauth entry ---
@@ -430,8 +450,10 @@ func (d *DepositPreauth) applyAuthorizeCredentials(ctx *tx.ApplyContext) ter.Res
 		dir.Owner = ctx.AccountID
 	})
 	if err != nil {
-		ctx.Log.Error("deposit preauth authorize credentials: directory full", "error", err)
-		return ter.TecDIR_FULL
+		if errors.Is(err, state.ErrDirFull) {
+			return ter.TecDIR_FULL
+		}
+		return ctx.Internal("DepositPreauth.AuthorizeCredentials.DirInsert", err)
 	}
 
 	// --- doApply: create and insert preauth entry with sorted credentials ---
@@ -481,21 +503,32 @@ func (d *DepositPreauth) applyUnauthorizeCredentials(ctx *tx.ApplyContext) ter.R
 func removeFromLedger(ctx *tx.ApplyContext, preauthKey keylet.Keylet) ter.Result {
 	// Read the preauth entry to get OwnerNode for directory removal
 	preauthData, err := ctx.View.Read(preauthKey)
-	if err != nil || preauthData == nil {
+	if err != nil {
+		return ctx.Internal("DepositPreauth.Remove.Read", err)
+	}
+	if preauthData == nil {
 		ctx.Log.Warn("deposit preauth remove: entry not found in ledger")
 		return ter.TecNO_ENTRY
 	}
 
-	// Parse OwnerNode from the binary entry
-	var ownerNode uint64
 	entry, err := state.ParseDepositPreauth(preauthData)
-	if err == nil && entry != nil {
-		ownerNode = entry.OwnerNode
+	if err != nil || entry == nil {
+		ctx.Log.Error("deposit preauth remove: malformed ledger entry", "error", err)
+		return ter.TefEXCEPTION
 	}
-	// If parsing fails, default to page 0 which handles the common case
+	if entry.Account != ctx.AccountID {
+		ctx.Log.Error("deposit preauth remove: ledger entry owner mismatch")
+		return ter.TefBAD_LEDGER
+	}
+	if ctx.Account == nil {
+		return ctx.Internal("DepositPreauth.Remove.Owner", errors.New("owner account missing"))
+	}
+	if ctx.Account.OwnerCount == 0 {
+		ctx.Log.Error("deposit preauth remove: owner count underflow")
+	}
 
-	ownerDirKey := keylet.OwnerDir(ctx.AccountID)
-	res, err := state.DirRemove(ctx.View, ownerDirKey, ownerNode, preauthKey.Key, false)
+	ownerDirKey := keylet.OwnerDir(entry.Account)
+	res, err := state.DirRemove(ctx.View, ownerDirKey, entry.OwnerNode, preauthKey.Key, false)
 	if err != nil || !res.Success {
 		ctx.Log.Error("deposit preauth remove: failed to remove from owner directory", "error", err)
 		return ter.TefBAD_LEDGER
@@ -507,9 +540,7 @@ func removeFromLedger(ctx *tx.ApplyContext, preauthKey keylet.Keylet) ter.Result
 		return ter.TefINTERNAL
 	}
 
-	if ctx.Account.OwnerCount > 0 {
-		ctx.Account.OwnerCount--
-	}
+	ctx.Account.OwnerCount = tx.ConfineOwnerCount(ctx.Account.OwnerCount, -1)
 
 	return ter.TesSUCCESS
 }

--- a/internal/tx/depositpreauth/handler_integrity_test.go
+++ b/internal/tx/depositpreauth/handler_integrity_test.go
@@ -1,0 +1,352 @@
+package depositpreauth
+
+import (
+	"bytes"
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/drops"
+	ledgercore "github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/engine"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
+)
+
+type faultView struct {
+	data        map[[32]byte][]byte
+	readErrors  map[[32]byte]error
+	updateError map[[32]byte]error
+	eraseError  map[[32]byte]error
+	rules       *amendment.Rules
+}
+
+func newFaultView() *faultView {
+	return &faultView{
+		data:        make(map[[32]byte][]byte),
+		readErrors:  make(map[[32]byte]error),
+		updateError: make(map[[32]byte]error),
+		eraseError:  make(map[[32]byte]error),
+		rules:       amendment.AllSupportedRules(),
+	}
+}
+
+func (v *faultView) Read(k keylet.Keylet) ([]byte, error) {
+	if err := v.readErrors[k.Key]; err != nil {
+		return nil, err
+	}
+	return bytes.Clone(v.data[k.Key]), nil
+}
+
+func (v *faultView) Exists(k keylet.Keylet) (bool, error) {
+	if err := v.readErrors[k.Key]; err != nil {
+		return false, err
+	}
+	_, ok := v.data[k.Key]
+	return ok, nil
+}
+
+func (v *faultView) Insert(k keylet.Keylet, data []byte) error {
+	v.data[k.Key] = bytes.Clone(data)
+	return nil
+}
+
+func (v *faultView) Update(k keylet.Keylet, data []byte) error {
+	if err := v.updateError[k.Key]; err != nil {
+		return err
+	}
+	v.data[k.Key] = bytes.Clone(data)
+	return nil
+}
+
+func (v *faultView) Erase(k keylet.Keylet) error {
+	if err := v.eraseError[k.Key]; err != nil {
+		return err
+	}
+	delete(v.data, k.Key)
+	return nil
+}
+
+func (v *faultView) ApplyAtomically(apply func(ledgercore.Writer) error) error {
+	staged := newFaultView()
+	staged.rules = v.rules
+	staged.readErrors = v.readErrors
+	staged.updateError = v.updateError
+	staged.eraseError = v.eraseError
+	for key, data := range v.data {
+		staged.data[key] = bytes.Clone(data)
+	}
+	if err := apply(staged); err != nil {
+		return err
+	}
+	v.data = staged.data
+	return nil
+}
+
+func (*faultView) AdjustDropsDestroyed(drops.XRPAmount) error { return nil }
+func (*faultView) TxExists([32]byte) (bool, error)            { return false, nil }
+func (v *faultView) Rules() *amendment.Rules                  { return v.rules }
+func (*faultView) LedgerSeq() uint32                          { return 1 }
+
+func (v *faultView) ForEach(fn func([32]byte, []byte) bool) error {
+	for key, data := range v.data {
+		if !fn(key, bytes.Clone(data)) {
+			break
+		}
+	}
+	return nil
+}
+
+func (v *faultView) Succ(after [32]byte) ([32]byte, []byte, bool, error) {
+	keys := make([][32]byte, 0, len(v.data))
+	for key := range v.data {
+		if bytes.Compare(key[:], after[:]) > 0 {
+			keys = append(keys, key)
+		}
+	}
+	if len(keys) == 0 {
+		return [32]byte{}, nil, false, nil
+	}
+	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i][:], keys[j][:]) < 0 })
+	return keys[0], bytes.Clone(v.data[keys[0]]), true, nil
+}
+
+func TestAuthorizationDirectoryFailuresAreClassified(t *testing.T) {
+	ownerID := [20]byte{1}
+	owner, err := state.EncodeAccountID(ownerID)
+	require.NoError(t, err)
+	targetID := [20]byte{2}
+	target, err := state.EncodeAccountID(targetID)
+	require.NoError(t, err)
+
+	for _, form := range []struct {
+		name string
+		make func() *DepositPreauth
+	}{
+		{
+			name: "account",
+			make: func() *DepositPreauth {
+				txn := NewDepositPreauth(owner)
+				txn.Authorize = target
+				return txn
+			},
+		},
+		{
+			name: "credentials",
+			make: func() *DepositPreauth {
+				txn := NewDepositPreauth(owner)
+				txn.AuthorizeCredentials = []CredentialWrapper{{Credential: CredentialSpec{
+					Issuer: target, CredentialType: "61",
+				}}}
+				return txn
+			},
+		},
+	} {
+		for _, failure := range []struct {
+			name string
+			err  error
+			want ter.Result
+		}{
+			{name: "capacity", err: state.ErrDirFull, want: ter.TecDIR_FULL},
+			{name: "storage", err: errors.New("storage failure"), want: ter.TefINTERNAL},
+		} {
+			t.Run(form.name+"/"+failure.name, func(t *testing.T) {
+				view := newFaultView()
+				view.readErrors[keylet.OwnerDir(ownerID).Key] = failure.err
+				ctx := applyContext(view, ownerID, 0)
+
+				require.Equal(t, failure.want, form.make().Apply(ctx))
+				require.Equal(t, uint32(0), ctx.Account.OwnerCount)
+			})
+		}
+	}
+}
+
+func TestRemovalFailsClosedOnCorruptLedgerState(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		fault func(*testing.T, *removalFixture)
+		want  ter.Result
+	}{
+		{
+			name: "read failure",
+			fault: func(_ *testing.T, f *removalFixture) {
+				f.view.readErrors[f.preauthKey.Key] = errors.New("storage failure")
+			},
+			want: ter.TefINTERNAL,
+		},
+		{
+			name: "malformed entry",
+			fault: func(_ *testing.T, f *removalFixture) {
+				f.view.data[f.preauthKey.Key] = []byte{1, 2, 3}
+			},
+			want: ter.TefEXCEPTION,
+		},
+		{
+			name: "mismatched owner",
+			fault: func(t *testing.T, f *removalFixture) {
+				other := [20]byte{9}
+				data, err := state.SerializeDepositPreauth(other, f.targetID, f.page)
+				require.NoError(t, err)
+				f.view.data[f.preauthKey.Key] = data
+			},
+			want: ter.TefBAD_LEDGER,
+		},
+		{
+			name: "missing directory link",
+			fault: func(_ *testing.T, f *removalFixture) {
+				delete(f.view.data, f.dirKey.Key)
+			},
+			want: ter.TefBAD_LEDGER,
+		},
+		{
+			name: "wrong directory page",
+			fault: func(t *testing.T, f *removalFixture) {
+				data, err := state.SerializeDepositPreauth(f.ownerID, f.targetID, f.page+1)
+				require.NoError(t, err)
+				f.view.data[f.preauthKey.Key] = data
+			},
+			want: ter.TefBAD_LEDGER,
+		},
+		{
+			name: "directory erase failure",
+			fault: func(_ *testing.T, f *removalFixture) {
+				f.view.eraseError[f.dirKey.Key] = errors.New("storage erase failure")
+			},
+			want: ter.TefBAD_LEDGER,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newRemovalFixture(t)
+			tc.fault(t, fixture)
+			beforeEntry := bytes.Clone(fixture.view.data[fixture.preauthKey.Key])
+			beforeDir := bytes.Clone(fixture.view.data[fixture.dirKey.Key])
+			beforeCount := fixture.ctx.Account.OwnerCount
+
+			result := removeFromLedger(fixture.ctx, fixture.preauthKey)
+
+			require.Equal(t, tc.want, result)
+			require.Equal(t, beforeEntry, fixture.view.data[fixture.preauthKey.Key])
+			require.Equal(t, beforeDir, fixture.view.data[fixture.dirKey.Key])
+			require.Equal(t, beforeCount, fixture.ctx.Account.OwnerCount)
+		})
+	}
+}
+
+func TestRemovalConfinesCorruptOwnerCount(t *testing.T) {
+	fixture := newRemovalFixture(t)
+	fixture.ctx.Account.OwnerCount = 0
+
+	require.Equal(t, ter.TesSUCCESS, removeFromLedger(fixture.ctx, fixture.preauthKey))
+	require.Equal(t, uint32(0), fixture.ctx.Account.OwnerCount)
+	require.NotContains(t, fixture.view.data, fixture.preauthKey.Key)
+}
+
+func TestRemovalRequiresOwnerAccount(t *testing.T) {
+	fixture := newRemovalFixture(t)
+	beforeEntry := bytes.Clone(fixture.view.data[fixture.preauthKey.Key])
+	beforeDir := bytes.Clone(fixture.view.data[fixture.dirKey.Key])
+	fixture.ctx.Account = nil
+
+	require.Equal(t, ter.TefINTERNAL, removeFromLedger(fixture.ctx, fixture.preauthKey))
+	require.Equal(t, beforeEntry, fixture.view.data[fixture.preauthKey.Key])
+	require.Equal(t, beforeDir, fixture.view.data[fixture.dirKey.Key])
+}
+
+func TestRemovalCommitFailureRollsBackAllLedgerChanges(t *testing.T) {
+	fixture := newRemovalFixture(t)
+	owner, err := state.EncodeAccountID(fixture.ownerID)
+	require.NoError(t, err)
+	accountKey := keylet.Account(fixture.ownerID)
+	accountData, err := state.SerializeAccountRoot(&state.AccountRoot{
+		Account:    owner,
+		Balance:    1_000_000_000,
+		Sequence:   1,
+		OwnerCount: 1,
+	})
+	require.NoError(t, err)
+	require.NoError(t, fixture.view.Insert(accountKey, accountData))
+
+	beforeAccount := bytes.Clone(fixture.view.data[accountKey.Key])
+	beforeEntry := bytes.Clone(fixture.view.data[fixture.preauthKey.Key])
+	beforeDir := bytes.Clone(fixture.view.data[fixture.dirKey.Key])
+	fixture.view.eraseError[fixture.preauthKey.Key] = errors.New("storage erase failure")
+
+	txn := NewDepositPreauth(owner)
+	txn.Unauthorize, err = state.EncodeAccountID(fixture.targetID)
+	require.NoError(t, err)
+	txn.Fee = "10"
+	txn.SetSequence(1)
+	result := engine.NewEngine(fixture.view, tx.EngineConfig{
+		BaseFee:                   10,
+		LedgerSequence:            1,
+		ReserveBase:               10_000_000,
+		ReserveIncrement:          2_000_000,
+		Rules:                     amendment.AllSupportedRules(),
+		SkipSignatureVerification: true,
+	}).Apply(txn)
+
+	require.Equal(t, ter.TefINTERNAL, result.Result)
+	require.False(t, result.Applied)
+	require.Equal(t, beforeAccount, fixture.view.data[accountKey.Key])
+	require.Equal(t, beforeEntry, fixture.view.data[fixture.preauthKey.Key])
+	require.Equal(t, beforeDir, fixture.view.data[fixture.dirKey.Key])
+}
+
+type removalFixture struct {
+	view       *faultView
+	ctx        *tx.ApplyContext
+	ownerID    [20]byte
+	targetID   [20]byte
+	preauthKey keylet.Keylet
+	dirKey     keylet.Keylet
+	page       uint64
+}
+
+func newRemovalFixture(t *testing.T) *removalFixture {
+	t.Helper()
+	ownerID := [20]byte{3}
+	targetID := [20]byte{4}
+	view := newFaultView()
+	preauthKey := keylet.DepositPreauth(ownerID, targetID)
+	dirKey := keylet.OwnerDir(ownerID)
+	dir, err := state.DirInsert(view, dirKey, preauthKey.Key, false, func(node *state.DirectoryNode) {
+		node.Owner = ownerID
+	})
+	require.NoError(t, err)
+	data, err := state.SerializeDepositPreauth(ownerID, targetID, dir.Page)
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(preauthKey, data))
+	return &removalFixture{
+		view:       view,
+		ctx:        applyContext(view, ownerID, 1),
+		ownerID:    ownerID,
+		targetID:   targetID,
+		preauthKey: preauthKey,
+		dirKey:     dirKey,
+		page:       dir.Page,
+	}
+}
+
+func applyContext(view tx.LedgerView, accountID [20]byte, ownerCount uint32) *tx.ApplyContext {
+	return &tx.ApplyContext{
+		View:      view,
+		AccountID: accountID,
+		Account: &state.AccountRoot{
+			Balance:    1_000_000_000,
+			OwnerCount: ownerCount,
+		},
+		Config: tx.EngineConfig{
+			ReserveBase:      10_000_000,
+			ReserveIncrement: 2_000_000,
+			Rules:            amendment.AllSupportedRules(),
+		},
+		Log: xrpllog.Discard(),
+	}
+}

--- a/internal/tx/depositpreauth/handler_integrity_test.go
+++ b/internal/tx/depositpreauth/handler_integrity_test.go
@@ -3,6 +3,7 @@ package depositpreauth
 import (
 	"bytes"
 	"errors"
+	"math"
 	"sort"
 	"testing"
 
@@ -22,6 +23,7 @@ import (
 type faultView struct {
 	data        map[[32]byte][]byte
 	readErrors  map[[32]byte]error
+	insertError map[[32]byte]error
 	updateError map[[32]byte]error
 	eraseError  map[[32]byte]error
 	rules       *amendment.Rules
@@ -31,6 +33,7 @@ func newFaultView() *faultView {
 	return &faultView{
 		data:        make(map[[32]byte][]byte),
 		readErrors:  make(map[[32]byte]error),
+		insertError: make(map[[32]byte]error),
 		updateError: make(map[[32]byte]error),
 		eraseError:  make(map[[32]byte]error),
 		rules:       amendment.AllSupportedRules(),
@@ -53,6 +56,9 @@ func (v *faultView) Exists(k keylet.Keylet) (bool, error) {
 }
 
 func (v *faultView) Insert(k keylet.Keylet, data []byte) error {
+	if err := v.insertError[k.Key]; err != nil {
+		return err
+	}
 	v.data[k.Key] = bytes.Clone(data)
 	return nil
 }
@@ -77,6 +83,7 @@ func (v *faultView) ApplyAtomically(apply func(ledgercore.Writer) error) error {
 	staged := newFaultView()
 	staged.rules = v.rules
 	staged.readErrors = v.readErrors
+	staged.insertError = v.insertError
 	staged.updateError = v.updateError
 	staged.eraseError = v.eraseError
 	for key, data := range v.data {
@@ -165,6 +172,234 @@ func TestAuthorizationDirectoryFailuresAreClassified(t *testing.T) {
 				require.Equal(t, uint32(0), ctx.Account.OwnerCount)
 			})
 		}
+	}
+}
+
+func TestPreclaimReadFailuresDoNotClaimFee(t *testing.T) {
+	ownerID := [20]byte{1}
+	owner, err := state.EncodeAccountID(ownerID)
+	require.NoError(t, err)
+	targetID := [20]byte{2}
+	target, err := state.EncodeAccountID(targetID)
+	require.NoError(t, err)
+	credentials := []CredentialWrapper{{Credential: CredentialSpec{
+		Issuer: target, CredentialType: "61",
+	}}}
+	credentialPairs := toKeyletPairs(makeSorted(credentials))
+	accountPreauthKey := keylet.DepositPreauth(ownerID, targetID)
+	credentialPreauthKey := keylet.DepositPreauthCredentials(ownerID, credentialPairs)
+	targetAccountKey := keylet.Account(targetID)
+
+	for _, tc := range []struct {
+		name    string
+		make    func() *DepositPreauth
+		readKey keylet.Keylet
+		setup   func(*faultView)
+	}{
+		{
+			name: "authorize target",
+			make: func() *DepositPreauth {
+				txn := NewDepositPreauth(owner)
+				txn.Authorize = target
+				return txn
+			},
+			readKey: targetAccountKey,
+		},
+		{
+			name: "authorize entry",
+			make: func() *DepositPreauth {
+				txn := NewDepositPreauth(owner)
+				txn.Authorize = target
+				return txn
+			},
+			readKey: accountPreauthKey,
+			setup: func(view *faultView) {
+				view.data[targetAccountKey.Key] = []byte{1}
+			},
+		},
+		{
+			name: "unauthorize entry",
+			make: func() *DepositPreauth {
+				txn := NewDepositPreauth(owner)
+				txn.Unauthorize = target
+				return txn
+			},
+			readKey: accountPreauthKey,
+		},
+		{
+			name: "authorize credentials issuer",
+			make: func() *DepositPreauth {
+				txn := NewDepositPreauth(owner)
+				txn.AuthorizeCredentials = credentials
+				return txn
+			},
+			readKey: targetAccountKey,
+		},
+		{
+			name: "authorize credentials entry",
+			make: func() *DepositPreauth {
+				txn := NewDepositPreauth(owner)
+				txn.AuthorizeCredentials = credentials
+				return txn
+			},
+			readKey: credentialPreauthKey,
+			setup: func(view *faultView) {
+				view.data[targetAccountKey.Key] = []byte{1}
+			},
+		},
+		{
+			name: "unauthorize credentials entry",
+			make: func() *DepositPreauth {
+				txn := NewDepositPreauth(owner)
+				txn.UnauthorizeCredentials = credentials
+				return txn
+			},
+			readKey: credentialPreauthKey,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			view := newFaultView()
+			accountData, err := state.SerializeAccountRoot(&state.AccountRoot{
+				Account: owner, Balance: 1_000_000_000, Sequence: 1,
+			})
+			require.NoError(t, err)
+			view.data[keylet.Account(ownerID).Key] = accountData
+			if tc.setup != nil {
+				tc.setup(view)
+			}
+			before := make(map[[32]byte][]byte, len(view.data))
+			for key, data := range view.data {
+				before[key] = bytes.Clone(data)
+			}
+			view.readErrors[tc.readKey.Key] = errors.New("storage failure")
+
+			txn := tc.make()
+			txn.Fee = "10"
+			txn.SetSequence(1)
+			result := engine.NewEngine(view, tx.EngineConfig{
+				BaseFee:                   10,
+				LedgerSequence:            1,
+				ReserveBase:               10_000_000,
+				ReserveIncrement:          2_000_000,
+				Rules:                     amendment.AllSupportedRules(),
+				SkipSignatureVerification: true,
+			}).Apply(txn)
+
+			require.Equal(t, ter.TefEXCEPTION, result.Result)
+			require.False(t, result.Applied)
+			require.Zero(t, result.Fee)
+			require.Equal(t, before, view.data)
+		})
+	}
+}
+
+func TestAuthorizationConfinesOwnerCountOverflow(t *testing.T) {
+	ownerID := [20]byte{1}
+	owner, err := state.EncodeAccountID(ownerID)
+	require.NoError(t, err)
+	targetID := [20]byte{2}
+	target, err := state.EncodeAccountID(targetID)
+	require.NoError(t, err)
+
+	for _, form := range []struct {
+		name string
+		make func() *DepositPreauth
+	}{
+		{
+			name: "account",
+			make: func() *DepositPreauth {
+				txn := NewDepositPreauth(owner)
+				txn.Authorize = target
+				return txn
+			},
+		},
+		{
+			name: "credentials",
+			make: func() *DepositPreauth {
+				txn := NewDepositPreauth(owner)
+				txn.AuthorizeCredentials = []CredentialWrapper{{Credential: CredentialSpec{
+					Issuer: target, CredentialType: "61",
+				}}}
+				return txn
+			},
+		},
+	} {
+		t.Run(form.name, func(t *testing.T) {
+			view := newFaultView()
+			ctx := applyContext(view, ownerID, math.MaxUint32)
+
+			require.Equal(t, ter.TesSUCCESS, form.make().Apply(ctx))
+			require.Equal(t, uint32(math.MaxUint32), ctx.Account.OwnerCount)
+		})
+	}
+}
+
+func TestAuthorizationCommitFailureRollsBackAllLedgerChanges(t *testing.T) {
+	ownerID := [20]byte{1}
+	owner, err := state.EncodeAccountID(ownerID)
+	require.NoError(t, err)
+	targetID := [20]byte{2}
+	target, err := state.EncodeAccountID(targetID)
+	require.NoError(t, err)
+	credentials := []CredentialWrapper{{Credential: CredentialSpec{
+		Issuer: target, CredentialType: "61",
+	}}}
+
+	for _, form := range []struct {
+		name       string
+		make       func() *DepositPreauth
+		preauthKey keylet.Keylet
+	}{
+		{
+			name: "account",
+			make: func() *DepositPreauth {
+				txn := NewDepositPreauth(owner)
+				txn.Authorize = target
+				return txn
+			},
+			preauthKey: keylet.DepositPreauth(ownerID, targetID),
+		},
+		{
+			name: "credentials",
+			make: func() *DepositPreauth {
+				txn := NewDepositPreauth(owner)
+				txn.AuthorizeCredentials = credentials
+				return txn
+			},
+			preauthKey: keylet.DepositPreauthCredentials(ownerID, toKeyletPairs(makeSorted(credentials))),
+		},
+	} {
+		t.Run(form.name, func(t *testing.T) {
+			view := newFaultView()
+			accountData, err := state.SerializeAccountRoot(&state.AccountRoot{
+				Account: owner, Balance: 1_000_000_000, Sequence: 1,
+			})
+			require.NoError(t, err)
+			view.data[keylet.Account(ownerID).Key] = accountData
+			view.data[keylet.Account(targetID).Key] = []byte{1}
+			before := make(map[[32]byte][]byte, len(view.data))
+			for key, data := range view.data {
+				before[key] = bytes.Clone(data)
+			}
+			view.insertError[form.preauthKey.Key] = errors.New("storage failure")
+
+			txn := form.make()
+			txn.Fee = "10"
+			txn.SetSequence(1)
+			result := engine.NewEngine(view, tx.EngineConfig{
+				BaseFee:                   10,
+				LedgerSequence:            1,
+				ReserveBase:               10_000_000,
+				ReserveIncrement:          2_000_000,
+				Rules:                     amendment.AllSupportedRules(),
+				SkipSignatureVerification: true,
+			}).Apply(txn)
+
+			require.Equal(t, ter.TefINTERNAL, result.Result)
+			require.False(t, result.Applied)
+			require.Zero(t, result.Fee)
+			require.Equal(t, before, view.data)
+		})
 	}
 }
 

--- a/internal/tx/depositpreauth/wire_presence_test.go
+++ b/internal/tx/depositpreauth/wire_presence_test.go
@@ -1,0 +1,154 @@
+package depositpreauth
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/crypto/ed25519"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/sign"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+var registerWireTests sync.Once
+
+func TestCredentialArrayPresenceRoundTrips(t *testing.T) {
+	registerWireTests.Do(Register)
+	const account = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	privateKey, publicKey, err := ed25519.Algorithm{}.DeriveKeypair([]byte("depositpreauth-field-presence"), false)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name  string
+		field string
+		set   func(*DepositPreauth)
+		get   func(*DepositPreauth) []CredentialWrapper
+	}{
+		{
+			name:  "authorize",
+			field: "AuthorizeCredentials",
+			set:   func(txn *DepositPreauth) { txn.AuthorizeCredentials = []CredentialWrapper{} },
+			get:   func(txn *DepositPreauth) []CredentialWrapper { return txn.AuthorizeCredentials },
+		},
+		{
+			name:  "unauthorize",
+			field: "UnauthorizeCredentials",
+			set:   func(txn *DepositPreauth) { txn.UnauthorizeCredentials = []CredentialWrapper{} },
+			get:   func(txn *DepositPreauth) []CredentialWrapper { return txn.UnauthorizeCredentials },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			txn := NewDepositPreauth(account)
+			txn.Fee = "10"
+			txn.SetSequence(1)
+			txn.SigningPubKey = publicKey
+			tc.set(txn)
+
+			flat, err := txn.Flatten()
+			require.NoError(t, err)
+			value, ok := flat[tc.field]
+			require.True(t, ok)
+			require.Empty(t, value)
+
+			jsonBytes, err := txcore.ToJSON(txn)
+			require.NoError(t, err)
+			var jsonFields map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(jsonBytes, &jsonFields))
+			require.JSONEq(t, "[]", string(jsonFields[tc.field]))
+
+			fromJSON, err := txcore.ParseJSON(jsonBytes)
+			require.NoError(t, err)
+			jsonTxn := fromJSON.(*DepositPreauth)
+			require.NotNil(t, tc.get(jsonTxn))
+			require.Empty(t, tc.get(jsonTxn))
+
+			jsonFields[tc.field] = json.RawMessage("null")
+			nullJSON, err := json.Marshal(jsonFields)
+			require.NoError(t, err)
+			fromNullJSON, err := txcore.ParseJSON(nullJSON)
+			require.NoError(t, err)
+			nullTxn := fromNullJSON.(*DepositPreauth)
+			require.True(t, nullTxn.GetCommon().HasField(tc.field))
+			nullFlat, err := nullTxn.Flatten()
+			require.NoError(t, err)
+			require.Equal(t, []map[string]any{}, nullFlat[tc.field])
+			featureErr := nullTxn.CheckExtraFeatures(amendment.EmptyRules())
+			resultErr, ok := ter.AsResultError(featureErr)
+			require.True(t, ok)
+			require.Equal(t, ter.TemDISABLED, resultErr.Code)
+			require.NoError(t, nullTxn.CheckExtraFeatures(amendment.AllSupportedRules()))
+			validationErr := nullTxn.Validate()
+			resultErr, ok = ter.AsResultError(validationErr)
+			require.True(t, ok)
+			require.Equal(t, ter.TemARRAY_EMPTY, resultErr.Code)
+
+			blob, err := binarycodec.EncodeBytes(flat)
+			require.NoError(t, err)
+			fromBinary, err := txcore.ParseFromBinary(blob)
+			require.NoError(t, err)
+			binaryTxn := fromBinary.(*DepositPreauth)
+			require.NotNil(t, tc.get(binaryTxn))
+			require.Empty(t, tc.get(binaryTxn))
+			require.True(t, binaryTxn.GetCommon().HasField(tc.field))
+			binaryFlat, err := binaryTxn.Flatten()
+			require.NoError(t, err)
+			reencoded, err := binarycodec.EncodeBytes(binaryFlat)
+			require.NoError(t, err)
+			require.Equal(t, blob, reencoded)
+
+			_, err = sign.SignTransaction(txn, privateKey)
+			require.NoError(t, err)
+
+			featureErr = binaryTxn.CheckExtraFeatures(amendment.EmptyRules())
+			resultErr, ok = ter.AsResultError(featureErr)
+			require.True(t, ok)
+			require.Equal(t, ter.TemDISABLED, resultErr.Code)
+			require.NoError(t, binaryTxn.CheckExtraFeatures(amendment.AllSupportedRules()))
+
+			validationErr = binaryTxn.Validate()
+			resultErr, ok = ter.AsResultError(validationErr)
+			require.True(t, ok)
+			require.Equal(t, ter.TemARRAY_EMPTY, resultErr.Code)
+		})
+	}
+}
+
+func TestNonEmptyCredentialArrayKeepsCanonicalSTArrayShape(t *testing.T) {
+	for _, field := range []string{"AuthorizeCredentials", "UnauthorizeCredentials"} {
+		t.Run(field, func(t *testing.T) {
+			txn := NewDepositPreauth("rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh")
+			credentials := []CredentialWrapper{{Credential: CredentialSpec{
+				Issuer:         "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+				CredentialType: "61",
+			}}}
+			if field == "AuthorizeCredentials" {
+				txn.AuthorizeCredentials = credentials
+			} else {
+				txn.UnauthorizeCredentials = credentials
+			}
+			flat, err := txn.Flatten()
+			require.NoError(t, err)
+			require.IsType(t, []map[string]any{}, flat[field])
+			_, err = binarycodec.EncodeBytes(flat)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestCredentialArrayAbsenceRoundTrips(t *testing.T) {
+	txn := NewDepositPreauth("rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh")
+	flat, err := txn.Flatten()
+	require.NoError(t, err)
+	require.NotContains(t, flat, "AuthorizeCredentials")
+	require.NotContains(t, flat, "UnauthorizeCredentials")
+	require.NoError(t, txn.CheckExtraFeatures(amendment.EmptyRules()))
+	validationErr := txn.Validate()
+	resultErr, ok := ter.AsResultError(validationErr)
+	require.True(t, ok)
+	require.Equal(t, ter.TemMALFORMED, resultErr.Code)
+}

--- a/internal/tx/depositpreauth/wire_presence_test.go
+++ b/internal/tx/depositpreauth/wire_presence_test.go
@@ -141,11 +141,29 @@ func TestNonEmptyCredentialArrayKeepsCanonicalSTArrayShape(t *testing.T) {
 }
 
 func TestCredentialArrayAbsenceRoundTrips(t *testing.T) {
+	registerWireTests.Do(Register)
 	txn := NewDepositPreauth("rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh")
 	flat, err := txn.Flatten()
 	require.NoError(t, err)
 	require.NotContains(t, flat, "AuthorizeCredentials")
 	require.NotContains(t, flat, "UnauthorizeCredentials")
+
+	jsonBytes, err := txcore.ToJSON(txn)
+	require.NoError(t, err)
+	fromJSON, err := txcore.ParseJSON(jsonBytes)
+	require.NoError(t, err)
+	jsonTxn := fromJSON.(*DepositPreauth)
+	require.False(t, jsonTxn.GetCommon().HasField("AuthorizeCredentials"))
+	require.False(t, jsonTxn.GetCommon().HasField("UnauthorizeCredentials"))
+
+	blob, err := binarycodec.EncodeBytes(flat)
+	require.NoError(t, err)
+	fromBinary, err := txcore.ParseFromBinary(blob)
+	require.NoError(t, err)
+	binaryTxn := fromBinary.(*DepositPreauth)
+	require.False(t, binaryTxn.GetCommon().HasField("AuthorizeCredentials"))
+	require.False(t, binaryTxn.GetCommon().HasField("UnauthorizeCredentials"))
+
 	require.NoError(t, txn.CheckExtraFeatures(amendment.EmptyRules()))
 	validationErr := txn.Validate()
 	resultErr, ok := ter.AsResultError(validationErr)

--- a/internal/tx/depositpreauth/wire_presence_test.go
+++ b/internal/tx/depositpreauth/wire_presence_test.go
@@ -142,7 +142,12 @@ func TestNonEmptyCredentialArrayKeepsCanonicalSTArrayShape(t *testing.T) {
 
 func TestCredentialArrayAbsenceRoundTrips(t *testing.T) {
 	registerWireTests.Do(Register)
+	_, publicKey, err := ed25519.Algorithm{}.DeriveKeypair([]byte("depositpreauth-field-absence"), false)
+	require.NoError(t, err)
 	txn := NewDepositPreauth("rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh")
+	txn.Fee = "10"
+	txn.SetSequence(1)
+	txn.SigningPubKey = publicKey
 	flat, err := txn.Flatten()
 	require.NoError(t, err)
 	require.NotContains(t, flat, "AuthorizeCredentials")


### PR DESCRIPTION
## Summary

- preserve `AuthorizeCredentials` and `UnauthorizeCredentials` field presence across JSON (including `null`), binary encoding, signing, and validation without changing non-empty STArray encoding
- fail closed when DepositPreauth ledger entries, owner links, or storage operations are inconsistent; distinguish true directory-capacity failures from fatal internal errors and prove atomic rollback at the engine boundary
- replace state-dependent lifecycle tests and placeholders with exact SLE, owner-directory, reserve, sorting, payment, NoRipple, and expired-credential escrow assertions
- make credential test builders explicit about text, byte, and hex representations and migrate affected consumers

## Rippled conformance

Reviewed against the retained rippled v3.2.0 sources for `DepositPreauth`, JSON STArray parsing, owner-count confinement, and the DepositAuth/DepositPreauth test suite. The stored-owner mismatch rejection is intentional issue-required hardening; all other reviewed observable outcomes match the oracle.

## Verification

- `go test ./internal/tx/depositpreauth ./internal/ledger/state ./internal/testing/depositpreauth ./internal/testing/credential ./internal/testing/payment ./internal/testing/escrow ./internal/testing/accountdelete ./internal/testing/paychan ./internal/testing/permissioneddex ./internal/testing/vault -count=1`
- `go test ./internal/testing/depositpreauth -count=20`
- `go test -race ./internal/tx/depositpreauth ./internal/testing/depositpreauth -count=1`
- `just vet`
- `golangci-lint run`
- `just lint`
- `just build-all`
- `git diff --check origin/main...HEAD`

`go test ./... -count=1` passes every changed package. Its sole failure is the pre-existing `internal/validator/list.TestAggregator_ApplyCollection_ExplicitEmptyLocalManifestDoesNotFallback`, reproduced unchanged on the original base checkout.

Fixes #1506


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened deposit preauthorization validation when required account or owner information is missing.
  - Improved handling of credential-based authorizations, including empty, invalid, expired, and malformed credential data.
  - Prevented inconsistent ledger updates and ensured failed authorization or removal operations roll back safely.
  - Improved error reporting for directory, storage, and ledger-state failures.

- **Testing**
  - Expanded coverage for credential lifecycles, escrow, payments, reserves, serialization, directory integrity, and rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->