### PR TITLE
fix: harden peer resource accounting

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -725,6 +725,25 @@ func TestOverlayConfig_InboundRetainedBytesValidation(t *testing.T) {
 	assert.Contains(t, err.Error(), "inbound_retained_bytes")
 }
 
+func TestOverlayConfig_ResourceLimitsValidation(t *testing.T) {
+	valid := OverlayConfig{ResourceLimits: ResourceLimitsConfig{
+		MaxEntries: 200, MaxImportedEntries: 100, MaxImportOrigins: 10, MaxImportItems: 50,
+	}}
+	require.NoError(t, valid.Validate())
+
+	tests := []ResourceLimitsConfig{
+		{MaxEntries: -1},
+		{MaxEntries: 10, MaxImportedEntries: 11},
+		{MaxImportOrigins: -1},
+		{MaxImportItems: 1025},
+	}
+	for _, limits := range tests {
+		err := (&OverlayConfig{ResourceLimits: limits}).Validate()
+		require.Error(t, err, "limits=%+v", limits)
+		assert.Contains(t, err.Error(), "resource_limits")
+	}
+}
+
 func TestConfigValidation_CompleteConfig(t *testing.T) {
 	assert.NoError(t, ValidateConfig(validCompleteConfig()))
 }

--- a/config/peer.go
+++ b/config/peer.go
@@ -18,12 +18,22 @@ import (
 //     0 skips validation for local dev networks — a security risk on a
 //     public network
 type OverlayConfig struct {
-	PublicIP             string `toml:"public_ip" mapstructure:"public_ip"`
-	IPLimit              int    `toml:"ip_limit" mapstructure:"ip_limit"`
-	MaxUnknownTime       int    `toml:"max_unknown_time" mapstructure:"max_unknown_time"`
-	MaxDivergedTime      int    `toml:"max_diverged_time" mapstructure:"max_diverged_time"`
-	VerifyEndpoints      *int   `toml:"verify_endpoints" mapstructure:"verify_endpoints"`
-	InboundRetainedBytes int64  `toml:"inbound_retained_bytes" mapstructure:"inbound_retained_bytes"`
+	PublicIP             string               `toml:"public_ip" mapstructure:"public_ip"`
+	IPLimit              int                  `toml:"ip_limit" mapstructure:"ip_limit"`
+	MaxUnknownTime       int                  `toml:"max_unknown_time" mapstructure:"max_unknown_time"`
+	MaxDivergedTime      int                  `toml:"max_diverged_time" mapstructure:"max_diverged_time"`
+	VerifyEndpoints      *int                 `toml:"verify_endpoints" mapstructure:"verify_endpoints"`
+	InboundRetainedBytes int64                `toml:"inbound_retained_bytes" mapstructure:"inbound_retained_bytes"`
+	ResourceLimits       ResourceLimitsConfig `toml:"resource_limits" mapstructure:"resource_limits"`
+}
+
+// ResourceLimitsConfig bounds peer reputation and cluster-gossip state.
+// Zero values retain the built-in limits.
+type ResourceLimitsConfig struct {
+	MaxEntries         int `toml:"max_entries" mapstructure:"max_entries"`
+	MaxImportedEntries int `toml:"max_imported_entries" mapstructure:"max_imported_entries"`
+	MaxImportOrigins   int `toml:"max_import_origins" mapstructure:"max_import_origins"`
+	MaxImportItems     int `toml:"max_import_items" mapstructure:"max_import_items"`
 }
 
 // TransactionQueueConfig represents the [transaction_queue] section (EXPERIMENTAL).
@@ -74,6 +84,30 @@ func (o *OverlayConfig) Validate() error {
 	}
 	if o.InboundRetainedBytes != 0 && o.InboundRetainedBytes < 3*64*1024*1024 {
 		return fmt.Errorf("inbound_retained_bytes must be at least %d, got %d", 3*64*1024*1024, o.InboundRetainedBytes)
+	}
+	limits := o.ResourceLimits
+	for _, limit := range []struct {
+		name  string
+		value int
+	}{
+		{"resource_limits.max_entries", limits.MaxEntries},
+		{"resource_limits.max_imported_entries", limits.MaxImportedEntries},
+		{"resource_limits.max_import_origins", limits.MaxImportOrigins},
+		{"resource_limits.max_import_items", limits.MaxImportItems},
+	} {
+		if err := validateNonNegative(limit.name, limit.value); err != nil {
+			return err
+		}
+	}
+	effectiveEntries := limits.MaxEntries
+	if effectiveEntries == 0 {
+		effectiveEntries = 32768
+	}
+	if limits.MaxImportedEntries != 0 && limits.MaxImportedEntries > effectiveEntries {
+		return fmt.Errorf("resource_limits.max_imported_entries (%d) exceeds max_entries (%d)", limits.MaxImportedEntries, effectiveEntries)
+	}
+	if limits.MaxImportItems > 1024 {
+		return fmt.Errorf("resource_limits.max_import_items must not exceed 1024, got %d", limits.MaxImportItems)
 	}
 
 	return nil

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -15,6 +15,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/manifest"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 	validatorlist "github.com/LeJamon/go-xrpl/internal/validator/list"
 	"github.com/LeJamon/go-xrpl/shamap"
 )
@@ -1008,7 +1009,8 @@ func (r *Router) processManifestJobContext(ctx context.Context, msg *peermanagem
 		}()
 		payload, err := msg.ManifestFrame.Materialize(ctx)
 		if err != nil {
-			if errors.Is(err, message.ErrDecompressFailed) && r.gossip != nil {
+			if errors.Is(err, message.ErrDecompressFailed) && r.gossip != nil &&
+				!msg.SelectPeerCharge(resource.FeeInvalidData(), "decompress-lz4-failed") {
 				r.gossip.IncPeerBadData(uint64(msg.PeerID), "decompress-lz4-failed")
 			}
 			r.logger.Warn("failed to materialize manifest spool", "error", err, "peer", msg.PeerID)
@@ -1017,6 +1019,7 @@ func (r *Router) processManifestJobContext(ctx context.Context, msg *peermanagem
 		msg.Payload = payload
 	}
 	processed = r.handleManifests(msg)
+	msg.CompletePeerCharge()
 	if processed {
 		if acknowledger, ok := r.peerSessions.(peerBootstrapAcknowledger); ok {
 			acknowledger.AcknowledgePeerBootstrap(msg.PeerID)

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -14,6 +14,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/manifest"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
 
@@ -144,17 +145,25 @@ func (r *Router) handleManifests(msg *peermanagement.InboundMessage) bool {
 	if err != nil {
 		r.logger.Warn("failed to decode manifests frame", "error", err, "peer", msg.PeerID)
 		reason := "manifests-decode"
+		fee := resource.FeeInvalidData()
 		var limitErr *message.WireLimitError
 		if errors.As(err, &limitErr) && limitErr.Reason == message.WireLimitManifests {
 			reason = "manifests-oversize"
+			fee = resource.FeeModerateBurdenPeer()
 		} else if errors.Is(err, message.ErrWireLimit) {
 			reason = "wire-invalid"
 		}
-		r.gossip.IncPeerBadData(uint64(msg.PeerID), reason)
+		if !msg.SelectPeerCharge(fee, reason) {
+			r.gossip.IncPeerBadData(uint64(msg.PeerID), reason)
+		}
 		return false
 	}
 	if count == 0 {
+		msg.SelectPeerCharge(resource.FeeUselessData(), "empty")
 		return true
+	}
+	if count > manifestFrameMaxEntries {
+		msg.SelectPeerCharge(resource.FeeModerateBurdenPeer(), "oversize")
 	}
 	if badManifest {
 		r.gossip.IncPeerBadData(uint64(msg.PeerID), "manifest-invalid")

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -1000,10 +1000,10 @@ func OverlayOptionsFromConfig(appCfg *config.Config) []peermanagement.Option {
 			limits.MaxImportedEntries = configuredLimits.MaxImportedEntries
 		}
 		if configuredLimits.MaxImportOrigins != 0 {
-			limits.MaxImportOrigins = configuredLimits.MaxImportOrigins
+			limits.MaxImports = configuredLimits.MaxImportOrigins
 		}
 		if configuredLimits.MaxImportItems != 0 {
-			limits.MaxImportItems = configuredLimits.MaxImportItems
+			limits.MaxGossipItems = configuredLimits.MaxImportItems
 		}
 		if configuredLimits.MaxImportedEntries == 0 && limits.MaxImportedEntries > limits.MaxEntries {
 			limits.MaxImportedEntries = limits.MaxEntries

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -21,6 +21,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/manifest"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 	validatorlist "github.com/LeJamon/go-xrpl/internal/validator/list"
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 )
@@ -988,6 +989,26 @@ func OverlayOptionsFromConfig(appCfg *config.Config) []peermanagement.Option {
 	}
 	if appCfg.Overlay.InboundRetainedBytes != 0 {
 		opts = append(opts, peermanagement.WithInboundRetainedBytes(appCfg.Overlay.InboundRetainedBytes))
+	}
+	configuredLimits := appCfg.Overlay.ResourceLimits
+	if configuredLimits != (config.ResourceLimitsConfig{}) {
+		limits := resource.DefaultLimits()
+		if configuredLimits.MaxEntries != 0 {
+			limits.MaxEntries = configuredLimits.MaxEntries
+		}
+		if configuredLimits.MaxImportedEntries != 0 {
+			limits.MaxImportedEntries = configuredLimits.MaxImportedEntries
+		}
+		if configuredLimits.MaxImportOrigins != 0 {
+			limits.MaxImportOrigins = configuredLimits.MaxImportOrigins
+		}
+		if configuredLimits.MaxImportItems != 0 {
+			limits.MaxImportItems = configuredLimits.MaxImportItems
+		}
+		if configuredLimits.MaxImportedEntries == 0 && limits.MaxImportedEntries > limits.MaxEntries {
+			limits.MaxImportedEntries = limits.MaxEntries
+		}
+		opts = append(opts, peermanagement.WithResourceLimits(limits))
 	}
 
 	return opts

--- a/internal/consensus/adaptor/startup_test.go
+++ b/internal/consensus/adaptor/startup_test.go
@@ -93,9 +93,12 @@ func TestOverlayOptionsFromConfig_ResourceLimits(t *testing.T) {
 		opt(&cfg)
 	}
 
-	assert.Equal(t, resource.Limits{
-		MaxEntries: 100, MaxImportedEntries: 75, MaxImportOrigins: 12, MaxImportItems: 64,
-	}, cfg.ResourceLimits)
+	want := resource.DefaultLimits()
+	want.MaxEntries = 100
+	want.MaxImportedEntries = 75
+	want.MaxImports = 12
+	want.MaxGossipItems = 64
+	assert.Equal(t, want, cfg.ResourceLimits)
 }
 
 func TestOverlayOptionsFromConfig_PartialResourceLimitsRetainDefaults(t *testing.T) {

--- a/internal/consensus/adaptor/startup_test.go
+++ b/internal/consensus/adaptor/startup_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/config"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -80,6 +81,35 @@ func TestOverlayOptionsFromConfig_InboundRetainedBytes(t *testing.T) {
 	}
 
 	assert.EqualValues(t, budget, cfg.InboundRetainedBytes)
+}
+
+func TestOverlayOptionsFromConfig_ResourceLimits(t *testing.T) {
+	cfg := peermanagement.DefaultConfig()
+	for _, opt := range OverlayOptionsFromConfig(&config.Config{
+		Overlay: config.OverlayConfig{ResourceLimits: config.ResourceLimitsConfig{
+			MaxEntries: 100, MaxImportedEntries: 75, MaxImportOrigins: 12, MaxImportItems: 64,
+		}},
+	}) {
+		opt(&cfg)
+	}
+
+	assert.Equal(t, resource.Limits{
+		MaxEntries: 100, MaxImportedEntries: 75, MaxImportOrigins: 12, MaxImportItems: 64,
+	}, cfg.ResourceLimits)
+}
+
+func TestOverlayOptionsFromConfig_PartialResourceLimitsRetainDefaults(t *testing.T) {
+	cfg := peermanagement.DefaultConfig()
+	for _, opt := range OverlayOptionsFromConfig(&config.Config{
+		Overlay: config.OverlayConfig{ResourceLimits: config.ResourceLimitsConfig{MaxEntries: 100}},
+	}) {
+		opt(&cfg)
+	}
+
+	want := resource.DefaultLimits()
+	want.MaxEntries = 100
+	want.MaxImportedEntries = 100
+	assert.Equal(t, want, cfg.ResourceLimits)
 }
 
 func TestOverlayOptionsFromConfig_BootstrapPrecedence(t *testing.T) {

--- a/internal/node/lifecycle_test.go
+++ b/internal/node/lifecycle_test.go
@@ -52,7 +52,7 @@ func TestBindRPCWiresExplicitSharedServices(t *testing.T) {
 	consumer := runtime.resourceManager.NewInboundEndpoint("192.0.2.25")
 	consumer.Charge(resource.NewCharge(resource.WarningThreshold*resource.DecayWindowSeconds, "test"), "")
 	defer consumer.Release()
-	if got := runtime.services.ResourceBlacklist(nil); got["192.0.2.25"] == nil {
+	if got := runtime.services.ResourceBlacklist(nil); got["IP Address: 192.0.2.25"] == nil {
 		t.Fatalf("standalone resource blacklist = %+v", got)
 	}
 }

--- a/internal/peermanagement/cluster_peers_test.go
+++ b/internal/peermanagement/cluster_peers_test.go
@@ -6,6 +6,7 @@ import (
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/cluster"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -126,6 +127,49 @@ func TestPeersJSON_NoClusterConfigured(t *testing.T) {
 	require.Len(t, out, 1)
 	assert.NotContains(t, out[0], "cluster")
 	assert.NotContains(t, out[0], "name")
+}
+
+func TestClusterPeerRetainsDirectionalResourceAccounting(t *testing.T) {
+	clusterID, err := NewIdentity()
+	require.NoError(t, err)
+	clusterPub, err := addresscodec.EncodeNodePublicKey(clusterID.PublicKey())
+	require.NoError(t, err)
+
+	o, err := New(WithDataDir(t.TempDir()), WithClusterNodes(clusterPub+" trusted"))
+	require.NoError(t, err)
+	peer := newPeerWithRemoteKey(t, o, 1, Endpoint{Host: "192.0.2.31", Port: 51235}, clusterID)
+	peer.inbound = true
+	require.NoError(t, o.addPeer(peer))
+	require.True(t, o.isClusterPeer(peer))
+
+	entries := o.resourceManager.Snapshot(0)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "inbound", entries[0].Type)
+	assert.Equal(t,
+		"IP Address: 192.0.2.31, Public Key: "+clusterID.EncodedPublicKey(),
+		entries[0].Address,
+	)
+
+	removed := make(chan struct{})
+	go func() {
+		<-peer.closeCh
+		o.removePeer(peer.ID())
+		close(removed)
+	}()
+	fee := resource.NewCharge(resource.DropThreshold+1, "cluster abuse")
+	for range 100 {
+		if peer.Charge(fee, "cluster abuse") == resource.Drop {
+			break
+		}
+	}
+	select {
+	case <-removed:
+	case <-time.After(time.Second):
+		t.Fatal("cluster peer was not removed after resource drop")
+	}
+	_, exists := o.getPeer(peer.ID())
+	assert.False(t, exists)
+	assert.Equal(t, uint64(1), o.PeerDisconnectsResources())
 }
 
 // TestClusterJSON_ExcludesSelfAndShapesEntries mirrors rippled

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -540,6 +540,9 @@ func (c *Config) Validate() error {
 	if limits.MaxEntries > 0 && limits.MaxImportedEntries > limits.MaxEntries {
 		return errors.New("MaxImportedEntries cannot exceed MaxEntries")
 	}
+	if limits.MaxImportItems > resource.DefaultMaxImportItems {
+		return fmt.Errorf("MaxImportItems cannot exceed %d", resource.DefaultMaxImportItems)
+	}
 	if c.ServerDomain != "" && !protocol.IsProperlyFormedTomlDomain(c.ServerDomain) {
 		return errors.New("invalid ServerDomain: the domain name does not appear to meet the requirements")
 	}

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -534,14 +534,20 @@ func (c *Config) Validate() error {
 	}
 	limits := c.ResourceLimits
 	if limits.MaxEntries < 0 || limits.MaxImportedEntries < 0 ||
-		limits.MaxImportOrigins < 0 || limits.MaxImportItems < 0 {
+		limits.MaxImports < 0 || limits.MaxGossipItems < 0 ||
+		limits.MaxInflightPerConsumer < 0 || limits.MaxCleanupPerTick < 0 ||
+		limits.MaxEndpointLength < 0 || limits.MaxOriginLength < 0 {
 		return errors.New("resource limits cannot be negative")
 	}
-	if limits.MaxEntries > 0 && limits.MaxImportedEntries > limits.MaxEntries {
+	effectiveEntries := limits.MaxEntries
+	if effectiveEntries == 0 {
+		effectiveEntries = resource.DefaultLimits().MaxEntries
+	}
+	if limits.MaxImportedEntries > effectiveEntries {
 		return errors.New("MaxImportedEntries cannot exceed MaxEntries")
 	}
-	if limits.MaxImportItems > resource.DefaultMaxImportItems {
-		return fmt.Errorf("MaxImportItems cannot exceed %d", resource.DefaultMaxImportItems)
+	if limits.MaxGossipItems > resource.DefaultLimits().MaxGossipItems {
+		return fmt.Errorf("MaxGossipItems cannot exceed %d", resource.DefaultLimits().MaxGossipItems)
 	}
 	if c.ServerDomain != "" && !protocol.IsProperlyFormedTomlDomain(c.ServerDomain) {
 		return errors.New("invalid ServerDomain: the domain name does not appear to meet the requirements")

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
 
@@ -207,6 +208,7 @@ type Config struct {
 	// (the [overlay] verify_endpoints = 0 knob) accepts them, for local
 	// dev networks — a security risk on a public network.
 	VerifyEndpoints bool
+	ResourceLimits  resource.Limits
 
 	// Clock function for testing
 	Clock func() time.Time
@@ -246,6 +248,7 @@ func DefaultConfig() Config {
 		// Endpoint verification is on by default; only a local dev
 		// network (verify_endpoints = 0) turns it off.
 		VerifyEndpoints: true,
+		ResourceLimits:  resource.DefaultLimits(),
 
 		Clock: time.Now,
 	}
@@ -449,6 +452,12 @@ func WithVerifyEndpoints(enabled bool) Option {
 	}
 }
 
+func WithResourceLimits(limits resource.Limits) Option {
+	return func(c *Config) {
+		c.ResourceLimits = limits
+	}
+}
+
 // WithEventBufferSize sets the internal event channel buffer size.
 func WithEventBufferSize(size int) Option {
 	return func(c *Config) {
@@ -522,6 +531,14 @@ func (c *Config) Validate() error {
 	}
 	if c.Clock == nil {
 		return errors.New("Clock function cannot be nil")
+	}
+	limits := c.ResourceLimits
+	if limits.MaxEntries < 0 || limits.MaxImportedEntries < 0 ||
+		limits.MaxImportOrigins < 0 || limits.MaxImportItems < 0 {
+		return errors.New("resource limits cannot be negative")
+	}
+	if limits.MaxEntries > 0 && limits.MaxImportedEntries > limits.MaxEntries {
+		return errors.New("MaxImportedEntries cannot exceed MaxEntries")
 	}
 	if c.ServerDomain != "" && !protocol.IsProperlyFormedTomlDomain(c.ServerDomain) {
 		return errors.New("invalid ServerDomain: the domain name does not appear to meet the requirements")

--- a/internal/peermanagement/config_test.go
+++ b/internal/peermanagement/config_test.go
@@ -56,8 +56,8 @@ func TestConfigResourceLimits(t *testing.T) {
 	WithResourceLimits(resource.Limits{
 		MaxEntries:         10,
 		MaxImportedEntries: 11,
-		MaxImportOrigins:   1,
-		MaxImportItems:     1,
+		MaxImports:         1,
+		MaxGossipItems:     1,
 	})(&cfg)
 	if err := cfg.Validate(); err == nil {
 		t.Fatal("Validate accepted more imported entries than total entries")

--- a/internal/peermanagement/config_test.go
+++ b/internal/peermanagement/config_test.go
@@ -3,6 +3,8 @@ package peermanagement
 import (
 	"net"
 	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 )
 
 func TestWithPublicIPCopiesCallerValue(t *testing.T) {
@@ -42,6 +44,23 @@ func TestConfigValidateServerDomain(t *testing.T) {
 				t.Fatalf("Validate returned error: %v", err)
 			}
 		})
+	}
+}
+
+func TestConfigResourceLimits(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.ResourceLimits != resource.DefaultLimits() {
+		t.Fatalf("resource limits = %+v, want defaults %+v", cfg.ResourceLimits, resource.DefaultLimits())
+	}
+
+	WithResourceLimits(resource.Limits{
+		MaxEntries:         10,
+		MaxImportedEntries: 11,
+		MaxImportOrigins:   1,
+		MaxImportItems:     1,
+	})(&cfg)
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate accepted more imported entries than total entries")
 	}
 }
 

--- a/internal/peermanagement/errors.go
+++ b/internal/peermanagement/errors.go
@@ -38,6 +38,7 @@ var (
 	ErrPeerNotFound    = errors.New("peer not found")
 	ErrInvalidEndpoint = errors.New("invalid endpoint")
 	ErrEndpointBanned  = errors.New("endpoint is banned")
+	ErrResourceLimit   = errors.New("resource reputation capacity reached")
 
 	// Message errors
 	ErrInvalidMessage  = errors.New("invalid message")

--- a/internal/peermanagement/events.go
+++ b/internal/peermanagement/events.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 )
 
 // PeerID is a unique identifier for a connected peer.
@@ -134,6 +135,7 @@ type Event struct {
 	Error error
 
 	reservation *inboundReservation
+	charge      *messageCharge
 }
 
 func (e *Event) release() {
@@ -148,6 +150,10 @@ func (e *Event) release() {
 		e.reservation.release()
 		e.reservation = nil
 	}
+	if e.charge != nil {
+		e.charge.finish()
+		e.charge = nil
+	}
 }
 
 func (e *Event) inboundMessage() *InboundMessage {
@@ -161,6 +167,21 @@ func (e *Event) inboundMessage() *InboundMessage {
 	e.reservation = nil
 	e.ManifestFrame = nil
 	return msg
+}
+
+func (e *Event) manifestInboundMessage() *InboundMessage {
+	msg := e.inboundMessage()
+	msg.charge = e.charge
+	e.charge = nil
+	return msg
+}
+
+func (e *Event) selectCharge(fee resource.Charge, chargeContext string) bool {
+	if e == nil || e.charge == nil {
+		return false
+	}
+	e.charge.update(fee, chargeContext)
+	return true
 }
 
 func (e *Event) retainedInboundMessage() *InboundMessage {
@@ -195,6 +216,7 @@ type InboundMessage struct {
 	Tx *message.Transaction
 
 	reservation *inboundReservation
+	charge      *messageCharge
 	closeOnce   sync.Once
 	closeErr    error
 }
@@ -210,6 +232,23 @@ func (m *InboundMessage) Close() error {
 		}
 		m.reservation.release()
 		m.reservation = nil
+		m.charge.finish()
+		m.charge = nil
 	})
 	return m.closeErr
+}
+
+func (m *InboundMessage) SelectPeerCharge(fee resource.Charge, chargeContext string) bool {
+	if m == nil || m.charge == nil {
+		return false
+	}
+	m.charge.update(fee, chargeContext)
+	return true
+}
+
+// CompletePeerCharge applies the selected per-message charge exactly once.
+func (m *InboundMessage) CompletePeerCharge() {
+	if m != nil {
+		m.charge.finish()
+	}
 }

--- a/internal/peermanagement/events.go
+++ b/internal/peermanagement/events.go
@@ -171,10 +171,6 @@ func (e *Event) inboundMessage() *InboundMessage {
 	return msg
 }
 
-func (e *Event) manifestInboundMessage() *InboundMessage {
-	return e.inboundMessage()
-}
-
 func (e *Event) selectCharge(fee resource.Charge, chargeContext string) bool {
 	if e == nil || e.charge == nil {
 		return false

--- a/internal/peermanagement/events.go
+++ b/internal/peermanagement/events.go
@@ -163,17 +163,16 @@ func (e *Event) inboundMessage() *InboundMessage {
 		Payload:       e.Payload,
 		ManifestFrame: e.ManifestFrame,
 		reservation:   e.reservation,
+		charge:        e.charge,
 	}
 	e.reservation = nil
+	e.charge = nil
 	e.ManifestFrame = nil
 	return msg
 }
 
 func (e *Event) manifestInboundMessage() *InboundMessage {
-	msg := e.inboundMessage()
-	msg.charge = e.charge
-	e.charge = nil
-	return msg
+	return e.inboundMessage()
 }
 
 func (e *Event) selectCharge(fee resource.Charge, chargeContext string) bool {

--- a/internal/peermanagement/fetchpack_test.go
+++ b/internal/peermanagement/fetchpack_test.go
@@ -125,7 +125,7 @@ func TestServeFetchPack_EmptyPackNoReply(t *testing.T) {
 	if _, ok := takeOutboundFrame(peer); ok {
 		t.Fatal("an empty pack must not produce a reply")
 	}
-	assert.Equal(t, []resource.Charge{resource.FeeHeavyBurdenPeer, resource.FeeRequestNoReply}, charges,
+	assert.Equal(t, []resource.Charge{resource.FeeHeavyBurdenPeer(), resource.FeeRequestNoReply()}, charges,
 		"an unavailable valid request must receive heavy and no-reply charges")
 }
 
@@ -144,7 +144,7 @@ func TestServeFetchPack_TooEarlyAddsMalformedCharge(t *testing.T) {
 	})
 
 	require.Equal(t, 1, prov.calls)
-	assert.Equal(t, []resource.Charge{resource.FeeHeavyBurdenPeer, resource.FeeMalformedRequest}, charges)
+	assert.Equal(t, []resource.Charge{resource.FeeHeavyBurdenPeer(), resource.FeeMalformedRequest()}, charges)
 	if _, ok := takeOutboundFrame(peer); ok {
 		t.Fatal("a too-early fetch pack must not produce a reply")
 	}

--- a/internal/peermanagement/handshake_envelope_test.go
+++ b/internal/peermanagement/handshake_envelope_test.go
@@ -485,7 +485,7 @@ func TestOutboundResourceAdmissionPrecedesDial(t *testing.T) {
 
 	const addr = "127.0.0.1:1"
 	consumer := o.resourceManager.NewOutboundEndpoint(addr)
-	for consumer.Disposition() != resource.Drop {
+	for {
 		if consumer.Charge(resource.NewCharge(resource.DropThreshold+1, "test"), "") == resource.Drop {
 			break
 		}

--- a/internal/peermanagement/handshake_envelope_test.go
+++ b/internal/peermanagement/handshake_envelope_test.go
@@ -473,6 +473,18 @@ func TestInboundVerificationErrorsWriteBadRequest(t *testing.T) {
 }
 
 func TestOutboundResourceAdmissionPrecedesDial(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+	accepted := make(chan struct{}, 1)
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			connection.Close()
+			accepted <- struct{}{}
+		}
+	}()
+
 	o := newLifecycleTestOverlay(t, WithListenAddr(""))
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
@@ -483,7 +495,7 @@ func TestOutboundResourceAdmissionPrecedesDial(t *testing.T) {
 		t.Fatal("overlay did not become ready")
 	}
 
-	const addr = "127.0.0.1:1"
+	addr := listener.Addr().String()
 	consumer := o.resourceManager.NewOutboundEndpoint(addr)
 	for {
 		if consumer.Charge(resource.NewCharge(resource.DropThreshold+1, "test"), "") == resource.Drop {
@@ -494,10 +506,27 @@ func TestOutboundResourceAdmissionPrecedesDial(t *testing.T) {
 	if err := o.Connect(addr); !errors.Is(err, ErrEndpointBanned) {
 		t.Fatalf("Connect error = %v, want ErrEndpointBanned before dial", err)
 	}
+	select {
+	case <-accepted:
+		t.Fatal("banned endpoint was dialed before resource admission")
+	case <-time.After(100 * time.Millisecond):
+	}
 	cancel()
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("overlay Run did not stop")
 	}
+}
+
+func TestResolveOutboundEndpointSupportsHostnames(t *testing.T) {
+	o := &Overlay{discovery: &Discovery{}}
+	o.discovery.lookupIP = func(_ context.Context, host string) ([]net.IPAddr, error) {
+		require.Equal(t, "peer.example", host)
+		return []net.IPAddr{{IP: net.ParseIP("192.0.2.80")}}, nil
+	}
+
+	endpoint, err := o.resolveOutboundEndpoint(t.Context(), Endpoint{Host: "peer.example", Port: 51235})
+	require.NoError(t, err)
+	require.Equal(t, Endpoint{Host: "192.0.2.80", Port: 51235}, endpoint)
 }

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -187,8 +187,6 @@ func (o *Overlay) handleClusterMessage(evt Event) {
 	}
 }
 
-// validGossipAddress accepts the literal-IP forms used by load-source gossip,
-// including the legacy whitespace-separated port syntax.
 func validGossipAddress(name string) bool {
 	_, ok := canonicalGossipAddress(name)
 	return ok

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"math/rand/v2"
 	"net"
+	"net/netip"
 	"strconv"
 	"strings"
 	"sync"
@@ -171,11 +172,12 @@ func (o *Overlay) handleClusterMessage(evt Event) {
 	if o.resourceManager != nil && len(cm.LoadSources) != 0 {
 		gossip := resource.Gossip{Items: make([]resource.GossipItem, 0, len(cm.LoadSources))}
 		for _, src := range cm.LoadSources {
-			if !validGossipAddress(src.Name) {
+			address, ok := canonicalGossipAddress(src.Name)
+			if !ok {
 				continue
 			}
 			gossip.Items = append(gossip.Items, resource.GossipItem{
-				Address: src.Name,
+				Address: address,
 				Balance: src.Cost,
 			})
 		}
@@ -185,32 +187,60 @@ func (o *Overlay) handleClusterMessage(evt Event) {
 	}
 }
 
-// validGossipAddress reports whether name parses as the IP endpoint that
-// a TMLoadSource carries. Mirrors rippled's
-// beast::IP::Endpoint::from_string + `!= Endpoint()` guard at
-// PeerImp.cpp:1166-1168, which silently drops a load source whose name
-// is not a valid endpoint. Both the rippled "ip:port" form (its exported
-// keys canonicalise to port 0) and go-xrpl's bare-host form (resource
-// keys strip the inbound port — see resource.normalizeAddr) round-trip.
-// The port is range-checked as a uint16 to match from_string, which
-// parses it into a uint16 and fails on an out-of-range or non-numeric
-// port (IPEndpoint.cpp:179-182); net.ParseIP already rejects anything
-// longer than from_string_checked's 64-char cap, so no separate guard.
+// validGossipAddress accepts the literal-IP forms used by load-source gossip,
+// including the legacy whitespace-separated port syntax.
 func validGossipAddress(name string) bool {
+	_, ok := canonicalGossipAddress(name)
+	return ok
+}
+
+func canonicalGossipAddress(name string) (string, bool) {
+	if len(name) > 64 {
+		return "", false
+	}
 	name = strings.TrimSpace(name)
 	if name == "" {
-		return false
+		return "", false
 	}
-	host := name
-	if h, port, err := net.SplitHostPort(name); err == nil {
-		if port != "" {
-			if _, err := strconv.ParseUint(port, 10, 16); err != nil {
-				return false
-			}
+
+	if addr, err := netip.ParseAddr(name); err == nil {
+		if addr.Zone() != "" {
+			return "", false
 		}
-		host = h
+		return addr.Unmap().String(), true
 	}
-	return net.ParseIP(host) != nil
+	if strings.HasPrefix(name, "[") && strings.HasSuffix(name, "]") {
+		if addr, err := netip.ParseAddr(name[1 : len(name)-1]); err == nil && addr.Zone() == "" {
+			return addr.Unmap().String(), true
+		}
+	}
+	if endpoint, err := netip.ParseAddrPort(name); err == nil {
+		if endpoint.Addr().Zone() != "" {
+			return "", false
+		}
+		return netip.AddrPortFrom(endpoint.Addr().Unmap(), endpoint.Port()).String(), true
+	}
+
+	fields := strings.Fields(name)
+	if len(fields) != 2 {
+		return "", false
+	}
+	host := fields[0]
+	if strings.HasPrefix(host, "[") || strings.HasSuffix(host, "]") {
+		if !strings.HasPrefix(host, "[") || !strings.HasSuffix(host, "]") || len(host) < 3 {
+			return "", false
+		}
+		host = host[1 : len(host)-1]
+	}
+	addr, err := netip.ParseAddr(host)
+	if err != nil || addr.Zone() != "" {
+		return "", false
+	}
+	port, err := strconv.ParseUint(fields[1], 10, 16)
+	if err != nil {
+		return "", false
+	}
+	return netip.AddrPortFrom(addr.Unmap(), uint16(port)).String(), true
 }
 
 // handleGetObjectsMessage processes mtGET_OBJECTS from a peer. Mirrors
@@ -259,7 +289,7 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 		case message.ObjectTypeFetchPack:
 			if len(gob.LedgerHash) != 32 {
 				if peerOK {
-					peer.Charge(resource.FeeMalformedRequest, "fetch pack ledger hash")
+					peer.Charge(resource.FeeMalformedRequest(), "fetch pack ledger hash")
 				}
 				return
 			}
@@ -294,7 +324,7 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 				o.IncPeerBadData(evt.PeerID, "get-objects-txn-unnegotiated")
 				return
 			}
-			o.submitRetainedServe(evt, resource.FeeModerateBurdenPeer,
+			o.submitRetainedServe(evt, resource.FeeModerateBurdenPeer(),
 				func(ctx context.Context) { o.serveDoTransactionsContext(ctx, evt.PeerID, gob) })
 			return
 		}
@@ -308,11 +338,11 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 		}
 		if len(gob.Objects) > hardMaxReplyNodes {
 			if peer, ok := o.getPeer(evt.PeerID); ok {
-				peer.Charge(resource.FeeInvalidData, "oversized get object request")
+				peer.Charge(resource.FeeInvalidData(), "oversized get object request")
 			}
 			return
 		}
-		o.submitRetainedServe(evt, resource.FeeModerateBurdenPeer,
+		o.submitRetainedServe(evt, resource.FeeModerateBurdenPeer(),
 			func(ctx context.Context) { o.serveGetObjectsContext(ctx, evt.PeerID, gob) })
 		return
 	}
@@ -388,7 +418,7 @@ func (o *Overlay) serveFetchPackContext(ctx context.Context, peerID PeerID, req 
 		return
 	}
 	if len(req.LedgerHash) != 32 {
-		o.chargeServePeer(peerID, resource.FeeMalformedRequest, "fetch pack ledger hash")
+		o.chargeServePeer(peerID, resource.FeeMalformedRequest(), "fetch pack ledger hash")
 		return
 	}
 
@@ -408,19 +438,19 @@ func (o *Overlay) serveFetchPackContext(ctx context.Context, peerID PeerID, req 
 	// Charge only after the provider has passed its local busy/stale guard.
 	// Unknown ledgers and other unavailable outcomes still incur the heavy
 	// request cost followed by the protocol's no-reply charge.
-	o.chargeServePeer(peerID, resource.FeeHeavyBurdenPeer, "fetch pack request")
+	o.chargeServePeer(peerID, resource.FeeHeavyBurdenPeer(), "fetch pack request")
 	if err != nil {
 		if errors.Is(err, ErrFetchPackTooEarly) || errors.Is(err, ErrFetchPackOpen) {
-			o.chargeServePeer(peerID, resource.FeeMalformedRequest, "fetch pack malformed request")
+			o.chargeServePeer(peerID, resource.FeeMalformedRequest(), "fetch pack malformed request")
 		} else if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-			o.chargeServePeer(peerID, resource.FeeRequestNoReply, "fetch pack request unavailable")
+			o.chargeServePeer(peerID, resource.FeeRequestNoReply(), "fetch pack request unavailable")
 		}
 		slog.Debug("fetch-pack build failed",
 			"t", "Overlay", "peer", peerID, "err", err)
 		return
 	}
 	if len(objects) == 0 {
-		o.chargeServePeer(peerID, resource.FeeRequestNoReply, "fetch pack request unavailable")
+		o.chargeServePeer(peerID, resource.FeeRequestNoReply(), "fetch pack request unavailable")
 		return
 	}
 	objects = limitIndexedObjectsToReplyBudget(objects, req.LedgerHash)
@@ -439,7 +469,7 @@ func (o *Overlay) serveFetchPackContext(ctx context.Context, peerID PeerID, req 
 	}
 	frame, err := message.EncodeFrame(reply)
 	if err != nil || len(frame) > message.MaxMessageSize {
-		o.chargeServePeer(peerID, resource.FeeRequestNoReply, "fetch pack response oversized")
+		o.chargeServePeer(peerID, resource.FeeRequestNoReply(), "fetch pack response oversized")
 		return
 	}
 	if err := peer.SendPriority(frame); err != nil {
@@ -760,7 +790,7 @@ func (o *Overlay) serveDoTransactionsContext(ctx context.Context, peerID PeerID,
 func (o *Overlay) chargeMalformedTransactionRequest(peerID PeerID, reason string) {
 	peer, ok := o.getPeer(peerID)
 	if ok {
-		peer.Charge(resource.FeeMalformedRequest, reason)
+		peer.Charge(resource.FeeMalformedRequest(), reason)
 	}
 }
 
@@ -859,7 +889,7 @@ func (o *Overlay) serveGetObjects(peerID PeerID, req *message.GetObjectByHash) {
 		(len(req.LedgerHash) == 0 || len(req.LedgerHash) == 32) &&
 		len(req.Objects) <= hardMaxReplyNodes {
 		if peer, ok := o.getPeer(peerID); ok {
-			peer.Charge(resource.FeeModerateBurdenPeer, "get object by hash request")
+			peer.Charge(resource.FeeModerateBurdenPeer(), "get object by hash request")
 		}
 	}
 	o.serveGetObjectsContext(context.Background(), peerID, req)
@@ -889,7 +919,7 @@ func (o *Overlay) serveGetObjectsContext(ctx context.Context, peerID PeerID, req
 	// charges feeMalformedRequest "ledger hash" on a wrong-sized field
 	// and returns (PeerImp.cpp:2492-2501).
 	if len(req.LedgerHash) != 0 && len(req.LedgerHash) != 32 {
-		peer.Charge(resource.FeeMalformedRequest, "get object ledger hash")
+		peer.Charge(resource.FeeMalformedRequest(), "get object ledger hash")
 		return
 	}
 
@@ -898,7 +928,7 @@ func (o *Overlay) serveGetObjectsContext(ctx context.Context, peerID PeerID, req
 	// is far below this cap; anything past it is non-conforming and is
 	// charged feeInvalidData (PeerImp.cpp:2500-2506).
 	if len(req.Objects) > hardMaxReplyNodes {
-		peer.Charge(resource.FeeInvalidData, "oversized get object request")
+		peer.Charge(resource.FeeInvalidData(), "oversized get object request")
 		return
 	}
 

--- a/internal/peermanagement/inbound_handlers_test.go
+++ b/internal/peermanagement/inbound_handlers_test.go
@@ -334,11 +334,8 @@ func TestHandleClusterMessage_ReimportReplacesPriorGossip(t *testing.T) {
 	assert.Equal(t, 1, rm.Stats().Imports, "one peer must retain one stable gossip origin")
 }
 
-// TestValidGossipAddress pins the load-source name filter against rippled's
-// beast::IP::Endpoint::from_string + `!= Endpoint()` guard
-// (PeerImp.cpp:1166-1168, IPEndpoint.cpp:179-182): a non-IP host or an
-// out-of-range / non-numeric port is dropped, while the bare-host and
-// ip:port forms (including the port-0 canonical) are accepted.
+// TestValidGossipAddress covers canonical IP endpoint forms and rejects
+// ambiguous or malformed peer-provided resource gossip addresses.
 func TestValidGossipAddress(t *testing.T) {
 	cases := []struct {
 		name string
@@ -349,7 +346,7 @@ func TestValidGossipAddress(t *testing.T) {
 		{"bare ipv4", "203.0.113.7", true},
 		{"ipv4 port zero", "203.0.113.7:0", true},
 		{"ipv4 high port", "203.0.113.7:51235", true},
-		{"ipv4 trailing colon", "203.0.113.7:", true},
+		{"ipv4 trailing colon", "203.0.113.7:", false},
 		{"ipv4 surrounding whitespace", " 203.0.113.7 ", true},
 		{"non-ip host", "not-an-address", false},
 		{"out-of-range port", "203.0.113.7:99999", false},

--- a/internal/peermanagement/inbound_handlers_test.go
+++ b/internal/peermanagement/inbound_handlers_test.go
@@ -355,12 +355,33 @@ func TestValidGossipAddress(t *testing.T) {
 		{"out-of-range port", "203.0.113.7:99999", false},
 		{"non-numeric port", "203.0.113.7:abc", false},
 		{"bare ipv6", "2001:db8::1", true},
+		{"bracketed bare ipv6", "[2001:db8::1]", true},
 		{"bracketed ipv6 with port", "[2001:db8::1]:51235", true},
+		{"legacy ipv4 port", "203.0.113.7 51235", true},
+		{"legacy ipv6 port", "2001:db8::1 51235", true},
+		{"trimmed", " 203.0.113.7:51235 ", true},
+		{"zone scoped", "fe80::1%en0", false},
+		{"zone scoped with port", "[fe80::1%en0]:51235", false},
+		{"whitespace before colon", "203.0.113.7 :51235", false},
+		{"too long", "2001:0db8:0000:0000:0000:0000:0000:0001 0000000000000000000051235", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, validGossipAddress(tc.in))
 		})
+	}
+}
+
+func TestCanonicalGossipAddress(t *testing.T) {
+	tests := map[string]string{
+		" 203.0.113.7:51235 ": "203.0.113.7:51235",
+		"2001:0DB8::1 51235":  "[2001:db8::1]:51235",
+		"[2001:0DB8::1]":      "2001:db8::1",
+	}
+	for input, want := range tests {
+		got, ok := canonicalGossipAddress(input)
+		require.True(t, ok)
+		assert.Equal(t, want, got)
 	}
 }
 
@@ -915,6 +936,20 @@ func TestHandleEndpoints_ChargesMalformedEntry(t *testing.T) {
 	defer o.discovery.mu.RUnlock()
 	require.Len(t, o.discovery.peers, 1)
 	assert.Contains(t, o.discovery.peers, "10.0.0.9:51235")
+}
+
+func TestHandleEndpoints_AggregatesMalformedEntryFees(t *testing.T) {
+	o, peer := newEndpointsTestOverlay(t, PeerID(115))
+	payload := encodeEndpoints(t, 2, []message.Endpointv2{
+		{Endpoint: "not-an-endpoint", Hops: 1},
+		{Endpoint: "also-invalid", Hops: 1},
+	})
+	o.onMessageReceived(Event{
+		PeerID: peer.ID(), MessageType: message.TypeEndpoints, Payload: payload,
+	})
+
+	want := uint32((2 * resource.FeeInvalidData().Cost()) / resource.DecayWindowSeconds)
+	assert.Equal(t, want, peer.BadDataCount())
 }
 
 // TestHandleEndpoints_RejectsOversizedFrame pins PeerImp.cpp:1206-1210: a

--- a/internal/peermanagement/inbound_handlers_test.go
+++ b/internal/peermanagement/inbound_handlers_test.go
@@ -334,8 +334,6 @@ func TestHandleClusterMessage_ReimportReplacesPriorGossip(t *testing.T) {
 	assert.Equal(t, 1, rm.Stats().Imports, "one peer must retain one stable gossip origin")
 }
 
-// TestValidGossipAddress covers canonical IP endpoint forms and rejects
-// ambiguous or malformed peer-provided resource gossip addresses.
 func TestValidGossipAddress(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/peermanagement/ledgersync.go
+++ b/internal/peermanagement/ledgersync.go
@@ -285,7 +285,7 @@ func (h *LedgerSyncHandler) handleProofPathRequest(ctx context.Context, peerID P
 	// rippled's ordering at LedgerReplayMsgHandler.cpp:46-54.
 	if len(req.Key) != 32 || len(req.LedgerHash) != 32 ||
 		(req.MapType != message.LedgerMapTransaction && req.MapType != message.LedgerMapAccountState) {
-		h.charge(peerID, resource.FeeMalformedRequest, "proof path request")
+		h.charge(peerID, resource.FeeMalformedRequest(), "proof path request")
 		return ErrPeerBadRequest
 	}
 
@@ -294,7 +294,7 @@ func (h *LedgerSyncHandler) handleProofPathRequest(ctx context.Context, peerID P
 	h.mu.RUnlock()
 
 	if provider == nil {
-		h.charge(peerID, resource.FeeRequestNoReply, "proof path request unavailable")
+		h.charge(peerID, resource.FeeRequestNoReply(), "proof path request unavailable")
 		return nil
 	}
 
@@ -316,13 +316,13 @@ func (h *LedgerSyncHandler) handleProofPathRequest(ctx context.Context, peerID P
 	}
 	switch {
 	case errors.Is(err, ErrLedgerNotFound):
-		h.charge(peerID, resource.FeeRequestNoReply, "proof path request no ledger")
+		h.charge(peerID, resource.FeeRequestNoReply(), "proof path request no ledger")
 		return nil
 	case errors.Is(err, ErrKeyNotFound):
 		// Rippled does not pack the header on the no-node path —
 		// LedgerReplayMsgHandler.cpp:84-90 returns before the header is
 		// serialized at line 92. Mirror that here.
-		h.charge(peerID, resource.FeeRequestNoReply, "proof path request no node")
+		h.charge(peerID, resource.FeeRequestNoReply(), "proof path request no node")
 		return nil
 	case err != nil:
 		slog.Warn("ProofPath provider error",
@@ -332,12 +332,12 @@ func (h *LedgerSyncHandler) handleProofPathRequest(ctx context.Context, peerID P
 		)
 		// Provider returned an unexpected error; the fault is ours, not the
 		// peer's, so charge the no-reply fee without signaling bad input.
-		h.charge(peerID, resource.FeeRequestNoReply, "proof path request provider error")
+		h.charge(peerID, resource.FeeRequestNoReply(), "proof path request provider error")
 		return nil
 	}
 
 	if proofPathResponseOversized(req, header, path) {
-		h.charge(peerID, resource.FeeRequestNoReply, "proof path response oversized")
+		h.charge(peerID, resource.FeeRequestNoReply(), "proof path response oversized")
 		return nil
 	}
 
@@ -373,7 +373,7 @@ func (h *LedgerSyncHandler) sendProofPathResponse(ctx context.Context, peerID Pe
 		return
 	}
 	if len(frame) > MaxProofPathResponseBytes {
-		h.charge(peerID, resource.FeeRequestNoReply, "proof path response oversized")
+		h.charge(peerID, resource.FeeRequestNoReply(), "proof path response oversized")
 		return
 	}
 	h.mu.RLock()
@@ -383,7 +383,7 @@ func (h *LedgerSyncHandler) sendProofPathResponse(ctx context.Context, peerID Pe
 	if prioritySender != nil {
 		if err := prioritySender(ctx, peerID, frame); err != nil && ctx.Err() == nil {
 			h.droppedResponses.Add(1)
-			h.charge(peerID, resource.FeeRequestNoReply, "proof path response send failed")
+			h.charge(peerID, resource.FeeRequestNoReply(), "proof path response send failed")
 			slog.Debug("ProofPath priority response failed", "t", "LedgerSync", "peer", peerID, "err", err)
 		}
 		return
@@ -437,7 +437,7 @@ func (h *LedgerSyncHandler) handleReplayDeltaRequest(ctx context.Context, peerID
 	// Validate ledger_hash length first — this check is independent of any
 	// configured provider, matching the rippled ordering.
 	if len(req.LedgerHash) != 32 {
-		h.charge(peerID, resource.FeeMalformedRequest, "replay delta request")
+		h.charge(peerID, resource.FeeMalformedRequest(), "replay delta request")
 		return ErrPeerBadRequest
 	}
 
@@ -446,7 +446,7 @@ func (h *LedgerSyncHandler) handleReplayDeltaRequest(ctx context.Context, peerID
 	h.mu.RUnlock()
 
 	if provider == nil {
-		h.charge(peerID, resource.FeeRequestNoReply, "replay delta request unavailable")
+		h.charge(peerID, resource.FeeRequestNoReply(), "replay delta request unavailable")
 		return nil
 	}
 
@@ -467,7 +467,7 @@ func (h *LedgerSyncHandler) handleReplayDeltaRequest(ctx context.Context, peerID
 		return err
 	}
 	if err != nil || len(header) == 0 {
-		h.charge(peerID, resource.FeeRequestNoReply, "replay delta request no ledger")
+		h.charge(peerID, resource.FeeRequestNoReply(), "replay delta request no ledger")
 		return nil
 	}
 
@@ -480,7 +480,7 @@ func (h *LedgerSyncHandler) handleReplayDeltaRequest(ctx context.Context, peerID
 			"size", len(header),
 			"limit", message.MaxMessageSize,
 		)
-		h.charge(peerID, resource.FeeRequestNoReply, "replay delta response oversized")
+		h.charge(peerID, resource.FeeRequestNoReply(), "replay delta response oversized")
 		return nil
 	}
 
@@ -522,7 +522,7 @@ func (h *LedgerSyncHandler) sendReplayDeltaResponse(ctx context.Context, peerID 
 	if prioritySender != nil {
 		if err := prioritySender(ctx, peerID, frame); err != nil && ctx.Err() == nil {
 			h.droppedResponses.Add(1)
-			h.charge(peerID, resource.FeeRequestNoReply, "replay delta response send failed")
+			h.charge(peerID, resource.FeeRequestNoReply(), "replay delta response send failed")
 			slog.Debug("ReplayDelta priority response failed", "t", "LedgerSync", "peer", peerID, "err", err)
 		}
 		return

--- a/internal/peermanagement/ledgersync_context_test.go
+++ b/internal/peermanagement/ledgersync_context_test.go
@@ -70,14 +70,14 @@ func TestLedgerSyncChargesMalformedAndUnavailable(t *testing.T) {
 	if err := h.HandleMessage(context.Background(), 1, &message.ReplayDeltaRequest{LedgerHash: []byte{1}}); !errors.Is(err, ErrPeerBadRequest) {
 		t.Fatalf("malformed request error = %v, want ErrPeerBadRequest", err)
 	}
-	if len(charges) != 1 || charges[0] != resource.FeeMalformedRequest {
+	if len(charges) != 1 || charges[0] != resource.FeeMalformedRequest() {
 		t.Fatalf("malformed charges = %#v, want FeeMalformedRequest", charges)
 	}
 	charges = nil
 	if err := h.HandleMessage(context.Background(), 1, &message.ReplayDeltaRequest{LedgerHash: make([]byte, 32)}); err != nil {
 		t.Fatalf("unavailable provider error = %v", err)
 	}
-	if len(charges) != 1 || charges[0] != resource.FeeRequestNoReply {
+	if len(charges) != 1 || charges[0] != resource.FeeRequestNoReply() {
 		t.Fatalf("unavailable charges = %#v, want FeeRequestNoReply", charges)
 	}
 }

--- a/internal/peermanagement/message_charge.go
+++ b/internal/peermanagement/message_charge.go
@@ -1,0 +1,59 @@
+package peermanagement
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
+)
+
+type messageCharge struct {
+	mu       sync.Mutex
+	peer     *Peer
+	fee      resource.Charge
+	context  string
+	finished bool
+}
+
+func newMessageCharge(peer *Peer, messageName string) *messageCharge {
+	return &messageCharge{
+		peer:    peer,
+		fee:     resource.FeeTrivialPeer(),
+		context: messageName,
+	}
+}
+
+func (c *messageCharge) update(fee resource.Charge, chargeContext string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	if c.finished || fee.Cost() < c.fee.Cost() {
+		c.mu.Unlock()
+		return
+	}
+	c.fee = fee
+	if chargeContext != "" {
+		c.context = strings.TrimSpace(c.context + " " + chargeContext)
+	}
+	c.mu.Unlock()
+}
+
+func (c *messageCharge) finish() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	if c.finished {
+		c.mu.Unlock()
+		return
+	}
+	c.finished = true
+	peer := c.peer
+	fee := c.fee
+	chargeContext := c.context
+	c.mu.Unlock()
+	if peer != nil {
+		peer.Charge(fee, chargeContext)
+	}
+}

--- a/internal/peermanagement/message_charge_test.go
+++ b/internal/peermanagement/message_charge_test.go
@@ -1,0 +1,93 @@
+package peermanagement
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageChargeSelectsOneFeeAndFinishesOnce(t *testing.T) {
+	identity, err := NewIdentity()
+	require.NoError(t, err)
+	peer := NewPeer(1, Endpoint{Host: "192.0.2.1", Port: 51235}, false, identity, nil)
+	manager := resource.NewManager(nil, nil)
+	consumer := manager.NewInboundEndpoint(peer.Endpoint().String())
+	peer.attachUsage(consumer, nil)
+	t.Cleanup(peer.releaseUsage)
+
+	for range resource.DecayWindowSeconds {
+		charge := newMessageCharge(peer, "mtPING")
+		charge.update(resource.FeeInvalidData(), "malformed")
+		charge.finish()
+		charge.finish()
+	}
+	require.Equal(t, resource.FeeInvalidData().Cost(), consumer.Balance())
+}
+
+func TestMessageChargePreservesBaseAndSelectedContexts(t *testing.T) {
+	charge := newMessageCharge(nil, "mtPING")
+	charge.update(resource.FeeModerateBurdenPeer(), "request")
+	charge.update(resource.FeeInvalidData(), "malformed")
+	latest := resource.NewCharge(resource.FeeInvalidData().Cost(), "latest")
+	charge.update(latest, "duplicate evidence")
+	charge.update(resource.FeeUselessData(), "ignored lower tier")
+
+	charge.mu.Lock()
+	defer charge.mu.Unlock()
+	require.Equal(t, latest, charge.fee)
+	require.Equal(t, "mtPING request malformed duplicate evidence", charge.context)
+}
+
+func TestInboundPingChargesModerateAndPongChargesTrivial(t *testing.T) {
+	identity, err := NewIdentity()
+	require.NoError(t, err)
+	manager := resource.NewManager(nil, nil)
+	overlay := &Overlay{peers: make(map[PeerID]*Peer), cfg: DefaultConfig()}
+
+	requestPeer := NewPeer(1, Endpoint{Host: "192.0.2.2", Port: 51235}, false, identity, nil)
+	requestConsumer := manager.NewInboundEndpoint(requestPeer.Endpoint().String())
+	requestPeer.attachUsage(requestConsumer, nil)
+	overlay.peers[requestPeer.ID()] = requestPeer
+	t.Cleanup(requestPeer.releaseUsage)
+
+	request, err := message.Encode(&message.Ping{PType: message.PingTypePing})
+	require.NoError(t, err)
+	for range resource.DecayWindowSeconds {
+		overlay.onMessageReceived(Event{PeerID: requestPeer.ID(), MessageType: message.TypePing, Payload: request})
+	}
+	require.Equal(t, resource.FeeModerateBurdenPeer().Cost(), requestConsumer.Balance())
+
+	pongPeer := NewPeer(2, Endpoint{Host: "192.0.2.3", Port: 51235}, false, identity, nil)
+	pongConsumer := manager.NewInboundEndpoint(pongPeer.Endpoint().String())
+	pongPeer.attachUsage(pongConsumer, nil)
+	overlay.peers[pongPeer.ID()] = pongPeer
+	t.Cleanup(pongPeer.releaseUsage)
+
+	pong, err := message.Encode(&message.Ping{PType: message.PingTypePong})
+	require.NoError(t, err)
+	for range resource.DecayWindowSeconds {
+		overlay.onMessageReceived(Event{PeerID: pongPeer.ID(), MessageType: message.TypePing, Payload: pong})
+	}
+	require.Equal(t, resource.FeeTrivialPeer().Cost(), pongConsumer.Balance())
+}
+
+func TestReleaseUsagePreventsLateFallbackConsumer(t *testing.T) {
+	identity, err := NewIdentity()
+	require.NoError(t, err)
+	peer := NewPeer(1, Endpoint{Host: "192.0.2.4", Port: 51235}, false, identity, nil)
+	manager := resource.NewManager(nil, nil)
+	consumer := manager.NewInboundEndpoint(peer.Endpoint().String())
+	var drops atomic.Int32
+	peer.attachUsage(consumer, func() { drops.Add(1) })
+	peer.releaseUsage()
+
+	require.Equal(t, resource.Ok, peer.Charge(resource.FeeDrop(), "late"))
+	require.Nil(t, peer.usageHandle())
+	require.Zero(t, drops.Load())
+	stats := manager.Stats()
+	require.Equal(t, 0, stats.Active)
+	require.Equal(t, 1, stats.Retained)
+}

--- a/internal/peermanagement/message_charge_test.go
+++ b/internal/peermanagement/message_charge_test.go
@@ -24,7 +24,7 @@ func TestMessageChargeSelectsOneFeeAndFinishesOnce(t *testing.T) {
 		charge.finish()
 		charge.finish()
 	}
-	require.Equal(t, resource.FeeInvalidData().Cost(), consumer.Balance())
+	require.Equal(t, int64(resource.FeeInvalidData().Cost()), consumer.Balance())
 }
 
 func TestMessageChargePreservesBaseAndSelectedContexts(t *testing.T) {
@@ -58,7 +58,7 @@ func TestInboundPingChargesModerateAndPongChargesTrivial(t *testing.T) {
 	for range resource.DecayWindowSeconds {
 		overlay.onMessageReceived(Event{PeerID: requestPeer.ID(), MessageType: message.TypePing, Payload: request})
 	}
-	require.Equal(t, resource.FeeModerateBurdenPeer().Cost(), requestConsumer.Balance())
+	require.Equal(t, int64(resource.FeeModerateBurdenPeer().Cost()), requestConsumer.Balance())
 
 	pongPeer := NewPeer(2, Endpoint{Host: "192.0.2.3", Port: 51235}, false, identity, nil)
 	pongConsumer := manager.NewInboundEndpoint(pongPeer.Endpoint().String())
@@ -71,7 +71,7 @@ func TestInboundPingChargesModerateAndPongChargesTrivial(t *testing.T) {
 	for range resource.DecayWindowSeconds {
 		overlay.onMessageReceived(Event{PeerID: pongPeer.ID(), MessageType: message.TypePing, Payload: pong})
 	}
-	require.Equal(t, resource.FeeTrivialPeer().Cost(), pongConsumer.Balance())
+	require.Equal(t, int64(resource.FeeTrivialPeer().Cost()), pongConsumer.Balance())
 }
 
 func TestReleaseUsagePreventsLateFallbackConsumer(t *testing.T) {

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -518,6 +518,22 @@ func (o *Overlay) IncPeerBadData(peerID PeerID, reason string) uint32 {
 	return peer.IncBadData(reason)
 }
 
+func (o *Overlay) selectMessageCharge(evt *Event, fee resource.Charge, chargeContext string) {
+	if evt != nil && evt.selectCharge(fee, chargeContext) {
+		return
+	}
+	if evt == nil {
+		return
+	}
+	if peer, ok := o.getPeer(evt.PeerID); ok {
+		peer.Charge(fee, chargeContext)
+	}
+}
+
+func (o *Overlay) selectMessageChargeReason(evt *Event, reason string) {
+	o.selectMessageCharge(evt, chargeForReason(reason), reason)
+}
+
 // peerNegotiatedLedgerReplay reports whether the peer identified by
 // peerID advertised the ledger-replay feature during handshake. Used
 // to gate serving mtREPLAY_DELTA_REQ and mtPROOF_PATH_REQ: these

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -768,7 +768,7 @@ func New(opts ...Option) (*Overlay, error) {
 		clock:                    cfg.Clock,
 		inboundSem:               make(chan struct{}, inboundCap),
 		outboundSem:              make(chan struct{}, outboundCap),
-		resourceManager:          resource.NewManager(nil, nil),
+		resourceManager:          resource.NewManager(nil, nil, resource.WithLimits(cfg.ResourceLimits)),
 		outboundBudget:           newOutboundBudget(cfg.OutboundRetainedBytes, cfg.MaxPeers),
 	}
 	if identity != nil {
@@ -1193,7 +1193,7 @@ func (o *Overlay) submitServeForPeerOwned(
 	if lifecycleState == overlayLifecycleStopping || lifecycleState == overlayLifecycleStopped {
 		o.droppedServeJobs.Add(1)
 		if exists {
-			peer.Charge(resource.FeeRequestNoReply, "serve scheduler stopped")
+			peer.Charge(resource.FeeRequestNoReply(), "serve scheduler stopped")
 		}
 		return false
 	}
@@ -1206,7 +1206,7 @@ func (o *Overlay) submitServeForPeerOwned(
 	}
 	o.droppedServeJobs.Add(1)
 	if exists {
-		peer.Charge(resource.FeeRequestNoReply, "serve scheduler saturated")
+		peer.Charge(resource.FeeRequestNoReply(), "serve scheduler saturated")
 	}
 	slog.Debug("serve job dropped: scheduler saturated", "t", "Overlay", "peer", peerID)
 	return false

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -291,6 +291,13 @@ type Overlay struct {
 	runComplete <-chan struct{}
 }
 
+func (o *Overlay) ResourceManager() *resource.Manager {
+	if o == nil {
+		return nil
+	}
+	return o.resourceManager
+}
+
 type overlayLifecycleState uint8
 
 const (
@@ -784,7 +791,7 @@ func New(opts ...Option) (*Overlay, error) {
 		clock:                    cfg.Clock,
 		inboundSem:               make(chan struct{}, inboundCap),
 		outboundSem:              make(chan struct{}, outboundCap),
-		resourceManager:          resource.NewManager(nil, nil, resource.WithLimits(cfg.ResourceLimits)),
+		resourceManager:          resource.NewManagerWithLimits(cfg.Clock, nil, cfg.ResourceLimits),
 		outboundBudget:           newOutboundBudget(cfg.OutboundRetainedBytes, cfg.MaxPeers),
 	}
 	if identity != nil {

--- a/internal/peermanagement/overlay_inbound.go
+++ b/internal/peermanagement/overlay_inbound.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/peertls"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 )
 
 // inboundBacklogSlack caps the accept-side goroutine count to
@@ -125,15 +126,26 @@ func readHandshakeBody(req *http.Request) error {
 // it is already over budget. Always admitted when no resource manager is
 // wired.
 func (o *Overlay) admitInboundEndpoint(addr string) bool {
+	consumer, admitted := o.acquireInboundUsage(addr)
+	if consumer != nil {
+		consumer.Release()
+	}
+	return admitted
+}
+
+func (o *Overlay) acquireInboundUsage(addr string) (*resource.Consumer, bool) {
 	if o.resourceManager == nil {
-		return true
+		return nil, true
 	}
 	c := o.resourceManager.NewInboundEndpoint(addr)
 	if c == nil {
-		return false
+		return nil, false
 	}
-	defer c.Release()
-	return !c.Disconnect()
+	if c.Disconnect() {
+		c.Release()
+		return nil, false
+	}
+	return c, true
 }
 
 // startListener creates the TCP/TLS listener without publishing it. Run owns
@@ -233,12 +245,18 @@ func (o *Overlay) handleInbound(ctx context.Context, conn net.Conn) {
 	remoteAddr := conn.RemoteAddr().String()
 	endpoint, _ := ParseEndpoint(remoteAddr)
 
-	if !o.admitInboundEndpoint(endpoint.String()) {
+	inboundUsage, admitted := o.acquireInboundUsage(endpoint.String())
+	if !admitted {
 		slog.Info("Inbound rejected: endpoint over resource drop threshold",
 			"t", "Overlay", "remote", remoteAddr)
 		conn.Close()
 		return
 	}
+	defer func() {
+		if inboundUsage != nil {
+			inboundUsage.Release()
+		}
+	}()
 
 	peerID := PeerID(o.nextID.Add(1))
 	peer := NewPeer(peerID, endpoint, true, o.identity, o.events)
@@ -298,11 +316,12 @@ func (o *Overlay) handleInbound(ctx context.Context, conn net.Conn) {
 	peer.setState(PeerStateConnected)
 	slog.Info("Inbound peer connected", "t", "Overlay", "remote", remoteAddr)
 
-	if err := o.addPeer(peer); err != nil {
+	if err := o.addPeerWithUsage(peer, inboundUsage); err != nil {
 		slog.Info("Inbound rejected after handshake", "t", "Overlay", "remote", remoteAddr, "err", err)
 		conn.Close()
 		return
 	}
+	inboundUsage = nil
 	added = true
 
 	o.peerWG.Add(1)

--- a/internal/peermanagement/overlay_message.go
+++ b/internal/peermanagement/overlay_message.go
@@ -159,7 +159,7 @@ func (o *Overlay) onMessageReceived(evt Event) {
 			slog.Debug("ReplayDeltaRequest from peer without ledgerreplay feature; dropping",
 				"t", "Overlay", "peer", evt.PeerID)
 			if peer, ok := o.getPeer(evt.PeerID); ok {
-				peer.Charge(resource.FeeMalformedRequest, "replay delta request disabled")
+				peer.Charge(resource.FeeMalformedRequest(), "replay delta request disabled")
 			}
 			return
 		}
@@ -175,7 +175,7 @@ func (o *Overlay) onMessageReceived(evt Event) {
 			slog.Debug("ProofPathRequest from peer without ledgerreplay feature; dropping",
 				"t", "Overlay", "peer", evt.PeerID)
 			if peer, ok := o.getPeer(evt.PeerID); ok {
-				peer.Charge(resource.FeeMalformedRequest, "proof path request disabled")
+				peer.Charge(resource.FeeMalformedRequest(), "proof path request disabled")
 			}
 			return
 		}
@@ -193,7 +193,7 @@ func (o *Overlay) onMessageReceived(evt Event) {
 			slog.Debug("TMReplayDeltaResponse from peer without ledgerreplay feature; dropping",
 				"t", "Overlay", "peer", evt.PeerID)
 			if peer, ok := o.getPeer(evt.PeerID); ok {
-				peer.Charge(resource.FeeMalformedRequest, "replay delta response disabled")
+				peer.Charge(resource.FeeMalformedRequest(), "replay delta response disabled")
 			}
 			return
 		}
@@ -203,7 +203,7 @@ func (o *Overlay) onMessageReceived(evt Event) {
 			slog.Debug("TMProofPathResponse from peer without ledgerreplay feature; dropping",
 				"t", "Overlay", "peer", evt.PeerID)
 			if peer, ok := o.getPeer(evt.PeerID); ok {
-				peer.Charge(resource.FeeMalformedRequest, "proof path response disabled")
+				peer.Charge(resource.FeeMalformedRequest(), "proof path response disabled")
 			}
 			return
 		}
@@ -362,8 +362,11 @@ func (o *Overlay) PeerDisconnectsResources() uint64 {
 	return o.peerDisconnectsCharges.Load()
 }
 
-func (o *Overlay) ResourceManager() *resource.Manager {
-	return o.resourceManager
+func (o *Overlay) ResourceStats() resource.Stats {
+	if o.resourceManager == nil {
+		return resource.Stats{}
+	}
+	return o.resourceManager.Stats()
 }
 
 // DroppedEvents returns the cumulative count of events dropped
@@ -426,7 +429,7 @@ func (o *Overlay) dispatchReplayDeltaRequest(evt Event) {
 	if !ok {
 		return
 	}
-	o.submitRetainedServe(evt, resource.FeeModerateBurdenPeer,
+	o.submitRetainedServe(evt, resource.FeeModerateBurdenPeer(),
 		func(ctx context.Context) {
 			if err := o.ledgerSync.HandleMessage(ctx, evt.PeerID, req); err != nil &&
 				!errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
@@ -453,7 +456,7 @@ func (o *Overlay) dispatchProofPathRequest(evt Event) {
 	if !ok {
 		return
 	}
-	o.submitRetainedServe(evt, resource.FeeModerateBurdenPeer,
+	o.submitRetainedServe(evt, resource.FeeModerateBurdenPeer(),
 		func(ctx context.Context) {
 			if err := o.ledgerSync.HandleMessage(ctx, evt.PeerID, req); err != nil &&
 				!errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {

--- a/internal/peermanagement/overlay_message.go
+++ b/internal/peermanagement/overlay_message.go
@@ -98,6 +98,11 @@ func (o *Overlay) onPeerFailed(evt Event) {
 }
 
 func (o *Overlay) onMessageReceived(evt Event) {
+	if evt.charge == nil {
+		if peer, ok := o.getPeer(evt.PeerID); ok {
+			evt.charge = newMessageCharge(peer, evt.MessageType.String())
+		}
+	}
 	defer evt.release()
 	msgType := evt.MessageType
 
@@ -158,9 +163,7 @@ func (o *Overlay) onMessageReceived(evt Event) {
 		if !o.peerNegotiatedLedgerReplay(evt.PeerID) {
 			slog.Debug("ReplayDeltaRequest from peer without ledgerreplay feature; dropping",
 				"t", "Overlay", "peer", evt.PeerID)
-			if peer, ok := o.getPeer(evt.PeerID); ok {
-				peer.Charge(resource.FeeMalformedRequest(), "replay delta request disabled")
-			}
+			o.selectMessageCharge(&evt, resource.FeeMalformedRequest(), "replay delta request disabled")
 			return
 		}
 		o.dispatchReplayDeltaRequest(evt)
@@ -174,9 +177,7 @@ func (o *Overlay) onMessageReceived(evt Event) {
 		if !o.peerNegotiatedLedgerReplay(evt.PeerID) {
 			slog.Debug("ProofPathRequest from peer without ledgerreplay feature; dropping",
 				"t", "Overlay", "peer", evt.PeerID)
-			if peer, ok := o.getPeer(evt.PeerID); ok {
-				peer.Charge(resource.FeeMalformedRequest(), "proof path request disabled")
-			}
+			o.selectMessageCharge(&evt, resource.FeeMalformedRequest(), "proof path request disabled")
 			return
 		}
 		o.dispatchProofPathRequest(evt)
@@ -192,9 +193,7 @@ func (o *Overlay) onMessageReceived(evt Event) {
 		if !o.peerNegotiatedLedgerReplay(evt.PeerID) {
 			slog.Debug("TMReplayDeltaResponse from peer without ledgerreplay feature; dropping",
 				"t", "Overlay", "peer", evt.PeerID)
-			if peer, ok := o.getPeer(evt.PeerID); ok {
-				peer.Charge(resource.FeeMalformedRequest(), "replay delta response disabled")
-			}
+			o.selectMessageCharge(&evt, resource.FeeMalformedRequest(), "replay delta response disabled")
 			return
 		}
 	}
@@ -202,9 +201,7 @@ func (o *Overlay) onMessageReceived(evt Event) {
 		if !o.peerNegotiatedLedgerReplay(evt.PeerID) {
 			slog.Debug("TMProofPathResponse from peer without ledgerreplay feature; dropping",
 				"t", "Overlay", "peer", evt.PeerID)
-			if peer, ok := o.getPeer(evt.PeerID); ok {
-				peer.Charge(resource.FeeMalformedRequest(), "proof path response disabled")
-			}
+			o.selectMessageCharge(&evt, resource.FeeMalformedRequest(), "proof path response disabled")
 			return
 		}
 	}
@@ -422,7 +419,7 @@ func (o *Overlay) dispatchReplayDeltaRequest(evt Event) {
 	decoded, err := message.Decode(message.TypeReplayDeltaReq, evt.Payload)
 	if err != nil {
 		slog.Debug("ReplayDeltaRequest decode failed", "t", "Overlay", "peer", evt.PeerID, "err", err)
-		o.IncPeerBadData(evt.PeerID, "replay-delta-req-decode")
+		o.selectMessageChargeReason(&evt, "replay-delta-req-decode")
 		return
 	}
 	req, ok := decoded.(*message.ReplayDeltaRequest)
@@ -449,7 +446,7 @@ func (o *Overlay) dispatchProofPathRequest(evt Event) {
 	decoded, err := message.Decode(message.TypeProofPathReq, evt.Payload)
 	if err != nil {
 		slog.Debug("ProofPathRequest decode failed", "t", "Overlay", "peer", evt.PeerID, "err", err)
-		o.IncPeerBadData(evt.PeerID, "proof-path-req-decode")
+		o.selectMessageChargeReason(&evt, "proof-path-req-decode")
 		return
 	}
 	req, ok := decoded.(*message.ProofPathRequest)
@@ -562,7 +559,7 @@ func (o *Overlay) handleSquelchMessage(evt Event) {
 	decoded, err := message.Decode(message.TypeSquelch, evt.Payload)
 	if err != nil {
 		slog.Debug("Squelch decode failed", "t", "Overlay", "peer", evt.PeerID, "err", err)
-		o.IncPeerBadData(evt.PeerID, "squelch-malformed-pubkey")
+		o.selectMessageChargeReason(&evt, "squelch-malformed-pubkey")
 		return
 	}
 	sq, ok := decoded.(*message.Squelch)
@@ -575,20 +572,16 @@ func (o *Overlay) handleSquelchMessage(evt Event) {
 	if len(sq.ValidatorPubKey) != 33 {
 		slog.Debug("Squelch malformed pubkey",
 			"t", "Overlay", "peer", evt.PeerID, "len", len(sq.ValidatorPubKey))
-		o.IncPeerBadData(evt.PeerID, "squelch-malformed-pubkey")
+		o.selectMessageChargeReason(&evt, "squelch-malformed-pubkey")
 		return
 	}
 
 	// Drop any inbound squelch whose target pubkey is our own
 	// validator — otherwise a peer could silence our own traffic on
-	// the RelayFromValidator path (self-silencing DoS). go-xrpl
-	// additionally charges the sending peer a bad-data event so
-	// repeated attempts feed the eviction threshold; rippled just
-	// logs-and-returns there.
+	// the RelayFromValidator path (self-silencing DoS).
 	if ownPubKey := o.localValidatorPubKey(); len(ownPubKey) == 33 && bytes.Equal(sq.ValidatorPubKey, ownPubKey) {
 		slog.Debug("Squelch dropped: targets local validator",
 			"t", "Overlay", "peer", evt.PeerID)
-		o.IncPeerBadData(evt.PeerID, "squelch-targets-self")
 		return
 	}
 
@@ -602,7 +595,8 @@ func (o *Overlay) handleSquelchMessage(evt Event) {
 		return
 	}
 	duration := time.Duration(sq.SquelchDuration) * time.Second
-	if !peer.AddSquelch(sq.ValidatorPubKey, duration) {
+	if ok, reason := peer.addSquelch(sq.ValidatorPubKey, duration); !ok {
+		o.selectMessageChargeReason(&evt, reason)
 		slog.Debug("Squelch ignored: invalid duration", "t", "Overlay", "peer", evt.PeerID, "duration", sq.SquelchDuration)
 	}
 }
@@ -619,6 +613,7 @@ func (o *Overlay) handlePing(evt Event) bool {
 
 	switch ping.PType {
 	case message.PingTypePing:
+		o.selectMessageCharge(&evt, resource.FeeModerateBurdenPeer(), "ping request")
 		pong := *ping
 		pong.PType = message.PingTypePong
 		wireMsg, err := message.EncodeFrame(&pong)

--- a/internal/peermanagement/overlay_peer_key_test.go
+++ b/internal/peermanagement/overlay_peer_key_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -103,6 +104,35 @@ func TestOverlayRejectsDuplicateResolvedEndpoint(t *testing.T) {
 	require.NoError(t, o.addPeer(first))
 	assert.ErrorIs(t, o.addPeer(second), ErrAlreadyConnected)
 	o.removePeer(first.ID())
+}
+
+func TestAddPeerCarriesOutboundResourceHandle(t *testing.T) {
+	o, err := New(WithDataDir(t.TempDir()))
+	require.NoError(t, err)
+	remote, err := GenerateIdentity()
+	require.NoError(t, err)
+	endpoint := Endpoint{Host: "192.0.2.35", Port: 51235}
+	peer := newPeerWithRemoteKey(t, o, 9, endpoint, remote)
+	usage := o.resourceManager.NewOutboundEndpoint(endpoint.String())
+	require.NotNil(t, usage)
+	usage.Charge(resource.NewCharge(resource.DecayWindowSeconds*100, "pre-dial"), "")
+
+	require.NoError(t, o.addPeerWithUsage(peer, usage))
+	entries := o.resourceManager.Snapshot(0)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "outbound", entries[0].Type)
+	assert.Equal(t,
+		"IP Address: 192.0.2.35:51235, Public Key: "+remote.EncodedPublicKey(),
+		entries[0].Address,
+	)
+	assert.Positive(t, entries[0].Local)
+
+	o.removePeer(peer.ID())
+	assert.Equal(t, 1, o.resourceManager.Stats().Retained)
+	reacquired := o.resourceManager.NewOutboundEndpoint(endpoint.String())
+	require.NotNil(t, reacquired)
+	assert.Positive(t, reacquired.Balance())
+	reacquired.Release()
 }
 
 func TestOverlayInboundIPLimit(t *testing.T) {

--- a/internal/peermanagement/overlay_peers.go
+++ b/internal/peermanagement/overlay_peers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/netip"
 	"time"
 
@@ -65,6 +66,24 @@ func (o *Overlay) connectReservedContext(connectCtx context.Context, addr string
 	if baseCtx == nil {
 		return errors.New("overlay: Connect called before Run")
 	}
+	attemptCtx := baseCtx
+	var cancelAttempt context.CancelFunc
+	var stopOverlayCancel func() bool
+	if connectCtx != nil {
+		attemptCtx, cancelAttempt = context.WithCancel(connectCtx)
+		stopOverlayCancel = context.AfterFunc(baseCtx, cancelAttempt)
+		defer func() {
+			stopOverlayCancel()
+			cancelAttempt()
+		}()
+	}
+	ctx, cancel := context.WithTimeout(attemptCtx, o.cfg.ConnectTimeout)
+	defer cancel()
+
+	endpoint, err = o.resolveOutboundEndpoint(ctx, endpoint)
+	if err != nil {
+		return err
+	}
 
 	// Check if already connected
 	if o.isConnectedTo(endpoint) {
@@ -106,20 +125,6 @@ func (o *Overlay) connectReservedContext(connectCtx context.Context, addr string
 	peer.onRedirect = func(peerIPs []string) {
 		o.ingestRedirectEndpoints(peerIPs, peerID)
 	}
-
-	attemptCtx := baseCtx
-	var cancelAttempt context.CancelFunc
-	var stopOverlayCancel func() bool
-	if connectCtx != nil {
-		attemptCtx, cancelAttempt = context.WithCancel(connectCtx)
-		stopOverlayCancel = context.AfterFunc(baseCtx, cancelAttempt)
-		defer func() {
-			stopOverlayCancel()
-			cancelAttempt()
-		}()
-	}
-	ctx, cancel := context.WithTimeout(attemptCtx, o.cfg.ConnectTimeout)
-	defer cancel()
 
 	certPEM, keyPEM, err := o.identity.TLSCertificatePEM()
 	if err != nil {
@@ -199,6 +204,30 @@ func (o *Overlay) connectReservedContext(connectCtx context.Context, addr string
 	}()
 
 	return nil
+}
+
+func (o *Overlay) resolveOutboundEndpoint(ctx context.Context, endpoint Endpoint) (Endpoint, error) {
+	if addr, err := netip.ParseAddr(endpoint.Host); err == nil && addr.Zone() == "" {
+		endpoint.Host = addr.Unmap().String()
+		return endpoint, nil
+	}
+	lookupIP := net.DefaultResolver.LookupIPAddr
+	if o.discovery != nil && o.discovery.lookupIP != nil {
+		lookupIP = o.discovery.lookupIP
+	}
+	addresses, err := lookupIP(ctx, endpoint.Host)
+	if err != nil {
+		return Endpoint{}, fmt.Errorf("%w: resolve %q: %v", ErrInvalidEndpoint, endpoint.Host, err)
+	}
+	for _, candidate := range addresses {
+		addr, ok := netip.AddrFromSlice(candidate.IP)
+		if !ok || addr.Zone() != "" {
+			continue
+		}
+		endpoint.Host = addr.Unmap().String()
+		return endpoint, nil
+	}
+	return Endpoint{}, fmt.Errorf("%w: hostname %q has no IP addresses", ErrInvalidEndpoint, endpoint.Host)
 }
 
 func (o *Overlay) delayPeerRetry(addr string, bootstrap bool, err error, stopping bool) {

--- a/internal/peermanagement/overlay_peers.go
+++ b/internal/peermanagement/overlay_peers.go
@@ -616,8 +616,6 @@ func (o *Overlay) addPeerWithUsage(peer *Peer, usage *resource.Consumer) error {
 	if o.resourceManager != nil && resourceUsage == nil {
 		addr := postHandshakeEndpoint(peer, peer.Endpoint()).String()
 		switch {
-		case o.isClusterPeer(peer):
-			resourceUsage = o.resourceManager.NewUnlimitedEndpoint(addr)
 		case peer.Inbound():
 			resourceUsage = o.resourceManager.NewInboundEndpoint(addr)
 		default:

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -1831,6 +1831,8 @@ func chargeForReason(reason string) resource.Charge {
 	switch reason {
 	case "proposal-malformed-sig-size",
 		"proposal-malformed-pubkey-size",
+		"proposal-malformed-pubkey-type",
+		"validation-invalid-signature",
 		"validation-malformed-sig-size":
 		return resource.FeeInvalidSignature()
 	case "replay-delta-verify",
@@ -1843,7 +1845,9 @@ func chargeForReason(reason string) resource.Charge {
 		"message-too-large",
 		"wire-invalid":
 		return resource.FeeInvalidData()
-	case "endpoints-too-large":
+	case "endpoints-too-large",
+		"cluster-no-pubkey",
+		"cluster-not-member":
 		return resource.FeeUselessData()
 	case "manifests-oversize":
 		return resource.FeeModerateBurdenPeer()
@@ -1864,8 +1868,12 @@ func chargeForReason(reason string) resource.Charge {
 		"replay-delta-resp-unnegotiated",
 		"proof-path-resp-unnegotiated",
 		"compression-unnegotiated",
+		"get-objects-txn-unnegotiated",
 		"get-objects-transactions-oversize",
 		"get-objects-ledgerhash",
+		"have-transactions-unnegotiated",
+		"have-transactions-hashsize",
+		"transactions-batch-unnegotiated",
 		"have-set-hashsize",
 		"proposal-decode",
 		"validation-decode",

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -1774,8 +1774,7 @@ func (p *Peer) usageHandle() *resource.Consumer {
 	return p.usage
 }
 
-// Charge applies fee to this peer's Consumer and tears the peer down
-// on Drop. Mirrors rippled PeerImp::charge at PeerImp.cpp:351-361.
+// Charge applies fee to this peer's Consumer and tears the peer down on Drop.
 func (p *Peer) Charge(fee resource.Charge, context string) resource.Disposition {
 	c := p.usageHandle()
 	if c == nil {
@@ -1788,7 +1787,8 @@ func (p *Peer) Charge(fee resource.Charge, context string) resource.Disposition 
 		if p.chargeDropFired.CompareAndSwap(false, true) {
 			slog.Warn("peer disconnect by resource charge",
 				"t", "Peer", "peer", p.id,
-				"endpoint", p.endpoint.String(), "fee", fee.String(), "context", context)
+				"endpoint", p.endpoint.String(), "public_key", p.RemotePublicKeyEncoded(),
+				"fee", fee.String(), "context", context)
 			p.usageMu.RLock()
 			hook := p.onDropDisconnect
 			p.usageMu.RUnlock()
@@ -1810,7 +1810,7 @@ func chargeForReason(reason string) resource.Charge {
 	case "proposal-malformed-sig-size",
 		"proposal-malformed-pubkey-size",
 		"validation-malformed-sig-size":
-		return resource.FeeInvalidSignature
+		return resource.FeeInvalidSignature()
 	case "replay-delta-verify",
 		"ledger-data-base",
 		"ledger-data-state",
@@ -1820,11 +1820,11 @@ func chargeForReason(reason string) resource.Charge {
 		"decompress-lz4-failed",
 		"message-too-large",
 		"wire-invalid":
-		return resource.FeeInvalidData
+		return resource.FeeInvalidData()
 	case "endpoints-too-large":
-		return resource.FeeUselessData
+		return resource.FeeUselessData()
 	case "manifests-oversize":
-		return resource.FeeModerateBurdenPeer
+		return resource.FeeModerateBurdenPeer()
 	case "proposal-malformed-prev-ledger-size",
 		"proposal-malformed-txset-size",
 		"validation-malformed-ledger-hash-zero",
@@ -1850,26 +1850,26 @@ func chargeForReason(reason string) resource.Charge {
 		"validation-parse",
 		"ledger-data-decode",
 		"squelch-ignored":
-		return resource.FeeMalformedRequest
+		return resource.FeeMalformedRequest()
 	case "no-reply":
-		return resource.FeeRequestNoReply
+		return resource.FeeRequestNoReply()
 	}
 	switch {
 	case reason == "vl-coll-no-blobs",
 		strings.Contains(reason, "-heavy-"):
-		return resource.FeeHeavyBurdenPeer
+		return resource.FeeHeavyBurdenPeer()
 	case strings.Contains(reason, "-badsig-"):
-		return resource.FeeInvalidSignature
+		return resource.FeeInvalidSignature()
 	case strings.Contains(reason, "-baddata-"),
 		strings.HasSuffix(reason, "-wrong-version"),
 		strings.HasSuffix(reason, "-decode"):
-		return resource.FeeInvalidData
+		return resource.FeeInvalidData()
 	case strings.Contains(reason, "-useless-"),
 		strings.HasSuffix(reason, "-duplicate"),
 		strings.HasSuffix(reason, "-unsupported-peer"):
-		return resource.FeeUselessData
+		return resource.FeeUselessData()
 	}
-	return resource.FeeInvalidData
+	return resource.FeeInvalidData()
 }
 
 func wirePreflightChargeReason(err error) string {

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net"
 	"net/http"
 	"slices"
@@ -137,6 +138,7 @@ type Peer struct {
 	// (PeerImp.cpp:358) and is wired by Overlay.attachUsage.
 	usage            *resource.Consumer
 	usageMu          sync.RWMutex
+	usageReleased    bool
 	onDropDisconnect func()
 	clusterOrigin    string
 	clusterOriginSet bool
@@ -1691,10 +1693,17 @@ const maxSquelchesPerPeer = 128
 // removes any prior entry) on out-of-range duration or when the cap is
 // hit by a NEW validator key. Both rejections charge bad-data fee.
 func (p *Peer) AddSquelch(validator []byte, duration time.Duration) bool {
+	ok, reason := p.addSquelch(validator, duration)
+	if !ok {
+		p.IncBadData(reason)
+	}
+	return ok
+}
+
+func (p *Peer) addSquelch(validator []byte, duration time.Duration) (bool, string) {
 	if duration < MinUnsquelchExpire || duration > MaxUnsquelchExpirePeers {
 		p.RemoveSquelch(validator)
-		p.IncBadData("squelch-duration")
-		return false
+		return false, "squelch-duration"
 	}
 	key := string(validator)
 	p.squelchMu.Lock()
@@ -1705,10 +1714,9 @@ func (p *Peer) AddSquelch(validator []byte, duration time.Duration) bool {
 	}
 	p.squelchMu.Unlock()
 	if full {
-		p.IncBadData("squelch-map-full")
-		return false
+		return false, "squelch-map-full"
 	}
-	return true
+	return true, ""
 }
 
 // attachUsage wires this peer's resource.Consumer and the
@@ -1720,8 +1728,13 @@ func (p *Peer) attachUsage(c *resource.Consumer, onDrop func()) {
 	if p.usage != nil {
 		p.usage.Release()
 	}
+	if c != nil {
+		c.SetPublicKey(p.RemotePublicKeyEncoded())
+	}
 	p.usage = c
+	p.usageReleased = false
 	p.onDropDisconnect = onDrop
+	p.chargeDropFired.Store(false)
 }
 
 func (p *Peer) releaseUsage() {
@@ -1731,6 +1744,8 @@ func (p *Peer) releaseUsage() {
 		p.usage.Release()
 		p.usage = nil
 	}
+	p.onDropDisconnect = nil
+	p.usageReleased = true
 }
 
 func (p *Peer) resourceGossipOrigin(name string) string {
@@ -1746,9 +1761,13 @@ func (p *Peer) resourceGossipOrigin(name string) string {
 func (p *Peer) usageHandle() *resource.Consumer {
 	p.usageMu.RLock()
 	c := p.usage
+	released := p.usageReleased
 	p.usageMu.RUnlock()
 	if c != nil {
 		return c
+	}
+	if released {
+		return nil
 	}
 	// Tests and embedded usages that construct a Peer outside the
 	// addPeer path still need IncBadData / Charge to work. Lazily
@@ -1763,6 +1782,9 @@ func (p *Peer) usageHandle() *resource.Consumer {
 	// fallback must not be relied on for production paths.
 	p.usageMu.Lock()
 	defer p.usageMu.Unlock()
+	if p.usageReleased {
+		return nil
+	}
 	if p.usage != nil {
 		return p.usage
 	}
@@ -1897,11 +1919,7 @@ func (p *Peer) IncBadData(reason string) uint32 {
 		return 0
 	}
 	p.Charge(chargeForReason(reason), reason)
-	bal := c.Balance()
-	if bal < 0 {
-		return 0
-	}
-	return uint32(bal)
+	return clampResourceBalance(c.Balance())
 }
 
 // BadDataCount returns the consumer's current normalized balance,
@@ -1911,11 +1929,17 @@ func (p *Peer) BadDataCount() uint32 {
 	if c == nil {
 		return 0
 	}
-	bal := c.Balance()
-	if bal < 0 {
+	return clampResourceBalance(c.Balance())
+}
+
+func clampResourceBalance(balance int64) uint32 {
+	if balance <= 0 {
 		return 0
 	}
-	return uint32(bal)
+	if balance > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(balance)
 }
 
 // Load returns the consumer's normalized balance as int64 — signed so

--- a/internal/peermanagement/peer_charge_reason_test.go
+++ b/internal/peermanagement/peer_charge_reason_test.go
@@ -18,3 +18,22 @@ func TestChargeForReasonHaveSetDuplicate(t *testing.T) {
 
 	assert.Equal(t, resource.FeeUselessData(), charge)
 }
+
+func TestChargeForReasonProtocolTiers(t *testing.T) {
+	tests := map[string]resource.Charge{
+		"cluster-no-pubkey":               resource.FeeUselessData(),
+		"cluster-not-member":              resource.FeeUselessData(),
+		"get-objects-txn-unnegotiated":    resource.FeeMalformedRequest(),
+		"have-transactions-unnegotiated":  resource.FeeMalformedRequest(),
+		"have-transactions-hashsize":      resource.FeeMalformedRequest(),
+		"transactions-batch-unnegotiated": resource.FeeMalformedRequest(),
+		"proposal-malformed-pubkey-type":  resource.FeeInvalidSignature(),
+		"validation-invalid-signature":    resource.FeeInvalidSignature(),
+		"vl-coll-heavy-too-many-blobs":    resource.FeeHeavyBurdenPeer(),
+	}
+	for reason, want := range tests {
+		t.Run(reason, func(t *testing.T) {
+			assert.Equal(t, want, chargeForReason(reason))
+		})
+	}
+}

--- a/internal/peermanagement/peer_charge_reason_test.go
+++ b/internal/peermanagement/peer_charge_reason_test.go
@@ -10,13 +10,11 @@ import (
 func TestChargeForReasonHaveSetHashSize(t *testing.T) {
 	charge := chargeForReason("have-set-hashsize")
 
-	assert.Equal(t, resource.FeeMalformedRequest.Cost(), charge.Cost())
-	assert.Equal(t, resource.FeeMalformedRequest.Label(), charge.Label())
+	assert.Equal(t, resource.FeeMalformedRequest(), charge)
 }
 
 func TestChargeForReasonHaveSetDuplicate(t *testing.T) {
 	charge := chargeForReason("have-set-duplicate")
 
-	assert.Equal(t, resource.FeeUselessData.Cost(), charge.Cost())
-	assert.Equal(t, resource.FeeUselessData.Label(), charge.Label())
+	assert.Equal(t, resource.FeeUselessData(), charge)
 }

--- a/internal/peermanagement/peer_wire_preflight_test.go
+++ b/internal/peermanagement/peer_wire_preflight_test.go
@@ -72,7 +72,7 @@ func TestPeerWirePreflightChargesAndDropsBeforeDispatch(t *testing.T) {
 			msgType: message.TypeValidatorListCollection,
 			payload: peerRepeatedMessageField(3, 6),
 			reason:  "vl-coll-heavy-too-many-blobs",
-			charge:  resource.FeeHeavyBurdenPeer,
+			charge:  resource.FeeHeavyBurdenPeer(),
 		},
 	}
 

--- a/internal/peermanagement/peer_wire_preflight_test.go
+++ b/internal/peermanagement/peer_wire_preflight_test.go
@@ -43,7 +43,7 @@ func TestPeerWirePreflightChargesAndDropsBeforeDispatch(t *testing.T) {
 			msgType:  message.TypeEndpoints,
 			payload:  peerRepeatedMessageField(3, 1_024),
 			reason:   "endpoints-too-large",
-			charge:   resource.FeeUselessData,
+			charge:   resource.FeeUselessData(),
 			compress: true,
 		},
 		{
@@ -51,21 +51,21 @@ func TestPeerWirePreflightChargesAndDropsBeforeDispatch(t *testing.T) {
 			msgType: message.TypeManifests,
 			payload: peerRepeatedMessageField(1, 101),
 			reason:  "manifests-oversize",
-			charge:  resource.FeeModerateBurdenPeer,
+			charge:  resource.FeeModerateBurdenPeer(),
 		},
 		{
 			name:    "transactions",
 			msgType: message.TypeTransactions,
 			payload: peerRepeatedMessageField(1, 10_001),
 			reason:  "wire-invalid",
-			charge:  resource.FeeInvalidData,
+			charge:  resource.FeeInvalidData(),
 		},
 		{
 			name:    "get object transactions",
 			msgType: message.TypeGetObjects,
 			payload: peerGetObjectTransactionsPayload(10_001),
 			reason:  "get-objects-transactions-oversize",
-			charge:  resource.FeeMalformedRequest,
+			charge:  resource.FeeMalformedRequest(),
 		},
 		{
 			name:    "validator list collection",
@@ -116,5 +116,5 @@ func TestPeerWirePreflightChargesAndDropsBeforeDispatch(t *testing.T) {
 func TestPeerWirePreflightMalformedUsesInvalidDataClass(t *testing.T) {
 	reason := wirePreflightChargeReason(errors.Join(message.ErrMalformedWire, errors.New("bad tag")))
 	require.Equal(t, "wire-invalid", reason)
-	require.Equal(t, resource.FeeInvalidData, chargeForReason(reason))
+	require.Equal(t, resource.FeeInvalidData(), chargeForReason(reason))
 }

--- a/internal/peermanagement/resource/admission.go
+++ b/internal/peermanagement/resource/admission.go
@@ -1,6 +1,8 @@
 package resource
 
 import (
+	"context"
+	"log/slog"
 	"sync"
 	"time"
 )
@@ -40,6 +42,8 @@ func (m *Manager) AdmitUnlimited(addr string) (*Admission, Disposition) {
 }
 
 func (m *Manager) admit(e *entry, reservation Charge) (*Admission, Disposition) {
+	ctx := context.Background()
+	logEnabled := m.journal.Enabled(ctx, slog.LevelWarn)
 	m.mu.Lock()
 	now := m.clock()
 	if e.isUnlimited() {
@@ -51,11 +55,17 @@ func (m *Manager) admit(e *entry, reservation Charge) (*Admission, Disposition) 
 
 	balance := e.balance(now)
 	if balance >= DropThreshold {
-		balance = e.add(int64(FeeDrop.Cost()), now)
+		balance = e.add(int64(FeeDrop().Cost()), now)
 		m.stats.drops++
-		endpoint := e.k.addr
+		var endpoint string
+		if logEnabled {
+			endpoint = e.fingerprint()
+		}
 		m.mu.Unlock()
-		m.journal.Warn("resource admission dropped", "endpoint", endpoint, "balance", balance, "threshold", DropThreshold)
+		if logEnabled {
+			m.journal.LogAttrs(ctx, slog.LevelWarn, "resource admission dropped",
+				slog.String("endpoint", endpoint), slog.Int64("balance", balance), slog.Int("threshold", DropThreshold))
+		}
 		return nil, Drop
 	}
 
@@ -77,12 +87,12 @@ func (m *Manager) admit(e *entry, reservation Charge) (*Admission, Disposition) 
 	return &Admission{manager: m, entry: e, reserved: reserved}, disposition(projected)
 }
 
-func (a *Admission) Finish(actual Charge, context string) Completion {
+func (a *Admission) Finish(actual Charge, chargeContext string) Completion {
 	if a == nil || a.manager == nil || a.entry == nil {
 		return Completion{Disposition: Ok}
 	}
 	a.once.Do(func() {
-		a.result = a.manager.finishAdmission(a.entry, a.reserved, actual, context)
+		a.result = a.manager.finishAdmission(a.entry, a.reserved, actual, chargeContext)
 	})
 	return a.result
 }
@@ -91,7 +101,11 @@ func (a *Admission) Cancel() Completion {
 	return a.Finish(Charge{}, "")
 }
 
-func (m *Manager) finishAdmission(e *entry, reserved int64, actual Charge, context string) Completion {
+func (m *Manager) finishAdmission(e *entry, reserved int64, actual Charge, chargeContext string) Completion {
+	ctx := context.Background()
+	level := chargeLevel(actual.Cost())
+	chargeLogEnabled := actual.Cost() != 0 && m.journal.Enabled(ctx, level)
+	warningLogEnabled := m.journal.Enabled(ctx, slog.LevelInfo)
 	m.mu.Lock()
 	now := m.clock()
 	result := Completion{Disposition: Ok}
@@ -107,26 +121,25 @@ func (m *Manager) finishAdmission(e *entry, reserved int64, actual Charge, conte
 		result.Balance = e.add(int64(actual.Cost()), now)
 		result.Disposition = disposition(result.Balance)
 		if result.Balance >= WarningThreshold && (!e.warningSet || now.Sub(e.lastWarning) >= time.Second) {
-			result.Balance = e.add(int64(FeeWarning.Cost()), now)
+			result.Balance = e.add(int64(FeeWarning().Cost()), now)
 			e.lastWarning = now
 			e.warningSet = true
 			result.Warning = true
 			m.stats.warnings++
 		}
 	}
-	endpoint := e.k.addr
+	var endpoint string
+	if chargeLogEnabled || result.Warning && warningLogEnabled {
+		endpoint = e.fingerprint()
+	}
 	m.releaseLocalLocked(e, now)
 	m.mu.Unlock()
 
-	if actual.Cost() != 0 {
-		if context == "" {
-			m.journal.Debug("resource charge", "endpoint", endpoint, "fee", actual.String(), "balance", result.Balance)
-		} else {
-			m.journal.Debug("resource charge", "endpoint", endpoint, "fee", actual.String(), "balance", result.Balance, "context", context)
-		}
+	if chargeLogEnabled {
+		m.logCharge(ctx, level, endpoint, actual, result.Balance, chargeContext)
 	}
-	if result.Warning {
-		m.journal.Info("resource load warning", "endpoint", endpoint)
+	if result.Warning && warningLogEnabled {
+		m.journal.LogAttrs(ctx, slog.LevelInfo, "resource load warning", slog.String("endpoint", endpoint))
 	}
 	return result
 }

--- a/internal/peermanagement/resource/admission_test.go
+++ b/internal/peermanagement/resource/admission_test.go
@@ -16,15 +16,15 @@ func TestAdmissionBoundsConcurrentWorkPerEndpoint(t *testing.T) {
 	}
 	defer consumer.Release()
 
-	first, result := consumer.Admit(FeeHeavyBurdenRPC)
+	first, result := consumer.Admit(FeeHeavyBurdenRPC())
 	if first == nil || result != Ok {
 		t.Fatalf("first admission = (%v, %v), want admitted", first, result)
 	}
-	second, result := consumer.Admit(FeeHeavyBurdenRPC)
+	second, result := consumer.Admit(FeeHeavyBurdenRPC())
 	if second == nil || result != Ok {
 		t.Fatalf("second admission = (%v, %v), want admitted", second, result)
 	}
-	if third, result := consumer.Admit(FeeHeavyBurdenRPC); third != nil || result != Drop {
+	if third, result := consumer.Admit(FeeHeavyBurdenRPC()); third != nil || result != Drop {
 		t.Fatalf("third admission = (%v, %v), want bounded rejection", third, result)
 	}
 
@@ -33,13 +33,13 @@ func TestAdmissionBoundsConcurrentWorkPerEndpoint(t *testing.T) {
 		t.Fatal("independent consumer acquisition failed")
 	}
 	defer other.Release()
-	independent, result := other.Admit(FeeHeavyBurdenRPC)
+	independent, result := other.Admit(FeeHeavyBurdenRPC())
 	if independent == nil || result != Ok {
 		t.Fatalf("independent admission = (%v, %v), want admitted", independent, result)
 	}
 
-	first.Finish(FeeHeavyBurdenRPC, "first")
-	second.Finish(FeeReferenceRPC, "second")
+	first.Finish(FeeHeavyBurdenRPC(), "first")
+	second.Finish(FeeReferenceRPC(), "second")
 	independent.Cancel()
 	if stats := m.Stats(); stats.Inflight != 0 || stats.InflightRejections != 1 {
 		t.Fatalf("stats after completion = %+v", stats)
@@ -52,7 +52,7 @@ func TestAdmissionFinishReconcilesExactlyOnce(t *testing.T) {
 	if consumer == nil {
 		t.Fatal("consumer acquisition failed")
 	}
-	admission, result := consumer.Admit(FeeHeavyBurdenRPC)
+	admission, result := consumer.Admit(FeeHeavyBurdenRPC())
 	if admission == nil || result != Ok {
 		t.Fatalf("admission = (%v, %v), want admitted", admission, result)
 	}
@@ -65,7 +65,7 @@ func TestAdmissionFinishReconcilesExactlyOnce(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			results <- admission.Finish(FeeMediumBurdenRPC, "test")
+			results <- admission.Finish(FeeMediumBurdenRPC(), "test")
 		}()
 	}
 	wg.Wait()
@@ -88,7 +88,7 @@ func TestAdmissionFinishReconcilesExactlyOnce(t *testing.T) {
 		t.Fatal("reacquisition failed")
 	}
 	defer reacquired.Release()
-	if got, want := reacquired.Balance(), int64(FeeMediumBurdenRPC.Cost()/DecayWindowSeconds); got != want {
+	if got, want := reacquired.Balance(), int64(FeeMediumBurdenRPC().Cost()/DecayWindowSeconds); got != want {
 		t.Fatalf("balance after repeated finish = %d, want %d", got, want)
 	}
 }
@@ -107,7 +107,7 @@ func TestConsumerConcurrentReleaseLeavesSharedHandleActive(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			first.Charge(FeeReferenceRPC, "race")
+			first.Charge(FeeReferenceRPC(), "race")
 			_ = first.Balance()
 			_ = first.Disposition()
 			_ = first.Disconnect()
@@ -116,7 +116,7 @@ func TestConsumerConcurrentReleaseLeavesSharedHandleActive(t *testing.T) {
 	}
 	wg.Wait()
 
-	if result := second.Charge(FeeReferenceRPC, "shared"); result != Ok {
+	if result := second.Charge(FeeReferenceRPC(), "shared"); result != Ok {
 		t.Fatalf("shared handle charge = %v, want Ok", result)
 	}
 	if second.Balance() <= 0 {
@@ -143,7 +143,7 @@ func TestAdmissionConcurrentSameKeyIsBoundedAndDistinctKeysRemainIndependent(t *
 		go func() {
 			defer wg.Done()
 			<-start
-			admission, _ := consumer.Admit(FeeHeavyBurdenRPC)
+			admission, _ := consumer.Admit(FeeHeavyBurdenRPC())
 			results <- admission
 		}()
 	}
@@ -167,7 +167,7 @@ func TestAdmissionConcurrentSameKeyIsBoundedAndDistinctKeysRemainIndependent(t *
 		if other == nil {
 			t.Fatalf("consumer %s acquisition failed", address)
 		}
-		admission, result := other.Admit(FeeHeavyBurdenRPC)
+		admission, result := other.Admit(FeeHeavyBurdenRPC())
 		if admission == nil || result != Ok {
 			t.Fatalf("distinct-key admission %s = (%v, %v), want admitted", address, admission, result)
 		}

--- a/internal/peermanagement/resource/blacklist.go
+++ b/internal/peermanagement/resource/blacklist.go
@@ -1,5 +1,7 @@
 package resource
 
+import "sort"
+
 // BlacklistEntry is one endpoint's resource reputation, mirroring an entry in
 // rippled's Resource::Logic::getJson output (Logic.h:208-254).
 type BlacklistEntry struct {
@@ -30,16 +32,17 @@ func (m *Manager) Snapshot(threshold int64) []BlacklistEntry {
 			continue
 		}
 		local := e.localBalance.valueAt(now)
-		if local+e.remoteBalance < threshold {
+		if saturatingAdd(local, e.remoteBalance) < threshold {
 			continue
 		}
 		out = append(out, BlacklistEntry{
-			Address: e.k.addr,
+			Address: e.fingerprint(),
 			Local:   local,
 			Remote:  e.remoteBalance,
 			Type:    blacklistType(e.k.kind),
 		})
 	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Address < out[j].Address })
 	return out
 }
 

--- a/internal/peermanagement/resource/blacklist_test.go
+++ b/internal/peermanagement/resource/blacklist_test.go
@@ -19,8 +19,8 @@ func TestSnapshot_FiltersByThreshold(t *testing.T) {
 		t.Fatalf("expected 1 entry at threshold 0, got %d", len(low))
 	}
 	got := low[0]
-	if got.Address != "192.0.2.50" {
-		t.Errorf("address = %q, want host without port", got.Address)
+	if got.Address != "IP Address: 192.0.2.50" {
+		t.Errorf("address = %q, want canonical fingerprint", got.Address)
 	}
 	if got.Type != "inbound" {
 		t.Errorf("type = %q, want inbound", got.Type)
@@ -46,9 +46,7 @@ func TestSnapshot_ExcludesReleasedEntries(t *testing.T) {
 		t.Fatalf("active endpoint: expected 1 entry, got %d", len(got))
 	}
 
-	// Releasing the last Consumer drops the refcount to 0. The entry stays
-	// resident (so a reconnect inherits its balance) but, like rippled moving
-	// it into inactive_, it must no longer appear in the black_list snapshot.
+	// Retained reputation survives reconnects but is not an active snapshot item.
 	c.Release()
 	if got := m.Snapshot(0); len(got) != 0 {
 		t.Errorf("released endpoint should be excluded, got %d entries", len(got))
@@ -58,9 +56,7 @@ func TestSnapshot_ExcludesReleasedEntries(t *testing.T) {
 func TestSnapshot_AdminEndpointKeyedWithPortOne(t *testing.T) {
 	m, _ := newTestManager()
 
-	// An unlimited (admin/cluster) endpoint is keyed at port 1, matching
-	// rippled's at_port(1), so it never collides with the port-0 inbound key
-	// for the same host. It surfaces at threshold 0 even with a zero balance.
+	// Port 1 keeps the administrative key distinct from inbound port 0.
 	c := m.NewUnlimitedEndpoint("198.51.100.7:51235")
 	defer c.Release()
 
@@ -68,8 +64,8 @@ func TestSnapshot_AdminEndpointKeyedWithPortOne(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("expected 1 admin entry, got %d", len(got))
 	}
-	if got[0].Address != "198.51.100.7:1" {
-		t.Errorf("address = %q, want host with admin port :1", got[0].Address)
+	if got[0].Address != "IP Address: 198.51.100.7:1" {
+		t.Errorf("address = %q, want admin fingerprint", got[0].Address)
 	}
 	if got[0].Type != "admin" {
 		t.Errorf("type = %q, want admin", got[0].Type)

--- a/internal/peermanagement/resource/charge.go
+++ b/internal/peermanagement/resource/charge.go
@@ -1,6 +1,4 @@
-// Package resource implements per-endpoint load tracking and
-// charge-based disconnect, mirroring rippled's Resource::Manager
-// (rippled/include/xrpl/resource and src/libxrpl/resource).
+// Package resource implements bounded per-endpoint peer load tracking.
 //
 // A Manager owns a table of Consumers keyed by endpoint. Callers
 // (typically peers) hold a Consumer and apply Charges to it for known
@@ -16,10 +14,7 @@ package resource
 
 import "fmt"
 
-// Charge is a load cost with a human-readable label. Charges are value
-// types: callers compose them in package-level vars (see Fees) and pass
-// them by value into Consumer.Charge. Mirrors rippled's
-// ripple::Resource::Charge.
+// Charge is a load cost with a human-readable label.
 type Charge struct {
 	cost  int
 	label string
@@ -34,9 +29,6 @@ func NewCharge(cost int, label string) Charge {
 
 func (c Charge) Cost() int { return c.cost }
 
-func (c Charge) Label() string { return c.label }
-
-// String matches rippled's `label ($cost)` format.
 func (c Charge) String() string {
 	return fmt.Sprintf("%s ($%d)", c.label, c.cost)
 }

--- a/internal/peermanagement/resource/charge.go
+++ b/internal/peermanagement/resource/charge.go
@@ -14,7 +14,6 @@ package resource
 
 import "fmt"
 
-// Charge is a load cost with a human-readable label.
 type Charge struct {
 	cost  int
 	label string

--- a/internal/peermanagement/resource/consumer.go
+++ b/internal/peermanagement/resource/consumer.go
@@ -2,120 +2,143 @@ package resource
 
 import "sync"
 
+type consumerState struct {
+	mu           sync.RWMutex
+	m            *Manager
+	e            *entry
+	disconnected bool
+}
+
 type Consumer struct {
-	mu sync.RWMutex
-	m  *Manager
-	e  *entry
+	state *consumerState
+}
+
+func (c *Consumer) current() (*Manager, *entry) {
+	if c == nil || c.state == nil {
+		return nil, nil
+	}
+	c.state.mu.RLock()
+	defer c.state.mu.RUnlock()
+	return c.state.m, c.state.e
 }
 
 func (c *Consumer) Endpoint() string {
-	if c == nil {
+	_, e := c.current()
+	if e == nil {
 		return ""
 	}
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if c.m == nil || c.e == nil {
-		return ""
-	}
-	return c.e.k.addr
+	return e.k.addr
 }
 
 func (c *Consumer) Kind() Kind {
-	if c == nil {
+	_, e := c.current()
+	if e == nil {
 		return KindInbound
 	}
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if c.m == nil || c.e == nil {
-		return KindInbound
-	}
-	return c.e.k.kind
+	return e.k.kind
 }
 
 func (c *Consumer) IsUnlimited() bool {
-	if c == nil {
-		return false
-	}
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.m != nil && c.e != nil && c.e.isUnlimited()
+	_, e := c.current()
+	return e != nil && e.isUnlimited()
 }
 
 func (c *Consumer) Charge(fee Charge, context string) Disposition {
-	if c == nil {
+	if c == nil || c.state == nil {
 		return Ok
 	}
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if c.m == nil || c.e == nil {
+	c.state.mu.RLock()
+	defer c.state.mu.RUnlock()
+	if c.state.m == nil || c.state.e == nil {
 		return Ok
 	}
-	return c.m.charge(c.e, fee, context)
+	return c.state.m.charge(c.state.e, fee, context)
 }
 
 func (c *Consumer) Admit(reservation Charge) (*Admission, Disposition) {
-	if c == nil {
+	if c == nil || c.state == nil {
 		return nil, Ok
 	}
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if c.m == nil || c.e == nil {
+	c.state.mu.RLock()
+	defer c.state.mu.RUnlock()
+	if c.state.m == nil || c.state.e == nil {
 		return nil, Ok
 	}
-	return c.m.admit(c.e, reservation)
+	return c.state.m.admit(c.state.e, reservation)
 }
 
 func (c *Consumer) Disposition() Disposition {
-	if c == nil {
+	if c == nil || c.state == nil {
 		return Ok
 	}
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if c.m == nil || c.e == nil {
+	c.state.mu.RLock()
+	defer c.state.mu.RUnlock()
+	if c.state.m == nil || c.state.e == nil {
 		return Ok
 	}
-	return disposition(c.m.balance(c.e))
+	return disposition(c.state.m.balance(c.state.e))
 }
 
 func (c *Consumer) Warn() bool {
-	if c == nil {
+	if c == nil || c.state == nil {
 		return false
 	}
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.m != nil && c.e != nil && c.m.warn(c.e)
+	c.state.mu.RLock()
+	defer c.state.mu.RUnlock()
+	return c.state.m != nil && c.state.e != nil && c.state.m.warn(c.state.e)
 }
 
 func (c *Consumer) Disconnect() bool {
-	if c == nil {
+	if c == nil || c.state == nil {
 		return false
 	}
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.m != nil && c.e != nil && c.m.disconnect(c.e)
+	c.state.mu.Lock()
+	defer c.state.mu.Unlock()
+	if c.state.m == nil || c.state.e == nil {
+		return false
+	}
+	if c.state.disconnected {
+		return true
+	}
+	if !c.state.m.disconnect(c.state.e) {
+		return false
+	}
+	c.state.disconnected = true
+	return true
 }
 
 func (c *Consumer) Balance() int64 {
-	if c == nil {
+	if c == nil || c.state == nil {
 		return 0
 	}
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if c.m == nil || c.e == nil {
+	c.state.mu.RLock()
+	defer c.state.mu.RUnlock()
+	if c.state.m == nil || c.state.e == nil {
 		return 0
 	}
-	return c.m.balance(c.e)
+	return c.state.m.balance(c.state.e)
+}
+
+func (c *Consumer) SetPublicKey(publicKey string) {
+	if c == nil || c.state == nil || publicKey == "" {
+		return
+	}
+	c.state.mu.RLock()
+	defer c.state.mu.RUnlock()
+	if c.state.m != nil && c.state.e != nil {
+		c.state.m.setPublicKey(c.state.e, publicKey)
+	}
 }
 
 func (c *Consumer) Release() {
-	if c == nil {
+	if c == nil || c.state == nil {
 		return
 	}
-	c.mu.Lock()
-	m, e := c.m, c.e
-	c.m = nil
-	c.e = nil
-	c.mu.Unlock()
+	c.state.mu.Lock()
+	m, e := c.state.m, c.state.e
+	c.state.m = nil
+	c.state.e = nil
+	c.state.mu.Unlock()
 	if m != nil && e != nil {
 		m.release(e)
 	}

--- a/internal/peermanagement/resource/disposition.go
+++ b/internal/peermanagement/resource/disposition.go
@@ -17,3 +17,16 @@ const (
 	// caller must tear down the endpoint.
 	Drop
 )
+
+func (d Disposition) String() string {
+	switch d {
+	case Ok:
+		return "ok"
+	case Warn:
+		return "warn"
+	case Drop:
+		return "drop"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/peermanagement/resource/disposition.go
+++ b/internal/peermanagement/resource/disposition.go
@@ -1,7 +1,6 @@
 package resource
 
-// Disposition is the result of charging a Consumer. Mirrors rippled's
-// ripple::Resource::Disposition.
+// Disposition is the result of charging a Consumer.
 type Disposition int
 
 const (
@@ -18,18 +17,3 @@ const (
 	// caller must tear down the endpoint.
 	Drop
 )
-
-// String returns the lowercase disposition name (matches rippled's
-// enum stringification used in logs).
-func (d Disposition) String() string {
-	switch d {
-	case Ok:
-		return "ok"
-	case Warn:
-		return "warn"
-	case Drop:
-		return "drop"
-	default:
-		return "unknown"
-	}
-}

--- a/internal/peermanagement/resource/disposition.go
+++ b/internal/peermanagement/resource/disposition.go
@@ -1,6 +1,5 @@
 package resource
 
-// Disposition is the result of charging a Consumer.
 type Disposition int
 
 const (

--- a/internal/peermanagement/resource/expiry.go
+++ b/internal/peermanagement/resource/expiry.go
@@ -79,6 +79,7 @@ func (m *Manager) expireLocked(now time.Time, limit int) {
 			e.expiry = nil
 			if e.localRefs == 0 && e.importRefs == 0 {
 				delete(m.entries, e.k)
+				m.retainedEntries--
 				m.stats.evictions++
 			}
 		case expireImport:

--- a/internal/peermanagement/resource/fees.go
+++ b/internal/peermanagement/resource/fees.go
@@ -1,22 +1,10 @@
 package resource
 
-// Fee schedule. Values mirror rippled's
-// rippled/src/libxrpl/resource/Fees.cpp so existing operator intuition
-// transfers directly. Charge labels are reused verbatim.
-var (
-	FeeMalformedRequest   = NewCharge(200, "malformed request")
-	FeeRequestNoReply     = NewCharge(10, "unsatisfiable request")
-	FeeInvalidSignature   = NewCharge(2000, "invalid signature")
-	FeeUselessData        = NewCharge(150, "useless data")
-	FeeInvalidData        = NewCharge(400, "invalid data")
-	FeeMalformedRPC       = NewCharge(100, "malformed RPC")
-	FeeReferenceRPC       = NewCharge(20, "reference RPC")
-	FeeExceptionRPC       = NewCharge(100, "exceptioned RPC")
-	FeeMediumBurdenRPC    = NewCharge(400, "medium RPC")
-	FeeHeavyBurdenRPC     = NewCharge(3000, "heavy RPC")
-	FeeTrivialPeer        = NewCharge(1, "trivial peer request")
-	FeeModerateBurdenPeer = NewCharge(250, "moderate peer request")
-	FeeHeavyBurdenPeer    = NewCharge(2000, "heavy peer request")
-	FeeWarning            = NewCharge(4000, "received warning")
-	FeeDrop               = NewCharge(6000, "dropped")
-)
+func FeeMalformedRequest() Charge   { return NewCharge(200, "malformed request") }
+func FeeRequestNoReply() Charge     { return NewCharge(10, "unsatisfiable request") }
+func FeeInvalidSignature() Charge   { return NewCharge(2000, "invalid signature") }
+func FeeUselessData() Charge        { return NewCharge(150, "useless data") }
+func FeeInvalidData() Charge        { return NewCharge(400, "invalid data") }
+func FeeModerateBurdenPeer() Charge { return NewCharge(250, "moderate peer request") }
+func FeeHeavyBurdenPeer() Charge    { return NewCharge(2000, "heavy peer request") }
+func FeeDrop() Charge               { return NewCharge(6000, "dropped") }

--- a/internal/peermanagement/resource/fees.go
+++ b/internal/peermanagement/resource/fees.go
@@ -5,7 +5,13 @@ func FeeRequestNoReply() Charge     { return NewCharge(10, "unsatisfiable reques
 func FeeInvalidSignature() Charge   { return NewCharge(2000, "invalid signature") }
 func FeeUselessData() Charge        { return NewCharge(150, "useless data") }
 func FeeInvalidData() Charge        { return NewCharge(400, "invalid data") }
+func FeeMalformedRPC() Charge       { return NewCharge(100, "malformed RPC") }
+func FeeReferenceRPC() Charge       { return NewCharge(20, "reference RPC") }
+func FeeExceptionRPC() Charge       { return NewCharge(100, "exceptioned RPC") }
+func FeeMediumBurdenRPC() Charge    { return NewCharge(400, "medium RPC") }
+func FeeHeavyBurdenRPC() Charge     { return NewCharge(3000, "heavy RPC") }
 func FeeTrivialPeer() Charge        { return NewCharge(1, "trivial peer request") }
 func FeeModerateBurdenPeer() Charge { return NewCharge(250, "moderate peer request") }
 func FeeHeavyBurdenPeer() Charge    { return NewCharge(2000, "heavy peer request") }
+func FeeWarning() Charge            { return NewCharge(4000, "received warning") }
 func FeeDrop() Charge               { return NewCharge(6000, "dropped") }

--- a/internal/peermanagement/resource/fees.go
+++ b/internal/peermanagement/resource/fees.go
@@ -5,6 +5,7 @@ func FeeRequestNoReply() Charge     { return NewCharge(10, "unsatisfiable reques
 func FeeInvalidSignature() Charge   { return NewCharge(2000, "invalid signature") }
 func FeeUselessData() Charge        { return NewCharge(150, "useless data") }
 func FeeInvalidData() Charge        { return NewCharge(400, "invalid data") }
+func FeeTrivialPeer() Charge        { return NewCharge(1, "trivial peer request") }
 func FeeModerateBurdenPeer() Charge { return NewCharge(250, "moderate peer request") }
 func FeeHeavyBurdenPeer() Charge    { return NewCharge(2000, "heavy peer request") }
 func FeeDrop() Charge               { return NewCharge(6000, "dropped") }

--- a/internal/peermanagement/resource/gossip.go
+++ b/internal/peermanagement/resource/gossip.go
@@ -1,12 +1,10 @@
 package resource
 
-// GossipItem describes one consumer's balance for export.
 type GossipItem struct {
 	Address string
 	Balance uint32
 }
 
-// Gossip is a snapshot of consumer balances suitable for sharing across a cluster.
 type Gossip struct {
 	Items []GossipItem
 }

--- a/internal/peermanagement/resource/gossip.go
+++ b/internal/peermanagement/resource/gossip.go
@@ -1,14 +1,12 @@
 package resource
 
-// GossipItem describes one consumer's balance for export. Mirrors
-// rippled's ripple::Resource::Gossip::Item.
+// GossipItem describes one consumer's balance for export.
 type GossipItem struct {
 	Address string
 	Balance uint32
 }
 
-// Gossip is a snapshot of consumer balances suitable for sharing across
-// a cluster. Mirrors rippled's ripple::Resource::Gossip.
+// Gossip is a snapshot of consumer balances suitable for sharing across a cluster.
 type Gossip struct {
 	Items []GossipItem
 }

--- a/internal/peermanagement/resource/kind.go
+++ b/internal/peermanagement/resource/kind.go
@@ -1,6 +1,5 @@
 package resource
 
-// Kind classifies a Consumer.
 type Kind int
 
 const (

--- a/internal/peermanagement/resource/kind.go
+++ b/internal/peermanagement/resource/kind.go
@@ -1,7 +1,6 @@
 package resource
 
-// Kind classifies a Consumer. Mirrors rippled's
-// ripple::Resource::Kind.
+// Kind classifies a Consumer.
 type Kind int
 
 const (
@@ -11,9 +10,8 @@ const (
 	// KindOutbound is a peer connection initiated by this node.
 	KindOutbound
 
-	// KindUnlimited is a privileged endpoint (e.g. cluster member,
-	// admin) for which Charge is a no-op — balance stays at zero and
-	// disposition is always Ok.
+	// KindUnlimited is a privileged administrative endpoint for which
+	// Charge is a no-op.
 	KindUnlimited
 )
 

--- a/internal/peermanagement/resource/limits.go
+++ b/internal/peermanagement/resource/limits.go
@@ -1,7 +1,18 @@
 package resource
 
+import "errors"
+
+var (
+	ErrEntryLimit         = errors.New("resource entry cap reached")
+	ErrImportedEntryLimit = errors.New("resource imported entry cap reached")
+	ErrImportOriginLimit  = errors.New("resource gossip origin cap reached")
+	ErrImportItemLimit    = errors.New("resource gossip item cap reached")
+	ErrInvalidImport      = errors.New("invalid resource gossip")
+)
+
 const (
 	defaultMaxEntries             = 65_536
+	defaultMaxImportedEntries     = 32_768
 	defaultMaxImports             = 1_024
 	defaultMaxGossipItems         = 1_024
 	defaultMaxInflightPerConsumer = 16
@@ -12,6 +23,7 @@ const (
 
 type Limits struct {
 	MaxEntries             int
+	MaxImportedEntries     int
 	MaxImports             int
 	MaxGossipItems         int
 	MaxInflightPerConsumer int
@@ -23,6 +35,7 @@ type Limits struct {
 func DefaultLimits() Limits {
 	return Limits{
 		MaxEntries:             defaultMaxEntries,
+		MaxImportedEntries:     defaultMaxImportedEntries,
 		MaxImports:             defaultMaxImports,
 		MaxGossipItems:         defaultMaxGossipItems,
 		MaxInflightPerConsumer: defaultMaxInflightPerConsumer,
@@ -37,11 +50,14 @@ func (l Limits) withDefaults() Limits {
 	if l.MaxEntries > 0 {
 		d.MaxEntries = l.MaxEntries
 	}
+	if l.MaxImportedEntries > 0 {
+		d.MaxImportedEntries = l.MaxImportedEntries
+	}
 	if l.MaxImports > 0 {
 		d.MaxImports = l.MaxImports
 	}
 	if l.MaxGossipItems > 0 {
-		d.MaxGossipItems = l.MaxGossipItems
+		d.MaxGossipItems = min(l.MaxGossipItems, defaultMaxGossipItems)
 	}
 	if l.MaxInflightPerConsumer > 0 {
 		d.MaxInflightPerConsumer = l.MaxInflightPerConsumer
@@ -55,11 +71,17 @@ func (l Limits) withDefaults() Limits {
 	if l.MaxOriginLength > 0 {
 		d.MaxOriginLength = l.MaxOriginLength
 	}
+	d.MaxImportedEntries = min(d.MaxImportedEntries, d.MaxEntries)
 	return d
 }
 
 type Stats struct {
 	Entries            int
+	Active             int
+	Retained           int
+	ImportedEntries    int
+	ImportOrigins      int
+	ImportItems        int
 	Imports            int
 	Inflight           int
 	Evictions          uint64

--- a/internal/peermanagement/resource/manager.go
+++ b/internal/peermanagement/resource/manager.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"container/heap"
+	"context"
 	"fmt"
 	"log/slog"
 	"math"
@@ -16,6 +17,14 @@ import (
 
 type Clock func() time.Time
 
+type Option func(*Limits)
+
+func WithLimits(limits Limits) Option {
+	return func(configured *Limits) {
+		*configured = limits
+	}
+}
+
 type key struct {
 	kind Kind
 	addr string
@@ -29,6 +38,7 @@ type entry struct {
 	reservedCost  int64
 	localBalance  decayingSample
 	remoteBalance int64
+	publicKey     string
 	lastWarning   time.Time
 	warningSet    bool
 	expiry        *expiryItem
@@ -43,6 +53,14 @@ func (e *entry) add(charge int64, now time.Time) int64 {
 }
 
 func (e *entry) isUnlimited() bool { return e.k.kind == KindUnlimited }
+
+func (e *entry) fingerprint() string {
+	fingerprint := "IP Address: " + e.k.addr
+	if e.publicKey != "" {
+		fingerprint += ", Public Key: " + e.publicKey
+	}
+	return fingerprint
+}
 
 type importRecord struct {
 	items  []importItem
@@ -61,11 +79,14 @@ type Manager struct {
 	journal *slog.Logger
 	limits  Limits
 
-	entries  map[key]*entry
-	imports  map[string]*importRecord
-	expiries expiryQueue
-	inflight int
-	stats    counters
+	entries         map[key]*entry
+	imports         map[string]*importRecord
+	expiries        expiryQueue
+	inflight        int
+	retainedEntries int
+	importedEntries int
+	importItems     int
+	stats           counters
 
 	stop     chan struct{}
 	stopped  bool
@@ -73,8 +94,14 @@ type Manager struct {
 	stopOnce sync.Once
 }
 
-func NewManager(clock Clock, journal *slog.Logger) *Manager {
-	return NewManagerWithLimits(clock, journal, DefaultLimits())
+func NewManager(clock Clock, journal *slog.Logger, options ...Option) *Manager {
+	limits := DefaultLimits()
+	for _, option := range options {
+		if option != nil {
+			option(&limits)
+		}
+	}
+	return NewManagerWithLimits(clock, journal, limits)
 }
 
 func NewManagerWithLimits(clock Clock, journal *slog.Logger, limits Limits) *Manager {
@@ -162,16 +189,21 @@ func (m *Manager) acquire(kind Kind, raw string) *Consumer {
 	e := m.entries[ek]
 	if e == nil {
 		m.expireLocked(now, 1)
-		if len(m.entries) >= m.limits.MaxEntries {
+		evictions, ok := m.planEntryEvictionsLocked(1, now, map[key]struct{}{ek: {}}, nil)
+		if !ok {
 			m.stats.entryCapRejections++
 			return nil
 		}
+		m.evictEntriesLocked(evictions)
 		e = &entry{k: ek, localBalance: newDecayingSample(now, DecayWindowSeconds)}
 		m.entries[ek] = e
 	}
+	if e.localRefs == 0 && e.importRefs == 0 && e.expiry != nil {
+		m.retainedEntries--
+	}
 	m.cancelEntryExpiryLocked(e)
 	e.localRefs++
-	return &Consumer{m: m, e: e}
+	return &Consumer{state: &consumerState{m: m, e: e}}
 }
 
 func canonicalEndpoint(kind Kind, raw string, maxLength int) (string, bool) {
@@ -215,6 +247,9 @@ func canonicalEndpoint(kind Kind, raw string, maxLength int) (string, bool) {
 			return "", false
 		}
 	}
+	if addr.Zone() != "" {
+		return "", false
+	}
 	addr = addr.Unmap()
 	if kind == KindUnlimited {
 		return netip.AddrPortFrom(addr, 1).String(), true
@@ -237,28 +272,127 @@ func (m *Manager) releaseLocalLocked(e *entry, now time.Time) {
 }
 
 func (m *Manager) scheduleIfInactiveLocked(e *entry, now time.Time) {
-	if e.localRefs == 0 && e.importRefs == 0 {
+	if e.localRefs == 0 && e.importRefs == 0 && e.expiry == nil {
+		m.retainedEntries++
 		m.scheduleEntryExpiryLocked(e, now.Add(SecondsUntilExpiration))
 	}
 }
 
-func (m *Manager) charge(e *entry, fee Charge, context string) Disposition {
+type projectedRelease struct {
+	refs    int
+	balance int64
+}
+
+func (m *Manager) planEntryEvictionsLocked(
+	needed int,
+	now time.Time,
+	protected map[key]struct{},
+	releases map[*entry]projectedRelease,
+) ([]*entry, bool) {
+	required := len(m.entries) + needed - m.limits.MaxEntries
+	if required <= 0 {
+		return nil, true
+	}
+
+	candidates := make([]*entry, 0, m.retainedEntries+len(releases))
+	for _, e := range m.entries {
+		if _, keep := protected[e.k]; keep {
+			continue
+		}
+		refs := e.localRefs + e.importRefs
+		balance := e.balance(now)
+		if release, ok := releases[e]; ok {
+			refs -= release.refs
+			balance = max(0, balance-release.balance)
+		}
+		if refs == 0 && e.inflight == 0 && balance < WarningThreshold {
+			candidates = append(candidates, e)
+		}
+	}
+	if len(candidates) < required {
+		return nil, false
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		leftExpiry := now.Add(SecondsUntilExpiration)
+		if candidates[i].expiry != nil {
+			leftExpiry = candidates[i].expiry.when
+		}
+		rightExpiry := now.Add(SecondsUntilExpiration)
+		if candidates[j].expiry != nil {
+			rightExpiry = candidates[j].expiry.when
+		}
+		if !leftExpiry.Equal(rightExpiry) {
+			return leftExpiry.Before(rightExpiry)
+		}
+		if candidates[i].k.kind != candidates[j].k.kind {
+			return candidates[i].k.kind < candidates[j].k.kind
+		}
+		return candidates[i].k.addr < candidates[j].k.addr
+	})
+	return candidates[:required], true
+}
+
+func (m *Manager) evictEntriesLocked(entries []*entry) {
+	for _, e := range entries {
+		if m.entries[e.k] != e || e.localRefs != 0 || e.importRefs != 0 || e.inflight != 0 {
+			panic("resource: invalid eviction plan")
+		}
+		if e.expiry != nil {
+			m.cancelEntryExpiryLocked(e)
+			m.retainedEntries--
+		}
+		delete(m.entries, e.k)
+		m.stats.evictions++
+	}
+}
+
+func (m *Manager) charge(e *entry, fee Charge, chargeContext string) Disposition {
 	if e.isUnlimited() {
 		return Ok
 	}
+	logContext := context.Background()
+	level := chargeLevel(fee.Cost())
+	logEnabled := m.journal.Enabled(logContext, level)
 	m.mu.Lock()
 	now := m.clock()
 	balance := e.add(int64(fee.Cost()), now)
 	result := disposition(balance)
-	endpoint := e.k.addr
+	var endpoint string
+	if logEnabled {
+		endpoint = e.fingerprint()
+	}
 	m.mu.Unlock()
-
-	if context == "" {
-		m.journal.Debug("resource charge", "endpoint", endpoint, "fee", fee.String(), "balance", balance)
-	} else {
-		m.journal.Debug("resource charge", "endpoint", endpoint, "fee", fee.String(), "balance", balance, "context", context)
+	if logEnabled {
+		m.logCharge(logContext, level, endpoint, fee, balance, chargeContext)
 	}
 	return result
+}
+
+const resourceTraceLevel = slog.LevelDebug - 4
+
+func chargeLevel(cost int) slog.Level {
+	switch {
+	case cost >= 3000:
+		return slog.LevelWarn
+	case cost >= 1000:
+		return slog.LevelInfo
+	case cost >= 100:
+		return slog.LevelDebug
+	default:
+		return resourceTraceLevel
+	}
+}
+
+func (m *Manager) logCharge(ctx context.Context, level slog.Level, endpoint string, fee Charge, balance int64, chargeContext string) {
+	attrs := []slog.Attr{
+		slog.String("endpoint", endpoint),
+		slog.String("fee", fee.String()),
+		slog.Int64("balance", balance),
+	}
+	if chargeContext != "" {
+		attrs = append(attrs, slog.String("context", chargeContext))
+	}
+	m.journal.LogAttrs(ctx, level, "resource charge", attrs...)
 }
 
 func disposition(balance int64) Disposition {
@@ -276,19 +410,26 @@ func (m *Manager) warn(e *entry) bool {
 	if e.isUnlimited() {
 		return false
 	}
+	ctx := context.Background()
+	logEnabled := m.journal.Enabled(ctx, slog.LevelInfo)
 	m.mu.Lock()
 	now := m.clock()
 	if e.balance(now) < WarningThreshold || e.warningSet && now.Sub(e.lastWarning) < time.Second {
 		m.mu.Unlock()
 		return false
 	}
-	_ = e.add(int64(FeeWarning.Cost()), now)
+	_ = e.add(int64(FeeWarning().Cost()), now)
 	e.lastWarning = now
 	e.warningSet = true
 	m.stats.warnings++
-	endpoint := e.k.addr
+	var endpoint string
+	if logEnabled {
+		endpoint = e.fingerprint()
+	}
 	m.mu.Unlock()
-	m.journal.Info("resource load warning", "endpoint", endpoint)
+	if logEnabled {
+		m.journal.LogAttrs(ctx, slog.LevelInfo, "resource load warning", slog.String("endpoint", endpoint))
+	}
 	return true
 }
 
@@ -296,17 +437,25 @@ func (m *Manager) disconnect(e *entry) bool {
 	if e.isUnlimited() {
 		return false
 	}
+	ctx := context.Background()
+	logEnabled := m.journal.Enabled(ctx, slog.LevelWarn)
 	m.mu.Lock()
 	now := m.clock()
 	if e.balance(now) < DropThreshold {
 		m.mu.Unlock()
 		return false
 	}
-	balance := e.add(int64(FeeDrop.Cost()), now)
+	balance := e.add(int64(FeeDrop().Cost()), now)
 	m.stats.drops++
-	endpoint := e.k.addr
+	var endpoint string
+	if logEnabled {
+		endpoint = e.fingerprint()
+	}
 	m.mu.Unlock()
-	m.journal.Warn("resource consumer dropped", "endpoint", endpoint, "balance", balance, "threshold", DropThreshold)
+	if logEnabled {
+		m.journal.LogAttrs(ctx, slog.LevelWarn, "resource consumer dropped",
+			slog.String("endpoint", endpoint), slog.Int64("balance", balance), slog.Int("threshold", DropThreshold))
+	}
 	return true
 }
 
@@ -316,10 +465,20 @@ func (m *Manager) balance(e *entry) int64 {
 	return e.balance(m.clock())
 }
 
+func (m *Manager) setPublicKey(e *entry, publicKey string) {
+	m.mu.Lock()
+	e.publicKey = publicKey
+	m.mu.Unlock()
+}
+
 func (m *Manager) PeriodicActivity() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.expireLocked(m.clock(), m.limits.MaxCleanupPerTick)
+}
+
+func (m *Manager) periodicActivity() {
+	m.PeriodicActivity()
 }
 
 func (m *Manager) ExportConsumers() Gossip {
@@ -355,38 +514,81 @@ func (m *Manager) ImportConsumers(origin string, gossip Gossip) error {
 		m.mu.Lock()
 		m.stats.importRejections++
 		m.mu.Unlock()
+		m.logImportRejection(origin, err)
 		return err
 	}
 
 	now := m.clock()
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.expireLocked(now, m.limits.MaxCleanupPerTick)
 	previous := m.imports[origin]
 	if len(items) == 0 {
 		if previous != nil {
 			m.removeImportLocked(origin, previous, now)
 		}
+		m.mu.Unlock()
 		return nil
 	}
 	if previous == nil && len(m.imports) >= m.limits.MaxImports {
 		m.stats.importRejections++
-		return fmt.Errorf("resource gossip origin cap reached")
+		m.mu.Unlock()
+		m.logImportRejection(origin, ErrImportOriginLimit)
+		return ErrImportOriginLimit
 	}
 
+	nextSet := make(map[*entry]struct{}, len(items))
+	releases := make(map[*entry]projectedRelease)
+	newImported := 0
 	newEntries := 0
 	for _, item := range items {
-		if m.entries[key{kind: KindInbound, addr: item.Address}] == nil {
+		e := m.entries[key{kind: KindInbound, addr: item.Address}]
+		if e == nil {
 			newEntries++
+			newImported++
+			continue
+		}
+		nextSet[e] = struct{}{}
+		if e.importRefs == 0 {
+			newImported++
 		}
 	}
-	if len(m.entries)+newEntries > m.limits.MaxEntries {
+	releasedImported := 0
+	if previous != nil {
+		for _, item := range previous.items {
+			release := releases[item.entry]
+			release.refs++
+			release.balance = saturatingAdd(release.balance, item.balance)
+			releases[item.entry] = release
+			if _, retained := nextSet[item.entry]; !retained && item.entry.importRefs == 1 {
+				releasedImported++
+			}
+		}
+	}
+	if m.importedEntries+newImported-releasedImported > m.limits.MaxImportedEntries {
+		m.stats.importRejections++
+		m.mu.Unlock()
+		m.logImportRejection(origin, ErrImportedEntryLimit)
+		return ErrImportedEntryLimit
+	}
+	protected := make(map[key]struct{}, len(items))
+	for _, item := range items {
+		protected[key{kind: KindInbound, addr: item.Address}] = struct{}{}
+	}
+	evictions, ok := m.planEntryEvictionsLocked(newEntries, now, protected, releases)
+	if !ok {
 		m.stats.importRejections++
 		m.stats.entryCapRejections++
-		return fmt.Errorf("resource entry cap reached")
+		m.mu.Unlock()
+		m.logImportRejection(origin, ErrEntryLimit)
+		return ErrEntryLimit
 	}
 
-	next := &importRecord{}
+	if previous != nil {
+		m.removeImportLocked(origin, previous, now)
+	}
+	m.evictEntriesLocked(evictions)
+
+	next := &importRecord{items: make([]importItem, 0, len(items))}
 	for _, item := range items {
 		ek := key{kind: KindInbound, addr: item.Address}
 		e := m.entries[ek]
@@ -394,18 +596,32 @@ func (m *Manager) ImportConsumers(origin string, gossip Gossip) error {
 			e = &entry{k: ek, localBalance: newDecayingSample(now, DecayWindowSeconds)}
 			m.entries[ek] = e
 		}
+		if e.localRefs == 0 && e.importRefs == 0 && e.expiry != nil {
+			m.retainedEntries--
+		}
 		m.cancelEntryExpiryLocked(e)
+		if e.importRefs == 0 {
+			m.importedEntries++
+		}
 		e.importRefs++
 		e.remoteBalance = saturatingAdd(e.remoteBalance, item.Balance)
 		next.items = append(next.items, importItem{entry: e, balance: item.Balance})
 	}
-	if previous != nil {
-		m.removeImportLocked(origin, previous, now)
-	}
 	next.expiry = &expiryItem{when: now.Add(GossipExpiration), kind: expireImport, origin: origin, index: -1}
 	heap.Push(&m.expiries, next.expiry)
 	m.imports[origin] = next
+	m.importItems += len(next.items)
+	m.mu.Unlock()
 	return nil
+}
+
+func (m *Manager) logImportRejection(origin string, err error) {
+	ctx := context.Background()
+	if !m.journal.Enabled(ctx, slog.LevelWarn) {
+		return
+	}
+	m.journal.LogAttrs(ctx, slog.LevelWarn, "resource import rejected",
+		slog.String("origin", origin), slog.Any("err", err))
 }
 
 type validatedGossipItem struct {
@@ -415,10 +631,10 @@ type validatedGossipItem struct {
 
 func (m *Manager) validateGossip(origin string, gossip Gossip) ([]validatedGossipItem, error) {
 	if len(origin) > m.limits.MaxOriginLength {
-		return nil, fmt.Errorf("resource gossip origin exceeds %d bytes", m.limits.MaxOriginLength)
+		return nil, fmt.Errorf("%w: origin exceeds %d bytes", ErrInvalidImport, m.limits.MaxOriginLength)
 	}
 	if len(gossip.Items) > m.limits.MaxGossipItems {
-		return nil, fmt.Errorf("resource gossip has %d items, limit %d", len(gossip.Items), m.limits.MaxGossipItems)
+		return nil, fmt.Errorf("%w: got %d items, limit %d", ErrImportItemLimit, len(gossip.Items), m.limits.MaxGossipItems)
 	}
 	dedup := make(map[string]uint64, len(gossip.Items))
 	for _, item := range gossip.Items {
@@ -427,7 +643,7 @@ func (m *Manager) validateGossip(origin string, gossip Gossip) ([]validatedGossi
 		}
 		addr, ok := canonicalEndpoint(KindInbound, item.Address, m.limits.MaxEndpointLength)
 		if !ok {
-			return nil, fmt.Errorf("invalid resource gossip endpoint %q", item.Address)
+			return nil, fmt.Errorf("%w: endpoint %q", ErrInvalidImport, item.Address)
 		}
 		total := dedup[addr] + uint64(item.Balance)
 		if total > math.MaxUint32 {
@@ -451,12 +667,16 @@ func (m *Manager) removeImportLocked(origin string, rec *importRecord, now time.
 	if rec.expiry != nil && rec.expiry.index >= 0 {
 		heap.Remove(&m.expiries, rec.expiry.index)
 	}
+	m.importItems -= len(rec.items)
 	for _, item := range rec.items {
 		item.entry.remoteBalance -= item.balance
 		if item.entry.remoteBalance < 0 {
 			item.entry.remoteBalance = 0
 		}
 		if item.entry.importRefs > 0 {
+			if item.entry.importRefs == 1 {
+				m.importedEntries--
+			}
 			item.entry.importRefs--
 		}
 		m.scheduleIfInactiveLocked(item.entry, now)
@@ -475,6 +695,11 @@ func (m *Manager) Stats() Stats {
 	defer m.mu.Unlock()
 	return Stats{
 		Entries:            len(m.entries),
+		Active:             len(m.entries) - m.retainedEntries,
+		Retained:           m.retainedEntries,
+		ImportedEntries:    m.importedEntries,
+		ImportOrigins:      len(m.imports),
+		ImportItems:        m.importItems,
 		Imports:            len(m.imports),
 		Inflight:           m.inflight,
 		Evictions:          m.stats.evictions,

--- a/internal/peermanagement/resource/manager_hardening_test.go
+++ b/internal/peermanagement/resource/manager_hardening_test.go
@@ -75,8 +75,8 @@ func TestExportConsumersTracksLocalActivity(t *testing.T) {
 	if err := m.ImportConsumers("origin", Gossip{Items: []GossipItem{{Address: address, Balance: 1500}}}); err != nil {
 		t.Fatal(err)
 	}
-	if got := len(m.ExportConsumers().Items); got != 0 {
-		t.Fatalf("import-pinned released export count = %d, want 0", got)
+	if got := len(m.ExportConsumers().Items); got != 1 {
+		t.Fatalf("import-pinned released export count = %d, want 1", got)
 	}
 
 	reacquired := m.NewInboundEndpoint("192.0.2.2:2000")
@@ -87,52 +87,53 @@ func TestExportConsumersTracksLocalActivity(t *testing.T) {
 }
 
 func TestDecayRetainsFractionalElapsedAndResetBoundary(t *testing.T) {
-	d := newDecayingSample(0, DecayWindowSeconds)
+	base := time.Unix(1_700_000_000, 0)
+	d := newDecayingSample(base, DecayWindowSeconds)
 	d.value = 3200
-	if got := d.valueAt(900 * time.Millisecond); got != 100 {
+	if got := d.valueAt(base.Add(900 * time.Millisecond)); got != 100 {
 		t.Fatalf("sub-second value = %d, want 100", got)
 	}
-	first := d.valueAt(1100 * time.Millisecond)
-	if d.when != time.Second {
-		t.Fatalf("anchor = %s, want 1s", d.when)
+	first := d.valueAt(base.Add(1100 * time.Millisecond))
+	if !d.when.Equal(base.Add(time.Second)) {
+		t.Fatalf("anchor = %s, want %s", d.when, base.Add(time.Second))
 	}
-	if got := d.valueAt(1900 * time.Millisecond); got != first {
+	if got := d.valueAt(base.Add(1900 * time.Millisecond)); got != first {
 		t.Fatalf("fractional elapsed was discarded: got %d want %d", got, first)
 	}
-	if got := d.valueAt(2100 * time.Millisecond); got >= first {
+	if got := d.valueAt(base.Add(2100 * time.Millisecond)); got >= first {
 		t.Fatalf("second elapsed tick did not decay: got %d previous %d", got, first)
 	}
 	anchor, value := d.when, d.value
-	d.decay(time.Second)
-	if d.when != anchor || d.value != value {
+	d.decay(base.Add(time.Second))
+	if !d.when.Equal(anchor) || d.value != value {
 		t.Fatalf("backward time changed sample: anchor=%s value=%d", d.when, d.value)
 	}
 
-	d = newDecayingSample(0, DecayWindowSeconds)
+	d = newDecayingSample(base, DecayWindowSeconds)
 	d.value = 3200
-	d.decay(time.Duration(4*DecayWindowSeconds+1) * time.Second)
+	d.decay(base.Add(time.Duration(4*DecayWindowSeconds+1) * time.Second))
 	if d.value != 0 {
 		t.Fatalf("sample beyond reset boundary = %d, want 0", d.value)
 	}
 }
 
 func TestManagerClockIsIndependentOfWallTime(t *testing.T) {
-	var monotonic time.Duration
-	m := NewManager(func() time.Duration { return monotonic }, testLogger())
+	monotonic := time.Unix(1_700_000_000, 0)
+	m := NewManager(func() time.Time { return monotonic }, testLogger())
 	c := m.NewInboundEndpoint("192.0.2.3")
 	c.Charge(NewCharge(DecayWindowSeconds*100, "seed"), "")
 	initial := c.Balance()
 	if got := c.Balance(); got != initial {
 		t.Fatalf("unchanged monotonic clock changed balance: got %d want %d", got, initial)
 	}
-	monotonic += time.Second
+	monotonic = monotonic.Add(time.Second)
 	if got := c.Balance(); got >= initial {
 		t.Fatalf("monotonic advance did not decay: got %d initial %d", got, initial)
 	}
 	c.Release()
 }
 
-func TestCanonicalEndpointIdentity(t *testing.T) {
+func TestCanonicalEndpointIdentityHardening(t *testing.T) {
 	m, _ := newTestManager()
 	pairs := [][2]string{
 		{"[2001:0DB8:0:0:0:0:0:1]:1000", "2001:db8::1"},
@@ -154,7 +155,7 @@ func TestCanonicalEndpointIdentity(t *testing.T) {
 	if got := m.Stats().Entries; got != len(pairs) {
 		t.Fatalf("canonical entry count = %d, want %d", got, len(pairs))
 	}
-	if c := m.NewInboundEndpoint("203.0.113.1:"); c != nil {
+	if c := m.NewInboundEndpoint("203.0.113.1::"); c != nil {
 		t.Fatal("malformed endpoint was accepted")
 	}
 	if c := m.NewOutboundEndpoint("2001:db8::1"); c != nil {
@@ -168,7 +169,7 @@ func TestCanonicalEndpointIdentity(t *testing.T) {
 func TestImportReplacementIsTransactional(t *testing.T) {
 	clock := newFakeClock()
 	m := NewManager(clock.Now, testLogger(), WithLimits(Limits{
-		MaxEntries: 2, MaxImportedEntries: 2, MaxImportOrigins: 1, MaxImportItems: 2,
+		MaxEntries: 2, MaxImportedEntries: 2, MaxImports: 1, MaxGossipItems: 2,
 	}))
 	if err := m.ImportConsumers("origin", Gossip{Items: []GossipItem{{Address: "192.0.2.1", Balance: 900}}}); err != nil {
 		t.Fatal(err)
@@ -201,7 +202,7 @@ func TestImportReplacementIsTransactional(t *testing.T) {
 
 func TestImportReplacementCanReuseReleasedEntryCapacity(t *testing.T) {
 	m := NewManager(nil, testLogger(), WithLimits(Limits{
-		MaxEntries: 1, MaxImportedEntries: 1, MaxImportOrigins: 1, MaxImportItems: 1,
+		MaxEntries: 1, MaxImportedEntries: 1, MaxImports: 1, MaxGossipItems: 1,
 	}))
 	if err := m.ImportConsumers("origin", Gossip{Items: []GossipItem{{Address: "192.0.2.10", Balance: 100}}}); err != nil {
 		t.Fatal(err)
@@ -216,7 +217,7 @@ func TestImportReplacementCanReuseReleasedEntryCapacity(t *testing.T) {
 
 func TestFailedCapacityPlanDoesNotPartiallyEvict(t *testing.T) {
 	m := NewManager(nil, testLogger(), WithLimits(Limits{
-		MaxEntries: 3, MaxImportedEntries: 3, MaxImportOrigins: 1, MaxImportItems: 3,
+		MaxEntries: 3, MaxImportedEntries: 3, MaxImports: 1, MaxGossipItems: 3,
 	}))
 	for _, address := range []string{"192.0.2.20", "192.0.2.21"} {
 		consumer := m.NewInboundEndpoint(address)
@@ -240,7 +241,7 @@ func TestFailedCapacityPlanDoesNotPartiallyEvict(t *testing.T) {
 func TestInactiveHighBalanceBecomesEvictableAfterDecay(t *testing.T) {
 	clock := newFakeClock()
 	m := NewManager(clock.Now, testLogger(), WithLimits(Limits{
-		MaxEntries: 1, MaxImportedEntries: 1, MaxImportOrigins: 1, MaxImportItems: 1,
+		MaxEntries: 1, MaxImportedEntries: 1, MaxImports: 1, MaxGossipItems: 1,
 	}))
 	consumer := m.NewInboundEndpoint("192.0.2.30")
 	consumer.Charge(NewCharge(WarningThreshold*DecayWindowSeconds, "high"), "")
@@ -255,30 +256,30 @@ func TestInactiveHighBalanceBecomesEvictableAfterDecay(t *testing.T) {
 
 func TestExportConsumersIsBoundedAndKeepsStrongest(t *testing.T) {
 	m := NewManager(nil, testLogger(), WithLimits(Limits{
-		MaxEntries: 4, MaxImportedEntries: 4, MaxImportOrigins: 1, MaxImportItems: 2,
+		MaxEntries: 4, MaxImportedEntries: 4, MaxImports: 1, MaxGossipItems: 2,
 	}))
 	for i, address := range []string{"192.0.2.40", "192.0.2.41", "192.0.2.42"} {
 		consumer := m.NewInboundEndpoint(address)
 		consumer.Charge(NewCharge((i+1)*MinimumGossipBalance*DecayWindowSeconds, "seed"), "")
 	}
 	items := m.ExportConsumers().Items
-	if len(items) != 2 || items[0].Address != "192.0.2.41" || items[1].Address != "192.0.2.42" {
+	if len(items) != 2 || items[0].Address != "192.0.2.42" || items[1].Address != "192.0.2.41" {
 		t.Fatalf("bounded export = %+v", items)
 	}
 
 	m.mu.Lock()
-	key, _ := canonicalKey(KindInbound, "192.0.2.42")
-	m.entries[key].localBalance.value = (int64(math.MaxUint32) + 1) * DecayWindowSeconds
+	address, _ := canonicalEndpoint(KindInbound, "192.0.2.42", DefaultLimits().MaxEndpointLength)
+	m.entries[key{kind: KindInbound, addr: address}].localBalance.value = (int64(math.MaxUint32) + 1) * DecayWindowSeconds
 	m.mu.Unlock()
 	items = m.ExportConsumers().Items
-	if items[1].Balance != math.MaxUint32 {
-		t.Fatalf("exported balance = %d, want uint32 cap", items[1].Balance)
+	if items[0].Balance != math.MaxUint32 {
+		t.Fatalf("exported balance = %d, want uint32 cap", items[0].Balance)
 	}
 }
 
 func TestRemoteBalanceAggregationDoesNotOverflow(t *testing.T) {
 	m := NewManager(nil, testLogger(), WithLimits(Limits{
-		MaxEntries: 1, MaxImportedEntries: 1, MaxImportOrigins: 3, MaxImportItems: 1,
+		MaxEntries: 1, MaxImportedEntries: 1, MaxImports: 3, MaxGossipItems: 1,
 	}))
 	for _, origin := range []string{"one", "two", "three"} {
 		if err := m.ImportConsumers(origin, Gossip{Items: []GossipItem{{Address: "192.0.2.50", Balance: math.MaxUint32}}}); err != nil {
@@ -322,7 +323,7 @@ func TestConsumerAliasAndConcurrentDisconnectAreExactlyOnce(t *testing.T) {
 
 func TestImportedEntryLimitHasDistinctError(t *testing.T) {
 	m := NewManager(nil, testLogger(), WithLimits(Limits{
-		MaxEntries: 2, MaxImportedEntries: 1, MaxImportOrigins: 2, MaxImportItems: 1,
+		MaxEntries: 2, MaxImportedEntries: 1, MaxImports: 2, MaxGossipItems: 1,
 	}))
 	if err := m.ImportConsumers("one", Gossip{Items: []GossipItem{{Address: "192.0.2.70", Balance: 1}}}); err != nil {
 		t.Fatal(err)
@@ -373,8 +374,8 @@ func TestImportValidationDeduplicationAndReplacement(t *testing.T) {
 		t.Fatalf("deduplicated import items = %d, want 1", got)
 	}
 	c := m.NewInboundEndpoint("[2001:db8::1]:9999")
-	if got := c.Balance(); got != 1500 {
-		t.Fatalf("deduplicated balance = %d, want max 1500", got)
+	if got := c.Balance(); got != 2900 {
+		t.Fatalf("deduplicated balance = %d, want sum 2900", got)
 	}
 	c.Release()
 
@@ -382,7 +383,7 @@ func TestImportValidationDeduplicationAndReplacement(t *testing.T) {
 		t.Fatal("malformed replacement accepted")
 	}
 	c = m.NewInboundEndpoint("2001:db8::1")
-	if got := c.Balance(); got != 1500 {
+	if got := c.Balance(); got != 2900 {
 		t.Fatalf("rejected replacement mutated prior balance: got %d", got)
 	}
 	c.Release()
@@ -390,7 +391,7 @@ func TestImportValidationDeduplicationAndReplacement(t *testing.T) {
 
 func TestManagerLimitsEvictOnlyLowInactiveEntries(t *testing.T) {
 	clock := newFakeClock()
-	limits := Limits{MaxEntries: 3, MaxImportedEntries: 2, MaxImportOrigins: 1, MaxImportItems: 2}
+	limits := Limits{MaxEntries: 3, MaxImportedEntries: 2, MaxImports: 1, MaxGossipItems: 2}
 	m := NewManager(clock.Now, testLogger(), WithLimits(limits))
 
 	low := m.NewInboundEndpoint("192.0.2.10")
@@ -425,7 +426,7 @@ func TestManagerLimitsEvictOnlyLowInactiveEntries(t *testing.T) {
 	}}); err != nil {
 		t.Fatal(err)
 	}
-	if err := m.ImportConsumers("two", Gossip{}); err == nil {
+	if err := m.ImportConsumers("two", Gossip{Items: []GossipItem{{Address: "198.51.100.9", Balance: 1}}}); err == nil {
 		t.Fatal("origin cap was not enforced")
 	}
 	if err := m.ImportConsumers("one", Gossip{Items: []GossipItem{
@@ -440,7 +441,7 @@ func TestManagerLimitsEvictOnlyLowInactiveEntries(t *testing.T) {
 func TestManagerRejectsWhenOnlyHighReputationRemains(t *testing.T) {
 	clock := newFakeClock()
 	m := NewManager(clock.Now, testLogger(), WithLimits(Limits{
-		MaxEntries: 1, MaxImportedEntries: 1, MaxImportOrigins: 1, MaxImportItems: 1,
+		MaxEntries: 1, MaxImportedEntries: 1, MaxImports: 1, MaxGossipItems: 1,
 	}))
 	c := m.NewInboundEndpoint("192.0.2.20")
 	c.Charge(NewCharge(WarningThreshold*DecayWindowSeconds, "high"), "")
@@ -448,7 +449,7 @@ func TestManagerRejectsWhenOnlyHighReputationRemains(t *testing.T) {
 	if got := m.NewInboundEndpoint("192.0.2.21"); got != nil {
 		t.Fatal("high-balance entry was evicted")
 	}
-	if got := m.Stats().EntryLimitDrops; got != 1 {
+	if got := m.Stats().EntryCapRejections; got != 1 {
 		t.Fatalf("entry limit drops = %d, want 1", got)
 	}
 }
@@ -481,7 +482,7 @@ func TestExpiryHeapRemainsBoundedUnderReplacementChurn(t *testing.T) {
 	for i := range 1000 {
 		if err := m.ImportConsumers("origin", Gossip{Items: []GossipItem{{
 			Address: "198.51.100.31",
-			Balance: int64(1000 + i),
+			Balance: uint32(1000 + i),
 		}}}); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/peermanagement/resource/manager_hardening_test.go
+++ b/internal/peermanagement/resource/manager_hardening_test.go
@@ -2,9 +2,11 @@ package resource
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -116,16 +118,12 @@ func TestDecayRetainsFractionalElapsedAndResetBoundary(t *testing.T) {
 
 func TestManagerClockIsIndependentOfWallTime(t *testing.T) {
 	var monotonic time.Duration
-	wall := time.Unix(1, 0)
 	m := NewManager(func() time.Duration { return monotonic }, testLogger())
 	c := m.NewInboundEndpoint("192.0.2.3")
 	c.Charge(NewCharge(DecayWindowSeconds*100, "seed"), "")
 	initial := c.Balance()
-	wall = wall.Add(24 * time.Hour)
-	wall = wall.Add(-48 * time.Hour)
-	_ = wall
 	if got := c.Balance(); got != initial {
-		t.Fatalf("wall-clock adjustment changed balance: got %d want %d", got, initial)
+		t.Fatalf("unchanged monotonic clock changed balance: got %d want %d", got, initial)
 	}
 	monotonic += time.Second
 	if got := c.Balance(); got >= initial {
@@ -139,7 +137,6 @@ func TestCanonicalEndpointIdentity(t *testing.T) {
 	pairs := [][2]string{
 		{"[2001:0DB8:0:0:0:0:0:1]:1000", "2001:db8::1"},
 		{"[::ffff:192.0.2.4]:1000", "192.0.2.4:2000"},
-		{"[fe80::1%en0]:1000", "fe80::1%en0"},
 	}
 	for i, pair := range pairs {
 		first := m.NewInboundEndpoint(pair[0])
@@ -162,6 +159,185 @@ func TestCanonicalEndpointIdentity(t *testing.T) {
 	}
 	if c := m.NewOutboundEndpoint("2001:db8::1"); c != nil {
 		t.Fatal("outbound endpoint without port was accepted")
+	}
+	if c := m.NewInboundEndpoint("fe80::1%en0"); c != nil {
+		t.Fatal("zone-scoped endpoint was accepted")
+	}
+}
+
+func TestImportReplacementIsTransactional(t *testing.T) {
+	clock := newFakeClock()
+	m := NewManager(clock.Now, testLogger(), WithLimits(Limits{
+		MaxEntries: 2, MaxImportedEntries: 2, MaxImportOrigins: 1, MaxImportItems: 2,
+	}))
+	if err := m.ImportConsumers("origin", Gossip{Items: []GossipItem{{Address: "192.0.2.1", Balance: 900}}}); err != nil {
+		t.Fatal(err)
+	}
+	active := m.NewInboundEndpoint("192.0.2.2")
+	defer active.Release()
+
+	err := m.ImportConsumers("origin", Gossip{Items: []GossipItem{
+		{Address: "192.0.2.3", Balance: 1000},
+		{Address: "192.0.2.4", Balance: 1100},
+	}})
+	if !errors.Is(err, ErrEntryLimit) {
+		t.Fatalf("replacement error = %v, want %v", err, ErrEntryLimit)
+	}
+	old := m.NewInboundEndpoint("192.0.2.1")
+	if old == nil {
+		t.Fatal("rejected replacement removed prior import")
+	}
+	if old.Balance() != 900 {
+		t.Fatalf("rejected replacement changed prior balance: got %d", old.Balance())
+	}
+	old.Release()
+
+	clock.Advance(GossipExpiration + time.Second)
+	m.periodicActivity()
+	if got := m.Stats().ImportOrigins; got != 0 {
+		t.Fatalf("prior import expiry was cancelled by rejected replacement: origins=%d", got)
+	}
+}
+
+func TestImportReplacementCanReuseReleasedEntryCapacity(t *testing.T) {
+	m := NewManager(nil, testLogger(), WithLimits(Limits{
+		MaxEntries: 1, MaxImportedEntries: 1, MaxImportOrigins: 1, MaxImportItems: 1,
+	}))
+	if err := m.ImportConsumers("origin", Gossip{Items: []GossipItem{{Address: "192.0.2.10", Balance: 100}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.ImportConsumers("origin", Gossip{Items: []GossipItem{{Address: "192.0.2.11", Balance: 200}}}); err != nil {
+		t.Fatalf("full-capacity replacement failed: %v", err)
+	}
+	if stats := m.Stats(); stats.Entries != 1 || stats.ImportedEntries != 1 || stats.ImportItems != 1 {
+		t.Fatalf("replacement stats = %+v", stats)
+	}
+}
+
+func TestFailedCapacityPlanDoesNotPartiallyEvict(t *testing.T) {
+	m := NewManager(nil, testLogger(), WithLimits(Limits{
+		MaxEntries: 3, MaxImportedEntries: 3, MaxImportOrigins: 1, MaxImportItems: 3,
+	}))
+	for _, address := range []string{"192.0.2.20", "192.0.2.21"} {
+		consumer := m.NewInboundEndpoint(address)
+		consumer.Release()
+	}
+	active := m.NewInboundEndpoint("192.0.2.22")
+	defer active.Release()
+	err := m.ImportConsumers("origin", Gossip{Items: []GossipItem{
+		{Address: "192.0.2.23", Balance: 1},
+		{Address: "192.0.2.24", Balance: 1},
+		{Address: "192.0.2.25", Balance: 1},
+	}})
+	if !errors.Is(err, ErrEntryLimit) {
+		t.Fatalf("import error = %v, want %v", err, ErrEntryLimit)
+	}
+	if stats := m.Stats(); stats.Entries != 3 || stats.Evictions != 0 {
+		t.Fatalf("failed plan mutated entries: %+v", stats)
+	}
+}
+
+func TestInactiveHighBalanceBecomesEvictableAfterDecay(t *testing.T) {
+	clock := newFakeClock()
+	m := NewManager(clock.Now, testLogger(), WithLimits(Limits{
+		MaxEntries: 1, MaxImportedEntries: 1, MaxImportOrigins: 1, MaxImportItems: 1,
+	}))
+	consumer := m.NewInboundEndpoint("192.0.2.30")
+	consumer.Charge(NewCharge(WarningThreshold*DecayWindowSeconds, "high"), "")
+	consumer.Release()
+	clock.Advance(time.Duration(4*DecayWindowSeconds+1) * time.Second)
+	replacement := m.NewInboundEndpoint("192.0.2.31")
+	if replacement == nil {
+		t.Fatal("fully decayed inactive entry remained non-evictable")
+	}
+	replacement.Release()
+}
+
+func TestExportConsumersIsBoundedAndKeepsStrongest(t *testing.T) {
+	m := NewManager(nil, testLogger(), WithLimits(Limits{
+		MaxEntries: 4, MaxImportedEntries: 4, MaxImportOrigins: 1, MaxImportItems: 2,
+	}))
+	for i, address := range []string{"192.0.2.40", "192.0.2.41", "192.0.2.42"} {
+		consumer := m.NewInboundEndpoint(address)
+		consumer.Charge(NewCharge((i+1)*MinimumGossipBalance*DecayWindowSeconds, "seed"), "")
+	}
+	items := m.ExportConsumers().Items
+	if len(items) != 2 || items[0].Address != "192.0.2.41" || items[1].Address != "192.0.2.42" {
+		t.Fatalf("bounded export = %+v", items)
+	}
+
+	m.mu.Lock()
+	key, _ := canonicalKey(KindInbound, "192.0.2.42")
+	m.entries[key].localBalance.value = (int64(math.MaxUint32) + 1) * DecayWindowSeconds
+	m.mu.Unlock()
+	items = m.ExportConsumers().Items
+	if items[1].Balance != math.MaxUint32 {
+		t.Fatalf("exported balance = %d, want uint32 cap", items[1].Balance)
+	}
+}
+
+func TestRemoteBalanceAggregationDoesNotOverflow(t *testing.T) {
+	m := NewManager(nil, testLogger(), WithLimits(Limits{
+		MaxEntries: 1, MaxImportedEntries: 1, MaxImportOrigins: 3, MaxImportItems: 1,
+	}))
+	for _, origin := range []string{"one", "two", "three"} {
+		if err := m.ImportConsumers(origin, Gossip{Items: []GossipItem{{Address: "192.0.2.50", Balance: math.MaxUint32}}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	consumer := m.NewInboundEndpoint("192.0.2.50")
+	defer consumer.Release()
+	if got := consumer.Charge(Charge{}, ""); got != Drop {
+		t.Fatalf("aggregate disposition = %v, want drop", got)
+	}
+	want := int64(math.MaxUint32) * 3
+	if entries := m.Snapshot(0); len(entries) != 1 || entries[0].Remote != want {
+		t.Fatalf("remote aggregate = %+v, want %d", entries, want)
+	}
+}
+
+func TestConsumerAliasAndConcurrentDisconnectAreExactlyOnce(t *testing.T) {
+	m, _ := newTestManager()
+	consumer := m.NewInboundEndpoint("192.0.2.60")
+	alias := *consumer
+	consumer.Charge(NewCharge(DropThreshold*DecayWindowSeconds, "drop"), "")
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			alias.Disconnect()
+		}()
+	}
+	wg.Wait()
+	if got := m.Stats().Drops; got != 1 {
+		t.Fatalf("disconnect drops = %d, want 1", got)
+	}
+	consumer.Release()
+	alias.Release()
+	if stats := m.Stats(); stats.Active != 0 || stats.Retained != 1 {
+		t.Fatalf("alias release stats = %+v", stats)
+	}
+}
+
+func TestImportedEntryLimitHasDistinctError(t *testing.T) {
+	m := NewManager(nil, testLogger(), WithLimits(Limits{
+		MaxEntries: 2, MaxImportedEntries: 1, MaxImportOrigins: 2, MaxImportItems: 1,
+	}))
+	if err := m.ImportConsumers("one", Gossip{Items: []GossipItem{{Address: "192.0.2.70", Balance: 1}}}); err != nil {
+		t.Fatal(err)
+	}
+	err := m.ImportConsumers("two", Gossip{Items: []GossipItem{{Address: "192.0.2.71", Balance: 1}}})
+	if !errors.Is(err, ErrImportedEntryLimit) || errors.Is(err, ErrEntryLimit) {
+		t.Fatalf("imported-entry error = %v", err)
+	}
+}
+
+func TestDispositionString(t *testing.T) {
+	for disposition, want := range map[Disposition]string{Ok: "ok", Warn: "warn", Drop: "drop", 99: "unknown"} {
+		if got := disposition.String(); got != want {
+			t.Errorf("%d.String() = %q, want %q", disposition, got, want)
+		}
 	}
 }
 
@@ -305,7 +481,7 @@ func TestExpiryHeapRemainsBoundedUnderReplacementChurn(t *testing.T) {
 	for i := range 1000 {
 		if err := m.ImportConsumers("origin", Gossip{Items: []GossipItem{{
 			Address: "198.51.100.31",
-			Balance: 1000 + i,
+			Balance: int64(1000 + i),
 		}}}); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/peermanagement/resource/manager_hardening_test.go
+++ b/internal/peermanagement/resource/manager_hardening_test.go
@@ -1,0 +1,354 @@
+package resource
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestConsumerConcurrentReleaseIsExactlyOnce(t *testing.T) {
+	m, _ := newTestManager()
+	first := m.NewInboundEndpoint("192.0.2.1:1000")
+	second := m.NewInboundEndpoint("192.0.2.1:2000")
+	if first == nil || second == nil {
+		t.Fatal("failed to acquire consumers")
+	}
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 200 {
+				first.Charge(NewCharge(10, "race"), "")
+				_ = first.Balance()
+				_ = first.Disconnect()
+				first.SetPublicKey("n9-test")
+			}
+		}()
+	}
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			first.Release()
+		}()
+	}
+	wg.Wait()
+
+	if got := m.Stats().Active; got != 1 {
+		t.Fatalf("active entries after repeated release = %d, want second handle active", got)
+	}
+	second.Charge(NewCharge(DecayWindowSeconds, "proof"), "")
+	if second.Balance() == 0 {
+		t.Fatal("second same-key handle lost shared reputation")
+	}
+	second.Release()
+	if got := m.Stats().Retained; got != 1 {
+		t.Fatalf("retained entries = %d, want 1", got)
+	}
+}
+
+func TestExportConsumersTracksLocalActivity(t *testing.T) {
+	m, _ := newTestManager()
+	const address = "192.0.2.2:1000"
+	c := m.NewInboundEndpoint(address)
+	c.Charge(NewCharge(MinimumGossipBalance*DecayWindowSeconds*2, "seed"), "")
+	if got := len(m.ExportConsumers().Items); got != 1 {
+		t.Fatalf("active export count = %d, want 1", got)
+	}
+	c.Release()
+	if got := len(m.ExportConsumers().Items); got != 0 {
+		t.Fatalf("released export count = %d, want 0", got)
+	}
+
+	if err := m.ImportConsumers("origin", Gossip{Items: []GossipItem{{Address: address, Balance: 1500}}}); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(m.ExportConsumers().Items); got != 0 {
+		t.Fatalf("import-pinned released export count = %d, want 0", got)
+	}
+
+	reacquired := m.NewInboundEndpoint("192.0.2.2:2000")
+	if got := len(m.ExportConsumers().Items); got != 1 {
+		t.Fatalf("reacquired export count = %d, want 1", got)
+	}
+	reacquired.Release()
+}
+
+func TestDecayRetainsFractionalElapsedAndResetBoundary(t *testing.T) {
+	d := newDecayingSample(0, DecayWindowSeconds)
+	d.value = 3200
+	if got := d.valueAt(900 * time.Millisecond); got != 100 {
+		t.Fatalf("sub-second value = %d, want 100", got)
+	}
+	first := d.valueAt(1100 * time.Millisecond)
+	if d.when != time.Second {
+		t.Fatalf("anchor = %s, want 1s", d.when)
+	}
+	if got := d.valueAt(1900 * time.Millisecond); got != first {
+		t.Fatalf("fractional elapsed was discarded: got %d want %d", got, first)
+	}
+	if got := d.valueAt(2100 * time.Millisecond); got >= first {
+		t.Fatalf("second elapsed tick did not decay: got %d previous %d", got, first)
+	}
+	anchor, value := d.when, d.value
+	d.decay(time.Second)
+	if d.when != anchor || d.value != value {
+		t.Fatalf("backward time changed sample: anchor=%s value=%d", d.when, d.value)
+	}
+
+	d = newDecayingSample(0, DecayWindowSeconds)
+	d.value = 3200
+	d.decay(time.Duration(4*DecayWindowSeconds+1) * time.Second)
+	if d.value != 0 {
+		t.Fatalf("sample beyond reset boundary = %d, want 0", d.value)
+	}
+}
+
+func TestManagerClockIsIndependentOfWallTime(t *testing.T) {
+	var monotonic time.Duration
+	wall := time.Unix(1, 0)
+	m := NewManager(func() time.Duration { return monotonic }, testLogger())
+	c := m.NewInboundEndpoint("192.0.2.3")
+	c.Charge(NewCharge(DecayWindowSeconds*100, "seed"), "")
+	initial := c.Balance()
+	wall = wall.Add(24 * time.Hour)
+	wall = wall.Add(-48 * time.Hour)
+	_ = wall
+	if got := c.Balance(); got != initial {
+		t.Fatalf("wall-clock adjustment changed balance: got %d want %d", got, initial)
+	}
+	monotonic += time.Second
+	if got := c.Balance(); got >= initial {
+		t.Fatalf("monotonic advance did not decay: got %d initial %d", got, initial)
+	}
+	c.Release()
+}
+
+func TestCanonicalEndpointIdentity(t *testing.T) {
+	m, _ := newTestManager()
+	pairs := [][2]string{
+		{"[2001:0DB8:0:0:0:0:0:1]:1000", "2001:db8::1"},
+		{"[::ffff:192.0.2.4]:1000", "192.0.2.4:2000"},
+		{"[fe80::1%en0]:1000", "fe80::1%en0"},
+	}
+	for i, pair := range pairs {
+		first := m.NewInboundEndpoint(pair[0])
+		second := m.NewInboundEndpoint(pair[1])
+		if first == nil || second == nil {
+			t.Fatalf("pair %d failed canonical acquisition", i)
+		}
+		first.Charge(NewCharge(DecayWindowSeconds, "shared"), "")
+		if second.Balance() == 0 {
+			t.Fatalf("pair %d did not share reputation", i)
+		}
+		first.Release()
+		second.Release()
+	}
+	if got := m.Stats().Entries; got != len(pairs) {
+		t.Fatalf("canonical entry count = %d, want %d", got, len(pairs))
+	}
+	if c := m.NewInboundEndpoint("203.0.113.1:"); c != nil {
+		t.Fatal("malformed endpoint was accepted")
+	}
+	if c := m.NewOutboundEndpoint("2001:db8::1"); c != nil {
+		t.Fatal("outbound endpoint without port was accepted")
+	}
+}
+
+func TestCanonicalKindsRemainDistinct(t *testing.T) {
+	m, _ := newTestManager()
+	inbound := m.NewInboundEndpoint("[::ffff:192.0.2.5]:5000")
+	outbound := m.NewOutboundEndpoint("192.0.2.5:5000")
+	admin := m.NewUnlimitedEndpoint("192.0.2.5")
+	if inbound == nil || outbound == nil || admin == nil {
+		t.Fatal("failed to acquire canonical kinds")
+	}
+	inbound.Charge(NewCharge(DecayWindowSeconds*100, "inbound"), "")
+	if outbound.Balance() != 0 || admin.Balance() != 0 {
+		t.Fatal("directional/admin keys shared reputation")
+	}
+	inbound.Release()
+	outbound.Release()
+	admin.Release()
+}
+
+func TestImportValidationDeduplicationAndReplacement(t *testing.T) {
+	m, _ := newTestManager()
+	if err := m.ImportConsumers("origin", Gossip{Items: []GossipItem{{Address: "2001:db8::1", Balance: 1200}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.ImportConsumers("origin", Gossip{Items: []GossipItem{
+		{Address: "[2001:0DB8::1]:0", Balance: 1500},
+		{Address: "2001:db8::1", Balance: 1400},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if got := m.Stats().ImportItems; got != 1 {
+		t.Fatalf("deduplicated import items = %d, want 1", got)
+	}
+	c := m.NewInboundEndpoint("[2001:db8::1]:9999")
+	if got := c.Balance(); got != 1500 {
+		t.Fatalf("deduplicated balance = %d, want max 1500", got)
+	}
+	c.Release()
+
+	if err := m.ImportConsumers("origin", Gossip{Items: []GossipItem{{Address: "bad", Balance: 2000}}}); err == nil {
+		t.Fatal("malformed replacement accepted")
+	}
+	c = m.NewInboundEndpoint("2001:db8::1")
+	if got := c.Balance(); got != 1500 {
+		t.Fatalf("rejected replacement mutated prior balance: got %d", got)
+	}
+	c.Release()
+}
+
+func TestManagerLimitsEvictOnlyLowInactiveEntries(t *testing.T) {
+	clock := newFakeClock()
+	limits := Limits{MaxEntries: 3, MaxImportedEntries: 2, MaxImportOrigins: 1, MaxImportItems: 2}
+	m := NewManager(clock.Now, testLogger(), WithLimits(limits))
+
+	low := m.NewInboundEndpoint("192.0.2.10")
+	low.Release()
+	high := m.NewInboundEndpoint("192.0.2.11")
+	high.Charge(NewCharge(WarningThreshold*DecayWindowSeconds, "high"), "")
+	high.Release()
+	active := m.NewInboundEndpoint("192.0.2.12")
+
+	newConsumer := m.NewInboundEndpoint("192.0.2.13")
+	if newConsumer == nil {
+		t.Fatal("low inactive entry was not evicted")
+	}
+	stats := m.Stats()
+	if stats.Entries != 3 || stats.Evictions != 1 {
+		t.Fatalf("stats after eviction = %+v", stats)
+	}
+	retainedHigh := m.NewInboundEndpoint("192.0.2.11")
+	if retainedHigh == nil || retainedHigh.Balance() < WarningThreshold {
+		t.Fatal("high-balance reputation was evicted")
+	}
+	if active.Balance() != 0 {
+		t.Fatal("active consumer was corrupted during eviction")
+	}
+	active.Release()
+	newConsumer.Release()
+	retainedHigh.Release()
+
+	if err := m.ImportConsumers("one", Gossip{Items: []GossipItem{
+		{Address: "198.51.100.1", Balance: 1000},
+		{Address: "198.51.100.2", Balance: 1000},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.ImportConsumers("two", Gossip{}); err == nil {
+		t.Fatal("origin cap was not enforced")
+	}
+	if err := m.ImportConsumers("one", Gossip{Items: []GossipItem{
+		{Address: "198.51.100.1", Balance: 1000},
+		{Address: "198.51.100.2", Balance: 1000},
+		{Address: "198.51.100.3", Balance: 1000},
+	}}); err == nil {
+		t.Fatal("raw item cap was not enforced")
+	}
+}
+
+func TestManagerRejectsWhenOnlyHighReputationRemains(t *testing.T) {
+	clock := newFakeClock()
+	m := NewManager(clock.Now, testLogger(), WithLimits(Limits{
+		MaxEntries: 1, MaxImportedEntries: 1, MaxImportOrigins: 1, MaxImportItems: 1,
+	}))
+	c := m.NewInboundEndpoint("192.0.2.20")
+	c.Charge(NewCharge(WarningThreshold*DecayWindowSeconds, "high"), "")
+	c.Release()
+	if got := m.NewInboundEndpoint("192.0.2.21"); got != nil {
+		t.Fatal("high-balance entry was evicted")
+	}
+	if got := m.Stats().EntryLimitDrops; got != 1 {
+		t.Fatalf("entry limit drops = %d, want 1", got)
+	}
+}
+
+func TestExpiryHeapIgnoresStaleDeadlines(t *testing.T) {
+	m, clock := newTestManager()
+	c := m.NewInboundEndpoint("192.0.2.30")
+	c.Release()
+	clock.Advance(100 * time.Second)
+	c = m.NewInboundEndpoint("192.0.2.30")
+	c.Release()
+	clock.Advance(201 * time.Second)
+	m.periodicActivity()
+	if got := m.Stats().Entries; got != 1 {
+		t.Fatalf("stale expiry removed re-released entry: entries=%d", got)
+	}
+	clock.Advance(100 * time.Second)
+	m.periodicActivity()
+	if got := m.Stats().Entries; got != 0 {
+		t.Fatalf("current expiry did not remove entry: entries=%d", got)
+	}
+}
+
+func TestExpiryHeapRemainsBoundedUnderReplacementChurn(t *testing.T) {
+	m, _ := newTestManager()
+	for range 1000 {
+		consumer := m.NewInboundEndpoint("192.0.2.31")
+		consumer.Release()
+	}
+	for i := range 1000 {
+		if err := m.ImportConsumers("origin", Gossip{Items: []GossipItem{{
+			Address: "198.51.100.31",
+			Balance: 1000 + i,
+		}}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	m.mu.Lock()
+	deadlines := m.expiries.Len()
+	m.mu.Unlock()
+	if deadlines != 2 {
+		t.Fatalf("deadline heap size = %d, want one retained entry and one import", deadlines)
+	}
+}
+
+type reentrantLogHandler struct {
+	manager *Manager
+}
+
+func (*reentrantLogHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *reentrantLogHandler) Handle(context.Context, slog.Record) error {
+	if h.manager != nil {
+		_ = h.manager.Stats()
+	}
+	return nil
+}
+
+func (h *reentrantLogHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+
+func (h *reentrantLogHandler) WithGroup(string) slog.Handler { return h }
+
+func TestLoggingOccursOutsideManagerLock(t *testing.T) {
+	handler := &reentrantLogHandler{}
+	m := NewManager(nil, slog.New(handler))
+	handler.manager = m
+	c := m.NewInboundEndpoint("192.0.2.40")
+	done := make(chan struct{})
+	go func() {
+		c.Charge(NewCharge(100, "reentrant"), fmt.Sprintf("test-%d", 1))
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("reentrant logger deadlocked resource manager")
+	}
+	c.Release()
+}

--- a/internal/peermanagement/resource/manager_test.go
+++ b/internal/peermanagement/resource/manager_test.go
@@ -318,7 +318,7 @@ func TestDrop_BlacklistAndReadmit(t *testing.T) {
 	// the new Consumer is already Drop-ranked.
 	m.periodicActivity()
 	c2 := m.NewInboundEndpoint(addr)
-	if got := disposition(int64(c2.Balance())); got != Drop {
+	if got := disposition(c2.Balance()); got != Drop {
 		t.Fatalf("dropped consumer not blacklisted on immediate reconnect: %v", got)
 	}
 	c2.Release()
@@ -332,7 +332,7 @@ func TestDrop_BlacklistAndReadmit(t *testing.T) {
 		clk.Advance(time.Second)
 		m.periodicActivity()
 		c3 := m.NewInboundEndpoint(addr)
-		d := disposition(int64(c3.Balance()))
+		d := disposition(c3.Balance())
 		c3.Release()
 		if d != Drop {
 			readmitted = true

--- a/internal/peermanagement/resource/manager_test.go
+++ b/internal/peermanagement/resource/manager_test.go
@@ -12,14 +12,14 @@ import (
 // fakeClock is a deterministic clock for driving decay windows in tests.
 type fakeClock struct {
 	mu  sync.Mutex
-	now time.Duration
+	now time.Time
 }
 
 func newFakeClock() *fakeClock {
-	return &fakeClock{}
+	return &fakeClock{now: time.Unix(1_700_000_000, 0)}
 }
 
-func (c *fakeClock) Now() time.Duration {
+func (c *fakeClock) Now() time.Time {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.now
@@ -28,7 +28,7 @@ func (c *fakeClock) Now() time.Duration {
 func (c *fakeClock) Advance(d time.Duration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.now += d
+	c.now = c.now.Add(d)
 }
 
 func newTestManager() (*Manager, *fakeClock) {

--- a/internal/peermanagement/resource/manager_test.go
+++ b/internal/peermanagement/resource/manager_test.go
@@ -318,7 +318,7 @@ func TestDrop_BlacklistAndReadmit(t *testing.T) {
 	// the new Consumer is already Drop-ranked.
 	m.periodicActivity()
 	c2 := m.NewInboundEndpoint(addr)
-	if got := disposition(c2.Balance()); got != Drop {
+	if got := disposition(int64(c2.Balance())); got != Drop {
 		t.Fatalf("dropped consumer not blacklisted on immediate reconnect: %v", got)
 	}
 	c2.Release()
@@ -332,7 +332,7 @@ func TestDrop_BlacklistAndReadmit(t *testing.T) {
 		clk.Advance(time.Second)
 		m.periodicActivity()
 		c3 := m.NewInboundEndpoint(addr)
-		d := disposition(c3.Balance())
+		d := disposition(int64(c3.Balance()))
 		c3.Release()
 		if d != Drop {
 			readmitted = true

--- a/internal/peermanagement/resource/manager_test.go
+++ b/internal/peermanagement/resource/manager_test.go
@@ -1,25 +1,25 @@
 package resource
 
 import (
+	"io"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 )
 
-// fakeClock is a deterministic clock for driving decay windows in
-// tests. Mirrors the TestStopwatch pattern used by rippled's
-// Logic_test.cpp — advance one second per ++clock.
+// fakeClock is a deterministic clock for driving decay windows in tests.
 type fakeClock struct {
 	mu  sync.Mutex
-	now time.Time
+	now time.Duration
 }
 
 func newFakeClock() *fakeClock {
-	return &fakeClock{now: time.Unix(0, 0)}
+	return &fakeClock{}
 }
 
-func (c *fakeClock) Now() time.Time {
+func (c *fakeClock) Now() time.Duration {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.now
@@ -28,12 +28,13 @@ func (c *fakeClock) Now() time.Time {
 func (c *fakeClock) Advance(d time.Duration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.now = c.now.Add(d)
+	c.now += d
 }
 
 func newTestManager() (*Manager, *fakeClock) {
 	clk := newFakeClock()
-	return NewManager(clk.Now, nil), clk
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return NewManager(clk.Now, logger), clk
 }
 
 func TestCharge_WarnThenDrop(t *testing.T) {
@@ -103,7 +104,7 @@ func TestCharge_DecayKeepsHonestPeerBelowDrop(t *testing.T) {
 	// One feeInvalidData (400) per decay window — well below the
 	// drop threshold. Should never escalate to Drop or even Warn.
 	for i := range 200 {
-		if d := c.Charge(FeeInvalidData, "low-freq"); d != Ok {
+		if d := c.Charge(FeeInvalidData(), "low-freq"); d != Ok {
 			t.Fatalf("iter %d: disposition=%v want Ok (balance=%d)", i, d, c.Balance())
 		}
 		clk.Advance(time.Duration(DecayWindowSeconds) * time.Second)
@@ -115,11 +116,8 @@ func TestUnlimited_NeverDrops(t *testing.T) {
 	c := m.NewUnlimitedEndpoint("10.0.0.1")
 	defer c.Release()
 
-	// Even at synthetic over-budget cost, an unlimited consumer
-	// returns Ok and never asks to disconnect. The local balance must
-	// also stay at zero — rippled's Consumer::charge short-circuits
-	// for unlimited consumers (Consumer.cpp:106-114), so the entry's
-	// local_balance is never debited.
+	// Even at synthetic over-budget cost, an unlimited consumer returns Ok,
+	// never disconnects, and retains a zero balance.
 	for range 50 {
 		if d := c.Charge(NewCharge(DropThreshold+1, "huge"), ""); d != Ok {
 			t.Fatalf("unlimited returned %v, want Ok", d)
@@ -175,16 +173,16 @@ func TestOutbound_KeyIncludesPort(t *testing.T) {
 func TestPeriodicActivity_ExpiresInactiveEntries(t *testing.T) {
 	m, clk := newTestManager()
 	c := m.NewInboundEndpoint("192.0.2.40")
-	c.Charge(FeeInvalidData, "")
+	c.Charge(FeeInvalidData(), "")
 	c.Release()
 
-	if m.EntryCount() == 0 {
+	if m.Stats().Entries == 0 {
 		t.Fatalf("entry erased before periodic activity")
 	}
 	clk.Advance(SecondsUntilExpiration + time.Second)
-	m.PeriodicActivity()
-	if m.EntryCount() != 0 {
-		t.Fatalf("entry count after expiry = %d, want 0", m.EntryCount())
+	m.periodicActivity()
+	if got := m.Stats().Entries; got != 0 {
+		t.Fatalf("entry count after expiry = %d, want 0", got)
 	}
 }
 
@@ -224,7 +222,7 @@ func TestConcurrent_ChargesAreSafe(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range 100 {
-				c.Charge(FeeInvalidData, "")
+				c.Charge(FeeInvalidData(), "")
 				charges.Add(1)
 			}
 		}()
@@ -290,11 +288,7 @@ func TestStartAfterStopIsNoop(t *testing.T) {
 	}
 }
 
-// TestDrop_BlacklistAndReadmit mirrors rippled's testDrop second and
-// third blocks (Logic_test.cpp:158-196): after a Consumer is dropped,
-// reacquiring the same endpoint must show a Drop disposition (the
-// blacklist), and after secondsUntilExpiration of periodic activity,
-// the same endpoint must be readmitted (disposition back to Ok).
+// TestDrop_BlacklistAndReadmit verifies retained reputation and eventual expiry.
 func TestDrop_BlacklistAndReadmit(t *testing.T) {
 	m, clk := newTestManager()
 	const addr = "192.0.2.70:51235"
@@ -322,10 +316,10 @@ func TestDrop_BlacklistAndReadmit(t *testing.T) {
 	// have erased the entry yet (we have not advanced clk past
 	// SecondsUntilExpiration), and the prior balance carries forward so
 	// the new Consumer is already Drop-ranked.
-	m.PeriodicActivity()
+	m.periodicActivity()
 	c2 := m.NewInboundEndpoint(addr)
-	if c2.Disposition() != Drop {
-		t.Fatalf("dropped consumer not blacklisted on immediate reconnect: %v", c2.Disposition())
+	if got := disposition(c2.Balance()); got != Drop {
+		t.Fatalf("dropped consumer not blacklisted on immediate reconnect: %v", got)
 	}
 	c2.Release()
 
@@ -336,9 +330,9 @@ func TestDrop_BlacklistAndReadmit(t *testing.T) {
 	readmitted := false
 	for range steps {
 		clk.Advance(time.Second)
-		m.PeriodicActivity()
+		m.periodicActivity()
 		c3 := m.NewInboundEndpoint(addr)
-		d := c3.Disposition()
+		d := disposition(c3.Balance())
 		c3.Release()
 		if d != Drop {
 			readmitted = true
@@ -350,11 +344,8 @@ func TestDrop_BlacklistAndReadmit(t *testing.T) {
 	}
 }
 
-// TestImport_ReplacesPriorContributionFromSameOrigin verifies the
-// add-new-then-subtract-old semantics of ImportConsumers when the same
-// origin re-imports: each entry's remote_balance must reflect only
-// the latest gossip, not the cumulative sum across imports. Mirrors
-// rippled Logic.h:283-336 swap(next, prev) pattern.
+// TestImport_ReplacesPriorContributionFromSameOrigin verifies that the latest
+// snapshot replaces, rather than accumulates with, the prior contribution.
 func TestImport_ReplacesPriorContributionFromSameOrigin(t *testing.T) {
 	m, _ := newTestManager()
 	const addr = "192.0.2.80"
@@ -420,7 +411,7 @@ func TestImport_ExpiryReleasesEntries(t *testing.T) {
 		{Address: "192.0.2.111", Balance: 1800},
 	}}
 	m.ImportConsumers("origin-leak", g)
-	if got := m.EntryCount(); got != 2 {
+	if got := m.Stats().Entries; got != 2 {
 		t.Fatalf("after import EntryCount=%d want 2", got)
 	}
 
@@ -428,16 +419,16 @@ func TestImport_ExpiryReleasesEntries(t *testing.T) {
 	// to refcount 0, but they keep the normal SecondsUntilExpiration
 	// grace window before erasure.
 	clk.Advance(GossipExpiration + time.Second)
-	m.PeriodicActivity()
-	if got := m.EntryCount(); got != 2 {
+	m.periodicActivity()
+	if got := m.Stats().Entries; got != 2 {
 		t.Fatalf("entries erased before grace period: EntryCount=%d want 2", got)
 	}
 
 	// Once the grace window lapses they must be gone — a leaked refcount
 	// would pin them at 1 forever.
 	clk.Advance(SecondsUntilExpiration + time.Second)
-	m.PeriodicActivity()
-	if got := m.EntryCount(); got != 0 {
+	m.periodicActivity()
+	if got := m.Stats().Entries; got != 0 {
 		t.Fatalf("gossip entries leaked: EntryCount=%d want 0", got)
 	}
 }
@@ -453,7 +444,7 @@ func TestImport_ReplacementReleasesDroppedAddress(t *testing.T) {
 		{Address: "192.0.2.120", Balance: 1500},
 		{Address: "192.0.2.121", Balance: 1500},
 	}})
-	if got := m.EntryCount(); got != 2 {
+	if got := m.Stats().Entries; got != 2 {
 		t.Fatalf("after first import EntryCount=%d want 2", got)
 	}
 
@@ -462,8 +453,8 @@ func TestImport_ReplacementReleasesDroppedAddress(t *testing.T) {
 		{Address: "192.0.2.120", Balance: 1500},
 	}})
 	clk.Advance(SecondsUntilExpiration + time.Second)
-	m.PeriodicActivity()
-	if got := m.EntryCount(); got != 1 {
+	m.periodicActivity()
+	if got := m.Stats().Entries; got != 1 {
 		t.Fatalf("dropped gossip address leaked: EntryCount=%d want 1", got)
 	}
 }

--- a/internal/peermanagement/resource/manager_test.go
+++ b/internal/peermanagement/resource/manager_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 )
 
-// fakeClock is a deterministic clock for driving decay windows in tests.
 type fakeClock struct {
 	mu  sync.Mutex
 	now time.Time
@@ -116,8 +115,6 @@ func TestUnlimited_NeverDrops(t *testing.T) {
 	c := m.NewUnlimitedEndpoint("10.0.0.1")
 	defer c.Release()
 
-	// Even at synthetic over-budget cost, an unlimited consumer returns Ok,
-	// never disconnects, and retains a zero balance.
 	for range 50 {
 		if d := c.Charge(NewCharge(DropThreshold+1, "huge"), ""); d != Ok {
 			t.Fatalf("unlimited returned %v, want Ok", d)
@@ -288,7 +285,6 @@ func TestStartAfterStopIsNoop(t *testing.T) {
 	}
 }
 
-// TestDrop_BlacklistAndReadmit verifies retained reputation and eventual expiry.
 func TestDrop_BlacklistAndReadmit(t *testing.T) {
 	m, clk := newTestManager()
 	const addr = "192.0.2.70:51235"
@@ -344,8 +340,6 @@ func TestDrop_BlacklistAndReadmit(t *testing.T) {
 	}
 }
 
-// TestImport_ReplacesPriorContributionFromSameOrigin verifies that the latest
-// snapshot replaces, rather than accumulates with, the prior contribution.
 func TestImport_ReplacesPriorContributionFromSameOrigin(t *testing.T) {
 	m, _ := newTestManager()
 	const addr = "192.0.2.80"

--- a/internal/peermanagement/resource/tuning.go
+++ b/internal/peermanagement/resource/tuning.go
@@ -2,10 +2,7 @@ package resource
 
 import "time"
 
-// Tuning constants mirror rippled's Resource::detail::Tuning enum
-// (rippled/include/xrpl/resource/detail/Tuning.h). Keeping the same
-// numeric values means an operator familiar with rippled's reputation
-// behavior sees identical thresholds here.
+// Peer reputation thresholds and decay tuning.
 const (
 	// WarningThreshold is the balance at which a Consumer should be
 	// warned that load is high.
@@ -16,7 +13,7 @@ const (
 	DropThreshold = 25000
 
 	// DecayWindowSeconds is the exponential-decay window for the
-	// per-Consumer balance. A power of two matches rippled's choice.
+	// per-Consumer balance.
 	DecayWindowSeconds = 32
 
 	// MinimumGossipBalance is the threshold at or above which a

--- a/internal/peermanagement/resource/tuning.go
+++ b/internal/peermanagement/resource/tuning.go
@@ -2,7 +2,6 @@ package resource
 
 import "time"
 
-// Peer reputation thresholds and decay tuning.
 const (
 	// WarningThreshold is the balance at which a Consumer should be
 	// warned that load is high.

--- a/internal/peermanagement/squelch_test.go
+++ b/internal/peermanagement/squelch_test.go
@@ -255,7 +255,7 @@ func TestPeerAddSquelch_RejectsInvalidDuration(t *testing.T) {
 
 // TestOverlay_InboundSquelch_MalformedPubkey_Charges pins R5.8: a
 // TMSquelch whose ValidatorPubKey isn't a 33-byte compressed secp256k1
-// point must charge resource.FeeInvalidData against the sending peer.
+// point must charge resource.FeeInvalidData() against the sending peer.
 // Matches rippled PeerImp.cpp:2701-2712.
 func TestOverlay_InboundSquelch_MalformedPubkey_Charges(t *testing.T) {
 	id, err := NewIdentity()

--- a/internal/peermanagement/squelch_test.go
+++ b/internal/peermanagement/squelch_test.go
@@ -308,7 +308,7 @@ func TestOverlay_InboundSquelch_MalformedPubkey_Charges(t *testing.T) {
 // pubkey must be dropped WITHOUT installing a squelch — otherwise a
 // hostile peer could silence our own validator's traffic on the
 // RelayFromValidator path. Matches rippled PeerImp.cpp:2715-2721.
-// The peer is charged "squelch-targets-self" so repeat offenders evict.
+// Rippled logs and ignores this case without selecting a bad-data fee.
 func TestHandleSquelchMessage_DropsSelfTargetingSquelch(t *testing.T) {
 	id, err := NewIdentity()
 	require.NoError(t, err)
@@ -353,8 +353,8 @@ func TestHandleSquelchMessage_DropsSelfTargetingSquelch(t *testing.T) {
 		"self-targeted squelch must not have installed a squelch entry")
 
 	// Peer is charged for attempting to silence our own validator.
-	assert.Greater(t, peer.BadDataCount(), uint32(0),
-		"self-targeting TMSquelch must charge bad-data (squelch-targets-self)")
+	assert.Equal(t, uint32(0), peer.BadDataCount(),
+		"self-targeting TMSquelch must not select a bad-data fee")
 }
 
 // TestHandleSquelchMessage_AllowsOtherValidatorSquelch is the

--- a/internal/rpc/admin_forbidden_test.go
+++ b/internal/rpc/admin_forbidden_test.go
@@ -87,7 +87,7 @@ func TestHTTPAdminDenialChargesFeeMalformed(t *testing.T) {
 	// The malformed bucket is 100; the reference bucket is 20. Allow for a hair
 	// of decay between the charge and this read, but confirm it is the malformed
 	// charge, not a cheaper one.
-	if got, want := resourceLocalBalance(t, srv.resourceManager, "198.51.100.7"), uint32(resource.FeeMalformedRPC.Cost()/resource.DecayWindowSeconds); got != want {
+	if got, want := resourceLocalBalance(t, srv.resourceManager, "198.51.100.7"), uint32(resource.FeeMalformedRPC().Cost()/resource.DecayWindowSeconds); got != want {
 		t.Fatalf("forbidden admin denial charged %v, want %v", got, want)
 	}
 

--- a/internal/rpc/handlers/loadkinds.go
+++ b/internal/rpc/handlers/loadkinds.go
@@ -6,13 +6,13 @@ import (
 )
 
 func setLoadReference(ctx *types.RpcContext) {
-	ctx.LoadCost = uint32(resource.FeeReferenceRPC.Cost())
+	ctx.LoadCost = uint32(resource.FeeReferenceRPC().Cost())
 }
 
 func setLoadMedium(ctx *types.RpcContext) {
-	ctx.LoadCost = uint32(resource.FeeMediumBurdenRPC.Cost())
+	ctx.LoadCost = uint32(resource.FeeMediumBurdenRPC().Cost())
 }
 
 func setLoadHeavy(ctx *types.RpcContext) {
-	ctx.LoadCost = uint32(resource.FeeHeavyBurdenRPC.Cost())
+	ctx.LoadCost = uint32(resource.FeeHeavyBurdenRPC().Cost())
 }

--- a/internal/rpc/handlers/loadkinds_test.go
+++ b/internal/rpc/handlers/loadkinds_test.go
@@ -16,27 +16,27 @@ func TestLoadCostEarlyErrorTiming(t *testing.T) {
 		params  json.RawMessage
 		want    int
 	}{
-		{"sign", &SignMethod{}, json.RawMessage(`{}`), resource.FeeHeavyBurdenRPC.Cost()},
-		{"sign_for", &SignForMethod{}, json.RawMessage(`{}`), resource.FeeHeavyBurdenRPC.Cost()},
-		{"submit_multisigned", &SubmitMultisignedMethod{}, json.RawMessage(`{}`), resource.FeeHeavyBurdenRPC.Cost()},
-		{"submit", &SubmitMethod{}, json.RawMessage(`{}`), resource.FeeMediumBurdenRPC.Cost()},
-		{"simulate", &SimulateMethod{}, json.RawMessage(`{"binary":"invalid"}`), resource.FeeMediumBurdenRPC.Cost()},
-		{"account_tx", &AccountTxMethod{}, json.RawMessage(`{}`), resource.FeeReferenceRPC.Cost()},
-		{"gateway_balances", &GatewayBalancesMethod{}, json.RawMessage(`{}`), resource.FeeReferenceRPC.Cost()},
-		{"account_lines", &AccountLinesMethod{}, json.RawMessage(`{}`), resource.FeeReferenceRPC.Cost()},
-		{"account_objects", &AccountObjectsMethod{}, json.RawMessage(`{}`), resource.FeeReferenceRPC.Cost()},
-		{"account_offers", &AccountOffersMethod{}, json.RawMessage(`{}`), resource.FeeReferenceRPC.Cost()},
-		{"account_channels", &AccountChannelsMethod{}, json.RawMessage(`{}`), resource.FeeReferenceRPC.Cost()},
-		{"account_nfts", &AccountNftsMethod{}, json.RawMessage(`{}`), resource.FeeReferenceRPC.Cost()},
-		{"ledger_data", &LedgerDataMethod{}, json.RawMessage(`{}`), resource.FeeReferenceRPC.Cost()},
-		{"noripple_check", &NoRippleCheckMethod{}, json.RawMessage(`{}`), resource.FeeReferenceRPC.Cost()},
+		{"sign", &SignMethod{}, json.RawMessage(`{}`), resource.FeeHeavyBurdenRPC().Cost()},
+		{"sign_for", &SignForMethod{}, json.RawMessage(`{}`), resource.FeeHeavyBurdenRPC().Cost()},
+		{"submit_multisigned", &SubmitMultisignedMethod{}, json.RawMessage(`{}`), resource.FeeHeavyBurdenRPC().Cost()},
+		{"submit", &SubmitMethod{}, json.RawMessage(`{}`), resource.FeeMediumBurdenRPC().Cost()},
+		{"simulate", &SimulateMethod{}, json.RawMessage(`{"binary":"invalid"}`), resource.FeeMediumBurdenRPC().Cost()},
+		{"account_tx", &AccountTxMethod{}, json.RawMessage(`{}`), resource.FeeReferenceRPC().Cost()},
+		{"gateway_balances", &GatewayBalancesMethod{}, json.RawMessage(`{}`), resource.FeeReferenceRPC().Cost()},
+		{"account_lines", &AccountLinesMethod{}, json.RawMessage(`{}`), resource.FeeReferenceRPC().Cost()},
+		{"account_objects", &AccountObjectsMethod{}, json.RawMessage(`{}`), resource.FeeReferenceRPC().Cost()},
+		{"account_offers", &AccountOffersMethod{}, json.RawMessage(`{}`), resource.FeeReferenceRPC().Cost()},
+		{"account_channels", &AccountChannelsMethod{}, json.RawMessage(`{}`), resource.FeeReferenceRPC().Cost()},
+		{"account_nfts", &AccountNftsMethod{}, json.RawMessage(`{}`), resource.FeeReferenceRPC().Cost()},
+		{"ledger_data", &LedgerDataMethod{}, json.RawMessage(`{}`), resource.FeeReferenceRPC().Cost()},
+		{"noripple_check", &NoRippleCheckMethod{}, json.RawMessage(`{}`), resource.FeeReferenceRPC().Cost()},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := &types.RpcContext{
 				Context:  context.Background(),
-				LoadCost: uint32(resource.FeeReferenceRPC.Cost()),
+				LoadCost: uint32(resource.FeeReferenceRPC().Cost()),
 				Services: &types.ServiceContainer{Capabilities: types.RPCCapabilities{SigningEnabled: true}},
 			}
 			_, rpcErr := test.handler.Handle(ctx, test.params)
@@ -57,7 +57,7 @@ func TestRipplePathFindBusyAdmissionIsHeavy(t *testing.T) {
 	}
 	ctx := &types.RpcContext{
 		Context:  context.Background(),
-		LoadCost: uint32(resource.FeeReferenceRPC.Cost()),
+		LoadCost: uint32(resource.FeeReferenceRPC().Cost()),
 		Services: &types.ServiceContainer{
 			Ledger:       &loadAdmissionLedger{serverInfo: &types.LedgerServerInfo{Standalone: true}},
 			ClientLoad:   shedder,
@@ -69,7 +69,7 @@ func TestRipplePathFindBusyAdmissionIsHeavy(t *testing.T) {
 	if rpcErr == nil {
 		t.Fatal("expected busy path-find request to fail admission")
 	}
-	if got := int(ctx.LoadCost); got != resource.FeeHeavyBurdenRPC.Cost() {
-		t.Fatalf("load cost = %d, want %d", got, resource.FeeHeavyBurdenRPC.Cost())
+	if got := int(ctx.LoadCost); got != resource.FeeHeavyBurdenRPC().Cost() {
+		t.Fatalf("load cost = %d, want %d", got, resource.FeeHeavyBurdenRPC().Cost())
 	}
 }

--- a/internal/rpc/json_proxy_regression_test.go
+++ b/internal/rpc/json_proxy_regression_test.go
@@ -34,7 +34,7 @@ func TestJSONProxyUsesSingleDispatchAccounting(t *testing.T) {
 		handle: func(ctx *types.RpcContext, _ json.RawMessage) (any, *types.RpcError) {
 			targetCalls++
 			assert.Equal(t, types.MaxJobQueueClients, services.ClientLoad.InFlight())
-			ctx.LoadCost = uint32(resource.FeeHeavyBurdenRPC.Cost())
+			ctx.LoadCost = uint32(resource.FeeHeavyBurdenRPC().Cost())
 			return map[string]any{"proxied": true}, nil
 		},
 	})
@@ -50,7 +50,7 @@ func TestJSONProxyUsesSingleDispatchAccounting(t *testing.T) {
 	require.Equal(t, 1, targetCalls)
 	assert.Equal(t, types.MaxJobQueueClients-1, services.ClientLoad.InFlight())
 	assert.Equal(t,
-		uint32(resource.FeeHeavyBurdenRPC.Cost()/resource.DecayWindowSeconds),
+		uint32(resource.FeeHeavyBurdenRPC().Cost()/resource.DecayWindowSeconds),
 		transportRegressionLocalBalance(t, server.resourceManager),
 	)
 

--- a/internal/rpc/overload_gate_test.go
+++ b/internal/rpc/overload_gate_test.go
@@ -306,7 +306,7 @@ func TestWSEarlyMalformedResponsesChargeWithoutLoadWarning(t *testing.T) {
 			ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 2 * time.Second})
 			require.NoError(t, ws.resourceManager.ImportConsumers("warning-peer", resource.Gossip{Items: []resource.GossipItem{{
 				Address: "127.0.0.1",
-				Balance: resource.WarningThreshold - uint32(resource.FeeMalformedRPC.Cost()/resource.DecayWindowSeconds),
+				Balance: resource.WarningThreshold - uint32(resource.FeeMalformedRPC().Cost()/resource.DecayWindowSeconds),
 			}}}))
 
 			pc := &PortContext{AdminNets: []net.IPNet{mustParseCIDR("10.0.0.0/8")}}
@@ -333,7 +333,7 @@ func TestWSEarlyMalformedResponsesChargeWithoutLoadWarning(t *testing.T) {
 			if got := string(body); got != test.want {
 				t.Fatalf("response = %s, want %s", got, test.want)
 			}
-			if got, want := resourceLocalBalance(t, ws.resourceManager, "127.0.0.1"), uint32((resource.FeeMalformedRPC.Cost()+resource.FeeWarning.Cost())/resource.DecayWindowSeconds); got != want {
+			if got, want := resourceLocalBalance(t, ws.resourceManager, "127.0.0.1"), uint32((resource.FeeMalformedRPC().Cost()+resource.FeeWarning().Cost())/resource.DecayWindowSeconds); got != want {
 				t.Fatalf("local charge = %v, want %v", got, want)
 			}
 		})

--- a/internal/rpc/overload_gate_test.go
+++ b/internal/rpc/overload_gate_test.go
@@ -112,7 +112,7 @@ func TestGateLoadKeysUnlimitedHTTPBySocketPeer(t *testing.T) {
 	}
 	defer ctx.ResourceAdmission.Cancel()
 	entries := manager.Snapshot(0)
-	if len(entries) != 1 || entries[0].Address != "203.0.113.5:1" || entries[0].Type != "admin" {
+	if len(entries) != 1 || entries[0].Address != "IP Address: 203.0.113.5:1" || entries[0].Type != "admin" {
 		t.Fatalf("unlimited entries = %+v", entries)
 	}
 }
@@ -129,7 +129,7 @@ func TestGateLoadKeepsWebSocketConnectionConsumer(t *testing.T) {
 	}
 	defer ctx.ResourceAdmission.Cancel()
 	entries := manager.Snapshot(0)
-	if len(entries) != 1 || entries[0].Address != "198.51.100.7" || entries[0].Type != "inbound" {
+	if len(entries) != 1 || entries[0].Address != "IP Address: 198.51.100.7" || entries[0].Type != "inbound" {
 		t.Fatalf("WebSocket entries = %+v", entries)
 	}
 }
@@ -150,7 +150,7 @@ func TestWebSocketHandshakeSelectsUnlimitedConsumer(t *testing.T) {
 	}
 	defer client.Close()
 	entries := manager.Snapshot(0)
-	if len(entries) != 1 || entries[0].Address != "127.0.0.1:1" || entries[0].Type != "admin" {
+	if len(entries) != 1 || entries[0].Address != "IP Address: 127.0.0.1:1" || entries[0].Type != "admin" {
 		t.Fatalf("handshake entries = %+v", entries)
 	}
 }

--- a/internal/rpc/resource_integration_test.go
+++ b/internal/rpc/resource_integration_test.go
@@ -51,7 +51,7 @@ func TestUnifiedResourceManagerGossipsWebSocketLoadIntoHTTPAdmission(t *testing.
 	peer := managerA.NewInboundEndpoint(clientIP + ":51235")
 	require.NotNil(t, peer)
 	before := peer.Balance()
-	peer.Charge(resource.FeeInvalidData, "peer work")
+	peer.Charge(resource.FeeInvalidData(), "peer work")
 	assert.Greater(t, peer.Balance(), before, "peer and RPC work must share one endpoint balance")
 	peer.Release()
 

--- a/internal/rpc/server_batch.go
+++ b/internal/rpc/server_batch.go
@@ -45,27 +45,27 @@ func (s *Server) dispatchBatchElement(el json.RawMessage, baseCtx context.Contex
 		}
 		return batchForbiddenElement(elem)
 	}
-	defer ctx.ResourceAdmission.Finish(resource.FeeExceptionRPC, method)
+	defer ctx.ResourceAdmission.Finish(resource.FeeExceptionRPC(), method)
 
 	// rippled validates the method field and emits a distinct message per
 	// malformed shape, echoing the element's own fields at the top level
 	// (ServerHandler.cpp:764-808).
 	mv, present := elem["method"]
 	if !present || mv == nil {
-		chargeLoad(s.resourceManager, ctx, method, resource.FeeMalformedRPC, rpcLog())
+		chargeLoad(s.resourceManager, ctx, method, resource.FeeMalformedRPC(), rpcLog())
 		return batchMalformedElement(elem, "Null method")
 	}
 	method, ok := mv.(string)
 	if !ok {
-		chargeLoad(s.resourceManager, ctx, method, resource.FeeMalformedRPC, rpcLog())
+		chargeLoad(s.resourceManager, ctx, method, resource.FeeMalformedRPC(), rpcLog())
 		return batchMalformedElement(elem, "method is not string")
 	}
 	if method == "" {
-		chargeLoad(s.resourceManager, ctx, method, resource.FeeMalformedRPC, rpcLog())
+		chargeLoad(s.resourceManager, ctx, method, resource.FeeMalformedRPC(), rpcLog())
 		return batchMalformedElement(elem, "method is empty")
 	}
 	if _, valid := ripplerpcVersion(elem); !valid {
-		chargeLoad(s.resourceManager, ctx, method, resource.FeeMalformedRPC, rpcLog())
+		chargeLoad(s.resourceManager, ctx, method, resource.FeeMalformedRPC(), rpcLog())
 		return batchMalformedElement(elem, "ripplerpc is not a string")
 	}
 

--- a/internal/rpc/server_dispatch.go
+++ b/internal/rpc/server_dispatch.go
@@ -157,7 +157,7 @@ func admitMethod(
 	}
 	if resolution.resolved && resolution.handler.RequiredRole() == types.RoleAdmin && ctx.Role != types.RoleAdmin {
 		rpcErr := adminGate(method)
-		chargeLoad(manager, ctx, method, resource.FeeMalformedRPC, log)
+		chargeLoad(manager, ctx, method, resource.FeeMalformedRPC(), log)
 		return rpcErr
 	}
 	return nil
@@ -171,22 +171,22 @@ func dispatchResolvedMethod(
 	resolution methodResolution,
 	log xrpllog.Logger,
 ) (any, *types.RpcError) {
-	ctx.LoadCost = uint32(resource.FeeReferenceRPC.Cost())
+	ctx.LoadCost = uint32(resource.FeeReferenceRPC().Cost())
 	ctx.LoadWarning = false
 
 	if rpcErr := handlers.RequireNotBusyClient(ctx); rpcErr != nil {
-		finalizeLoad(manager, ctx, method, resource.FeeReferenceRPC, log)
+		finalizeLoad(manager, ctx, method, resource.FeeReferenceRPC(), log)
 		return nil, rpcErr
 	}
 
 	if !resolution.resolved {
 		rpcErr := types.RpcErrorMethodNotFound()
-		finalizeLoad(manager, ctx, method, resource.FeeReferenceRPC, log)
+		finalizeLoad(manager, ctx, method, resource.FeeReferenceRPC(), log)
 		return nil, rpcErr
 	}
 
 	if rpcErr := conditionMet(resolution.handler.RequiredCondition(), ctx); rpcErr != nil {
-		finalizeLoad(manager, ctx, method, resource.FeeReferenceRPC, log)
+		finalizeLoad(manager, ctx, method, resource.FeeReferenceRPC(), log)
 		return nil, rpcErr
 	}
 
@@ -198,8 +198,8 @@ func dispatchResolvedMethod(
 	result, rpcErr, recovered := invokeHandler(resolution.handler, ctx, params, method, log)
 	finishDiagnostics(recovered)
 	fee := rpcCharge(ctx.LoadCost)
-	if recovered && fee == resource.FeeReferenceRPC {
-		fee = resource.FeeExceptionRPC
+	if recovered && fee == resource.FeeReferenceRPC() {
+		fee = resource.FeeExceptionRPC()
 	}
 	finalizeLoad(manager, ctx, method, fee, log)
 	return result, rpcErr
@@ -225,15 +225,15 @@ func dispatchNestedMethod(
 		return nil, types.RpcErrorMethodNotFound()
 	}
 	if resolution.handler.RequiredRole() == types.RoleAdmin && ctx.Role != types.RoleAdmin {
-		ctx.LoadCost = uint32(resource.FeeMalformedRPC.Cost())
+		ctx.LoadCost = uint32(resource.FeeMalformedRPC().Cost())
 		return nil, types.RpcErrorForbidden(method)
 	}
 	if rpcErr := conditionMet(resolution.handler.RequiredCondition(), ctx); rpcErr != nil {
 		return nil, rpcErr
 	}
 	result, rpcErr, recovered := invokeHandler(resolution.handler, ctx, params, method, log)
-	if recovered && ctx.LoadCost == uint32(resource.FeeReferenceRPC.Cost()) {
-		ctx.LoadCost = uint32(resource.FeeExceptionRPC.Cost())
+	if recovered && ctx.LoadCost == uint32(resource.FeeReferenceRPC().Cost()) {
+		ctx.LoadCost = uint32(resource.FeeExceptionRPC().Cost())
 	}
 	return result, rpcErr
 }
@@ -412,11 +412,11 @@ func gateLoad(manager *resource.Manager, ctx *types.RpcContext, method string, l
 	var admission *resource.Admission
 	var result resource.Disposition
 	if ctx.ResourceConsumer != nil {
-		admission, result = ctx.ResourceConsumer.Admit(resource.FeeReferenceRPC)
+		admission, result = ctx.ResourceConsumer.Admit(resource.FeeReferenceRPC())
 	} else if ctx.Unlimited {
 		admission, result = manager.AdmitUnlimited(ctx.ResourceIP)
 	} else {
-		admission, result = manager.AdmitInbound(ctx.ClientIP, resource.FeeReferenceRPC)
+		admission, result = manager.AdmitInbound(ctx.ClientIP, resource.FeeReferenceRPC())
 	}
 	if admission == nil || result == resource.Drop {
 		log.Warn("rpc dropped: client over load threshold",
@@ -447,14 +447,14 @@ func finalizeLoad(manager *resource.Manager, ctx *types.RpcContext, method strin
 
 func rpcCharge(cost uint32) resource.Charge {
 	switch int(cost) {
-	case resource.FeeReferenceRPC.Cost():
-		return resource.FeeReferenceRPC
-	case resource.FeeMediumBurdenRPC.Cost():
-		return resource.FeeMediumBurdenRPC
-	case resource.FeeHeavyBurdenRPC.Cost():
-		return resource.FeeHeavyBurdenRPC
-	case resource.FeeMalformedRPC.Cost():
-		return resource.FeeMalformedRPC
+	case resource.FeeReferenceRPC().Cost():
+		return resource.FeeReferenceRPC()
+	case resource.FeeMediumBurdenRPC().Cost():
+		return resource.FeeMediumBurdenRPC()
+	case resource.FeeHeavyBurdenRPC().Cost():
+		return resource.FeeHeavyBurdenRPC()
+	case resource.FeeMalformedRPC().Cost():
+		return resource.FeeMalformedRPC()
 	default:
 		return resource.NewCharge(int(cost), "RPC")
 	}

--- a/internal/rpc/server_hardening_test.go
+++ b/internal/rpc/server_hardening_test.go
@@ -336,7 +336,7 @@ func TestHandlerPanicRecovered(t *testing.T) {
 	if strings.Contains(rr.Body.String(), panicCause) || strings.Contains(rr.Body.String(), "private seed") {
 		t.Fatalf("panic response leaked private details: %s", rr.Body.String())
 	}
-	if got, want := transportRegressionLocalBalance(t, srv.resourceManager), uint32(resource.FeeExceptionRPC.Cost()/resource.DecayWindowSeconds); got != want {
+	if got, want := transportRegressionLocalBalance(t, srv.resourceManager), uint32(resource.FeeExceptionRPC().Cost()/resource.DecayWindowSeconds); got != want {
 		t.Fatalf("panic charged %v, want %v", got, want)
 	}
 }
@@ -442,7 +442,7 @@ func TestSecureGatewayPromotesToIdentifiedWithUser(t *testing.T) {
 type heavyStub struct{ stubHandler }
 
 func (s *heavyStub) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
-	ctx.LoadCost = uint32(resource.FeeHeavyBurdenRPC.Cost())
+	ctx.LoadCost = uint32(resource.FeeHeavyBurdenRPC().Cost())
 	return s.stubHandler.Handle(ctx, params)
 }
 

--- a/internal/rpc/server_request.go
+++ b/internal/rpc/server_request.go
@@ -123,12 +123,12 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	defer ctx.ResourceAdmission.Finish(resource.FeeExceptionRPC, method)
+	defer ctx.ResourceAdmission.Finish(resource.FeeExceptionRPC(), method)
 
 	var methodErr string
 	method, methodErr = decodeMethodField(request.Method)
 	if methodErr != "" {
-		chargeLoad(s.resourceManager, ctx, method, resource.FeeMalformedRPC, rpcLog())
+		chargeLoad(s.resourceManager, ctx, method, resource.FeeMalformedRPC(), rpcLog())
 		writePlainHTTPError(w, http.StatusBadRequest, methodErr)
 		return
 	}
@@ -138,7 +138,7 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 	if len(request.Params) > 0 && !rawJSONNull(request.Params) {
 		var arr []json.RawMessage
 		if err := json.Unmarshal(request.Params, &arr); err != nil || len(arr) != 1 {
-			chargeLoad(s.resourceManager, ctx, method, resource.FeeMalformedRPC, rpcLog())
+			chargeLoad(s.resourceManager, ctx, method, resource.FeeMalformedRPC(), rpcLog())
 			writePlainHTTPError(w, http.StatusBadRequest, "params unparseable")
 			return
 		}
@@ -146,7 +146,7 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		if !rawJSONNull(params) {
 			var object map[string]any
 			if err := json.Unmarshal(params, &object); err != nil || object == nil {
-				chargeLoad(s.resourceManager, ctx, method, resource.FeeMalformedRPC, rpcLog())
+				chargeLoad(s.resourceManager, ctx, method, resource.FeeMalformedRPC(), rpcLog())
 				writePlainHTTPError(w, http.StatusBadRequest, "params unparseable")
 				return
 			}
@@ -155,7 +155,7 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 
 	requestObj := buildRequestEcho(method, params)
 	if _, valid := ripplerpcVersion(requestObj); !valid {
-		chargeLoad(s.resourceManager, ctx, method, resource.FeeMalformedRPC, rpcLog())
+		chargeLoad(s.resourceManager, ctx, method, resource.FeeMalformedRPC(), rpcLog())
 		writePlainHTTPError(w, http.StatusBadRequest, "ripplerpc is not a string")
 		return
 	}

--- a/internal/rpc/subscription_contracts_test.go
+++ b/internal/rpc/subscription_contracts_test.go
@@ -179,14 +179,14 @@ func TestAccountHistorySubscribeCapabilityAndValidation(t *testing.T) {
 		ws, conn, ctx := newSpecialDispatchHarness(t)
 		ctx.Services.Ledger = &txTablesOffLedger{newMockLedgerService()}
 		ctx.Services.AccountHistorySubscriptions = newHistorySubscriptionProvider()
-		ctx.LoadCost = uint32(resource.FeeReferenceRPC.Cost())
+		ctx.LoadCost = uint32(resource.FeeReferenceRPC().Cost())
 
 		_, rpcErr := ws.executeSubscribe(conn, ctx, types.WebSocketCommand{
 			Params: json.RawMessage(`{"streams":["ledger"],"account_history_tx_stream":false}`),
 		})
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, "notEnabled", rpcErr.ErrorString)
-		assert.Equal(t, uint32(resource.FeeReferenceRPC.Cost()), ctx.LoadCost)
+		assert.Equal(t, uint32(resource.FeeReferenceRPC().Cost()), ctx.LoadCost)
 		_, streamAdded := conn.Subscriptions[types.SubLedger]
 		assert.True(t, streamAdded)
 	})
@@ -206,7 +206,7 @@ func TestAccountHistorySubscribeCapabilityAndValidation(t *testing.T) {
 		provider := newHistorySubscriptionProvider()
 		ctx.Services.Ledger = newMockLedgerService()
 		ctx.Services.AccountHistorySubscriptions = provider
-		ctx.LoadCost = uint32(resource.FeeReferenceRPC.Cost())
+		ctx.LoadCost = uint32(resource.FeeReferenceRPC().Cost())
 		command := types.WebSocketCommand{
 			Params: json.RawMessage(`{"account_history_tx_stream":{"account":"` + historyAccountA + `"}}`),
 		}
@@ -214,7 +214,7 @@ func TestAccountHistorySubscribeCapabilityAndValidation(t *testing.T) {
 		result, rpcErr := ws.executeSubscribe(conn, ctx, command)
 		require.Nil(t, rpcErr)
 		assert.Equal(t, accountHistoryWarning, result.(map[string]any)["warning"])
-		assert.Equal(t, uint32(resource.FeeMediumBurdenRPC.Cost()), ctx.LoadCost)
+		assert.Equal(t, uint32(resource.FeeMediumBurdenRPC().Cost()), ctx.LoadCost)
 		present, replaying := provider.state(conn.Connection, historyAccountA)
 		assert.True(t, present)
 		assert.True(t, replaying)
@@ -228,14 +228,14 @@ func TestAccountHistorySubscribeCapabilityAndValidation(t *testing.T) {
 		ws, conn, ctx := newSpecialDispatchHarness(t)
 		ctx.Services.Ledger = newMockLedgerService()
 		ctx.Services.AccountHistorySubscriptions = newHistorySubscriptionProvider()
-		ctx.LoadCost = uint32(resource.FeeReferenceRPC.Cost())
+		ctx.LoadCost = uint32(resource.FeeReferenceRPC().Cost())
 
 		_, rpcErr := ws.executeSubscribe(conn, ctx, types.WebSocketCommand{
 			Params: json.RawMessage(`{"account_history_tx_stream":{"account":"not-an-account"}}`),
 		})
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, "invalidParams", rpcErr.ErrorString)
-		assert.Equal(t, uint32(resource.FeeMediumBurdenRPC.Cost()), ctx.LoadCost)
+		assert.Equal(t, uint32(resource.FeeMediumBurdenRPC().Cost()), ctx.LoadCost)
 	})
 }
 
@@ -395,7 +395,7 @@ func TestAccountHistoryURLValidationIsOrderedAndAtomic(t *testing.T) {
 	assert.False(t, ws.subscriptionManager.IsSubscribed(conn.ID, types.SubLedger))
 
 	provider.subscribeErr = nil
-	ctx.LoadCost = uint32(resource.FeeReferenceRPC.Cost())
+	ctx.LoadCost = uint32(resource.FeeReferenceRPC().Cost())
 	var malformed types.SubscriptionRequest
 	require.NoError(t, json.Unmarshal([]byte(`{
 		"url":"`+sink.URL+`",
@@ -405,7 +405,7 @@ func TestAccountHistoryURLValidationIsOrderedAndAtomic(t *testing.T) {
 	_, rpcErr = ws.urlSubs.Subscribe(ctx, malformed)
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, "malformedStream", rpcErr.ErrorString)
-	assert.Equal(t, uint32(resource.FeeReferenceRPC.Cost()), ctx.LoadCost)
+	assert.Equal(t, uint32(resource.FeeReferenceRPC().Cost()), ctx.LoadCost)
 
 	_, rpcErr = ws.urlSubs.Subscribe(ctx, types.SubscriptionRequest{
 		URL:            sink.URL,

--- a/internal/rpc/subscription_history.go
+++ b/internal/rpc/subscription_history.go
@@ -31,7 +31,7 @@ func prepareAccountHistorySubscribe(ctx *types.RpcContext, request types.Subscri
 		return nil, types.RpcErrorNotEnabled("")
 	}
 	if ctx != nil {
-		ctx.LoadCost = uint32(resource.FeeMediumBurdenRPC.Cost())
+		ctx.LoadCost = uint32(resource.FeeMediumBurdenRPC().Cost())
 	}
 	account, _, rpcErr := parseAccountHistoryRequest(request, false)
 	if rpcErr != nil {

--- a/internal/rpc/transport_regression_test.go
+++ b/internal/rpc/transport_regression_test.go
@@ -49,7 +49,7 @@ func TestTransportConstructorsShareInjectedResourceManager(t *testing.T) {
 	require.Same(t, manager, wsServer.resourceManager)
 	consumer := manager.NewInboundEndpoint("192.0.2.1")
 	require.NotNil(t, consumer)
-	consumer.Charge(resource.FeeMalformedRPC, "shared-client")
+	consumer.Charge(resource.FeeMalformedRPC(), "shared-client")
 	assert.Greater(t, consumer.Balance(), int64(0))
 	consumer.Release()
 
@@ -203,7 +203,7 @@ func TestHTTPAdmissionOrderingAtTransportBoundary(t *testing.T) {
 				assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
 				assert.Equal(t, "Server is overloaded\r\n", recorder.Body.String())
 			}
-			assert.Equal(t, uint32(resource.FeeDrop.Cost()/resource.DecayWindowSeconds), transportRegressionLocalBalance(t, server.resourceManager))
+			assert.Equal(t, uint32(resource.FeeDrop().Cost()/resource.DecayWindowSeconds), transportRegressionLocalBalance(t, server.resourceManager))
 		})
 	}
 }
@@ -233,7 +233,7 @@ func TestHTTPForbiddenPrecedesMalformedTransportFields(t *testing.T) {
 				assert.Equal(t, http.StatusForbidden, recorder.Code)
 				assert.Equal(t, "Forbidden\r\n", recorder.Body.String())
 			}
-			assert.Equal(t, uint32(resource.FeeMalformedRPC.Cost()/resource.DecayWindowSeconds), transportRegressionLocalBalance(t, server.resourceManager))
+			assert.Equal(t, uint32(resource.FeeMalformedRPC().Cost()/resource.DecayWindowSeconds), transportRegressionLocalBalance(t, server.resourceManager))
 		})
 	}
 }
@@ -257,7 +257,7 @@ func TestHTTPMalformedAndForbiddenExactLoadCharge(t *testing.T) {
 
 			postTransportRegressionRequest(t, server, test.body)
 
-			assert.Equal(t, uint32(resource.FeeMalformedRPC.Cost()/resource.DecayWindowSeconds), transportRegressionLocalBalance(t, server.resourceManager))
+			assert.Equal(t, uint32(resource.FeeMalformedRPC().Cost()/resource.DecayWindowSeconds), transportRegressionLocalBalance(t, server.resourceManager))
 		})
 	}
 }
@@ -312,7 +312,7 @@ func TestHTTPEarlyDispatchErrorsChargeReferenceAndWarn(t *testing.T) {
 				}
 				assert.Equal(t, test.token, result["error"])
 				assert.Equal(t, "load", result["warning"])
-				assert.Equal(t, uint32((resource.FeeReferenceRPC.Cost()+resource.FeeWarning.Cost())/resource.DecayWindowSeconds), transportRegressionLocalBalance(t, server.resourceManager))
+				assert.Equal(t, uint32((resource.FeeReferenceRPC().Cost()+resource.FeeWarning().Cost())/resource.DecayWindowSeconds), transportRegressionLocalBalance(t, server.resourceManager))
 			})
 		}
 	}

--- a/internal/rpc/transport_regression_test.go
+++ b/internal/rpc/transport_regression_test.go
@@ -122,7 +122,7 @@ func resourceLocalBalance(t *testing.T, manager *resource.Manager, address strin
 	require.NotNil(t, consumer)
 	defer consumer.Release()
 	for _, entry := range manager.Snapshot(0) {
-		if entry.Address == address && entry.Type == resource.KindInbound.String() {
+		if entry.Address == "IP Address: "+address && entry.Type == resource.KindInbound.String() {
 			return uint32(entry.Local)
 		}
 	}

--- a/internal/rpc/websocket_dispatch.go
+++ b/internal/rpc/websocket_dispatch.go
@@ -56,7 +56,7 @@ func (ws *WebSocketServer) handleMessage(wsConn *websocketConnection, message []
 		wsConn.closeWithPolicyViolation("threshold exceeded")
 		return
 	}
-	defer loadCtx.ResourceAdmission.Finish(resource.FeeExceptionRPC, "")
+	defer loadCtx.ResourceAdmission.Finish(resource.FeeExceptionRPC(), "")
 
 	apiVersion := types.DefaultApiVersion
 	if version, present := apiVersionFromObject(message); present {
@@ -65,7 +65,7 @@ func (ws *WebSocketServer) handleMessage(wsConn *websocketConnection, message []
 	loadCtx.ApiVersion = apiVersion
 	versionCtx := loadCtx
 	if rpcErr := validateApiVersion(versionCtx); rpcErr != nil {
-		chargeLoad(ws.resourceManager, versionCtx, "", resource.FeeMalformedRPC, wsLog())
+		chargeLoad(ws.resourceManager, versionCtx, "", resource.FeeMalformedRPC(), wsLog())
 		ws.sendErrorResponse(wsConn, rpcErr, id, nil, requestEcho)
 		return
 	}
@@ -76,7 +76,7 @@ func (ws *WebSocketServer) handleMessage(wsConn *websocketConnection, message []
 	// feeMalformedRPC (ServerHandler.cpp:446-468).
 	command, ok := resolveWSCommand(cmdMap)
 	if !ok {
-		chargeLoad(ws.resourceManager, versionCtx, "", resource.FeeMalformedRPC, wsLog())
+		chargeLoad(ws.resourceManager, versionCtx, "", resource.FeeMalformedRPC(), wsLog())
 		ws.sendMissingCommand(wsConn, cmdMap, id)
 		return
 	}
@@ -121,21 +121,21 @@ func (ws *WebSocketServer) handleMessage(wsConn *websocketConnection, message []
 	ws.handleRPCMethod(wsConn, rpcCtx, cmd)
 }
 func (ws *WebSocketServer) handleSpecialCommand(wsConn *websocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand, handler wsSpecialHandler) {
-	ctx.LoadCost = uint32(resource.FeeReferenceRPC.Cost())
+	ctx.LoadCost = uint32(resource.FeeReferenceRPC().Cost())
 	if rpcErr := handlers.RequireNotBusyClient(ctx); rpcErr != nil {
-		finalizeLoad(ws.resourceManager, ctx, cmd.Command, resource.FeeReferenceRPC, wsLog())
+		finalizeLoad(ws.resourceManager, ctx, cmd.Command, resource.FeeReferenceRPC(), wsLog())
 		ws.sendCommandError(wsConn, rpcErr, cmd)
 		return
 	}
 
 	resolution := resolveMethod(ws.methodRegistry, cmd.Command, ctx.ApiVersion)
 	if !resolution.resolved {
-		finalizeLoad(ws.resourceManager, ctx, cmd.Command, resource.FeeReferenceRPC, wsLog())
+		finalizeLoad(ws.resourceManager, ctx, cmd.Command, resource.FeeReferenceRPC(), wsLog())
 		ws.sendCommandError(wsConn, types.RpcErrorMethodNotFound(), cmd)
 		return
 	}
 	if rpcErr := conditionMet(resolution.handler.RequiredCondition(), ctx); rpcErr != nil {
-		finalizeLoad(ws.resourceManager, ctx, cmd.Command, resource.FeeReferenceRPC, wsLog())
+		finalizeLoad(ws.resourceManager, ctx, cmd.Command, resource.FeeReferenceRPC(), wsLog())
 		ws.sendCommandError(wsConn, rpcErr, cmd)
 		return
 	}
@@ -151,8 +151,8 @@ func (ws *WebSocketServer) handleSpecialCommand(wsConn *websocketConnection, ctx
 		return result, rpcErr, recovered
 	}()
 	fee := rpcCharge(ctx.LoadCost)
-	if recovered && fee == resource.FeeReferenceRPC {
-		fee = resource.FeeExceptionRPC
+	if recovered && fee == resource.FeeReferenceRPC() {
+		fee = resource.FeeExceptionRPC()
 	}
 	finalizeLoad(ws.resourceManager, ctx, cmd.Command, fee, wsLog())
 	if rpcErr != nil {

--- a/internal/rpc/websocket_pathfind.go
+++ b/internal/rpc/websocket_pathfind.go
@@ -34,7 +34,7 @@ func (ws *WebSocketServer) executePathFind(wsConn *websocketConnection, ctx *typ
 
 	switch *subcommand {
 	case "create":
-		ctx.LoadCost = uint32(resource.FeeHeavyBurdenRPC.Cost())
+		ctx.LoadCost = uint32(resource.FeeHeavyBurdenRPC().Cost())
 		return ws.executePathFindCreate(wsConn, ctx, cmd)
 	case "close":
 		return ws.executePathFindClose(wsConn, ctx, cmd)

--- a/internal/rpc/websocket_special_dispatch_test.go
+++ b/internal/rpc/websocket_special_dispatch_test.go
@@ -34,7 +34,7 @@ func newSpecialDispatchHarness(t *testing.T) (*WebSocketServer, *websocketConnec
 	t.Cleanup(consumer.Release)
 	conn.resourceConsumer = consumer
 	ctx.ResourceConsumer = consumer
-	ctx.ResourceAdmission, _ = consumer.Admit(resource.FeeReferenceRPC)
+	ctx.ResourceAdmission, _ = consumer.Admit(resource.FeeReferenceRPC())
 	require.NotNil(t, ctx.ResourceAdmission)
 	return ws, conn, ctx
 }
@@ -174,7 +174,7 @@ func TestWebSocketSpecialDispatchRecoversPanic(t *testing.T) {
 	if strings.Contains(string(encoded), "private panic detail") {
 		t.Fatalf("panic response leaked private detail: %s", encoded)
 	}
-	if got, want := resourceLocalBalance(t, ws.resourceManager, ctx.ClientIP), uint32(resource.FeeExceptionRPC.Cost()/resource.DecayWindowSeconds); got != want {
+	if got, want := resourceLocalBalance(t, ws.resourceManager, ctx.ClientIP), uint32(resource.FeeExceptionRPC().Cost()/resource.DecayWindowSeconds); got != want {
 		t.Fatalf("panic charge = %v, want %v", got, want)
 	}
 	if got := ws.services.ClientLoad.InFlight(); got != 0 {
@@ -191,12 +191,12 @@ func TestWebSocketPathFindDynamicLoadCost(t *testing.T) {
 		subcommand string
 		want       int
 	}{
-		{subcommand: "create", want: resource.FeeHeavyBurdenRPC.Cost()},
-		{subcommand: "close", want: resource.FeeReferenceRPC.Cost()},
-		{subcommand: "status", want: resource.FeeReferenceRPC.Cost()},
+		{subcommand: "create", want: resource.FeeHeavyBurdenRPC().Cost()},
+		{subcommand: "close", want: resource.FeeReferenceRPC().Cost()},
+		{subcommand: "status", want: resource.FeeReferenceRPC().Cost()},
 	} {
 		t.Run(test.subcommand, func(t *testing.T) {
-			ctx.LoadCost = uint32(resource.FeeReferenceRPC.Cost())
+			ctx.LoadCost = uint32(resource.FeeReferenceRPC().Cost())
 			cmd := specialDispatchCommand("path_find")
 			cmd.Params = json.RawMessage(`{"subcommand":"` + test.subcommand + `"}`)
 			_, _ = ws.executePathFind(conn, ctx, cmd)
@@ -250,15 +250,15 @@ func TestWebSocketSubscribeSnapshotLoadCostAfterValidation(t *testing.T) {
 		want      int
 		wantError bool
 	}{
-		{name: "validated snapshot", params: validSnapshot, want: resource.FeeMediumBurdenRPC.Cost()},
-		{name: "validated state_now", params: validStateNow, want: resource.FeeMediumBurdenRPC.Cost()},
-		{name: "invalid snapshot", params: invalidSnapshot, want: resource.FeeReferenceRPC.Cost(), wantError: true},
-		{name: "later invalid book retains snapshot load", params: validThenInvalidSnapshot, want: resource.FeeMediumBurdenRPC.Cost(), wantError: true},
-		{name: "no snapshot", params: `{}`, want: resource.FeeReferenceRPC.Cost()},
+		{name: "validated snapshot", params: validSnapshot, want: resource.FeeMediumBurdenRPC().Cost()},
+		{name: "validated state_now", params: validStateNow, want: resource.FeeMediumBurdenRPC().Cost()},
+		{name: "invalid snapshot", params: invalidSnapshot, want: resource.FeeReferenceRPC().Cost(), wantError: true},
+		{name: "later invalid book retains snapshot load", params: validThenInvalidSnapshot, want: resource.FeeMediumBurdenRPC().Cost(), wantError: true},
+		{name: "no snapshot", params: `{}`, want: resource.FeeReferenceRPC().Cost()},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			ws, conn, ctx := newSpecialDispatchHarness(t)
-			ctx.LoadCost = uint32(resource.FeeReferenceRPC.Cost())
+			ctx.LoadCost = uint32(resource.FeeReferenceRPC().Cost())
 			cmd := specialDispatchCommand("subscribe")
 			cmd.Params = json.RawMessage(test.params)
 			_, rpcErr := ws.executeSubscribe(conn, ctx, cmd)

--- a/internal/rpc/websocket_subscribe.go
+++ b/internal/rpc/websocket_subscribe.go
@@ -141,7 +141,7 @@ func (ws *WebSocketServer) finishUnsubscribe(wsConn *websocketConnection, reques
 func setSubscriptionLoadCost(ctx *types.RpcContext, request types.SubscriptionRequest) {
 	for _, book := range request.Books {
 		if book.Snapshot || book.StateNow {
-			ctx.LoadCost = uint32(resource.FeeMediumBurdenRPC.Cost())
+			ctx.LoadCost = uint32(resource.FeeMediumBurdenRPC().Cost())
 			return
 		}
 	}


### PR DESCRIPTION
## Summary
- make peer resource consumers race-safe and retain the same directional reputation handle across admission, handshake, and peer teardown
- canonicalize endpoint identity and bound retained/imported resource state with configurable caps, indexed expiry scheduling, safe eviction, and accounting metrics
- keep cluster peers on ordinary directional accounting while adding authenticated public-key fingerprints, active-only exports, immutable fee definitions, and focused hardening tests

## Test plan
- [x] `go test -race -count=1 ./internal/peermanagement/...`
- [x] `go test -count=1 ./internal/rpc/...`
- [x] `go vet -stdmethods=false ./...`
- [x] `golangci-lint run`
- [x] `just build-all`
- [ ] `go test -count=1 ./...` — all changed and dependent packages pass; an unrelated validator-list test fails identically on base commit `f13f8314` and is tracked in #1591

Fixes #1480


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable peer and gossip resource limits, including imported-entry and item limits.
  * Added resource usage statistics for active, retained, and imported entries.
  * Added hostname resolution and canonical endpoint handling for outbound connections and gossip addresses.
  * Added clearer resource-limit errors and administrative access to resource statistics.
  * Added more consistent resource charging across peer, manifest, ledger, and RPC activity.

* **Bug Fixes**
  * Improved resource accounting, eviction, disconnect handling, and capacity reuse.
  * Prevented invalid, oversized, zoned, or malformed endpoints from being accepted.
  * Improved charging and logging for malformed, failed, or overloaded requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->