### PR TITLE
Harden replay-data ingestion boundaries

### DIFF
--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -223,7 +223,7 @@ func (r *replayRangeRunner) run(parentCtx context.Context) (runErr error) {
 	fmt.Fprintln(r.out, "================================================================================")
 	fmt.Fprintln(r.out, "                    XRPL Continuous State Replay")
 	fmt.Fprintln(r.out, "================================================================================")
-	fmt.Fprintf(r.out, "Range:      %d -> %d (%d blocks)\n", r.from, r.to, r.to-r.from)
+	fmt.Fprintf(r.out, "Range:      %d -> %d (%d blocks)\n", r.from, r.to, uint64(r.to)-uint64(r.from))
 	switch {
 	case !r.legacyPayChanDirGate:
 		fmt.Fprintln(r.out, "Compatibility: post-fix fixPayChanRecipientOwnerDir semantics for every target ledger (rippled v3.2.0)")
@@ -237,11 +237,11 @@ func (r *replayRangeRunner) run(parentCtx context.Context) (runErr error) {
 
 	// Connect to database
 	fmt.Fprintln(r.out, "[1/3] Connecting to database...")
-	client, err := statecompare.NewClientFromEnv()
+	client, err := statecompare.NewClientFromEnv(ctx)
 	if err != nil {
 		return fmt.Errorf("connecting to database: %w", err)
 	}
-	defer client.Close()
+	defer func() { runErr = errors.Join(runErr, client.Close()) }()
 	fmt.Fprintln(r.out, "      Connected to PostgreSQL")
 
 	// Validate range exists
@@ -253,13 +253,13 @@ func (r *replayRangeRunner) run(parentCtx context.Context) (runErr error) {
 	if !valid {
 		return fmt.Errorf("ledger %d not found in database; run 'python main.py sync-range %d %d' first", missingLedger, startLedger, r.to)
 	}
-	fmt.Fprintf(r.out, "      All %d ledgers present in database\n", r.to-startLedger+1)
+	fmt.Fprintf(r.out, "      All %d ledgers present in database\n", uint64(r.to)-uint64(startLedger)+1)
 
 	source, err := newStateSource(client, r.nodestoreDir, r.baseCacheMB, r.overlayCacheMB)
 	if err != nil {
 		return fmt.Errorf("initializing state source: %w", err)
 	}
-	defer source.Close()
+	defer func() { runErr = errors.Join(runErr, source.Close()) }()
 
 	var findings *findingsWriter
 	if r.continueOnDivergence {
@@ -267,7 +267,7 @@ func (r *replayRangeRunner) run(parentCtx context.Context) (runErr error) {
 		if err != nil {
 			return fmt.Errorf("opening findings file: %w", err)
 		}
-		defer findings.Close()
+		defer func() { runErr = errors.Join(runErr, findings.Close()) }()
 	}
 
 	var stateMap *shamap.SHAMap
@@ -301,7 +301,8 @@ func (r *replayRangeRunner) run(parentCtx context.Context) (runErr error) {
 	currentStateMap := stateMap
 	previousSnapshot := preSnapshot
 
-	for targetLedger := startLedger + 1; targetLedger <= r.to; targetLedger++ {
+	for seq := uint64(startLedger) + 1; seq <= uint64(r.to); seq++ {
+		targetLedger := uint32(seq)
 		blockStart := time.Now()
 
 		// Process this block
@@ -447,7 +448,7 @@ func recordDivergenceAndReset(
 	result *BlockResult,
 	preState, goxrplPost *shamap.SHAMap,
 ) (*shamap.SHAMap, error) {
-	corrected, verified, err := reconstructMainnetState(ctx, client, preState, ledgerIndex, result.ExpectedAccountHash)
+	corrected, verified, err := reconstructMainnetState(ctx, client, preState, result.PostSnapshot)
 	if err != nil {
 		return nil, fmt.Errorf("reconstructing mainnet state: %w", err)
 	}
@@ -495,7 +496,7 @@ func loadInitialState(ctx context.Context, client *statecompare.Client, ledgerIn
 	// Stream the state pack into the map so the whole pack and the full entry
 	// slice are never materialized in RAM at once.
 	stateMap := shamap.New(shamap.TypeState)
-	if err := client.StreamStateEntries(ctx, ledgerIndex, func(entry statecompare.StateEntry) error {
+	if err := client.StreamStateEntries(ctx, snapshot, func(entry statecompare.StateEntry) error {
 		if err := stateMap.Put(entry.Index, entry.Data); err != nil {
 			return fmt.Errorf("injecting entry: %w", err)
 		}
@@ -627,7 +628,7 @@ func (r *replayRangeRunner) processBlock(
 	result.ExpectedTotalCoins = postSnapshot.TotalCoins
 
 	// Get transactions for this ledger
-	txs, err := client.Transactions(ctx, targetLedger)
+	txs, err := client.Transactions(ctx, postSnapshot)
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting transactions: %w", err)
 	}
@@ -725,7 +726,7 @@ func (r *replayRangeRunner) processBlock(
 	wantTxDetail := r.verbose || r.dumpDir != ""
 	for _, txEntry := range txs {
 		txInfo := TxApplyInfo{
-			Index: txEntry.TxIndex,
+			Index: int(txEntry.TxIndex),
 			Hash:  hex.EncodeToString(txEntry.TxHash[:]),
 		}
 
@@ -781,7 +782,7 @@ func (r *replayRangeRunner) processBlock(
 	accountHashMatch := result.AccountHash == result.ExpectedAccountHash
 	txHashMatch := result.TransactionHash == result.ExpectedTransactionHash
 
-	result.Success = ledgerHashMatch && accountHashMatch && txHashMatch && len(result.Errors) == 0
+	result.Success = ledgerHashMatch && accountHashMatch && txHashMatch && result.TotalCoins == result.ExpectedTotalCoins && len(result.Errors) == 0
 
 	// Get the new state map for next iteration
 	newStateMap, err := openLedger.StateMapSnapshot()

--- a/internal/replaytool/replay_reconstruct.go
+++ b/internal/replaytool/replay_reconstruct.go
@@ -28,10 +28,12 @@ func reconstructMainnetState(
 	ctx context.Context,
 	client *statecompare.Client,
 	preState *shamap.SHAMap,
-	ledgerIndex uint32,
-	expectedAccountHash [32]byte,
+	snapshot *statecompare.LedgerSnapshot,
 ) (*shamap.SHAMap, bool, error) {
-	txs, err := client.Transactions(ctx, ledgerIndex)
+	if snapshot == nil {
+		return nil, false, errors.New("nil ledger snapshot")
+	}
+	txs, err := client.Transactions(ctx, snapshot)
 	if err != nil {
 		return nil, false, fmt.Errorf("getting transactions: %w", err)
 	}
@@ -40,7 +42,7 @@ func reconstructMainnetState(
 		metas[i] = metaTx{Blob: t.MetaBlob, TxHash: t.TxHash}
 	}
 
-	corrected, err := reconstructFromMeta(preState, metas, ledgerIndex)
+	corrected, err := reconstructFromMeta(preState, metas, snapshot.LedgerIndex)
 	if err != nil {
 		return nil, false, err
 	}
@@ -49,7 +51,7 @@ func reconstructMainnetState(
 	if err != nil {
 		return nil, false, fmt.Errorf("computing reconstructed root: %w", err)
 	}
-	return corrected, root == expectedAccountHash, nil
+	return corrected, root == snapshot.AccountHash, nil
 }
 
 // metaTx pairs a transaction's metadata blob with its hash. The hash is threaded

--- a/internal/replaytool/replay_state_source.go
+++ b/internal/replaytool/replay_state_source.go
@@ -2,9 +2,12 @@ package replaytool
 
 import (
 	"context"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/statecompare"
@@ -60,6 +63,7 @@ type nodestoreStateSource struct {
 const (
 	baseNodeCacheItems    = 262144
 	overlayNodeCacheItems = 65536
+	baseCompleteMarker    = "statecompare.complete"
 )
 
 func newNodestoreStateSource(client *statecompare.Client, dir string, baseCacheMB, overlayCacheMB int) (*nodestoreStateSource, error) {
@@ -95,17 +99,16 @@ func (s *nodestoreStateSource) Load(ctx context.Context, ledgerIndex uint32) (*s
 	}
 
 	basePath := filepath.Join(s.dir, fmt.Sprintf("ckpt-%d", ledgerIndex))
-	base, err := backend.OpenPebble(basePath, s.baseCacheMB, baseNodeCacheItems)
-	if err != nil {
-		return nil, nil, drops.Fees{}, fmt.Errorf("opening base nodestore %s: %w", basePath, err)
-	}
-	s.opened = append(s.opened, base)
-
-	stateMap, err := buildOrOpenLazyState(ctx, base, s.overlay, snapshot.AccountHash, func(fn func(statecompare.StateEntry) error) error {
-		return s.client.StreamStateEntries(ctx, ledgerIndex, fn)
+	base, err := s.openOrBuildBase(ctx, basePath, snapshot.AccountHash, func(fn func(statecompare.StateEntry) error) error {
+		return s.client.StreamStateEntries(ctx, snapshot, fn)
 	})
 	if err != nil {
 		return nil, nil, drops.Fees{}, err
+	}
+	s.opened = append(s.opened, base)
+	stateMap, err := shamap.NewFromRootHash(shamap.TypeState, snapshot.AccountHash, shamap.NewOverlayFamily(base, s.overlay))
+	if err != nil {
+		return nil, nil, drops.Fees{}, fmt.Errorf("opening checkpoint %d state root: %w", ledgerIndex, err)
 	}
 
 	// Targeted lookup; lazily fetches only the FeeSettings path, not the tree.
@@ -113,17 +116,122 @@ func (s *nodestoreStateSource) Load(ctx context.Context, ledgerIndex uint32) (*s
 	return stateMap, snapshot, fees, nil
 }
 
-func (s *nodestoreStateSource) Close() error {
-	var firstErr error
-	for _, fam := range s.opened {
-		if err := fam.Close(); err != nil && firstErr == nil {
-			firstErr = err
+func (s *nodestoreStateSource) openOrBuildBase(
+	ctx context.Context,
+	basePath string,
+	accountHash [32]byte,
+	streamEntries func(func(statecompare.StateEntry) error) error,
+) (*backend.NodeStore, error) {
+	complete, err := baseIsComplete(basePath, accountHash)
+	if err != nil {
+		return nil, err
+	}
+	if complete {
+		return openVerifiedBase(ctx, basePath, s.baseCacheMB, accountHash)
+	}
+	if _, err := os.Stat(basePath); err == nil {
+		if err := os.RemoveAll(basePath); err != nil {
+			return nil, fmt.Errorf("removing incomplete base nodestore %s: %w", basePath, err)
 		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("inspecting base nodestore %s: %w", basePath, err)
 	}
-	if err := os.RemoveAll(s.overlayDir); err != nil && firstErr == nil {
-		firstErr = err
+
+	stagePath, err := os.MkdirTemp(s.dir, ".checkpoint-build-")
+	if err != nil {
+		return nil, fmt.Errorf("creating staged base nodestore: %w", err)
 	}
-	return firstErr
+	removeStage := true
+	defer func() {
+		if removeStage {
+			_ = os.RemoveAll(stagePath)
+		}
+	}()
+
+	stage, err := backend.OpenPebble(stagePath, s.baseCacheMB, baseNodeCacheItems)
+	if err != nil {
+		return nil, fmt.Errorf("opening staged base nodestore: %w", err)
+	}
+	_, buildErr := buildOrOpenLazyState(ctx, stage, s.overlay, accountHash, streamEntries)
+	if buildErr == nil {
+		buildErr = stage.Sync(ctx)
+	}
+	buildErr = errors.Join(buildErr, stage.Close())
+	if buildErr != nil {
+		return nil, fmt.Errorf("building staged base nodestore: %w", buildErr)
+	}
+	if err := writeBaseMarker(stagePath, accountHash); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := os.Rename(stagePath, basePath); err != nil {
+		if complete, checkErr := baseIsComplete(basePath, accountHash); checkErr == nil && complete {
+			return openVerifiedBase(ctx, basePath, s.baseCacheMB, accountHash)
+		}
+		return nil, fmt.Errorf("publishing base nodestore %s: %w", basePath, err)
+	}
+	removeStage = false
+	if err := syncDirectory(s.dir); err != nil {
+		return nil, err
+	}
+	return openVerifiedBase(ctx, basePath, s.baseCacheMB, accountHash)
+}
+
+func baseIsComplete(path string, accountHash [32]byte) (bool, error) {
+	marker, err := os.ReadFile(filepath.Join(path, baseCompleteMarker))
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("reading base nodestore marker: %w", err)
+	}
+	return strings.TrimSpace(string(marker)) == hex.EncodeToString(accountHash[:]), nil
+}
+
+func writeBaseMarker(path string, accountHash [32]byte) error {
+	markerPath := filepath.Join(path, baseCompleteMarker)
+	file, err := os.OpenFile(markerPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("creating base nodestore marker: %w", err)
+	}
+	_, writeErr := fmt.Fprintln(file, hex.EncodeToString(accountHash[:]))
+	if writeErr == nil {
+		writeErr = file.Sync()
+	}
+	return errors.Join(writeErr, file.Close(), syncDirectory(path))
+}
+
+func syncDirectory(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("opening directory %s for sync: %w", path, err)
+	}
+	return errors.Join(dir.Sync(), dir.Close())
+}
+
+func openVerifiedBase(ctx context.Context, path string, cacheMB int, accountHash [32]byte) (*backend.NodeStore, error) {
+	base, err := backend.OpenPebble(path, cacheMB, baseNodeCacheItems)
+	if err != nil {
+		return nil, fmt.Errorf("opening base nodestore %s: %w", path, err)
+	}
+	root, fetchErr := base.Fetch(ctx, accountHash)
+	if fetchErr != nil {
+		return nil, errors.Join(fmt.Errorf("verifying base nodestore %s root: %w", path, fetchErr), base.Close())
+	}
+	if root == nil {
+		return nil, errors.Join(fmt.Errorf("verifying base nodestore %s: root is missing", path), base.Close())
+	}
+	return base, nil
+}
+
+func (s *nodestoreStateSource) Close() error {
+	var closeErr error
+	for _, fam := range s.opened {
+		closeErr = errors.Join(closeErr, fam.Close())
+	}
+	return errors.Join(closeErr, os.RemoveAll(s.overlayDir))
 }
 
 // buildOrOpenLazyState returns a state SHAMap whose backing is a shared

--- a/internal/replaytool/replay_state_source.go
+++ b/internal/replaytool/replay_state_source.go
@@ -5,14 +5,20 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
+	"syscall"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/statecompare"
 	"github.com/LeJamon/go-xrpl/shamap"
 	"github.com/LeJamon/go-xrpl/shamap/backend"
+	"github.com/cockroachdb/pebble/vfs"
 )
 
 // StateSource loads the seed account-state SHAMap for a ledger. It exists so
@@ -66,6 +72,8 @@ const (
 	baseCompleteMarker    = "statecompare.complete"
 )
 
+var checkpointBuildGates sync.Map
+
 func newNodestoreStateSource(client *statecompare.Client, dir string, baseCacheMB, overlayCacheMB int) (*nodestoreStateSource, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("creating nodestore dir: %w", err)
@@ -106,7 +114,7 @@ func (s *nodestoreStateSource) Load(ctx context.Context, ledgerIndex uint32) (*s
 		return nil, nil, drops.Fees{}, err
 	}
 	s.opened = append(s.opened, base)
-	stateMap, err := shamap.NewFromRootHash(shamap.TypeState, snapshot.AccountHash, shamap.NewOverlayFamily(base, s.overlay))
+	stateMap, err := shamap.NewFromRootHashContext(ctx, shamap.TypeState, snapshot.AccountHash, shamap.NewOverlayFamily(base, s.overlay))
 	if err != nil {
 		return nil, nil, drops.Fees{}, fmt.Errorf("opening checkpoint %d state root: %w", ledgerIndex, err)
 	}
@@ -123,6 +131,19 @@ func (s *nodestoreStateSource) openOrBuildBase(
 	streamEntries func(func(statecompare.StateEntry) error) error,
 ) (*backend.NodeStore, error) {
 	complete, err := baseIsComplete(basePath, accountHash)
+	if err != nil {
+		return nil, err
+	}
+	if complete {
+		return openVerifiedBase(ctx, basePath, s.baseCacheMB, accountHash)
+	}
+	buildLock, err := acquireCheckpointBuildLock(ctx, basePath)
+	if err != nil {
+		return nil, err
+	}
+	defer buildLock.Close()
+
+	complete, err = baseIsComplete(basePath, accountHash)
 	if err != nil {
 		return nil, err
 	}
@@ -179,6 +200,57 @@ func (s *nodestoreStateSource) openOrBuildBase(
 	return openVerifiedBase(ctx, basePath, s.baseCacheMB, accountHash)
 }
 
+type checkpointBuildLock struct {
+	io.Closer
+	release func()
+}
+
+func (l *checkpointBuildLock) Close() error {
+	err := l.Closer.Close()
+	l.release()
+	return err
+}
+
+func acquireCheckpointBuildLock(ctx context.Context, basePath string) (*checkpointBuildLock, error) {
+	gateValue, _ := checkpointBuildGates.LoadOrStore(basePath, make(chan struct{}, 1))
+	gate := gateValue.(chan struct{})
+	select {
+	case gate <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	release := func() { <-gate }
+
+	lockPath := basePath + ".lock"
+	for {
+		lock, err := vfs.Default.Lock(lockPath)
+		if err == nil {
+			return &checkpointBuildLock{Closer: lock, release: release}, nil
+		}
+		if !checkpointLockBusy(err) {
+			release()
+			return nil, fmt.Errorf("locking base nodestore %s: %w", basePath, err)
+		}
+		timer := time.NewTimer(100 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			release()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func checkpointLockBusy(err error) bool {
+	if runtime.GOOS == "windows" {
+		return errors.Is(err, syscall.Errno(32)) || errors.Is(err, syscall.Errno(33))
+	}
+	return errors.Is(err, syscall.EACCES) || errors.Is(err, syscall.EAGAIN)
+}
+
 func baseIsComplete(path string, accountHash [32]byte) (bool, error) {
 	marker, err := os.ReadFile(filepath.Join(path, baseCompleteMarker))
 	if errors.Is(err, os.ErrNotExist) {
@@ -212,7 +284,7 @@ func syncDirectory(path string) error {
 }
 
 func openVerifiedBase(ctx context.Context, path string, cacheMB int, accountHash [32]byte) (*backend.NodeStore, error) {
-	base, err := backend.OpenPebble(path, cacheMB, baseNodeCacheItems)
+	base, err := backend.OpenPebbleReadOnly(path, cacheMB, baseNodeCacheItems)
 	if err != nil {
 		return nil, fmt.Errorf("opening base nodestore %s: %w", path, err)
 	}
@@ -257,7 +329,7 @@ func buildOrOpenLazyState(
 		return nil, fmt.Errorf("probing base nodestore: %w", err)
 	}
 	if root != nil {
-		return shamap.NewFromRootHash(shamap.TypeState, accountHash, shamap.NewOverlayFamily(base, overlay))
+		return shamap.NewFromRootHashContext(ctx, shamap.TypeState, accountHash, shamap.NewOverlayFamily(base, overlay))
 	}
 
 	// Cold path: build the derived nodestore once, streaming the raw entries.
@@ -298,7 +370,7 @@ func buildOrOpenLazyState(
 		return nil, fmt.Errorf("seed state account_hash mismatch: built root %x != expected %x (incomplete or corrupt state import)", builtRoot[:8], accountHash[:8])
 	}
 
-	return shamap.NewFromRootHash(shamap.TypeState, accountHash, shamap.NewOverlayFamily(base, overlay))
+	return shamap.NewFromRootHashContext(ctx, shamap.TypeState, accountHash, shamap.NewOverlayFamily(base, overlay))
 }
 
 // flushToFamily flushes the map's dirty nodes into fam, releasing child

--- a/internal/replaytool/replay_state_source_test.go
+++ b/internal/replaytool/replay_state_source_test.go
@@ -2,12 +2,79 @@ package replaytool
 
 import (
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/internal/statecompare"
 	"github.com/LeJamon/go-xrpl/shamap"
 	"github.com/LeJamon/go-xrpl/shamap/backend"
 )
+
+func TestOpenOrBuildBasePublishesOnlyVerifiedImport(t *testing.T) {
+	entries, root := syntheticEntries(t, 4)
+	dir := t.TempDir()
+	source := &nodestoreStateSource{
+		dir:         dir,
+		baseCacheMB: 8,
+		overlay:     backend.NewMemory(),
+	}
+	basePath := filepath.Join(dir, "ckpt-1")
+	callbackErr := errors.New("stream failed")
+	if _, err := source.openOrBuildBase(context.Background(), basePath, root, func(fn func(statecompare.StateEntry) error) error {
+		if err := fn(entries[0]); err != nil {
+			return err
+		}
+		return callbackErr
+	}); !errors.Is(err, callbackErr) {
+		t.Fatalf("openOrBuildBase error = %v", err)
+	}
+	if _, err := os.Stat(basePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("failed import was published: %v", err)
+	}
+
+	base, err := source.openOrBuildBase(context.Background(), basePath, root, streamAll(entries))
+	if err != nil {
+		t.Fatalf("openOrBuildBase valid: %v", err)
+	}
+	if err := base.Close(); err != nil {
+		t.Fatal(err)
+	}
+	complete, err := baseIsComplete(basePath, root)
+	if err != nil || !complete {
+		t.Fatalf("baseIsComplete = %t, %v", complete, err)
+	}
+
+	called := false
+	base, err = source.openOrBuildBase(context.Background(), basePath, root, func(func(statecompare.StateEntry) error) error {
+		called = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("openOrBuildBase warm: %v", err)
+	}
+	if called {
+		t.Fatal("warm open streamed checkpoint again")
+	}
+	if err := base.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOpenOrBuildBaseRejectsWrongRootWithoutPublication(t *testing.T) {
+	entries, root := syntheticEntries(t, 2)
+	root[0] ^= 0xff
+	dir := t.TempDir()
+	source := &nodestoreStateSource{dir: dir, baseCacheMB: 8, overlay: backend.NewMemory()}
+	basePath := filepath.Join(dir, "ckpt-2")
+	if _, err := source.openOrBuildBase(context.Background(), basePath, root, streamAll(entries)); err == nil {
+		t.Fatal("wrong root accepted")
+	}
+	if _, err := os.Stat(basePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("wrong-root import was published: %v", err)
+	}
+}
 
 // syntheticEntries returns n state entries with distinct keys and >=12-byte
 // data, plus the account_hash they hash to (the in-memory state root).

--- a/internal/replaytool/replay_state_source_test.go
+++ b/internal/replaytool/replay_state_source_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/statecompare"
 	"github.com/LeJamon/go-xrpl/shamap"
@@ -59,6 +60,51 @@ func TestOpenOrBuildBasePublishesOnlyVerifiedImport(t *testing.T) {
 	}
 	if err := base.Close(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestOpenOrBuildBaseSerializesConcurrentBuilders(t *testing.T) {
+	entries, root := syntheticEntries(t, 8)
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "ckpt-3")
+	firstSource := &nodestoreStateSource{dir: dir, baseCacheMB: 8, overlay: backend.NewMemory()}
+	secondSource := &nodestoreStateSource{dir: dir, baseCacheMB: 8, overlay: backend.NewMemory()}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	type result struct {
+		base *backend.NodeStore
+		err  error
+	}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	firstResult := make(chan result, 1)
+	go func() {
+		base, err := firstSource.openOrBuildBase(ctx, basePath, root, func(fn func(statecompare.StateEntry) error) error {
+			close(started)
+			<-release
+			return streamAll(entries)(fn)
+		})
+		firstResult <- result{base: base, err: err}
+	}()
+	<-started
+
+	secondResult := make(chan result, 1)
+	go func() {
+		base, err := secondSource.openOrBuildBase(ctx, basePath, root, func(func(statecompare.StateEntry) error) error {
+			return errors.New("second builder streamed checkpoint")
+		})
+		secondResult <- result{base: base, err: err}
+	}()
+	close(release)
+
+	for _, result := range []result{<-firstResult, <-secondResult} {
+		if result.err != nil {
+			t.Fatal(result.err)
+		}
+		if err := result.base.Close(); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 

--- a/internal/statecompare/blobstore.go
+++ b/internal/statecompare/blobstore.go
@@ -9,112 +9,135 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
 
-// blobStore reads the immutable pack objects the lab writes to object storage.
-// Two backends mirror the lab's core/blobstore.py: a local directory for
-// dev/test, and S3/MinIO for production cross-pod blob sharing.
+type blobObject struct {
+	io.ReadCloser
+	size int64
+}
+
 type blobStore interface {
-	get(ctx context.Context, key string) ([]byte, error)
-	// getReader returns the object as a stream so a large pack is consumed
-	// incrementally rather than buffered whole. The caller owns the reader and
-	// must Close it.
-	getReader(ctx context.Context, key string) (io.ReadCloser, error)
+	open(ctx context.Context, key string) (*blobObject, error)
+	Close() error
 }
 
-// BlobStoreConfig selects and configures the blob backend. Field defaults and
-// env-var names match the lab's BlobStoreConfig so the same deployment env
-// drives both the Python workers and this Go reader.
-type BlobStoreConfig struct {
-	Backend     string // "local", "s3", or "minio"
-	EndpointURL string
-	AccessKey   string
-	SecretKey   string
-	Bucket      string
-	Region      string
-	Secure      bool
-	LocalRoot   string
+type blobStoreConfig struct {
+	backend     string
+	endpointURL string
+	accessKey   string
+	secretKey   string
+	bucket      string
+	region      string
+	secure      bool
+	localRoot   string
 }
 
-// BlobStoreConfigFromEnv builds a BlobStoreConfig from the environment.
-func BlobStoreConfigFromEnv() BlobStoreConfig {
-	return BlobStoreConfig{
-		Backend:     strings.ToLower(strings.TrimSpace(getEnvOrDefault("BLOBSTORE_BACKEND", "local"))),
-		EndpointURL: getEnvOrDefault("MINIO_ENDPOINT_URL", "http://localhost:9000"),
-		AccessKey:   getEnvOrDefault("MINIO_ACCESS_KEY", "minioadmin"),
-		SecretKey:   getEnvOrDefault("MINIO_SECRET_KEY", "minioadmin"),
-		Bucket:      getEnvOrDefault("MINIO_BUCKET", "xrpl-replay"),
-		Region:      getEnvOrDefault("MINIO_REGION", "us-east-1"),
-		Secure:      getBoolEnv("MINIO_SECURE", false),
-		LocalRoot:   getEnvOrDefault("BLOBSTORE_LOCAL_ROOT", "./.blobstore"),
+func blobStoreConfigFromEnv() (blobStoreConfig, error) {
+	secure, err := getBoolEnv("MINIO_SECURE", false)
+	if err != nil {
+		return blobStoreConfig{}, err
 	}
+	return blobStoreConfig{
+		backend:     strings.ToLower(strings.TrimSpace(getEnvOrDefault("BLOBSTORE_BACKEND", "local"))),
+		endpointURL: getEnvOrDefault("MINIO_ENDPOINT_URL", "http://localhost:9000"),
+		accessKey:   getEnvOrDefault("MINIO_ACCESS_KEY", "minioadmin"),
+		secretKey:   getEnvOrDefault("MINIO_SECRET_KEY", "minioadmin"),
+		bucket:      getEnvOrDefault("MINIO_BUCKET", "xrpl-replay"),
+		region:      getEnvOrDefault("MINIO_REGION", "us-east-1"),
+		secure:      secure,
+		localRoot:   getEnvOrDefault("BLOBSTORE_LOCAL_ROOT", "./.blobstore"),
+	}, nil
 }
 
-// getBoolEnv parses a truthy env var the same way the lab's _bool helper does.
-func getBoolEnv(key string, defaultValue bool) bool {
+func getBoolEnv(key string, defaultValue bool) (bool, error) {
 	raw := strings.TrimSpace(strings.ToLower(os.Getenv(key)))
 	if raw == "" {
-		return defaultValue
+		return defaultValue, nil
 	}
 	switch raw {
 	case "1", "true", "yes", "on":
-		return true
+		return true, nil
+	case "0", "false", "no", "off":
+		return false, nil
 	default:
-		return false
+		return false, fmt.Errorf("statecompare: %s must be a boolean, got %q", key, os.Getenv(key))
 	}
 }
 
-// newBlobStore constructs the backend selected by cfg.Backend.
-func newBlobStore(cfg BlobStoreConfig) (blobStore, error) {
-	switch cfg.Backend {
+func newBlobStore(cfg blobStoreConfig) (blobStore, error) {
+	switch strings.ToLower(strings.TrimSpace(cfg.backend)) {
 	case "local":
-		return &localBlobStore{root: cfg.LocalRoot}, nil
+		if strings.TrimSpace(cfg.localRoot) == "" {
+			return nil, errors.New("statecompare: BLOBSTORE_LOCAL_ROOT is empty")
+		}
+		root, err := os.OpenRoot(cfg.localRoot)
+		if err != nil {
+			return nil, fmt.Errorf("statecompare: opening blobstore root %q: %w", cfg.localRoot, err)
+		}
+		return &localBlobStore{root: root}, nil
 	case "s3", "minio":
 		return newS3BlobStore(cfg)
 	default:
-		return nil, fmt.Errorf("statecompare: unknown blobstore backend %q", cfg.Backend)
+		return nil, fmt.Errorf("statecompare: unknown blobstore backend %q", cfg.backend)
 	}
 }
 
-// localBlobStore reads packs from a directory tree, needing no running service.
 type localBlobStore struct {
-	root string
+	root *os.Root
 }
 
-func (l *localBlobStore) get(_ context.Context, key string) ([]byte, error) {
-	path := filepath.Join(l.root, filepath.FromSlash(key))
-	data, err := os.ReadFile(path)
+func (l *localBlobStore) open(ctx context.Context, key string) (*blobObject, error) {
+	if _, _, err := parseBlobKey(key); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	file, err := l.root.Open(key)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return nil, fmt.Errorf("blob %q: %w", key, ErrNotFound)
+			return nil, fmt.Errorf("blob %q: %w", key, errNotFound)
 		}
-		return nil, fmt.Errorf("reading blob %q: %w", key, err)
+		return nil, fmt.Errorf("opening blob %q: %w", key, err)
 	}
-	return data, nil
-}
-
-func (l *localBlobStore) getReader(_ context.Context, key string) (io.ReadCloser, error) {
-	path := filepath.Join(l.root, filepath.FromSlash(key))
-	f, err := os.Open(path)
+	info, err := file.Stat()
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil, fmt.Errorf("blob %q: %w", key, ErrNotFound)
-		}
-		return nil, fmt.Errorf("reading blob %q: %w", key, err)
+		return nil, errors.Join(fmt.Errorf("stating blob %q: %w", key, err), file.Close())
 	}
-	return f, nil
+	if !info.Mode().IsRegular() {
+		return nil, errors.Join(fmt.Errorf("blob %q is not a regular file", key), file.Close())
+	}
+	return &blobObject{
+		ReadCloser: &contextReadCloser{ctx: ctx, ReadCloser: file},
+		size:       info.Size(),
+	}, nil
 }
 
-// s3BlobStore fetches packs from S3/MinIO over plain HTTP, signing each GET
-// with AWS Signature Version 4. Path-style addressing (the MinIO default) is
-// used: the object URL is <endpoint>/<bucket>/<key>.
+func (l *localBlobStore) Close() error {
+	return l.root.Close()
+}
+
+type contextReadCloser struct {
+	ctx context.Context
+	io.ReadCloser
+}
+
+func (r *contextReadCloser) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.ReadCloser.Read(p)
+}
+
 type s3BlobStore struct {
 	endpoint  *url.URL
 	bucket    string
@@ -124,59 +147,93 @@ type s3BlobStore struct {
 	client    *http.Client
 }
 
-func newS3BlobStore(cfg BlobStoreConfig) (*s3BlobStore, error) {
-	ep := cfg.EndpointURL
-	if !strings.Contains(ep, "://") {
-		scheme := "http"
-		if cfg.Secure {
-			scheme = "https"
-		}
-		ep = scheme + "://" + ep
-	}
-	u, err := url.Parse(ep)
-	if err != nil {
-		return nil, fmt.Errorf("statecompare: invalid MINIO_ENDPOINT_URL %q: %w", cfg.EndpointURL, err)
-	}
-	if u.Host == "" {
-		return nil, fmt.Errorf("statecompare: MINIO_ENDPOINT_URL %q has no host", cfg.EndpointURL)
-	}
-	region := cfg.Region
-	if region == "" {
-		region = "us-east-1"
-	}
-	return &s3BlobStore{
-		endpoint:  u,
-		bucket:    cfg.Bucket,
-		accessKey: cfg.AccessKey,
-		secretKey: cfg.SecretKey,
-		region:    region,
-		// No client-wide timeout: packs are large and the caller's context
-		// governs the deadline. The default transport handles connection reuse.
-		client: &http.Client{},
-	}, nil
-}
+var (
+	bucketPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$`)
+	regionPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9-]*$`)
+)
 
-// emptyPayloadSHA256 is the SHA-256 of an empty body, used as the signed
-// content hash for an unsigned-payload GET.
-const emptyPayloadSHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-
-func (s *s3BlobStore) get(ctx context.Context, key string) ([]byte, error) {
-	r, err := s.getReader(ctx, key)
+func newS3BlobStore(cfg blobStoreConfig) (*s3BlobStore, error) {
+	u, err := validateS3Config(cfg)
 	if err != nil {
 		return nil, err
 	}
-	defer r.Close()
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return nil, fmt.Errorf("reading blob %q: %w", key, err)
-	}
-	return data, nil
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = (&net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}).DialContext
+	transport.TLSHandshakeTimeout = 10 * time.Second
+	transport.ResponseHeaderTimeout = 30 * time.Second
+	transport.IdleConnTimeout = 90 * time.Second
+	return &s3BlobStore{
+		endpoint:  u,
+		bucket:    cfg.bucket,
+		accessKey: cfg.accessKey,
+		secretKey: cfg.secretKey,
+		region:    cfg.region,
+		client: &http.Client{
+			Transport: transport,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}, nil
 }
 
-func (s *s3BlobStore) getReader(ctx context.Context, key string) (io.ReadCloser, error) {
+func validateS3Config(cfg blobStoreConfig) (*url.URL, error) {
+	endpoint := strings.TrimSpace(cfg.endpointURL)
+	if endpoint == "" {
+		return nil, errors.New("statecompare: MINIO_ENDPOINT_URL is empty")
+	}
+	if !strings.Contains(endpoint, "://") {
+		scheme := "http"
+		if cfg.secure {
+			scheme = "https"
+		}
+		endpoint = scheme + "://" + endpoint
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("statecompare: invalid MINIO_ENDPOINT_URL %q: %w", cfg.endpointURL, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("statecompare: MINIO_ENDPOINT_URL scheme %q is not http or https", u.Scheme)
+	}
+	if (u.Scheme == "https") != cfg.secure {
+		return nil, fmt.Errorf("statecompare: MINIO_SECURE=%t conflicts with endpoint scheme %q", cfg.secure, u.Scheme)
+	}
+	if u.Host == "" || u.Hostname() == "" {
+		return nil, fmt.Errorf("statecompare: MINIO_ENDPOINT_URL %q has no host", cfg.endpointURL)
+	}
+	if u.User != nil || (u.Path != "" && u.Path != "/") || u.RawQuery != "" || u.Fragment != "" {
+		return nil, fmt.Errorf("statecompare: MINIO_ENDPOINT_URL %q must not contain credentials, path, query, or fragment", cfg.endpointURL)
+	}
+	if !validBucket(cfg.bucket) {
+		return nil, fmt.Errorf("statecompare: invalid MINIO_BUCKET %q", cfg.bucket)
+	}
+	if strings.TrimSpace(cfg.accessKey) == "" || strings.TrimSpace(cfg.secretKey) == "" {
+		return nil, errors.New("statecompare: MINIO_ACCESS_KEY and MINIO_SECRET_KEY must be non-empty")
+	}
+	if !regionPattern.MatchString(cfg.region) {
+		return nil, fmt.Errorf("statecompare: invalid MINIO_REGION %q", cfg.region)
+	}
+	u.Path = ""
+	return u, nil
+}
+
+func validBucket(bucket string) bool {
+	if !bucketPattern.MatchString(bucket) || strings.Contains(bucket, "..") ||
+		strings.Contains(bucket, ".-") || strings.Contains(bucket, "-.") {
+		return false
+	}
+	return net.ParseIP(bucket) == nil
+}
+
+const emptyPayloadSHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+func (s *s3BlobStore) open(ctx context.Context, key string) (*blobObject, error) {
+	if _, _, err := parseBlobKey(key); err != nil {
+		return nil, err
+	}
 	reqURL := *s.endpoint
 	reqURL.Path = "/" + s.bucket + "/" + key
-
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("building request for blob %q: %w", key, err)
@@ -188,24 +245,60 @@ func (s *s3BlobStore) getReader(ctx context.Context, key string) (io.ReadCloser,
 	if err != nil {
 		return nil, fmt.Errorf("fetching blob %q: %w", key, err)
 	}
-
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return resp.Body, nil
+		if resp.ContentLength < 0 {
+			return nil, errors.Join(fmt.Errorf("fetching blob %q: response has no Content-Length", key), resp.Body.Close())
+		}
+		return &blobObject{ReadCloser: resp.Body, size: resp.ContentLength}, nil
 	case http.StatusNotFound:
-		resp.Body.Close()
-		return nil, fmt.Errorf("blob %q: %w", key, ErrNotFound)
+		return nil, errors.Join(fmt.Errorf("blob %q: %w", key, errNotFound), resp.Body.Close())
 	default:
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		resp.Body.Close()
-		return nil, fmt.Errorf("fetching blob %q: status %s: %s", key, resp.Status, strings.TrimSpace(string(body)))
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 512))
+		closeErr := resp.Body.Close()
+		return nil, errors.Join(
+			fmt.Errorf("fetching blob %q: status %s: %s", key, resp.Status, strings.TrimSpace(string(body))),
+			readErr,
+			closeErr,
+		)
 	}
 }
 
-// signV4 signs req in place with AWS Signature Version 4 for service "s3",
-// setting the x-amz-date, x-amz-content-sha256 and Authorization headers. It
-// signs the Host header plus every header already present on req, so callers
-// that set extra headers (e.g. Range) get them covered.
+func (s *s3BlobStore) Close() error {
+	s.client.CloseIdleConnections()
+	return nil
+}
+
+func parseBlobKey(key string) (kind byte, seq uint32, err error) {
+	parts := strings.Split(key, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" || strings.Contains(key, "\\") {
+		return 0, 0, fmt.Errorf("statecompare: invalid blob key %q", key)
+	}
+	name := parts[1]
+	var number string
+	switch parts[0] {
+	case "state":
+		kind = kindState
+		if !strings.HasPrefix(name, "ckpt-") || !strings.HasSuffix(name, ".pack") {
+			return 0, 0, fmt.Errorf("statecompare: invalid state blob key %q", key)
+		}
+		number = strings.TrimSuffix(strings.TrimPrefix(name, "ckpt-"), ".pack")
+	case "ledger":
+		kind = kindLedger
+		if !strings.HasSuffix(name, ".pack") {
+			return 0, 0, fmt.Errorf("statecompare: invalid ledger blob key %q", key)
+		}
+		number = strings.TrimSuffix(name, ".pack")
+	default:
+		return 0, 0, fmt.Errorf("statecompare: invalid blob key prefix %q", parts[0])
+	}
+	value, parseErr := strconv.ParseUint(number, 10, 32)
+	if parseErr != nil || strconv.FormatUint(value, 10) != number {
+		return 0, 0, fmt.Errorf("statecompare: invalid blob key sequence in %q", key)
+	}
+	return kind, uint32(value), nil
+}
+
 func signV4(req *http.Request, payloadSHA256 string, t time.Time, region, accessKey, secretKey string) {
 	const (
 		algorithm = "AWS4-HMAC-SHA256"
@@ -213,7 +306,6 @@ func signV4(req *http.Request, payloadSHA256 string, t time.Time, region, access
 	)
 	amzDate := t.Format("20060102T150405Z")
 	dateStamp := t.Format("20060102")
-
 	req.Header.Set("x-amz-date", amzDate)
 	req.Header.Set("x-amz-content-sha256", payloadSHA256)
 
@@ -221,12 +313,9 @@ func signV4(req *http.Request, payloadSHA256 string, t time.Time, region, access
 	if host == "" {
 		host = req.URL.Host
 	}
-
-	// Canonical + signed headers: host plus everything currently on the
-	// request, lowercased and sorted by name.
 	headers := map[string]string{"host": host}
-	for name, vals := range req.Header {
-		headers[strings.ToLower(name)] = strings.TrimSpace(strings.Join(vals, ","))
+	for name, values := range req.Header {
+		headers[strings.ToLower(name)] = strings.TrimSpace(strings.Join(values, ","))
 	}
 	names := make([]string, 0, len(headers))
 	for name := range headers {
@@ -242,7 +331,6 @@ func signV4(req *http.Request, payloadSHA256 string, t time.Time, region, access
 		canonicalHeaders.WriteByte('\n')
 	}
 	signedHeaders := strings.Join(names, ";")
-
 	canonicalRequest := strings.Join([]string{
 		req.Method,
 		canonicalURI(req.URL.Path),
@@ -251,7 +339,6 @@ func signV4(req *http.Request, payloadSHA256 string, t time.Time, region, access
 		signedHeaders,
 		payloadSHA256,
 	}, "\n")
-
 	scope := strings.Join([]string{dateStamp, region, service, "aws4_request"}, "/")
 	stringToSign := strings.Join([]string{
 		algorithm,
@@ -259,7 +346,6 @@ func signV4(req *http.Request, payloadSHA256 string, t time.Time, region, access
 		scope,
 		hex.EncodeToString(sha256Sum([]byte(canonicalRequest))),
 	}, "\n")
-
 	signingKey := hmacSHA256(
 		hmacSHA256(
 			hmacSHA256(
@@ -268,38 +354,31 @@ func signV4(req *http.Request, payloadSHA256 string, t time.Time, region, access
 			service),
 		"aws4_request")
 	signature := hex.EncodeToString(hmacSHA256(signingKey, stringToSign))
-
 	req.Header.Set("Authorization", fmt.Sprintf(
 		"%s Credential=%s/%s, SignedHeaders=%s, Signature=%s",
 		algorithm, accessKey, scope, signedHeaders, signature,
 	))
 }
 
-// canonicalURI URI-encodes each path segment per RFC 3986 while preserving the
-// '/' separators, as S3's SigV4 canonical URI requires.
 func canonicalURI(path string) string {
 	if path == "" {
 		return "/"
 	}
 	segments := strings.Split(path, "/")
-	for i, seg := range segments {
-		segments[i] = uriEncode(seg)
+	for i, segment := range segments {
+		segments[i] = uriEncode(segment)
 	}
 	return strings.Join(segments, "/")
 }
 
-// uriEncode percent-encodes a single path segment, leaving the RFC 3986
-// unreserved set untouched (S3 also treats '/' specially, handled by the
-// caller).
-func uriEncode(s string) string {
+func uriEncode(value string) string {
 	const unreserved = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
 	var b strings.Builder
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if strings.IndexByte(unreserved, c) >= 0 {
+	for i := 0; i < len(value); i++ {
+		if c := value[i]; strings.IndexByte(unreserved, c) >= 0 {
 			b.WriteByte(c)
 		} else {
-			fmt.Fprintf(&b, "%%%02X", c)
+			fmt.Fprintf(&b, "%%%02X", value[i])
 		}
 	}
 	return b.String()
@@ -312,6 +391,6 @@ func sha256Sum(data []byte) []byte {
 
 func hmacSHA256(key []byte, data string) []byte {
 	h := hmac.New(sha256.New, key)
-	h.Write([]byte(data))
+	_, _ = h.Write([]byte(data))
 	return h.Sum(nil)
 }

--- a/internal/statecompare/blobstore.go
+++ b/internal/statecompare/blobstore.go
@@ -147,6 +147,18 @@ type s3BlobStore struct {
 	client    *http.Client
 }
 
+type idleReadConn struct {
+	net.Conn
+	timeout time.Duration
+}
+
+func (c *idleReadConn) Read(p []byte) (int, error) {
+	if err := c.Conn.SetReadDeadline(time.Now().Add(c.timeout)); err != nil {
+		return 0, err
+	}
+	return c.Conn.Read(p)
+}
+
 var (
 	bucketPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$`)
 	regionPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9-]*$`)
@@ -157,8 +169,19 @@ func newS3BlobStore(cfg blobStoreConfig) (*s3BlobStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.DialContext = (&net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}).DialContext
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, errors.New("statecompare: default HTTP transport is not configurable")
+	}
+	transport := defaultTransport.Clone()
+	dialer := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		conn, err := dialer.DialContext(ctx, network, address)
+		if err != nil {
+			return nil, err
+		}
+		return &idleReadConn{Conn: conn, timeout: 90 * time.Second}, nil
+	}
 	transport.TLSHandshakeTimeout = 10 * time.Second
 	transport.ResponseHeaderTimeout = 30 * time.Second
 	transport.IdleConnTimeout = 90 * time.Second

--- a/internal/statecompare/blobstore_test.go
+++ b/internal/statecompare/blobstore_test.go
@@ -3,282 +3,155 @@ package statecompare
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
-	"time"
 )
 
-func TestGetBoolEnv(t *testing.T) {
-	const key = "STATECOMPARE_TEST_BOOL"
-	cases := map[string]bool{
-		"1": true, "true": true, "yes": true, "on": true,
-		"TRUE": true, " On ": true,
-		"0": false, "false": false, "no": false, "off": false, "bogus": false,
+func TestGetBoolEnvStrict(t *testing.T) {
+	t.Setenv("TEST_BOOL", "true")
+	value, err := getBoolEnv("TEST_BOOL", false)
+	if err != nil || !value {
+		t.Fatalf("getBoolEnv = %t, %v", value, err)
 	}
-	for raw, want := range cases {
-		t.Setenv(key, raw)
-		if got := getBoolEnv(key, false); got != want {
-			t.Errorf("getBoolEnv(%q) = %v, want %v", raw, got, want)
-		}
-	}
-	t.Setenv(key, "")
-	if got := getBoolEnv(key, true); got != true {
-		t.Errorf("getBoolEnv(empty) = %v, want default true", got)
+	t.Setenv("TEST_BOOL", "truthy")
+	if _, err := getBoolEnv("TEST_BOOL", false); err == nil {
+		t.Fatal("invalid boolean accepted")
 	}
 }
 
-func TestBlobStoreConfigFromEnvDefaults(t *testing.T) {
-	for _, k := range []string{
-		"BLOBSTORE_BACKEND", "MINIO_ENDPOINT_URL", "MINIO_ACCESS_KEY",
-		"MINIO_SECRET_KEY", "MINIO_BUCKET", "MINIO_REGION", "MINIO_SECURE",
-		"BLOBSTORE_LOCAL_ROOT",
+func TestParseBlobKeyGrammar(t *testing.T) {
+	valid := map[string]struct {
+		kind byte
+		seq  uint32
+	}{
+		"state/ckpt-0.pack":          {kindState, 0},
+		"state/ckpt-4294967295.pack": {kindState, ^uint32(0)},
+		"ledger/42.pack":             {kindLedger, 42},
+	}
+	for key, want := range valid {
+		kind, seq, err := parseBlobKey(key)
+		if err != nil || kind != want.kind || seq != want.seq {
+			t.Fatalf("parseBlobKey(%q) = %d,%d,%v", key, kind, seq, err)
+		}
+	}
+	for _, key := range []string{
+		"../ledger/1.pack", "ledger/../1.pack", "ledger/01.pack", "ledger/+1.pack",
+		"ledger/1.pack/extra", `ledger\1.pack`, "/ledger/1.pack", "state/1.pack",
+		"state/ckpt-4294967296.pack", "unknown/1.pack",
 	} {
-		t.Setenv(k, "")
-	}
-	want := BlobStoreConfig{
-		Backend:     "local",
-		EndpointURL: "http://localhost:9000",
-		AccessKey:   "minioadmin",
-		SecretKey:   "minioadmin",
-		Bucket:      "xrpl-replay",
-		Region:      "us-east-1",
-		Secure:      false,
-		LocalRoot:   "./.blobstore",
-	}
-	if got := BlobStoreConfigFromEnv(); got != want {
-		t.Errorf("BlobStoreConfigFromEnv() = %+v, want %+v", got, want)
-	}
-}
-
-func TestBlobStoreConfigFromEnvOverrides(t *testing.T) {
-	t.Setenv("BLOBSTORE_BACKEND", "S3")
-	t.Setenv("MINIO_ENDPOINT_URL", "https://minio.example.com")
-	t.Setenv("MINIO_ACCESS_KEY", "ak")
-	t.Setenv("MINIO_SECRET_KEY", "sk")
-	t.Setenv("MINIO_BUCKET", "packs")
-	t.Setenv("MINIO_REGION", "eu-west-1")
-	t.Setenv("MINIO_SECURE", "true")
-	t.Setenv("BLOBSTORE_LOCAL_ROOT", "/data")
-
-	want := BlobStoreConfig{
-		Backend:     "s3", // lowercased/trimmed
-		EndpointURL: "https://minio.example.com",
-		AccessKey:   "ak",
-		SecretKey:   "sk",
-		Bucket:      "packs",
-		Region:      "eu-west-1",
-		Secure:      true,
-		LocalRoot:   "/data",
-	}
-	if got := BlobStoreConfigFromEnv(); got != want {
-		t.Errorf("BlobStoreConfigFromEnv() = %+v, want %+v", got, want)
-	}
-}
-
-func TestNewBlobStoreUnknownBackend(t *testing.T) {
-	if _, err := newBlobStore(BlobStoreConfig{Backend: "azure"}); err == nil {
-		t.Fatal("expected error for unknown backend, got nil")
-	}
-}
-
-func TestLocalBlobStoreGet(t *testing.T) {
-	root := t.TempDir()
-	store := &localBlobStore{root: root}
-
-	blob := packState(7, []StateEntry{{Index: idx(0x01), Data: []byte("x")}})
-	key := "state/ckpt-7.pack"
-	if err := os.MkdirAll(filepath.Join(root, "state"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(key)), blob, 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := store.get(context.Background(), key)
-	if err != nil {
-		t.Fatalf("get: %v", err)
-	}
-	if string(got) != string(blob) {
-		t.Errorf("get returned %d bytes, want %d", len(got), len(blob))
-	}
-
-	if _, err := store.get(context.Background(), "state/missing.pack"); !errors.Is(err, ErrNotFound) {
-		t.Errorf("missing key err = %v, want ErrNotFound", err)
-	}
-}
-
-func TestLocalBlobStoreGetReader(t *testing.T) {
-	root := t.TempDir()
-	store := &localBlobStore{root: root}
-
-	entries := []StateEntry{{Index: idx(0x01), Data: []byte("x")}, {Index: idx(0x02), Data: []byte("yz")}}
-	blob := packState(7, entries)
-	key := "state/ckpt-7.pack"
-	if err := os.MkdirAll(filepath.Join(root, "state"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(key)), blob, 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	r, err := store.getReader(context.Background(), key)
-	if err != nil {
-		t.Fatalf("getReader: %v", err)
-	}
-	defer r.Close()
-
-	got := 0
-	seq, _, err := unpackStateStream(r, func([32]byte, []byte) error {
-		got++
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("unpackStateStream: %v", err)
-	}
-	if seq != 7 || got != len(entries) {
-		t.Errorf("seq=%d entries=%d, want seq=7 entries=%d", seq, got, len(entries))
-	}
-
-	if _, err := store.getReader(context.Background(), "state/missing.pack"); !errors.Is(err, ErrNotFound) {
-		t.Errorf("missing key err = %v, want ErrNotFound", err)
-	}
-}
-
-// TestSignV4GoldenVector verifies the SigV4 signer against the documented AWS
-// "GET Object" example, which fixes the expected signature for a known
-// request. Matching it proves the canonical request, string-to-sign and
-// signing-key derivation are all correct.
-func TestSignV4GoldenVector(t *testing.T) {
-	const (
-		accessKey = "AKIAIOSFODNN7EXAMPLE"
-		secretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-		wantSig   = "f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41"
-		wantSH    = "host;range;x-amz-content-sha256;x-amz-date"
-	)
-	req, err := http.NewRequest(http.MethodGet, "https://examplebucket.s3.amazonaws.com/test.txt", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Set("Range", "bytes=0-9")
-
-	when := time.Date(2013, 5, 24, 0, 0, 0, 0, time.UTC)
-	signV4(req, emptyPayloadSHA256, when, "us-east-1", accessKey, secretKey)
-
-	auth := req.Header.Get("Authorization")
-	if !strings.Contains(auth, "Signature="+wantSig) {
-		t.Errorf("Authorization = %q\nwant Signature=%s", auth, wantSig)
-	}
-	if !strings.Contains(auth, "SignedHeaders="+wantSH) {
-		t.Errorf("Authorization = %q\nwant SignedHeaders=%s", auth, wantSH)
-	}
-	if req.Header.Get("x-amz-date") != "20130524T000000Z" {
-		t.Errorf("x-amz-date = %q, want 20130524T000000Z", req.Header.Get("x-amz-date"))
-	}
-	if req.Header.Get("x-amz-content-sha256") != emptyPayloadSHA256 {
-		t.Errorf("x-amz-content-sha256 = %q, want empty-payload hash", req.Header.Get("x-amz-content-sha256"))
-	}
-}
-
-func TestS3BlobStoreGet(t *testing.T) {
-	blob := packState(1, []StateEntry{{Index: idx(0x01), Data: []byte("x")}})
-	const wantPath = "/xrpl-replay/ledger/1000.pack"
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.HasPrefix(r.Header.Get("Authorization"), "AWS4-HMAC-SHA256 ") {
-			t.Errorf("missing/bad Authorization header: %q", r.Header.Get("Authorization"))
+		if _, _, err := parseBlobKey(key); err == nil {
+			t.Errorf("parseBlobKey(%q) unexpectedly succeeded", key)
 		}
-		if r.Header.Get("x-amz-content-sha256") == "" {
-			t.Error("missing x-amz-content-sha256 header")
+	}
+}
+
+func TestLocalBlobStoreConfinesSymlinks(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "ledger"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "ledger", "1.pack"), []byte("ok"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := newBlobStore(blobStoreConfig{backend: "local", localRoot: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	object, err := store.open(context.Background(), "ledger/1.pack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(object)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = object.Close()
+	if string(data) != "ok" || object.size != 2 {
+		t.Fatalf("object = %q size=%d", data, object.size)
+	}
+
+	if runtime.GOOS == "windows" {
+		return
+	}
+	outside := filepath.Join(t.TempDir(), "outside.pack")
+	if err := os.WriteFile(outside, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "ledger", "2.pack")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.open(context.Background(), "ledger/2.pack"); err == nil {
+		t.Fatal("outside-root symlink accepted")
+	}
+}
+
+func TestS3ConfigValidation(t *testing.T) {
+	valid := blobStoreConfig{
+		backend: "s3", endpointURL: "https://example.com", bucket: "valid-bucket",
+		accessKey: "access", secretKey: "secret", region: "us-east-1", secure: true,
+	}
+	if _, err := validateS3Config(valid); err != nil {
+		t.Fatalf("valid config rejected: %v", err)
+	}
+	tests := []func(*blobStoreConfig){
+		func(c *blobStoreConfig) { c.endpointURL = "file:///tmp/data" },
+		func(c *blobStoreConfig) { c.endpointURL = "https://user@example.com" },
+		func(c *blobStoreConfig) { c.endpointURL = "https://example.com/path" },
+		func(c *blobStoreConfig) { c.bucket = "127.0.0.1" },
+		func(c *blobStoreConfig) { c.accessKey = "" },
+		func(c *blobStoreConfig) { c.secure = false },
+	}
+	for i, mutate := range tests {
+		cfg := valid
+		mutate(&cfg)
+		if _, err := validateS3Config(cfg); err == nil {
+			t.Errorf("invalid config %d accepted", i)
 		}
+	}
+}
+
+func TestS3BlobStoreRequiresLengthAndRejectsRedirect(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case wantPath:
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(blob)
+		case "/bucket/ledger/1.pack":
+			w.Header().Set("Location", "/bucket/ledger/2.pack")
+			w.WriteHeader(http.StatusFound)
+		case "/bucket/ledger/2.pack":
+			w.Header().Set("Transfer-Encoding", "chunked")
+			_, _ = io.WriteString(w, "data")
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
-	defer srv.Close()
-
-	store, err := newS3BlobStore(BlobStoreConfig{
-		Backend:     "s3",
-		EndpointURL: srv.URL,
-		AccessKey:   "ak",
-		SecretKey:   "sk",
-		Bucket:      "xrpl-replay",
-		Region:      "us-east-1",
+	defer server.Close()
+	store, err := newS3BlobStore(blobStoreConfig{
+		backend: "s3", endpointURL: server.URL, bucket: "bucket", accessKey: "access",
+		secretKey: "secret", region: "us-east-1", secure: false,
 	})
 	if err != nil {
-		t.Fatalf("newS3BlobStore: %v", err)
+		t.Fatal(err)
 	}
-
-	got, err := store.get(context.Background(), "ledger/1000.pack")
-	if err != nil {
-		t.Fatalf("get: %v", err)
+	defer store.Close()
+	if _, err := store.open(context.Background(), "ledger/1.pack"); err == nil || !strings.Contains(err.Error(), "302") {
+		t.Fatalf("redirect error = %v", err)
 	}
-	if string(got) != string(blob) {
-		t.Errorf("get returned %d bytes, want %d", len(got), len(blob))
-	}
-
-	if _, err := store.get(context.Background(), "ledger/missing.pack"); !errors.Is(err, ErrNotFound) {
-		t.Errorf("missing key err = %v, want ErrNotFound", err)
+	if _, err := store.open(context.Background(), "ledger/2.pack"); err == nil || !strings.Contains(err.Error(), "Content-Length") {
+		t.Fatalf("missing length error = %v", err)
 	}
 }
 
-func TestS3BlobStoreGetReader(t *testing.T) {
-	entries := []StateEntry{{Index: idx(0x01), Data: []byte("x")}, {Index: idx(0xaa), Data: []byte("abc")}}
-	blob := packState(99250000, entries)
-	const wantPath = "/xrpl-replay/state/ckpt-99250000.pack"
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.HasPrefix(r.Header.Get("Authorization"), "AWS4-HMAC-SHA256 ") {
-			t.Errorf("missing/bad Authorization header: %q", r.Header.Get("Authorization"))
-		}
-		switch r.URL.Path {
-		case wantPath:
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(blob)
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer srv.Close()
-
-	store, err := newS3BlobStore(BlobStoreConfig{
-		Backend:     "s3",
-		EndpointURL: srv.URL,
-		AccessKey:   "ak",
-		SecretKey:   "sk",
-		Bucket:      "xrpl-replay",
-		Region:      "us-east-1",
-	})
-	if err != nil {
-		t.Fatalf("newS3BlobStore: %v", err)
-	}
-
-	r, err := store.getReader(context.Background(), "state/ckpt-99250000.pack")
-	if err != nil {
-		t.Fatalf("getReader: %v", err)
-	}
-	defer r.Close()
-
-	got := 0
-	seq, _, err := unpackStateStream(r, func([32]byte, []byte) error {
-		got++
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("unpackStateStream: %v", err)
-	}
-	if seq != 99250000 || got != len(entries) {
-		t.Errorf("seq=%d entries=%d, want seq=99250000 entries=%d", seq, got, len(entries))
-	}
-
-	if _, err := store.getReader(context.Background(), "state/missing.pack"); !errors.Is(err, ErrNotFound) {
-		t.Errorf("missing key err = %v, want ErrNotFound", err)
+func TestContextReadCloserCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	r := &contextReadCloser{ctx: ctx, ReadCloser: io.NopCloser(strings.NewReader("data"))}
+	if _, err := r.Read(make([]byte, 1)); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Read error = %v", err)
 	}
 }

--- a/internal/statecompare/blobstore_test.go
+++ b/internal/statecompare/blobstore_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestGetBoolEnvStrict(t *testing.T) {
@@ -22,6 +24,19 @@ func TestGetBoolEnvStrict(t *testing.T) {
 	t.Setenv("TEST_BOOL", "truthy")
 	if _, err := getBoolEnv("TEST_BOOL", false); err == nil {
 		t.Fatal("invalid boolean accepted")
+	}
+}
+
+func TestIdleReadConnTimesOutStalledReads(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	conn := &idleReadConn{Conn: client, timeout: 20 * time.Millisecond}
+	_, err := conn.Read(make([]byte, 1))
+	var netErr net.Error
+	if !errors.As(err, &netErr) || !netErr.Timeout() {
+		t.Fatalf("Read error = %v, want timeout", err)
 	}
 }
 

--- a/internal/statecompare/client.go
+++ b/internal/statecompare/client.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/crypto/sha512half"
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	txcodec "github.com/LeJamon/go-xrpl/internal/tx"
@@ -107,13 +108,8 @@ func manifestDSNFromEnv() (string, error) {
 	cfg.Port = port
 	cfg.Database = getEnvOrDefault("POSTGRES_DB", "xrpl_state")
 	cfg.Username = getEnvOrDefault("POSTGRES_USER", "postgres")
-	cfg.Password = os.Getenv("POSTGRES_PASSWORD")
+	cfg.Password = getEnvOrDefault("POSTGRES_PASSWORD", "postgres")
 	cfg.SSLMode = getEnvOrDefault("POSTGRES_SSLMODE", "disable")
-	switch cfg.SSLMode {
-	case "disable", "require", "verify-ca", "verify-full":
-	default:
-		return "", fmt.Errorf("invalid POSTGRES_SSLMODE %q", cfg.SSLMode)
-	}
 	if err := cfg.Validate(); err != nil {
 		return "", fmt.Errorf("invalid manifest database configuration: %w", err)
 	}
@@ -209,7 +205,7 @@ func (c *Client) Transactions(ctx context.Context, snapshot *LedgerSnapshot) ([]
 	if err != nil {
 		return nil, err
 	}
-	record, err := pack.readLedgerAt(int(snapshot.blobOffset), snapshot.TransactionCount)
+	record, err := pack.readLedgerAtContext(ctx, int(snapshot.blobOffset), snapshot.TransactionCount)
 	if err != nil {
 		return nil, fmt.Errorf("decoding ledger pack %q at offset %d: %w", snapshot.blobKey, snapshot.blobOffset, err)
 	}
@@ -219,7 +215,7 @@ func (c *Client) Transactions(ctx context.Context, snapshot *LedgerSnapshot) ([]
 	if err := validateLedgerHeader(record.headerBlob, snapshot); err != nil {
 		return nil, fmt.Errorf("ledger %d header: %w", snapshot.LedgerIndex, err)
 	}
-	return validateTransactions(record.txs, snapshot)
+	return validateTransactions(ctx, record.txs, snapshot)
 }
 
 func (c *Client) ledgerPack(ctx context.Context, key string) (*ledgerPack, error) {
@@ -255,7 +251,7 @@ func (c *Client) ledgerPack(ctx context.Context, key string) (*ledgerPack, error
 	if int64(len(data)) != object.size {
 		return nil, fmt.Errorf("ledger pack %q size changed while reading: got %d, want %d", key, len(data), object.size)
 	}
-	pack, err := indexLedgerPack(data)
+	pack, err := indexLedgerPackContext(ctx, data)
 	if err != nil {
 		return nil, fmt.Errorf("indexing ledger pack %q: %w", key, err)
 	}
@@ -300,7 +296,7 @@ func validateLedgerHeader(raw []byte, snapshot *LedgerSnapshot) error {
 	return nil
 }
 
-func validateTransactions(records []txRecord, snapshot *LedgerSnapshot) ([]Transaction, error) {
+func validateTransactions(ctx context.Context, records []txRecord, snapshot *LedgerSnapshot) ([]Transaction, error) {
 	if uint64(len(records)) != uint64(snapshot.TransactionCount) {
 		return nil, fmt.Errorf("ledger %d contains %d transactions, manifest declares %d", snapshot.LedgerIndex, len(records), snapshot.TransactionCount)
 	}
@@ -309,6 +305,15 @@ func validateTransactions(records []txRecord, snapshot *LedgerSnapshot) ([]Trans
 	seenIndices := make([]bool, len(records))
 	tree := shamap.New(shamap.TypeTransaction)
 	for _, record := range records {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := validateCanonicalObject(record.txBlob); err != nil {
+			return nil, fmt.Errorf("ledger %d transaction %x is not canonical: %w", snapshot.LedgerIndex, record.txHash, err)
+		}
+		if err := validateCanonicalObject(record.metaBlob); err != nil {
+			return nil, fmt.Errorf("ledger %d metadata for transaction %x is not canonical: %w", snapshot.LedgerIndex, record.txHash, err)
+		}
 		calculated := sha512half.Sum(protocol.HashPrefixTransactionID().Bytes(), record.txBlob)
 		if calculated != record.txHash {
 			return nil, fmt.Errorf("ledger %d transaction hash does not match blob", snapshot.LedgerIndex)
@@ -356,6 +361,21 @@ func validateTransactions(records []txRecord, snapshot *LedgerSnapshot) ([]Trans
 		return nil, fmt.Errorf("ledger %d transaction tree root does not match manifest", snapshot.LedgerIndex)
 	}
 	return ordered, nil
+}
+
+func validateCanonicalObject(blob []byte) error {
+	decoded, err := binarycodec.DecodeBytes(blob)
+	if err != nil {
+		return err
+	}
+	canonical, err := binarycodec.EncodeBytesTrusted(decoded)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(blob, canonical) {
+		return errors.New("non-canonical binary object")
+	}
+	return nil
 }
 
 func (c *Client) ValidateRange(ctx context.Context, from, to uint32) (bool, uint32, error) {

--- a/internal/statecompare/client.go
+++ b/internal/statecompare/client.go
@@ -1,60 +1,37 @@
-// Package statecompare provides a client for reading mainnet ledgers from the
-// xrpl-state-compare lab's data plane, used by the offline replay tooling to
-// load seed state and transactions rather than reading fixture files.
-//
-// The lab keeps a small relational manifest in PostgreSQL — the queryable
-// index — while the bulk immutable bytes live in object storage (MinIO/S3) as
-// length-prefixed "packs" (see pack.go). A ledger header row points at one
-// ledger inside a batch pack via (blob_key, blob_offset); a checkpoint row
-// points at the full state of a checkpoint ledger.
+// Package statecompare reads replay manifests and immutable pack objects from
+// the xrpl-state-compare data plane.
 package statecompare
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
-	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"os"
-	"sort"
+	"strconv"
 	"sync"
 	"time"
 
-	"github.com/LeJamon/go-xrpl/codec/binarycodec"
-	_ "github.com/lib/pq" // PostgreSQL driver
+	"github.com/LeJamon/go-xrpl/crypto/sha512half"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	txcodec "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/protocol"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/LeJamon/go-xrpl/storage/relationaldb"
+	_ "github.com/lib/pq"
 )
 
-// ErrNotFound is returned (wrapped) when a requested ledger, checkpoint or
-// blob is absent, so callers can distinguish a missing record from a query
-// failure with errors.Is.
-var ErrNotFound = errors.New("statecompare: ledger not found")
-
-// Client reads from the lab's PostgreSQL manifest plus its blob store.
 type Client struct {
-	db    *sql.DB
-	blobs blobStore
+	manifest manifestStore
+	blobs    blobStore
 
-	// The replay loop walks a ledger-batch pack sequentially, so memoizing the
-	// most recently fetched pack object turns ~1000 redundant downloads of the
-	// same object into one.
 	mu        sync.Mutex
 	cacheKey  string
-	cacheData []byte
+	cachePack *ledgerPack
 }
 
-// toHash32 copies a database hash column into a fixed 32-byte array,
-// erroring on a malformed length instead of silently zero-padding or
-// truncating.
-func toHash32(b []byte) ([32]byte, error) {
-	var h [32]byte
-	if len(b) != len(h) {
-		return h, fmt.Errorf("expected %d-byte hash, got %d bytes", len(h), len(b))
-	}
-	copy(h[:], b)
-	return h, nil
-}
-
-// LedgerSnapshot is a ledger's header row from the manifest.
 type LedgerSnapshot struct {
 	LedgerIndex         uint32
 	LedgerHash          [32]byte
@@ -65,50 +42,86 @@ type LedgerSnapshot struct {
 	CloseTime           int64
 	CloseTimeResolution uint32
 	CloseFlags          uint8
+	TransactionCount    uint32
+
+	blobKey    string
+	blobOffset int64
+	hasBlob    bool
 }
 
-// StateEntry is one serialized ledger entry (SLE) of a checkpoint ledger.
 type StateEntry struct {
 	Index [32]byte
 	Data  []byte
 }
 
-// Transaction is one applied transaction and its metadata.
 type Transaction struct {
-	// TxIndex is sfTransactionIndex from the metadata: the position the
-	// transaction was applied at ledger close. GetTransactions returns the
-	// slice sorted ascending by it so a single forward replay pass matches
-	// mainnet's apply order.
-	TxIndex  int
+	TxIndex  uint32
 	TxHash   [32]byte
 	TxBlob   []byte
 	MetaBlob []byte
 }
 
-// Config holds the PostgreSQL manifest connection settings.
-type Config struct {
-	Host     string
-	Port     string
-	Database string
-	User     string
-	Password string
-	// SSLMode controls libpq sslmode. Defaults to "disable" via ConfigFromEnv
-	// to match local-dev setups; production deployments should set this to
-	// "require" or higher via POSTGRES_SSLMODE.
-	SSLMode string
+func toHash32(value []byte) ([32]byte, error) {
+	if len(value) != 32 {
+		return [32]byte{}, fmt.Errorf("invalid hash length %d", len(value))
+	}
+	var hash [32]byte
+	copy(hash[:], value)
+	return hash, nil
 }
 
-// ConfigFromEnv creates a Config from environment variables.
-// Uses the same env vars as the Python xrpl-state-compare tool.
-func ConfigFromEnv() Config {
-	return Config{
-		Host:     getEnvOrDefault("POSTGRES_HOST", "localhost"),
-		Port:     getEnvOrDefault("POSTGRES_PORT", "5432"),
-		Database: getEnvOrDefault("POSTGRES_DB", "xrpl_state"),
-		User:     getEnvOrDefault("POSTGRES_USER", "postgres"),
-		Password: getEnvOrDefault("POSTGRES_PASSWORD", "postgres"),
-		SSLMode:  getEnvOrDefault("POSTGRES_SSLMODE", "disable"),
+func NewClientFromEnv(ctx context.Context) (*Client, error) {
+	blobConfig, err := blobStoreConfigFromEnv()
+	if err != nil {
+		return nil, err
 	}
+	dsn, err := manifestDSNFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("opening manifest database: %w", err)
+	}
+	connectCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := db.PingContext(connectCtx); err != nil {
+		return nil, errors.Join(fmt.Errorf("connecting to manifest database: %w", err), db.Close())
+	}
+
+	blobs, err := newBlobStore(blobConfig)
+	if err != nil {
+		return nil, errors.Join(fmt.Errorf("initializing blob store: %w", err), db.Close())
+	}
+	return newClient(newSQLManifest(db), blobs), nil
+}
+
+func manifestDSNFromEnv() (string, error) {
+	port, err := strconv.Atoi(getEnvOrDefault("POSTGRES_PORT", "5432"))
+	if err != nil {
+		return "", fmt.Errorf("POSTGRES_PORT: %w", err)
+	}
+	cfg := relationaldb.NewConfig()
+	cfg.Host = getEnvOrDefault("POSTGRES_HOST", "localhost")
+	cfg.Port = port
+	cfg.Database = getEnvOrDefault("POSTGRES_DB", "xrpl_state")
+	cfg.Username = getEnvOrDefault("POSTGRES_USER", "postgres")
+	cfg.Password = os.Getenv("POSTGRES_PASSWORD")
+	cfg.SSLMode = getEnvOrDefault("POSTGRES_SSLMODE", "disable")
+	switch cfg.SSLMode {
+	case "disable", "require", "verify-ca", "verify-full":
+	default:
+		return "", fmt.Errorf("invalid POSTGRES_SSLMODE %q", cfg.SSLMode)
+	}
+	if err := cfg.Validate(); err != nil {
+		return "", fmt.Errorf("invalid manifest database configuration: %w", err)
+	}
+	dsn, err := cfg.BuildConnectionString()
+	if err != nil {
+		return "", fmt.Errorf("building manifest database connection string: %w", err)
+	}
+	return dsn, nil
 }
 
 func getEnvOrDefault(key, defaultValue string) string {
@@ -118,314 +131,233 @@ func getEnvOrDefault(key, defaultValue string) string {
 	return defaultValue
 }
 
-// NewClient creates a client from the manifest and blob-store configs.
-func NewClient(cfg Config, blobCfg BlobStoreConfig) (*Client, error) {
-	sslMode := cfg.SSLMode
-	if sslMode == "" {
-		sslMode = "disable"
-	}
-	connStr := fmt.Sprintf(
-		"host=%s port=%s dbname=%s user=%s password=%s sslmode=%s",
-		cfg.Host, cfg.Port, cfg.Database, cfg.User, cfg.Password, sslMode,
-	)
-
-	db, err := sql.Open("postgres", connStr)
-	if err != nil {
-		return nil, fmt.Errorf("opening database: %w", err)
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	if err := db.PingContext(ctx); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("connecting to database: %w", err)
-	}
-
-	blobs, err := newBlobStore(blobCfg)
-	if err != nil {
-		db.Close()
-		return nil, fmt.Errorf("initializing blob store: %w", err)
-	}
-
-	return &Client{db: db, blobs: blobs}, nil
+func newClient(manifest manifestStore, blobs blobStore) *Client {
+	return &Client{manifest: manifest, blobs: blobs}
 }
 
-// NewClientFromEnv creates a client using environment variables.
-func NewClientFromEnv() (*Client, error) {
-	return NewClient(ConfigFromEnv(), BlobStoreConfigFromEnv())
-}
-
-// Close closes the database connection.
 func (c *Client) Close() error {
-	return c.db.Close()
+	return errors.Join(c.manifest.Close(), c.blobs.Close())
 }
 
-// fetchBlob returns a pack object's bytes, memoizing the most recent one. The
-// returned slice is shared and must not be mutated by callers.
-func (c *Client) fetchBlob(ctx context.Context, key string) ([]byte, error) {
+func (c *Client) Snapshot(ctx context.Context, seq uint32) (*LedgerSnapshot, error) {
+	return c.manifest.snapshot(ctx, seq)
+}
+
+func (c *Client) StreamStateEntries(
+	ctx context.Context,
+	snapshot *LedgerSnapshot,
+	fn func(StateEntry) error,
+) (retErr error) {
+	if snapshot == nil {
+		return errors.New("statecompare: nil checkpoint snapshot")
+	}
+	if fn == nil {
+		return errors.New("statecompare: state callback is nil")
+	}
+	checkpoint, err := c.manifest.checkpoint(ctx, snapshot.LedgerIndex)
+	if err != nil {
+		return err
+	}
+	if checkpoint.accountHash != snapshot.AccountHash {
+		return fmt.Errorf("checkpoint %d account hash does not match ledger manifest", snapshot.LedgerIndex)
+	}
+	kind, keySeq, err := parseBlobKey(checkpoint.blobKey)
+	if err != nil {
+		return fmt.Errorf("checkpoint %d blob key: %w", snapshot.LedgerIndex, err)
+	}
+	if kind != kindState || keySeq != snapshot.LedgerIndex {
+		return fmt.Errorf("checkpoint %d has mismatched blob key %q", snapshot.LedgerIndex, checkpoint.blobKey)
+	}
+
+	object, err := c.blobs.open(ctx, checkpoint.blobKey)
+	if err != nil {
+		return fmt.Errorf("opening state pack %q: %w", checkpoint.blobKey, err)
+	}
+	defer func() { retErr = errors.Join(retErr, object.Close()) }()
+	if object.size != checkpoint.sizeBytes {
+		return fmt.Errorf("state pack %q size is %d, manifest declares %d", checkpoint.blobKey, object.size, checkpoint.sizeBytes)
+	}
+	expected := statePackExpectation{
+		seq:   snapshot.LedgerIndex,
+		count: checkpoint.objectCount,
+		size:  checkpoint.sizeBytes,
+	}
+	if err := unpackStateStream(ctx, object, expected, func(index [32]byte, data []byte) error {
+		return fn(StateEntry{Index: index, Data: data})
+	}); err != nil {
+		return fmt.Errorf("decoding state pack %q: %w", checkpoint.blobKey, err)
+	}
+	return nil
+}
+
+func (c *Client) Transactions(ctx context.Context, snapshot *LedgerSnapshot) ([]Transaction, error) {
+	if snapshot == nil {
+		return nil, errors.New("statecompare: nil ledger snapshot")
+	}
+	if !snapshot.hasBlob {
+		return nil, fmt.Errorf("ledger %d has no transaction blob: %w", snapshot.LedgerIndex, errNotFound)
+	}
+	kind, _, err := parseBlobKey(snapshot.blobKey)
+	if err != nil {
+		return nil, fmt.Errorf("ledger %d blob key: %w", snapshot.LedgerIndex, err)
+	}
+	if kind != kindLedger {
+		return nil, fmt.Errorf("ledger %d has non-ledger blob key %q", snapshot.LedgerIndex, snapshot.blobKey)
+	}
+
+	pack, err := c.ledgerPack(ctx, snapshot.blobKey)
+	if err != nil {
+		return nil, err
+	}
+	record, err := pack.readLedgerAt(int(snapshot.blobOffset), snapshot.TransactionCount)
+	if err != nil {
+		return nil, fmt.Errorf("decoding ledger pack %q at offset %d: %w", snapshot.blobKey, snapshot.blobOffset, err)
+	}
+	if record.seq != snapshot.LedgerIndex {
+		return nil, fmt.Errorf("ledger pack %q offset %d holds ledger %d, want %d", snapshot.blobKey, snapshot.blobOffset, record.seq, snapshot.LedgerIndex)
+	}
+	if err := validateLedgerHeader(record.headerBlob, snapshot); err != nil {
+		return nil, fmt.Errorf("ledger %d header: %w", snapshot.LedgerIndex, err)
+	}
+	return validateTransactions(record.txs, snapshot)
+}
+
+func (c *Client) ledgerPack(ctx context.Context, key string) (*ledgerPack, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	c.mu.Lock()
-	if key == c.cacheKey && c.cacheData != nil {
-		data := c.cacheData
+	if key == c.cacheKey && c.cachePack != nil {
+		pack := c.cachePack
 		c.mu.Unlock()
-		return data, nil
+		return pack, nil
 	}
 	c.mu.Unlock()
 
-	data, err := c.blobs.get(ctx, key)
+	object, err := c.blobs.open(ctx, key)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("opening ledger pack %q: %w", key, err)
+	}
+	if object.size < packEnvelopeLen || object.size > maxLedgerPackBytes {
+		return nil, errors.Join(
+			fmt.Errorf("ledger pack %q size %d is outside [%d,%d]", key, object.size, packEnvelopeLen, maxLedgerPackBytes),
+			object.Close(),
+		)
+	}
+	data, readErr := io.ReadAll(io.LimitReader(object, object.size+1))
+	closeErr := object.Close()
+	if readErr != nil || closeErr != nil {
+		if readErr != nil {
+			readErr = fmt.Errorf("reading ledger pack %q: %w", key, readErr)
+		}
+		return nil, errors.Join(readErr, closeErr)
+	}
+	if int64(len(data)) != object.size {
+		return nil, fmt.Errorf("ledger pack %q size changed while reading: got %d, want %d", key, len(data), object.size)
+	}
+	pack, err := indexLedgerPack(data)
+	if err != nil {
+		return nil, fmt.Errorf("indexing ledger pack %q: %w", key, err)
+	}
+	_, keySeq, _ := parseBlobKey(key)
+	if pack.batchStart != keySeq {
+		return nil, fmt.Errorf("ledger pack %q declares batch start %d", key, pack.batchStart)
 	}
 
 	c.mu.Lock()
 	c.cacheKey = key
-	c.cacheData = data
+	c.cachePack = pack
 	c.mu.Unlock()
-	return data, nil
+	return pack, nil
 }
 
-// Snapshot retrieves a ledger header from the manifest by sequence number.
-func (c *Client) Snapshot(ctx context.Context, seq uint32) (*LedgerSnapshot, error) {
-	const query = `
-		SELECT seq, ledger_hash, parent_hash, account_hash, transaction_hash,
-		       total_coins, close_time, close_time_resolution, close_flags
-		FROM ledgers
-		WHERE seq = $1
-	`
-
-	var snapshot LedgerSnapshot
-	var ledgerHash, parentHash, accountHash, txHash []byte
-
-	err := c.db.QueryRowContext(ctx, query, seq).Scan(
-		&snapshot.LedgerIndex,
-		&ledgerHash,
-		&parentHash,
-		&accountHash,
-		&txHash,
-		&snapshot.TotalCoins,
-		&snapshot.CloseTime,
-		&snapshot.CloseTimeResolution,
-		&snapshot.CloseFlags,
-	)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, fmt.Errorf("ledger %d: %w", seq, ErrNotFound)
-	}
+func validateLedgerHeader(raw []byte, snapshot *LedgerSnapshot) error {
+	parsed, err := header.DeserializeHeader(raw, false)
 	if err != nil {
-		return nil, fmt.Errorf("querying snapshot: %w", err)
+		return err
 	}
-
-	for _, h := range []struct {
-		name string
-		src  []byte
-		dst  *[32]byte
-	}{
-		{"ledger_hash", ledgerHash, &snapshot.LedgerHash},
-		{"parent_hash", parentHash, &snapshot.ParentHash},
-		{"account_hash", accountHash, &snapshot.AccountHash},
-		{"transaction_hash", txHash, &snapshot.TransactionHash},
-	} {
-		v, err := toHash32(h.src)
-		if err != nil {
-			return nil, fmt.Errorf("ledger %d %s: %w", seq, h.name, err)
-		}
-		*h.dst = v
+	if !bytes.Equal(raw, header.AddRaw(*parsed, false)) {
+		return errors.New("non-canonical raw header")
 	}
-
-	return &snapshot, nil
-}
-
-// StateEntries retrieves every SLE of a checkpoint ledger by decoding its
-// STATE pack. seq must be a checkpoint ledger; full state is captured only at
-// checkpoints, so a non-checkpoint seq returns ErrNotFound.
-func (c *Client) StateEntries(ctx context.Context, seq uint32) ([]StateEntry, error) {
-	var blobKey string
-	err := c.db.QueryRowContext(ctx,
-		`SELECT blob_key FROM checkpoints WHERE seq = $1`, seq,
-	).Scan(&blobKey)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, fmt.Errorf("checkpoint %d: %w", seq, ErrNotFound)
+	if parsed.LedgerIndex != snapshot.LedgerIndex {
+		return fmt.Errorf("sequence %d does not match manifest %d", parsed.LedgerIndex, snapshot.LedgerIndex)
 	}
-	if err != nil {
-		return nil, fmt.Errorf("querying checkpoint %d: %w", seq, err)
+	if header.CalculateHash(*parsed) != snapshot.LedgerHash {
+		return errors.New("ledger hash does not match manifest")
 	}
-
-	data, err := c.blobs.get(ctx, blobKey)
-	if err != nil {
-		return nil, fmt.Errorf("fetching state pack %q: %w", blobKey, err)
+	if parsed.ParentHash != snapshot.ParentHash || parsed.AccountHash != snapshot.AccountHash || parsed.TxHash != snapshot.TransactionHash {
+		return errors.New("header roots do not match manifest")
 	}
-	packSeq, entries, err := unpackState(data)
-	if err != nil {
-		return nil, fmt.Errorf("decoding state pack %q: %w", blobKey, err)
+	if parsed.Drops != snapshot.TotalCoins {
+		return fmt.Errorf("total coins %d does not match manifest %d", parsed.Drops, snapshot.TotalCoins)
 	}
-	if packSeq != uint64(seq) {
-		return nil, fmt.Errorf("state pack %q is for checkpoint %d, want %d", blobKey, packSeq, seq)
+	if uint64(snapshot.CloseTime) > uint64(^uint32(0)) || protocol.ToRippleTime(parsed.CloseTime) != uint32(snapshot.CloseTime) {
+		return errors.New("close time does not match manifest")
 	}
-	return entries, nil
-}
-
-// StreamStateEntries decodes a checkpoint's STATE pack on the fly, invoking fn
-// for each SLE as it is read from the blob store. Unlike GetStateEntries it
-// never materializes the whole pack or the full entry slice, so seeding a
-// multi-gigabyte mainnet checkpoint stays within a bounded memory footprint.
-// seq must be a checkpoint ledger; a non-checkpoint seq returns ErrNotFound.
-func (c *Client) StreamStateEntries(ctx context.Context, seq uint32, fn func(StateEntry) error) error {
-	var blobKey string
-	err := c.db.QueryRowContext(ctx,
-		`SELECT blob_key FROM checkpoints WHERE seq = $1`, seq,
-	).Scan(&blobKey)
-	if errors.Is(err, sql.ErrNoRows) {
-		return fmt.Errorf("checkpoint %d: %w", seq, ErrNotFound)
-	}
-	if err != nil {
-		return fmt.Errorf("querying checkpoint %d: %w", seq, err)
-	}
-
-	r, err := c.blobs.getReader(ctx, blobKey)
-	if err != nil {
-		return fmt.Errorf("fetching state pack %q: %w", blobKey, err)
-	}
-	defer r.Close()
-
-	packSeq, _, err := unpackStateStream(r, func(index [32]byte, data []byte) error {
-		return fn(StateEntry{Index: index, Data: data})
-	})
-	if err != nil {
-		return fmt.Errorf("decoding state pack %q: %w", blobKey, err)
-	}
-	if packSeq != uint64(seq) {
-		return fmt.Errorf("state pack %q is for checkpoint %d, want %d", blobKey, packSeq, seq)
+	if uint32(parsed.CloseTimeResolution) != snapshot.CloseTimeResolution || parsed.CloseFlags != snapshot.CloseFlags {
+		return errors.New("close fields do not match manifest")
 	}
 	return nil
 }
 
-// Transactions retrieves the transactions of a ledger by seeking into its
-// batch pack at the manifest-recorded offset.
-func (c *Client) Transactions(ctx context.Context, seq uint32) ([]Transaction, error) {
-	var blobKey sql.NullString
-	var blobOffset sql.NullInt64
-	err := c.db.QueryRowContext(ctx,
-		`SELECT blob_key, blob_offset FROM ledgers WHERE seq = $1`, seq,
-	).Scan(&blobKey, &blobOffset)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, fmt.Errorf("ledger %d: %w", seq, ErrNotFound)
+func validateTransactions(records []txRecord, snapshot *LedgerSnapshot) ([]Transaction, error) {
+	if uint64(len(records)) != uint64(snapshot.TransactionCount) {
+		return nil, fmt.Errorf("ledger %d contains %d transactions, manifest declares %d", snapshot.LedgerIndex, len(records), snapshot.TransactionCount)
 	}
-	if err != nil {
-		return nil, fmt.Errorf("querying ledger %d: %w", seq, err)
-	}
-	if !blobKey.Valid || !blobOffset.Valid {
-		return nil, fmt.Errorf("ledger %d has no transaction blob (manifest synced without bytes): %w", seq, ErrNotFound)
-	}
-
-	data, err := c.fetchBlob(ctx, blobKey.String)
-	if err != nil {
-		return nil, fmt.Errorf("fetching ledger pack %q: %w", blobKey.String, err)
-	}
-	ledger, err := readLedgerAt(data, int(blobOffset.Int64))
-	if err != nil {
-		return nil, fmt.Errorf("decoding ledger pack %q at offset %d: %w", blobKey.String, blobOffset.Int64, err)
-	}
-	if ledger.seq != uint64(seq) {
-		return nil, fmt.Errorf("ledger pack %q offset %d holds ledger %d, want %d", blobKey.String, blobOffset.Int64, ledger.seq, seq)
-	}
-
-	txs := make([]Transaction, len(ledger.txs))
-	for i, t := range ledger.txs {
-		txs[i] = Transaction{
-			TxHash:   t.txHash,
-			TxBlob:   t.txBlob,
-			MetaBlob: t.metaBlob,
+	ordered := make([]Transaction, len(records))
+	seenHashes := make(map[[32]byte]struct{}, len(records))
+	seenIndices := make([]bool, len(records))
+	tree := shamap.New(shamap.TypeTransaction)
+	for _, record := range records {
+		calculated := sha512half.Sum(protocol.HashPrefixTransactionID().Bytes(), record.txBlob)
+		if calculated != record.txHash {
+			return nil, fmt.Errorf("ledger %d transaction hash does not match blob", snapshot.LedgerIndex)
 		}
-	}
-	if err := orderByTransactionIndex(txs); err != nil {
-		return nil, fmt.Errorf("ordering ledger %d transactions: %w", seq, err)
-	}
-	return txs, nil
-}
+		if _, exists := seenHashes[record.txHash]; exists {
+			return nil, fmt.Errorf("ledger %d contains duplicate transaction %x", snapshot.LedgerIndex, record.txHash)
+		}
+		seenHashes[record.txHash] = struct{}{}
+		index, ok := txcodec.TransactionIndexFromMetadata(record.metaBlob)
+		if !ok {
+			return nil, fmt.Errorf("ledger %d transaction %x has invalid TransactionIndex", snapshot.LedgerIndex, record.txHash)
+		}
+		if uint64(index) >= uint64(len(records)) || seenIndices[index] {
+			return nil, fmt.Errorf("ledger %d transaction %x has duplicate or out-of-range TransactionIndex %d", snapshot.LedgerIndex, record.txHash, index)
+		}
+		seenIndices[index] = true
 
-// orderByTransactionIndex sets each transaction's TxIndex from its metadata's
-// sfTransactionIndex and sorts the slice into that order. A pack stores
-// transactions in transaction-tree (hash) order; replaying them in that order
-// applies an account's transactions out of sequence, so all but the lowest in-
-// order one fail terPRE_SEQ and are dropped. sfTransactionIndex is the order in
-// which the ledger close actually applied them, so a single forward pass over it
-// reproduces mainnet — this mirrors rippled's replay build path, which applies
-// the close-ordered tx set rather than re-running consensus's multi-pass retry.
-func orderByTransactionIndex(txs []Transaction) error {
-	for i := range txs {
-		idx, err := metaTransactionIndex(txs[i].MetaBlob)
+		vlTx, err := txcodec.EncodeWithVL(record.txBlob)
 		if err != nil {
-			return fmt.Errorf("tx %x: %w", txs[i].TxHash, err)
+			return nil, fmt.Errorf("encoding transaction %x: %w", record.txHash, err)
 		}
-		txs[i].TxIndex = int(idx)
+		vlMeta, err := txcodec.EncodeWithVL(record.metaBlob)
+		if err != nil {
+			return nil, fmt.Errorf("encoding metadata for transaction %x: %w", record.txHash, err)
+		}
+		leaf := append(vlTx, vlMeta...)
+		if err := tree.PutWithNodeType(record.txHash, leaf, shamap.NodeTypeTransactionWithMeta); err != nil {
+			return nil, fmt.Errorf("building ledger %d transaction tree: %w", snapshot.LedgerIndex, err)
+		}
+		ordered[index] = Transaction{
+			TxIndex:  index,
+			TxHash:   record.txHash,
+			TxBlob:   bytes.Clone(record.txBlob),
+			MetaBlob: bytes.Clone(record.metaBlob),
+		}
 	}
-	sort.SliceStable(txs, func(i, j int) bool { return txs[i].TxIndex < txs[j].TxIndex })
-	return nil
-}
-
-// metaTransactionIndex decodes a transaction metadata blob and returns its
-// sfTransactionIndex value.
-func metaTransactionIndex(meta []byte) (uint32, error) {
-	if len(meta) == 0 {
-		return 0, errors.New("empty metadata")
+	if err := tree.SetImmutable(); err != nil {
+		return nil, fmt.Errorf("finalizing ledger %d transaction tree: %w", snapshot.LedgerIndex, err)
 	}
-	decoded, err := binarycodec.Decode(hex.EncodeToString(meta))
+	root, err := tree.Hash()
 	if err != nil {
-		return 0, fmt.Errorf("decode metadata: %w", err)
+		return nil, fmt.Errorf("hashing ledger %d transaction tree: %w", snapshot.LedgerIndex, err)
 	}
-	raw, ok := decoded["TransactionIndex"]
-	if !ok {
-		return 0, errors.New("metadata missing TransactionIndex")
+	if root != snapshot.TransactionHash {
+		return nil, fmt.Errorf("ledger %d transaction tree root does not match manifest", snapshot.LedgerIndex)
 	}
-	switch v := raw.(type) {
-	case uint32:
-		return v, nil
-	case int:
-		return uint32(v), nil
-	case int64:
-		return uint32(v), nil
-	case uint64:
-		return uint32(v), nil
-	case float64:
-		return uint32(v), nil
-	default:
-		return 0, fmt.Errorf("metadata TransactionIndex has unexpected type %T", raw)
-	}
+	return ordered, nil
 }
 
-// ValidateRange checks that every ledger in [from, to] is present in the
-// manifest, returning the first missing sequence if any.
-//
-// Implemented as a single range query rather than N round-trips so validating
-// a multi-thousand-ledger range stays cheap.
 func (c *Client) ValidateRange(ctx context.Context, from, to uint32) (bool, uint32, error) {
-	if from > to {
-		return true, 0, nil
-	}
-	rows, err := c.db.QueryContext(ctx,
-		`SELECT seq FROM ledgers
-		 WHERE seq BETWEEN $1 AND $2
-		 ORDER BY seq`,
-		from, to,
-	)
-	if err != nil {
-		return false, from, fmt.Errorf("querying ledger range: %w", err)
-	}
-	defer rows.Close()
-
-	expected := from
-	for rows.Next() {
-		var idx uint32
-		if err := rows.Scan(&idx); err != nil {
-			return false, expected, fmt.Errorf("scanning ledger seq: %w", err)
-		}
-		if idx != expected {
-			return false, expected, nil
-		}
-		expected++
-	}
-	if err := rows.Err(); err != nil {
-		return false, expected, fmt.Errorf("iterating ledger range: %w", err)
-	}
-	if expected <= to {
-		return false, expected, nil
-	}
-	return true, 0, nil
+	return c.manifest.validateRange(ctx, from, to)
 }

--- a/internal/statecompare/client_test.go
+++ b/internal/statecompare/client_test.go
@@ -1,173 +1,384 @@
 package statecompare
 
 import (
+	"bytes"
 	"context"
-	"encoding/hex"
+	"database/sql"
+	"encoding/binary"
+	"errors"
+	"io"
+	"math"
+	"net/url"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/crypto/sha512half"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	txcodec "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/protocol"
+	"github.com/LeJamon/go-xrpl/shamap"
 )
 
-func TestGetEnvOrDefault(t *testing.T) {
-	const key = "STATECOMPARE_TEST_GETENV"
-	const def = "fallback"
-
-	t.Run("unset returns default", func(t *testing.T) {
-		if got := getEnvOrDefault(key, def); got != def {
-			t.Errorf("getEnvOrDefault(unset) = %q, want %q", got, def)
-		}
-	})
-
-	t.Run("empty returns default", func(t *testing.T) {
-		t.Setenv(key, "")
-		if got := getEnvOrDefault(key, def); got != def {
-			t.Errorf("getEnvOrDefault(empty) = %q, want %q", got, def)
-		}
-	})
-
-	t.Run("set returns value", func(t *testing.T) {
-		t.Setenv(key, "custom")
-		if got := getEnvOrDefault(key, def); got != "custom" {
-			t.Errorf("getEnvOrDefault(set) = %q, want %q", got, "custom")
-		}
-	})
+type fakeManifest struct {
+	snap           *LedgerSnapshot
+	checkpointData checkpointManifest
+	err            error
 }
 
-func TestConfigFromEnvDefaults(t *testing.T) {
-	// getEnvOrDefault treats an empty value the same as unset, so clearing each
-	// var exercises the default branch while letting t.Setenv restore the
-	// caller's environment afterwards.
-	for _, k := range []string{
-		"POSTGRES_HOST", "POSTGRES_PORT", "POSTGRES_DB",
-		"POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_SSLMODE",
-	} {
-		t.Setenv(k, "")
-	}
+func (f *fakeManifest) snapshot(context.Context, uint32) (*LedgerSnapshot, error) {
+	return f.snap, f.err
+}
+func (f *fakeManifest) checkpoint(context.Context, uint32) (checkpointManifest, error) {
+	return f.checkpointData, f.err
+}
+func (f *fakeManifest) validateRange(context.Context, uint32, uint32) (bool, uint32, error) {
+	return true, 0, f.err
+}
+func (f *fakeManifest) Close() error { return nil }
 
-	want := Config{
-		Host:     "localhost",
-		Port:     "5432",
-		Database: "xrpl_state",
-		User:     "postgres",
-		Password: "postgres",
-		SSLMode:  "disable",
-	}
-	if got := ConfigFromEnv(); got != want {
-		t.Errorf("ConfigFromEnv() = %+v, want %+v", got, want)
-	}
+type memoryBlobStore struct {
+	objects map[string][]byte
+	opens   int
 }
 
-func TestConfigFromEnvOverrides(t *testing.T) {
-	t.Setenv("POSTGRES_HOST", "db.example.com")
-	t.Setenv("POSTGRES_PORT", "6543")
-	t.Setenv("POSTGRES_DB", "ledgers")
-	t.Setenv("POSTGRES_USER", "alice")
-	t.Setenv("POSTGRES_PASSWORD", "s3cret")
-	t.Setenv("POSTGRES_SSLMODE", "require")
-
-	want := Config{
-		Host:     "db.example.com",
-		Port:     "6543",
-		Database: "ledgers",
-		User:     "alice",
-		Password: "s3cret",
-		SSLMode:  "require",
+func (s *memoryBlobStore) open(ctx context.Context, key string) (*blobObject, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
-	if got := ConfigFromEnv(); got != want {
-		t.Errorf("ConfigFromEnv() = %+v, want %+v", got, want)
-	}
-}
-
-func TestValidateRangeFromGreaterThanTo(t *testing.T) {
-	// from > to is a degenerate (empty) range: it returns early before any DB
-	// access, so a Client with a nil *sql.DB is sufficient and must not panic.
-	c := &Client{}
-	ok, missing, err := c.ValidateRange(context.Background(), 10, 5)
-	if err != nil {
-		t.Fatalf("ValidateRange returned error: %v", err)
-	}
+	s.opens++
+	data, ok := s.objects[key]
 	if !ok {
-		t.Errorf("ValidateRange(10, 5) ok = false, want true for an empty range")
+		return nil, errNotFound
 	}
-	if missing != 0 {
-		t.Errorf("ValidateRange(10, 5) missing = %d, want 0", missing)
-	}
+	return &blobObject{ReadCloser: io.NopCloser(bytes.NewReader(data)), size: int64(len(data))}, nil
 }
+func (s *memoryBlobStore) Close() error { return nil }
 
-// testMetaBlob serializes a minimal metadata STObject carrying the given
-// sfTransactionIndex, the way the engine writes it at ledger close.
-func testMetaBlob(t *testing.T, txIndex uint32) []byte {
+func encodeMeta(t *testing.T, index uint32) []byte {
 	t.Helper()
-	hexStr, err := binarycodec.Encode(map[string]any{
-		"TransactionResult": "tesSUCCESS",
-		"TransactionIndex":  txIndex,
-	})
+	data, err := binarycodec.EncodeBytes(map[string]any{"TransactionIndex": index})
 	if err != nil {
 		t.Fatalf("encode metadata: %v", err)
 	}
-	b, err := hex.DecodeString(hexStr)
-	if err != nil {
-		t.Fatalf("decode hex: %v", err)
-	}
-	return b
+	return data
 }
 
-func TestMetaTransactionIndex(t *testing.T) {
-	for _, want := range []uint32{0, 1, 5, 60, 1000} {
-		got, err := metaTransactionIndex(testMetaBlob(t, want))
+func makeTransactions(t *testing.T, indices ...uint32) []txRecord {
+	t.Helper()
+	records := make([]txRecord, len(indices))
+	for i, index := range indices {
+		blob := bytes.Repeat([]byte{byte(i + 1)}, minTransactionBytes)
+		records[i] = txRecord{
+			txHash:   sha512half.Sum(protocol.HashPrefixTransactionID().Bytes(), blob),
+			txBlob:   blob,
+			metaBlob: encodeMeta(t, index),
+		}
+	}
+	return records
+}
+
+func transactionRoot(t *testing.T, records []txRecord) [32]byte {
+	t.Helper()
+	tree := shamap.New(shamap.TypeTransaction)
+	for _, record := range records {
+		txVL, err := txcodec.EncodeWithVL(record.txBlob)
 		if err != nil {
-			t.Fatalf("metaTransactionIndex(%d): %v", want, err)
+			t.Fatal(err)
 		}
-		if got != want {
-			t.Errorf("metaTransactionIndex = %d, want %d", got, want)
+		metaVL, err := txcodec.EncodeWithVL(record.metaBlob)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := tree.PutWithNodeType(record.txHash, append(txVL, metaVL...), shamap.NodeTypeTransactionWithMeta); err != nil {
+			t.Fatal(err)
 		}
 	}
-}
-
-func TestMetaTransactionIndexErrors(t *testing.T) {
-	if _, err := metaTransactionIndex(nil); err == nil {
-		t.Error("empty metadata: want error, got nil")
-	}
-	hexStr, err := binarycodec.Encode(map[string]any{"TransactionResult": "tesSUCCESS"})
+	root, err := tree.Hash()
 	if err != nil {
-		t.Fatalf("encode: %v", err)
+		t.Fatal(err)
 	}
-	noIdx, err := hex.DecodeString(hexStr)
+	return root
+}
+
+func ledgerFixture(t *testing.T) (*LedgerSnapshot, []byte) {
+	t.Helper()
+	const seq = uint32(25)
+	records := makeTransactions(t, 1, 0)
+	txRoot := transactionRoot(t, records)
+	ledgerHeader := header.LedgerHeader{
+		LedgerIndex:         seq,
+		ParentHash:          [32]byte{1},
+		TxHash:              txRoot,
+		AccountHash:         [32]byte{2},
+		Drops:               99,
+		ParentCloseTime:     protocol.FromRippleTime(100),
+		CloseTime:           protocol.FromRippleTime(110),
+		CloseTimeResolution: 10,
+		CloseFlags:          1,
+	}
+	snapshot := &LedgerSnapshot{
+		LedgerIndex:         seq,
+		LedgerHash:          header.CalculateHash(ledgerHeader),
+		ParentHash:          ledgerHeader.ParentHash,
+		AccountHash:         ledgerHeader.AccountHash,
+		TransactionHash:     txRoot,
+		TotalCoins:          ledgerHeader.Drops,
+		CloseTime:           110,
+		CloseTimeResolution: 10,
+		CloseFlags:          1,
+		TransactionCount:    uint32(len(records)),
+		blobKey:             "ledger/25.pack",
+		blobOffset:          packEnvelopeLen,
+		hasBlob:             true,
+	}
+	return snapshot, encodeLedgerPack(seq, []ledgerBlob{{seq: seq, headerBlob: header.AddRaw(ledgerHeader, false), txs: records}})
+}
+
+func encodeLedgerPack(start uint32, ledgers []ledgerBlob) []byte {
+	var out bytes.Buffer
+	out.WriteString(packMagic)
+	out.WriteByte(packVersion)
+	out.WriteByte(kindLedger)
+	_ = binary.Write(&out, binary.BigEndian, uint64(start))
+	_ = binary.Write(&out, binary.BigEndian, uint32(len(ledgers)))
+	for _, ledger := range ledgers {
+		_ = binary.Write(&out, binary.BigEndian, uint64(ledger.seq))
+		writeSized(&out, ledger.headerBlob)
+		_ = binary.Write(&out, binary.BigEndian, uint32(len(ledger.txs)))
+		for _, record := range ledger.txs {
+			out.Write(record.txHash[:])
+			writeSized(&out, record.txBlob)
+			writeSized(&out, record.metaBlob)
+		}
+	}
+	return out.Bytes()
+}
+
+func writeSized(out *bytes.Buffer, data []byte) {
+	_ = binary.Write(out, binary.BigEndian, uint32(len(data)))
+	out.Write(data)
+}
+
+func TestTransactionsValidatesAndOrders(t *testing.T) {
+	snapshot, pack := ledgerFixture(t)
+	blobs := &memoryBlobStore{objects: map[string][]byte{snapshot.blobKey: pack}}
+	client := newClient(&fakeManifest{}, blobs)
+
+	txs, err := client.Transactions(context.Background(), snapshot)
 	if err != nil {
-		t.Fatalf("decode hex: %v", err)
+		t.Fatalf("Transactions: %v", err)
 	}
-	if _, err := metaTransactionIndex(noIdx); err == nil {
-		t.Error("metadata missing TransactionIndex: want error, got nil")
+	if len(txs) != 2 || txs[0].TxIndex != 0 || txs[1].TxIndex != 1 {
+		t.Fatalf("unexpected transaction order: %+v", txs)
 	}
-}
-
-// TestOrderByTransactionIndex feeds transactions in transaction-tree (hash)
-// order — unrelated to apply order — and asserts they come back in
-// sfTransactionIndex order so a single replay pass matches mainnet.
-func TestOrderByTransactionIndex(t *testing.T) {
-	txs := []Transaction{
-		{TxHash: [32]byte{0xAA}, MetaBlob: testMetaBlob(t, 2)},
-		{TxHash: [32]byte{0xBB}, MetaBlob: testMetaBlob(t, 0)},
-		{TxHash: [32]byte{0xCC}, MetaBlob: testMetaBlob(t, 1)},
+	first := txs[0].TxBlob[0]
+	txs[0].TxBlob[0] ^= 0xff
+	again, err := client.Transactions(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Transactions cached: %v", err)
 	}
-	if err := orderByTransactionIndex(txs); err != nil {
-		t.Fatalf("orderByTransactionIndex: %v", err)
-	}
-
-	wantFirstByte := []byte{0xBB, 0xCC, 0xAA} // indices 0, 1, 2
-	for i := range txs {
-		if txs[i].TxIndex != i {
-			t.Errorf("txs[%d].TxIndex = %d, want %d", i, txs[i].TxIndex, i)
-		}
-		if txs[i].TxHash[0] != wantFirstByte[i] {
-			t.Errorf("txs[%d].TxHash[0] = %#x, want %#x", i, txs[i].TxHash[0], wantFirstByte[i])
-		}
+	if again[0].TxBlob[0] != first || blobs.opens != 1 {
+		t.Fatalf("cache ownership/open count violated: byte=%d opens=%d", again[0].TxBlob[0], blobs.opens)
 	}
 }
 
-func TestOrderByTransactionIndexBadMeta(t *testing.T) {
-	txs := []Transaction{{TxHash: [32]byte{0x01}, MetaBlob: nil}}
-	if err := orderByTransactionIndex(txs); err == nil {
-		t.Error("nil metadata: want error, got nil")
+func TestStreamStateEntriesValidatesIdentityBeforeCallback(t *testing.T) {
+	const seq = uint32(10)
+	entries := []StateEntry{{Index: [32]byte{1}, Data: []byte{2}}}
+	data := encodeStatePack(seq+1, entries)
+	snapshot := &LedgerSnapshot{LedgerIndex: seq, AccountHash: [32]byte{3}}
+	manifest := &fakeManifest{checkpointData: checkpointManifest{
+		seq: seq, blobKey: "state/ckpt-10.pack", accountHash: snapshot.AccountHash,
+		objectCount: 1, sizeBytes: int64(len(data)),
+	}}
+	blobs := &memoryBlobStore{objects: map[string][]byte{"state/ckpt-10.pack": data}}
+	client := newClient(manifest, blobs)
+	called := 0
+	if err := client.StreamStateEntries(context.Background(), snapshot, func(StateEntry) error { called++; return nil }); !errors.Is(err, errPack) {
+		t.Fatalf("StreamStateEntries error = %v", err)
+	}
+	if called != 0 {
+		t.Fatalf("callback ran %d times before identity validation", called)
+	}
+
+	manifest.checkpointData.accountHash[0] ^= 1
+	if err := client.StreamStateEntries(context.Background(), snapshot, func(StateEntry) error { called++; return nil }); err == nil {
+		t.Fatal("account hash mismatch accepted")
+	}
+	if called != 0 || blobs.opens != 1 {
+		t.Fatalf("account mismatch reached blob/callback: opens=%d callbacks=%d", blobs.opens, called)
+	}
+}
+
+func TestStreamStateEntriesPropagatesCancellation(t *testing.T) {
+	const seq = uint32(10)
+	data := encodeStatePack(seq, []StateEntry{{Index: [32]byte{1}, Data: []byte{2}}})
+	snapshot := &LedgerSnapshot{LedgerIndex: seq, AccountHash: [32]byte{3}}
+	manifest := &fakeManifest{checkpointData: checkpointManifest{
+		seq: seq, blobKey: "state/ckpt-10.pack", accountHash: snapshot.AccountHash,
+		objectCount: 1, sizeBytes: int64(len(data)),
+	}}
+	client := newClient(manifest, &memoryBlobStore{objects: map[string][]byte{"state/ckpt-10.pack": data}})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := client.StreamStateEntries(ctx, snapshot, func(StateEntry) error { return nil }); !errors.Is(err, context.Canceled) {
+		t.Fatalf("StreamStateEntries error = %v", err)
+	}
+}
+
+func TestTransactionsRejectsNonBoundaryOffset(t *testing.T) {
+	snapshot, pack := ledgerFixture(t)
+	snapshot.blobOffset++
+	client := newClient(&fakeManifest{}, &memoryBlobStore{objects: map[string][]byte{snapshot.blobKey: pack}})
+	if _, err := client.Transactions(context.Background(), snapshot); !errors.Is(err, errPack) {
+		t.Fatalf("Transactions error = %v, want malformed pack", err)
+	}
+}
+
+func TestValidateTransactionsRejectsCorruption(t *testing.T) {
+	snapshot, _ := ledgerFixture(t)
+	valid := makeTransactions(t, 0, 1)
+	snapshot.TransactionHash = transactionRoot(t, valid)
+
+	tests := []struct {
+		name   string
+		mutate func([]txRecord, *LedgerSnapshot)
+	}{
+		{"hash", func(records []txRecord, _ *LedgerSnapshot) { records[0].txHash[0] ^= 1 }},
+		{"duplicate index", func(records []txRecord, _ *LedgerSnapshot) { records[1].metaBlob = encodeMeta(t, 0) }},
+		{"count", func(_ []txRecord, snap *LedgerSnapshot) { snap.TransactionCount++ }},
+		{"root", func(_ []txRecord, snap *LedgerSnapshot) { snap.TransactionHash[0] ^= 1 }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			records := make([]txRecord, len(valid))
+			for i := range valid {
+				records[i] = txRecord{txHash: valid[i].txHash, txBlob: bytes.Clone(valid[i].txBlob), metaBlob: bytes.Clone(valid[i].metaBlob)}
+			}
+			snap := *snapshot
+			test.mutate(records, &snap)
+			if _, err := validateTransactions(records, &snap); err == nil {
+				t.Fatal("validateTransactions unexpectedly succeeded")
+			}
+		})
+	}
+}
+
+func TestValidateLedgerHeaderRejectsMismatch(t *testing.T) {
+	snapshot, packData := ledgerFixture(t)
+	pack, err := indexLedgerPack(packData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := pack.readLedgerAt(packEnvelopeLen, snapshot.TransactionCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bad := *snapshot
+	bad.TotalCoins++
+	if err := validateLedgerHeader(record.headerBlob, &bad); err == nil {
+		t.Fatal("validateLedgerHeader unexpectedly succeeded")
+	}
+}
+
+func TestManifestDSNEscapesCredentials(t *testing.T) {
+	t.Setenv("POSTGRES_USER", "user:name")
+	t.Setenv("POSTGRES_PASSWORD", "p@ss/word")
+	dsn, err := manifestDSNFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	password, _ := parsed.User.Password()
+	if parsed.User.Username() != "user:name" || password != "p@ss/word" {
+		t.Fatalf("credentials did not round trip through DSN: %q", dsn)
+	}
+	t.Setenv("POSTGRES_PORT", "not-a-port")
+	if _, err := manifestDSNFromEnv(); err == nil {
+		t.Fatal("invalid POSTGRES_PORT accepted")
+	}
+}
+
+type fakeRows struct {
+	values []int64
+	index  int
+	err    error
+	closed bool
+}
+
+func (r *fakeRows) Next() bool { return r.index < len(r.values) }
+func (r *fakeRows) Scan(dest ...any) error {
+	*(dest[0].(*int64)) = r.values[r.index]
+	r.index++
+	return nil
+}
+func (r *fakeRows) Err() error   { return r.err }
+func (r *fakeRows) Close() error { r.closed = true; return nil }
+
+type scannerFunc func(...any) error
+
+func (f scannerFunc) Scan(dest ...any) error { return f(dest...) }
+
+type fakeManifestDB struct {
+	row  rowScanner
+	rows *fakeRows
+}
+
+func (f fakeManifestDB) queryRow(context.Context, string, ...any) rowScanner { return f.row }
+func (f fakeManifestDB) query(context.Context, string, ...any) (rowIterator, error) {
+	return f.rows, nil
+}
+func (f fakeManifestDB) close() error { return nil }
+
+func TestValidateRangeMaxUint32(t *testing.T) {
+	rows := &fakeRows{values: []int64{math.MaxUint32}}
+	manifest := &sqlManifest{db: fakeManifestDB{rows: rows}}
+	valid, missing, err := manifest.validateRange(context.Background(), math.MaxUint32, math.MaxUint32)
+	if err != nil || !valid || missing != 0 || !rows.closed {
+		t.Fatalf("validateRange = (%t,%d,%v), closed=%t", valid, missing, err, rows.closed)
+	}
+}
+
+func TestSQLManifestSnapshotLoadsTrustMetadata(t *testing.T) {
+	hash := bytes.Repeat([]byte{7}, 32)
+	row := scannerFunc(func(dest ...any) error {
+		*(dest[0].(*int64)) = 25
+		for _, i := range []int{1, 2, 3, 4} {
+			*(dest[i].(*[]byte)) = bytes.Clone(hash)
+		}
+		*(dest[5].(*uint64)) = 100
+		*(dest[6].(*int64)) = 200
+		*(dest[7].(*int64)) = 10
+		*(dest[8].(*int64)) = 1
+		*(dest[9].(*int64)) = 2
+		*(dest[10].(*sql.NullString)) = sql.NullString{String: "ledger/0.pack", Valid: true}
+		*(dest[11].(*sql.NullInt64)) = sql.NullInt64{Int64: packEnvelopeLen, Valid: true}
+		return nil
+	})
+	manifest := &sqlManifest{db: fakeManifestDB{row: row}}
+	snapshot, err := manifest.snapshot(context.Background(), 25)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if snapshot.TransactionCount != 2 || snapshot.blobKey != "ledger/0.pack" || snapshot.blobOffset != packEnvelopeLen || !snapshot.hasBlob {
+		t.Fatalf("snapshot trust metadata not loaded: %+v", snapshot)
+	}
+}
+
+func TestSQLManifestRejectsImpossibleCheckpoint(t *testing.T) {
+	row := scannerFunc(func(dest ...any) error {
+		*(dest[0].(*int64)) = 10
+		*(dest[1].(*string)) = "state/ckpt-10.pack"
+		*(dest[2].(*[]byte)) = make([]byte, 32)
+		*(dest[3].(*int64)) = 2
+		*(dest[4].(*int64)) = packEnvelopeLen + minStateRecordLen
+		return nil
+	})
+	manifest := &sqlManifest{db: fakeManifestDB{row: row}}
+	if _, err := manifest.checkpoint(context.Background(), 10); err == nil {
+		t.Fatal("checkpoint with impossible object count accepted")
 	}
 }

--- a/internal/statecompare/client_test.go
+++ b/internal/statecompare/client_test.go
@@ -67,7 +67,17 @@ func makeTransactions(t *testing.T, indices ...uint32) []txRecord {
 	t.Helper()
 	records := make([]txRecord, len(indices))
 	for i, index := range indices {
-		blob := bytes.Repeat([]byte{byte(i + 1)}, minTransactionBytes)
+		blob, err := binarycodec.EncodeBytes(map[string]any{
+			"TransactionType": "Payment",
+			"Sequence":        uint32(i + 1),
+			"Fee":             "10",
+			"Account":         "rMBzp8CgpE441cp5PVyA9rpVV7oT8hP3ys",
+			"Destination":     "rMBzp8CgpE441cp5PVyA9rpVV7oT8hP3ys",
+			"Amount":          "1000000",
+		})
+		if err != nil {
+			t.Fatalf("encode transaction: %v", err)
+		}
 		records[i] = txRecord{
 			txHash:   sha512half.Sum(protocol.HashPrefixTransactionID().Bytes(), blob),
 			txBlob:   blob,
@@ -246,6 +256,15 @@ func TestValidateTransactionsRejectsCorruption(t *testing.T) {
 	}{
 		{"hash", func(records []txRecord, _ *LedgerSnapshot) { records[0].txHash[0] ^= 1 }},
 		{"duplicate index", func(records []txRecord, _ *LedgerSnapshot) { records[1].metaBlob = encodeMeta(t, 0) }},
+		{"noncanonical transaction", func(records []txRecord, snap *LedgerSnapshot) {
+			blob := records[0].txBlob
+			if len(blob) < 8 || blob[0] != 0x12 || blob[3] != 0x24 {
+				t.Fatalf("unexpected transaction prefix %x", blob[:min(len(blob), 8)])
+			}
+			records[0].txBlob = append(append(bytes.Clone(blob[3:8]), blob[:3]...), blob[8:]...)
+			records[0].txHash = sha512half.Sum(protocol.HashPrefixTransactionID().Bytes(), records[0].txBlob)
+			snap.TransactionHash = transactionRoot(t, records)
+		}},
 		{"count", func(_ []txRecord, snap *LedgerSnapshot) { snap.TransactionCount++ }},
 		{"root", func(_ []txRecord, snap *LedgerSnapshot) { snap.TransactionHash[0] ^= 1 }},
 	}
@@ -257,7 +276,7 @@ func TestValidateTransactionsRejectsCorruption(t *testing.T) {
 			}
 			snap := *snapshot
 			test.mutate(records, &snap)
-			if _, err := validateTransactions(records, &snap); err == nil {
+			if _, err := validateTransactions(context.Background(), records, &snap); err == nil {
 				t.Fatal("validateTransactions unexpectedly succeeded")
 			}
 		})
@@ -295,6 +314,33 @@ func TestManifestDSNEscapesCredentials(t *testing.T) {
 	password, _ := parsed.User.Password()
 	if parsed.User.Username() != "user:name" || password != "p@ss/word" {
 		t.Fatalf("credentials did not round trip through DSN: %q", dsn)
+	}
+	t.Setenv("POSTGRES_PASSWORD", "")
+	dsn, err = manifestDSNFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err = url.Parse(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	password, _ = parsed.User.Password()
+	if password != "postgres" {
+		t.Fatalf("default password = %q, want postgres", password)
+	}
+	for _, mode := range []string{"allow", "prefer"} {
+		t.Setenv("POSTGRES_SSLMODE", mode)
+		dsn, err = manifestDSNFromEnv()
+		if err != nil {
+			t.Fatalf("POSTGRES_SSLMODE=%s: %v", mode, err)
+		}
+		parsed, err = url.Parse(dsn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := parsed.Query().Get("sslmode"); got != mode {
+			t.Fatalf("sslmode = %q, want %q", got, mode)
+		}
 	}
 	t.Setenv("POSTGRES_PORT", "not-a-port")
 	if _, err := manifestDSNFromEnv(); err == nil {

--- a/internal/statecompare/manifest.go
+++ b/internal/statecompare/manifest.go
@@ -1,0 +1,253 @@
+package statecompare
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+)
+
+var errNotFound = errors.New("statecompare: ledger not found")
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+type rowIterator interface {
+	Next() bool
+	Scan(dest ...any) error
+	Err() error
+	Close() error
+}
+
+type manifestDB interface {
+	queryRow(ctx context.Context, query string, args ...any) rowScanner
+	query(ctx context.Context, query string, args ...any) (rowIterator, error)
+	close() error
+}
+
+type sqlDatabase struct {
+	db *sql.DB
+}
+
+func (d sqlDatabase) queryRow(ctx context.Context, query string, args ...any) rowScanner {
+	return d.db.QueryRowContext(ctx, query, args...)
+}
+
+func (d sqlDatabase) query(ctx context.Context, query string, args ...any) (rowIterator, error) {
+	return d.db.QueryContext(ctx, query, args...)
+}
+
+func (d sqlDatabase) close() error {
+	return d.db.Close()
+}
+
+type manifestStore interface {
+	snapshot(ctx context.Context, seq uint32) (*LedgerSnapshot, error)
+	checkpoint(ctx context.Context, seq uint32) (checkpointManifest, error)
+	validateRange(ctx context.Context, from, to uint32) (bool, uint32, error)
+	Close() error
+}
+
+type checkpointManifest struct {
+	seq         uint32
+	blobKey     string
+	accountHash [32]byte
+	objectCount uint32
+	sizeBytes   int64
+}
+
+type sqlManifest struct {
+	db manifestDB
+}
+
+func newSQLManifest(db *sql.DB) *sqlManifest {
+	return &sqlManifest{db: sqlDatabase{db: db}}
+}
+
+func (m *sqlManifest) snapshot(ctx context.Context, requested uint32) (*LedgerSnapshot, error) {
+	const query = `
+		SELECT seq, ledger_hash, parent_hash, account_hash, transaction_hash,
+		       total_coins, close_time, close_time_resolution, close_flags,
+		       tx_count, blob_key, blob_offset
+		FROM ledgers
+		WHERE seq = $1
+	`
+
+	var (
+		seq                                         int64
+		ledgerHash, parentHash, accountHash, txHash []byte
+		closeResolution, closeFlags, txCount        int64
+		blobKey                                     sql.NullString
+		blobOffset                                  sql.NullInt64
+		snapshot                                    LedgerSnapshot
+	)
+	err := m.db.queryRow(ctx, query, requested).Scan(
+		&seq,
+		&ledgerHash,
+		&parentHash,
+		&accountHash,
+		&txHash,
+		&snapshot.TotalCoins,
+		&snapshot.CloseTime,
+		&closeResolution,
+		&closeFlags,
+		&txCount,
+		&blobKey,
+		&blobOffset,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("ledger %d: %w", requested, errNotFound)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying ledger %d snapshot: %w", requested, err)
+	}
+	if seq != int64(requested) {
+		return nil, fmt.Errorf("ledger query for %d returned sequence %d", requested, seq)
+	}
+	if snapshot.CloseTime < 0 || snapshot.CloseTime > math.MaxUint32 {
+		return nil, fmt.Errorf("ledger %d close_time %d is outside uint32", requested, snapshot.CloseTime)
+	}
+	if closeResolution < 0 || closeResolution > math.MaxUint8 {
+		return nil, fmt.Errorf("ledger %d close_time_resolution %d is outside uint8", requested, closeResolution)
+	}
+	if closeFlags < 0 || closeFlags > math.MaxUint8 {
+		return nil, fmt.Errorf("ledger %d close_flags %d is outside uint8", requested, closeFlags)
+	}
+	if txCount < 0 || txCount > math.MaxUint32 {
+		return nil, fmt.Errorf("ledger %d tx_count %d is outside uint32", requested, txCount)
+	}
+	if txCount > (maxLedgerPackBytes-minLedgerRecordLen)/minTransactionEntry {
+		return nil, fmt.Errorf("ledger %d tx_count %d cannot fit in a ledger pack", requested, txCount)
+	}
+	if blobKey.Valid != blobOffset.Valid {
+		return nil, fmt.Errorf("ledger %d has incomplete blob location", requested)
+	}
+	if blobOffset.Valid && (blobOffset.Int64 < packEnvelopeLen || blobOffset.Int64 > maxLedgerPackBytes) {
+		return nil, fmt.Errorf("ledger %d blob_offset %d is outside pack bounds", requested, blobOffset.Int64)
+	}
+
+	snapshot.LedgerIndex = requested
+	snapshot.CloseTimeResolution = uint32(closeResolution)
+	snapshot.CloseFlags = uint8(closeFlags)
+	snapshot.TransactionCount = uint32(txCount)
+	snapshot.blobKey = blobKey.String
+	snapshot.blobOffset = blobOffset.Int64
+	snapshot.hasBlob = blobKey.Valid
+
+	for _, hash := range []struct {
+		name string
+		src  []byte
+		dst  *[32]byte
+	}{
+		{"ledger_hash", ledgerHash, &snapshot.LedgerHash},
+		{"parent_hash", parentHash, &snapshot.ParentHash},
+		{"account_hash", accountHash, &snapshot.AccountHash},
+		{"transaction_hash", txHash, &snapshot.TransactionHash},
+	} {
+		value, err := toHash32(hash.src)
+		if err != nil {
+			return nil, fmt.Errorf("ledger %d %s: %w", requested, hash.name, err)
+		}
+		*hash.dst = value
+	}
+	return &snapshot, nil
+}
+
+func (m *sqlManifest) checkpoint(ctx context.Context, requested uint32) (checkpointManifest, error) {
+	const query = `
+		SELECT seq, blob_key, account_hash, object_count, size_bytes
+		FROM checkpoints
+		WHERE seq = $1
+	`
+	var (
+		seq, objectCount, sizeBytes int64
+		accountHash                 []byte
+		checkpoint                  checkpointManifest
+	)
+	err := m.db.queryRow(ctx, query, requested).Scan(
+		&seq,
+		&checkpoint.blobKey,
+		&accountHash,
+		&objectCount,
+		&sizeBytes,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return checkpointManifest{}, fmt.Errorf("checkpoint %d: %w", requested, errNotFound)
+	}
+	if err != nil {
+		return checkpointManifest{}, fmt.Errorf("querying checkpoint %d: %w", requested, err)
+	}
+	if seq != int64(requested) {
+		return checkpointManifest{}, fmt.Errorf("checkpoint query for %d returned sequence %d", requested, seq)
+	}
+	if objectCount < 0 || objectCount > math.MaxUint32 {
+		return checkpointManifest{}, fmt.Errorf("checkpoint %d object_count %d is outside uint32", requested, objectCount)
+	}
+	if sizeBytes < packEnvelopeLen || sizeBytes > maxStatePackBytes {
+		return checkpointManifest{}, fmt.Errorf("checkpoint %d size_bytes %d is outside [%d,%d]", requested, sizeBytes, packEnvelopeLen, maxStatePackBytes)
+	}
+	if objectCount > (sizeBytes-packEnvelopeLen)/minStateRecordLen {
+		return checkpointManifest{}, fmt.Errorf("checkpoint %d object_count %d cannot fit in %d bytes", requested, objectCount, sizeBytes)
+	}
+	checkpoint.seq = requested
+	checkpoint.objectCount = uint32(objectCount)
+	checkpoint.sizeBytes = sizeBytes
+	var hashErr error
+	checkpoint.accountHash, hashErr = toHash32(accountHash)
+	if hashErr != nil {
+		return checkpointManifest{}, fmt.Errorf("checkpoint %d account_hash: %w", requested, hashErr)
+	}
+	return checkpoint, nil
+}
+
+func (m *sqlManifest) validateRange(ctx context.Context, from, to uint32) (valid bool, missing uint32, retErr error) {
+	if from > to {
+		return true, 0, nil
+	}
+	rows, err := m.db.query(ctx, `
+		SELECT seq FROM ledgers
+		WHERE seq BETWEEN $1 AND $2
+		ORDER BY seq
+	`, from, to)
+	if err != nil {
+		return false, from, fmt.Errorf("querying ledger range: %w", err)
+	}
+	defer func() {
+		retErr = errors.Join(retErr, rows.Close())
+	}()
+
+	expected := uint64(from)
+	for rows.Next() {
+		var seq int64
+		if err := rows.Scan(&seq); err != nil {
+			return false, rangeMissing(expected), fmt.Errorf("scanning ledger sequence: %w", err)
+		}
+		if seq < 0 || uint64(seq) > math.MaxUint32 {
+			return false, rangeMissing(expected), fmt.Errorf("ledger sequence %d is outside uint32", seq)
+		}
+		if uint64(seq) != expected {
+			return false, rangeMissing(expected), nil
+		}
+		expected++
+	}
+	if err := rows.Err(); err != nil {
+		return false, rangeMissing(expected), fmt.Errorf("iterating ledger range: %w", err)
+	}
+	if expected <= uint64(to) {
+		return false, uint32(expected), nil
+	}
+	return true, 0, nil
+}
+
+func rangeMissing(expected uint64) uint32 {
+	if expected > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(expected)
+}
+
+func (m *sqlManifest) Close() error {
+	return m.db.close()
+}

--- a/internal/statecompare/pack.go
+++ b/internal/statecompare/pack.go
@@ -212,6 +212,13 @@ func packReadError(ctx context.Context, message string, err error) error {
 }
 
 func indexLedgerPack(blob []byte) (*ledgerPack, error) {
+	return indexLedgerPackContext(context.Background(), blob)
+}
+
+func indexLedgerPackContext(ctx context.Context, blob []byte) (*ledgerPack, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if int64(len(blob)) > maxLedgerPackBytes {
 		return nil, fmt.Errorf("%w: ledger pack size %d exceeds limit %d", errPack, len(blob), maxLedgerPackBytes)
 	}
@@ -240,6 +247,9 @@ func indexLedgerPack(blob []byte) (*ledgerPack, error) {
 		records:    make([]recordBoundary, 0, int(count)),
 	}
 	for i := uint32(0); i < count; i++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		start := off
 		seq, next, err := readUint64(blob, off, fmt.Sprintf("ledger %d sequence", i))
 		if err != nil {
@@ -249,7 +259,7 @@ func indexLedgerPack(blob []byte) (*ledgerPack, error) {
 		if expectedSeq > math.MaxUint32 || seq != expectedSeq {
 			return nil, fmt.Errorf("%w: ledger record %d has sequence %d, want %d", errPack, i, seq, expectedSeq)
 		}
-		off, err = skipLedgerRecord(blob, next, i)
+		off, err = skipLedgerRecord(ctx, blob, next, i)
 		if err != nil {
 			return nil, err
 		}
@@ -261,7 +271,7 @@ func indexLedgerPack(blob []byte) (*ledgerPack, error) {
 	return pack, nil
 }
 
-func skipLedgerRecord(blob []byte, off int, record uint32) (int, error) {
+func skipLedgerRecord(ctx context.Context, blob []byte, off int, record uint32) (int, error) {
 	headerBlob, off, err := readBytes(blob, off, header.SizeBase, fmt.Sprintf("ledger %d header", record))
 	if err != nil {
 		return 0, err
@@ -277,6 +287,9 @@ func skipLedgerRecord(blob []byte, off int, record uint32) (int, error) {
 		return 0, fmt.Errorf("%w: ledger %d transaction count %d cannot fit in %d bytes", errPack, record, txCount, len(blob)-off)
 	}
 	for i := uint32(0); i < txCount; i++ {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
 		if _, next, err := take(blob, off, hashLen, fmt.Sprintf("ledger %d transaction %d hash", record, i)); err != nil {
 			return 0, err
 		} else {
@@ -303,6 +316,13 @@ func skipLedgerRecord(blob []byte, off int, record uint32) (int, error) {
 }
 
 func (p *ledgerPack) readLedgerAt(offset int, expectedTxCount uint32) (ledgerBlob, error) {
+	return p.readLedgerAtContext(context.Background(), offset, expectedTxCount)
+}
+
+func (p *ledgerPack) readLedgerAtContext(ctx context.Context, offset int, expectedTxCount uint32) (ledgerBlob, error) {
+	if err := ctx.Err(); err != nil {
+		return ledgerBlob{}, err
+	}
 	i := sort.Search(len(p.records), func(i int) bool { return p.records[i].start >= offset })
 	if i == len(p.records) || p.records[i].start != offset {
 		return ledgerBlob{}, fmt.Errorf("%w: ledger offset %d is not a record boundary", errPack, offset)
@@ -325,6 +345,9 @@ func (p *ledgerPack) readLedgerAt(offset int, expectedTxCount uint32) (ledgerBlo
 	}
 	lb := ledgerBlob{seq: uint32(seq), headerBlob: headerBlob, txs: make([]txRecord, 0, int(txCount))}
 	for i := uint32(0); i < txCount; i++ {
+		if err := ctx.Err(); err != nil {
+			return ledgerBlob{}, err
+		}
 		hashBytes, next, err := take(p.data, off, hashLen, fmt.Sprintf("transaction %d hash", i))
 		if err != nil {
 			return ledgerBlob{}, err

--- a/internal/statecompare/pack.go
+++ b/internal/statecompare/pack.go
@@ -2,52 +2,70 @@ package statecompare
 
 import (
 	"bufio"
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
+	"math"
+	"sort"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 )
 
-// XSCP is the deterministic, length-prefixed binary format the
-// xrpl-state-compare lab writes into object storage. Two kinds of pack hold
-// raw mainnet bytes only, so they survive any goXRPL rebuild:
-//
-//	STATE  — every SLE of a checkpoint ledger (state/ckpt-<seq>.pack).
-//	LEDGER — header + per-tx (hash, tx_blob, meta_blob) for a batch of
-//	         ledgers, ~1000 per object (ledger/<batch>.pack).
-//
-// Every integer is big-endian. The LEDGER pack records each ledger's absolute
-// byte offset in the manifest so a reader can seek straight to one ledger
-// without scanning the whole batch.
 const (
 	packMagic   = "XSCP"
 	packVersion = 1
 	kindState   = 1
 	kindLedger  = 2
 
-	packHeaderLen = 6 // 4-byte magic + version (u8) + kind (u8)
-	indexLen      = 32
-	hashLen       = 32
+	packHeaderLen       = 6
+	packEnvelopeLen     = packHeaderLen + 8 + 4
+	indexLen            = 32
+	hashLen             = 32
+	minStateRecordLen   = indexLen + 4
+	minLedgerRecordLen  = 8 + 4 + header.SizeBase + 4
+	minTransactionEntry = hashLen + 4 + minTransactionBytes + 4 + 1
+
+	maxStatePackBytes   int64  = 4 << 30
+	maxLedgerPackBytes  int64  = 512 << 20
+	maxStateEntryBytes  uint32 = 16 << 20
+	minTransactionBytes        = 32
+	maxTransactionBytes        = 1 << 20
+	maxMetadataBytes           = 918744
 )
 
-// errPack signals a malformed or truncated pack; callers wrap it with context.
 var errPack = errors.New("statecompare: malformed pack")
 
-// txRecord is one transaction's raw bytes within a LEDGER pack.
+type statePackExpectation struct {
+	seq   uint32
+	count uint32
+	size  int64
+}
+
 type txRecord struct {
 	txHash   [32]byte
 	txBlob   []byte
 	metaBlob []byte
 }
 
-// ledgerBlob is one ledger's raw bytes as bundled into a LEDGER pack.
 type ledgerBlob struct {
-	seq        uint64
+	seq        uint32
 	headerBlob []byte
 	txs        []txRecord
 }
 
-// checkHeader validates the magic/version/kind and returns the body offset.
+type ledgerPack struct {
+	batchStart uint32
+	data       []byte
+	records    []recordBoundary
+}
+
+type recordBoundary struct {
+	start int
+	end   int
+}
+
 func checkHeader(blob []byte, expectedKind byte) (int, error) {
 	if len(blob) < packHeaderLen {
 		return 0, fmt.Errorf("%w: blob too short for header", errPack)
@@ -64,138 +82,266 @@ func checkHeader(blob []byte, expectedKind byte) (int, error) {
 	return packHeaderLen, nil
 }
 
-// getBytes reads a u32-length-prefixed byte run, returning a sub-slice of blob
-// (no copy) and the offset just past it.
-func getBytes(blob []byte, off int) ([]byte, int, error) {
-	if off+4 > len(blob) {
-		return nil, 0, fmt.Errorf("%w: length prefix overruns buffer", errPack)
+func take(blob []byte, off, n int, field string) ([]byte, int, error) {
+	if off < 0 || n < 0 || off > len(blob) || n > len(blob)-off {
+		return nil, 0, fmt.Errorf("%w: truncated %s", errPack, field)
 	}
-	n := int(binary.BigEndian.Uint32(blob[off:]))
-	off += 4
-	end := off + n
-	if end > len(blob) {
-		return nil, 0, fmt.Errorf("%w: truncated blob (length prefix overruns buffer)", errPack)
-	}
-	return blob[off:end], end, nil
+	return blob[off : off+n], off + n, nil
 }
 
-// unpackState decodes a STATE pack into its checkpoint seq and SLE entries.
-func unpackState(blob []byte) (uint64, []StateEntry, error) {
-	off, err := checkHeader(blob, kindState)
+func readUint32(blob []byte, off int, field string) (uint32, int, error) {
+	b, next, err := take(blob, off, 4, field)
 	if err != nil {
-		return 0, nil, err
-	}
-	if off+12 > len(blob) {
-		return 0, nil, fmt.Errorf("%w: truncated state header", errPack)
-	}
-	seq := binary.BigEndian.Uint64(blob[off:])
-	off += 8
-	count := binary.BigEndian.Uint32(blob[off:])
-	off += 4
-
-	entries := make([]StateEntry, 0, count)
-	for range count {
-		if off+indexLen > len(blob) {
-			return 0, nil, fmt.Errorf("%w: truncated state index", errPack)
-		}
-		var e StateEntry
-		copy(e.Index[:], blob[off:off+indexLen])
-		off += indexLen
-		if e.Data, off, err = getBytes(blob, off); err != nil {
-			return 0, nil, err
-		}
-		entries = append(entries, e)
-	}
-	return seq, entries, nil
-}
-
-// unpackStateStream decodes a STATE pack from r, invoking fn for each SLE as it
-// is read so peak memory stays O(one entry) regardless of state size. A STATE
-// pack is strictly sequential, so it decodes from a stream without ever holding
-// the whole pack or the full entry slice in memory. It returns the checkpoint
-// seq and entry count from the header.
-func unpackStateStream(r io.Reader, fn func(index [32]byte, data []byte) error) (uint64, uint32, error) {
-	br := bufio.NewReaderSize(r, 1<<20)
-
-	var head [packHeaderLen]byte
-	if _, err := io.ReadFull(br, head[:]); err != nil {
-		return 0, 0, fmt.Errorf("%w: truncated header", errPack)
-	}
-	if _, err := checkHeader(head[:], kindState); err != nil {
 		return 0, 0, err
 	}
+	return binary.BigEndian.Uint32(b), next, nil
+}
 
-	var meta [12]byte // u64 seq + u32 count
-	if _, err := io.ReadFull(br, meta[:]); err != nil {
-		return 0, 0, fmt.Errorf("%w: truncated state header", errPack)
+func readUint64(blob []byte, off int, field string) (uint64, int, error) {
+	b, next, err := take(blob, off, 8, field)
+	if err != nil {
+		return 0, 0, err
 	}
-	seq := binary.BigEndian.Uint64(meta[:8])
-	count := binary.BigEndian.Uint32(meta[8:])
+	return binary.BigEndian.Uint64(b), next, nil
+}
 
-	var index [32]byte
+func readBytes(blob []byte, off int, limit uint32, field string) ([]byte, int, error) {
+	n, next, err := readUint32(blob, off, field+" length")
+	if err != nil {
+		return nil, 0, err
+	}
+	if n > limit {
+		return nil, 0, fmt.Errorf("%w: %s length %d exceeds limit %d", errPack, field, n, limit)
+	}
+	b, next, err := take(blob, next, int(n), field)
+	if err != nil {
+		return nil, 0, err
+	}
+	return b, next, nil
+}
+
+func unpackStateStream(
+	ctx context.Context,
+	r io.Reader,
+	expected statePackExpectation,
+	fn func(index [32]byte, data []byte) error,
+) error {
+	if fn == nil {
+		return errors.New("statecompare: state callback is nil")
+	}
+	if expected.size < packEnvelopeLen || expected.size > maxStatePackBytes {
+		return fmt.Errorf("%w: state pack size %d outside [%d,%d]", errPack, expected.size, packEnvelopeLen, maxStatePackBytes)
+	}
+	if int64(expected.count) > (expected.size-packEnvelopeLen)/minStateRecordLen {
+		return fmt.Errorf("%w: state count %d cannot fit in %d bytes", errPack, expected.count, expected.size)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	br := bufio.NewReaderSize(r, 1<<20)
+	var envelope [packEnvelopeLen]byte
+	if _, err := io.ReadFull(br, envelope[:]); err != nil {
+		return packReadError(ctx, "truncated state envelope", err)
+	}
+	if _, err := checkHeader(envelope[:], kindState); err != nil {
+		return err
+	}
+	packSeq := binary.BigEndian.Uint64(envelope[packHeaderLen : packHeaderLen+8])
+	if packSeq != uint64(expected.seq) {
+		return fmt.Errorf("%w: state checkpoint %d, want %d", errPack, packSeq, expected.seq)
+	}
+	packCount := binary.BigEndian.Uint32(envelope[packHeaderLen+8:])
+	if packCount != expected.count {
+		return fmt.Errorf("%w: state count %d, manifest says %d", errPack, packCount, expected.count)
+	}
+
+	remaining := expected.size - packEnvelopeLen
+	var index [indexLen]byte
 	var lenBuf [4]byte
-	for range count {
+	for i := uint32(0); i < packCount; i++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if remaining < minStateRecordLen {
+			return fmt.Errorf("%w: state entry %d cannot fit in remaining %d bytes", errPack, i, remaining)
+		}
 		if _, err := io.ReadFull(br, index[:]); err != nil {
-			return 0, 0, fmt.Errorf("%w: truncated state index", errPack)
+			return packReadError(ctx, fmt.Sprintf("truncated state index %d", i), err)
 		}
 		if _, err := io.ReadFull(br, lenBuf[:]); err != nil {
-			return 0, 0, fmt.Errorf("%w: truncated data length", errPack)
+			return packReadError(ctx, fmt.Sprintf("truncated state data length %d", i), err)
 		}
-		data := make([]byte, binary.BigEndian.Uint32(lenBuf[:]))
+		remaining -= minStateRecordLen
+		dataLen := binary.BigEndian.Uint32(lenBuf[:])
+		if dataLen > maxStateEntryBytes {
+			return fmt.Errorf("%w: state entry %d length %d exceeds limit %d", errPack, i, dataLen, maxStateEntryBytes)
+		}
+		if int64(dataLen) > remaining {
+			return fmt.Errorf("%w: state entry %d length %d exceeds remaining %d bytes", errPack, i, dataLen, remaining)
+		}
+		data := make([]byte, int(dataLen))
 		if _, err := io.ReadFull(br, data); err != nil {
-			return 0, 0, fmt.Errorf("%w: truncated data", errPack)
+			return packReadError(ctx, fmt.Sprintf("truncated state data %d", i), err)
+		}
+		remaining -= int64(dataLen)
+		if err := ctx.Err(); err != nil {
+			return err
 		}
 		if err := fn(index, data); err != nil {
-			return 0, 0, err
+			return err
 		}
 	}
-	return seq, count, nil
+	if remaining != 0 {
+		return fmt.Errorf("%w: %d trailing state pack bytes", errPack, remaining)
+	}
+	if _, err := br.ReadByte(); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return fmt.Errorf("%w: state pack exceeds manifest size", errPack)
+		}
+		return packReadError(ctx, "checking state pack EOF", err)
+	}
+	return nil
 }
 
-// readOneLedger decodes the ledger record starting at off and returns the
-// offset just past it.
-func readOneLedger(blob []byte, off int) (ledgerBlob, int, error) {
-	if off+8 > len(blob) {
-		return ledgerBlob{}, 0, fmt.Errorf("%w: truncated ledger seq", errPack)
+func packReadError(ctx context.Context, message string, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
 	}
-	lb := ledgerBlob{seq: binary.BigEndian.Uint64(blob[off:])}
-	off += 8
-
-	var err error
-	if lb.headerBlob, off, err = getBytes(blob, off); err != nil {
-		return ledgerBlob{}, 0, err
-	}
-	if off+4 > len(blob) {
-		return ledgerBlob{}, 0, fmt.Errorf("%w: truncated tx count", errPack)
-	}
-	txCount := binary.BigEndian.Uint32(blob[off:])
-	off += 4
-
-	lb.txs = make([]txRecord, 0, txCount)
-	for range txCount {
-		if off+hashLen > len(blob) {
-			return ledgerBlob{}, 0, fmt.Errorf("%w: truncated tx hash", errPack)
-		}
-		var tr txRecord
-		copy(tr.txHash[:], blob[off:off+hashLen])
-		off += hashLen
-		if tr.txBlob, off, err = getBytes(blob, off); err != nil {
-			return ledgerBlob{}, 0, err
-		}
-		if tr.metaBlob, off, err = getBytes(blob, off); err != nil {
-			return ledgerBlob{}, 0, err
-		}
-		lb.txs = append(lb.txs, tr)
-	}
-	return lb, off, nil
+	return fmt.Errorf("%w: %s: %v", errPack, message, err)
 }
 
-// readLedgerAt decodes a single ledger from a LEDGER pack at a
-// manifest-recorded absolute byte offset.
-func readLedgerAt(blob []byte, offset int) (ledgerBlob, error) {
-	if offset < packHeaderLen || offset >= len(blob) {
-		return ledgerBlob{}, fmt.Errorf("%w: ledger offset %d out of range", errPack, offset)
+func indexLedgerPack(blob []byte) (*ledgerPack, error) {
+	if int64(len(blob)) > maxLedgerPackBytes {
+		return nil, fmt.Errorf("%w: ledger pack size %d exceeds limit %d", errPack, len(blob), maxLedgerPackBytes)
 	}
-	lb, _, err := readOneLedger(blob, offset)
-	return lb, err
+	off, err := checkHeader(blob, kindLedger)
+	if err != nil {
+		return nil, err
+	}
+	batchStart, off, err := readUint64(blob, off, "ledger batch start")
+	if err != nil {
+		return nil, err
+	}
+	if batchStart > math.MaxUint32 {
+		return nil, fmt.Errorf("%w: ledger batch start %d exceeds uint32", errPack, batchStart)
+	}
+	count, off, err := readUint32(blob, off, "ledger count")
+	if err != nil {
+		return nil, err
+	}
+	if uint64(count) > uint64((len(blob)-off)/minLedgerRecordLen) {
+		return nil, fmt.Errorf("%w: ledger count %d cannot fit in %d bytes", errPack, count, len(blob)-off)
+	}
+
+	pack := &ledgerPack{
+		batchStart: uint32(batchStart),
+		data:       blob,
+		records:    make([]recordBoundary, 0, int(count)),
+	}
+	for i := uint32(0); i < count; i++ {
+		start := off
+		seq, next, err := readUint64(blob, off, fmt.Sprintf("ledger %d sequence", i))
+		if err != nil {
+			return nil, err
+		}
+		expectedSeq := batchStart + uint64(i)
+		if expectedSeq > math.MaxUint32 || seq != expectedSeq {
+			return nil, fmt.Errorf("%w: ledger record %d has sequence %d, want %d", errPack, i, seq, expectedSeq)
+		}
+		off, err = skipLedgerRecord(blob, next, i)
+		if err != nil {
+			return nil, err
+		}
+		pack.records = append(pack.records, recordBoundary{start: start, end: off})
+	}
+	if off != len(blob) {
+		return nil, fmt.Errorf("%w: %d trailing ledger pack bytes", errPack, len(blob)-off)
+	}
+	return pack, nil
+}
+
+func skipLedgerRecord(blob []byte, off int, record uint32) (int, error) {
+	headerBlob, off, err := readBytes(blob, off, header.SizeBase, fmt.Sprintf("ledger %d header", record))
+	if err != nil {
+		return 0, err
+	}
+	if len(headerBlob) != header.SizeBase {
+		return 0, fmt.Errorf("%w: ledger %d header length %d, want %d", errPack, record, len(headerBlob), header.SizeBase)
+	}
+	txCount, off, err := readUint32(blob, off, fmt.Sprintf("ledger %d transaction count", record))
+	if err != nil {
+		return 0, err
+	}
+	if uint64(txCount) > uint64((len(blob)-off)/minTransactionEntry) {
+		return 0, fmt.Errorf("%w: ledger %d transaction count %d cannot fit in %d bytes", errPack, record, txCount, len(blob)-off)
+	}
+	for i := uint32(0); i < txCount; i++ {
+		if _, next, err := take(blob, off, hashLen, fmt.Sprintf("ledger %d transaction %d hash", record, i)); err != nil {
+			return 0, err
+		} else {
+			off = next
+		}
+		txBlob, next, err := readBytes(blob, off, maxTransactionBytes, fmt.Sprintf("ledger %d transaction %d", record, i))
+		if err != nil {
+			return 0, err
+		}
+		if len(txBlob) < minTransactionBytes {
+			return 0, fmt.Errorf("%w: ledger %d transaction %d length %d below minimum %d", errPack, record, i, len(txBlob), minTransactionBytes)
+		}
+		off = next
+		metaBlob, next, err := readBytes(blob, off, maxMetadataBytes, fmt.Sprintf("ledger %d transaction %d metadata", record, i))
+		if err != nil {
+			return 0, err
+		}
+		if len(metaBlob) == 0 {
+			return 0, fmt.Errorf("%w: ledger %d transaction %d has empty metadata", errPack, record, i)
+		}
+		off = next
+	}
+	return off, nil
+}
+
+func (p *ledgerPack) readLedgerAt(offset int, expectedTxCount uint32) (ledgerBlob, error) {
+	i := sort.Search(len(p.records), func(i int) bool { return p.records[i].start >= offset })
+	if i == len(p.records) || p.records[i].start != offset {
+		return ledgerBlob{}, fmt.Errorf("%w: ledger offset %d is not a record boundary", errPack, offset)
+	}
+	end := p.records[i].end
+	seq, off, err := readUint64(p.data, offset, "ledger sequence")
+	if err != nil {
+		return ledgerBlob{}, err
+	}
+	headerBlob, off, err := readBytes(p.data, off, header.SizeBase, "ledger header")
+	if err != nil {
+		return ledgerBlob{}, err
+	}
+	txCount, off, err := readUint32(p.data, off, "transaction count")
+	if err != nil {
+		return ledgerBlob{}, err
+	}
+	if txCount != expectedTxCount {
+		return ledgerBlob{}, fmt.Errorf("%w: ledger transaction count %d, manifest says %d", errPack, txCount, expectedTxCount)
+	}
+	lb := ledgerBlob{seq: uint32(seq), headerBlob: headerBlob, txs: make([]txRecord, 0, int(txCount))}
+	for i := uint32(0); i < txCount; i++ {
+		hashBytes, next, err := take(p.data, off, hashLen, fmt.Sprintf("transaction %d hash", i))
+		if err != nil {
+			return ledgerBlob{}, err
+		}
+		off = next
+		var record txRecord
+		copy(record.txHash[:], hashBytes)
+		if record.txBlob, off, err = readBytes(p.data, off, maxTransactionBytes, fmt.Sprintf("transaction %d", i)); err != nil {
+			return ledgerBlob{}, err
+		}
+		if record.metaBlob, off, err = readBytes(p.data, off, maxMetadataBytes, fmt.Sprintf("transaction %d metadata", i)); err != nil {
+			return ledgerBlob{}, err
+		}
+		lb.txs = append(lb.txs, record)
+	}
+	if off != end {
+		return ledgerBlob{}, fmt.Errorf("%w: ledger record ends at %d, indexed end is %d", errPack, off, end)
+	}
+	return lb, nil
 }

--- a/internal/statecompare/pack_test.go
+++ b/internal/statecompare/pack_test.go
@@ -2,279 +2,113 @@ package statecompare
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
-	"encoding/hex"
 	"errors"
+	"math"
 	"testing"
 )
 
-// packState and packLedgerBatch mirror the lab's core/pack.py encoders. The Go
-// client only ever decodes packs in production, so the encoders live here as
-// fixture builders that exercise the decoder over a faithful round trip.
-func packState(seq uint64, entries []StateEntry) []byte {
-	out := []byte(packMagic)
-	out = append(out, packVersion, kindState)
-	out = binary.BigEndian.AppendUint64(out, seq)
-	out = binary.BigEndian.AppendUint32(out, uint32(len(entries)))
-	for _, e := range entries {
-		out = append(out, e.Index[:]...)
-		out = binary.BigEndian.AppendUint32(out, uint32(len(e.Data)))
-		out = append(out, e.Data...)
+func encodeStatePack(seq uint32, entries []StateEntry) []byte {
+	var out bytes.Buffer
+	out.WriteString(packMagic)
+	out.WriteByte(packVersion)
+	out.WriteByte(kindState)
+	_ = binary.Write(&out, binary.BigEndian, uint64(seq))
+	_ = binary.Write(&out, binary.BigEndian, uint32(len(entries)))
+	for _, entry := range entries {
+		out.Write(entry.Index[:])
+		writeSized(&out, entry.Data)
 	}
-	return out
+	return out.Bytes()
 }
 
-func packLedgerBatch(batchStart uint64, ledgers []ledgerBlob) ([]byte, map[uint64]int) {
-	out := []byte(packMagic)
-	out = append(out, packVersion, kindLedger)
-	out = binary.BigEndian.AppendUint64(out, batchStart)
-	out = binary.BigEndian.AppendUint32(out, uint32(len(ledgers)))
-	offsets := make(map[uint64]int, len(ledgers))
-	for _, lg := range ledgers {
-		offsets[lg.seq] = len(out)
-		out = binary.BigEndian.AppendUint64(out, lg.seq)
-		out = binary.BigEndian.AppendUint32(out, uint32(len(lg.headerBlob)))
-		out = append(out, lg.headerBlob...)
-		out = binary.BigEndian.AppendUint32(out, uint32(len(lg.txs)))
-		for _, tx := range lg.txs {
-			out = append(out, tx.txHash[:]...)
-			out = binary.BigEndian.AppendUint32(out, uint32(len(tx.txBlob)))
-			out = append(out, tx.txBlob...)
-			out = binary.BigEndian.AppendUint32(out, uint32(len(tx.metaBlob)))
-			out = append(out, tx.metaBlob...)
+func TestUnpackStateStreamValidatesBeforeCallback(t *testing.T) {
+	entries := []StateEntry{{Index: [32]byte{1}, Data: []byte{2, 3}}}
+	data := encodeStatePack(10, entries)
+	called := 0
+	err := unpackStateStream(context.Background(), bytes.NewReader(data), statePackExpectation{
+		seq: 11, count: 1, size: int64(len(data)),
+	}, func([32]byte, []byte) error { called++; return nil })
+	if !errors.Is(err, errPack) || called != 0 {
+		t.Fatalf("wrong identity error=%v callbacks=%d", err, called)
+	}
+
+	err = unpackStateStream(context.Background(), bytes.NewReader(data), statePackExpectation{
+		seq: 10, count: 1, size: int64(len(data)),
+	}, func(index [32]byte, value []byte) error {
+		called++
+		if index != entries[0].Index || !bytes.Equal(value, entries[0].Data) {
+			t.Fatalf("callback entry = %x/%x", index, value)
 		}
-	}
-	return out, offsets
-}
-
-func idx(b byte) [32]byte {
-	var a [32]byte
-	for i := range a {
-		a[i] = b
-	}
-	return a
-}
-
-func TestStatePackRoundtrip(t *testing.T) {
-	entries := []StateEntry{
-		{Index: idx(0x01), Data: []byte("hello")},
-		{Index: idx(0x02), Data: []byte{}},
-		{Index: idx(0xff), Data: []byte{0x00, 0x01, 0x02}},
-	}
-	blob := packState(99250000, entries)
-
-	seq, got, err := unpackState(blob)
-	if err != nil {
-		t.Fatalf("unpackState: %v", err)
-	}
-	if seq != 99250000 {
-		t.Errorf("seq = %d, want 99250000", seq)
-	}
-	if len(got) != len(entries) {
-		t.Fatalf("got %d entries, want %d", len(got), len(entries))
-	}
-	for i, e := range entries {
-		if got[i].Index != e.Index {
-			t.Errorf("entry %d index = %x, want %x", i, got[i].Index, e.Index)
-		}
-		if !bytes.Equal(got[i].Data, e.Data) {
-			t.Errorf("entry %d data = %x, want %x", i, got[i].Data, e.Data)
-		}
-	}
-}
-
-// TestStatePackGoldenBytes pins the on-wire encoding so it cannot silently
-// drift from the lab's pack.py format (which the bytes were derived from).
-func TestStatePackGoldenBytes(t *testing.T) {
-	blob := packState(1, []StateEntry{{Index: idx(0x01), Data: []byte("x")}})
-	const want = "58534350" + "01" + "01" + // magic, version, kind=state
-		"0000000000000001" + // checkpoint seq = 1
-		"00000001" + // entry count = 1
-		"0101010101010101010101010101010101010101010101010101010101010101" + // index
-		"00000001" + "78" // data len = 1, "x"
-	if got := hex.EncodeToString(blob); got != want {
-		t.Errorf("state pack bytes:\n got %s\nwant %s", got, want)
-	}
-}
-
-func TestUnpackStateStreamRoundtrip(t *testing.T) {
-	entries := []StateEntry{
-		{Index: idx(0x01), Data: []byte("hello")},
-		{Index: idx(0x02), Data: []byte{}},
-		{Index: idx(0xff), Data: []byte{0x00, 0x01, 0x02}},
-	}
-	blob := packState(99250000, entries)
-
-	var got []StateEntry
-	seq, count, err := unpackStateStream(bytes.NewReader(blob), func(index [32]byte, data []byte) error {
-		got = append(got, StateEntry{Index: index, Data: append([]byte(nil), data...)})
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("unpackStateStream: %v", err)
 	}
-	if seq != 99250000 {
-		t.Errorf("seq = %d, want 99250000", seq)
+}
+
+func TestUnpackStateStreamRejectsBoundsTrailingAndCancellation(t *testing.T) {
+	data := encodeStatePack(10, []StateEntry{{Index: [32]byte{1}, Data: []byte{2}}})
+	tests := []struct {
+		name string
+		data []byte
+		exp  statePackExpectation
+	}{
+		{"truncated", data[:len(data)-1], statePackExpectation{seq: 10, count: 1, size: int64(len(data))}},
+		{"trailing", append(bytes.Clone(data), 0), statePackExpectation{seq: 10, count: 1, size: int64(len(data))}},
+		{"oversized count", data, statePackExpectation{seq: 10, count: math.MaxUint32, size: int64(len(data))}},
 	}
-	if count != uint32(len(entries)) {
-		t.Errorf("count = %d, want %d", count, len(entries))
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := unpackStateStream(context.Background(), bytes.NewReader(test.data), test.exp, func([32]byte, []byte) error { return nil }); err == nil {
+				t.Fatal("malformed pack accepted")
+			}
+		})
 	}
-	if len(got) != len(entries) {
-		t.Fatalf("got %d entries, want %d", len(got), len(entries))
-	}
-	for i, e := range entries {
-		if got[i].Index != e.Index {
-			t.Errorf("entry %d index = %x, want %x", i, got[i].Index, e.Index)
-		}
-		if !bytes.Equal(got[i].Data, e.Data) {
-			t.Errorf("entry %d data = %x, want %x", i, got[i].Data, e.Data)
-		}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := unpackStateStream(ctx, bytes.NewReader(data), statePackExpectation{seq: 10, count: 1, size: int64(len(data))}, func([32]byte, []byte) error { return nil }); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancellation error = %v", err)
 	}
 }
 
-// TestUnpackStateStreamMatchesBuffered cross-checks the streaming decoder
-// against the buffered one over the same pack, so the two paths cannot drift.
-func TestUnpackStateStreamMatchesBuffered(t *testing.T) {
-	entries := []StateEntry{
-		{Index: idx(0x10), Data: []byte("abcdefghijkl")},
-		{Index: idx(0x20), Data: bytes.Repeat([]byte{0x7e}, 300)},
-	}
-	blob := packState(42, entries)
-
-	wantSeq, want, err := unpackState(blob)
-	if err != nil {
-		t.Fatalf("unpackState: %v", err)
-	}
-
-	var got []StateEntry
-	gotSeq, _, err := unpackStateStream(bytes.NewReader(blob), func(index [32]byte, data []byte) error {
-		got = append(got, StateEntry{Index: index, Data: append([]byte(nil), data...)})
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("unpackStateStream: %v", err)
-	}
-	if gotSeq != wantSeq {
-		t.Errorf("stream seq = %d, want %d", gotSeq, wantSeq)
-	}
-	if len(got) != len(want) {
-		t.Fatalf("stream got %d entries, want %d", len(got), len(want))
-	}
-	for i := range want {
-		if got[i].Index != want[i].Index || !bytes.Equal(got[i].Data, want[i].Data) {
-			t.Errorf("entry %d mismatch between stream and buffered decode", i)
+func TestIndexLedgerPackRejectsMalformedEnvelope(t *testing.T) {
+	_, valid := ledgerFixture(t)
+	for _, data := range [][]byte{
+		valid[:len(valid)-1],
+		append(bytes.Clone(valid), 0),
+		func() []byte { b := bytes.Clone(valid); binary.BigEndian.PutUint32(b[14:18], math.MaxUint32); return b }(),
+		func() []byte {
+			b := bytes.Clone(valid)
+			binary.BigEndian.PutUint64(b[6:14], uint64(math.MaxUint32)+1)
+			return b
+		}(),
+	} {
+		if _, err := indexLedgerPack(data); !errors.Is(err, errPack) {
+			t.Fatalf("indexLedgerPack error = %v, want malformed pack", err)
 		}
 	}
 }
 
-func TestUnpackStateStreamRejectsBadMagicAndKind(t *testing.T) {
-	if _, _, err := unpackStateStream(bytes.NewReader([]byte("NOTAPACK"+"\x00\x00\x00\x00")), nil); !errors.Is(err, errPack) {
-		t.Errorf("bad magic: err = %v, want errPack", err)
-	}
-	lblob, _ := packLedgerBatch(1, nil)
-	if _, _, err := unpackStateStream(bytes.NewReader(lblob), nil); !errors.Is(err, errPack) {
-		t.Errorf("kind mismatch: err = %v, want errPack", err)
-	}
-}
-
-func TestUnpackStateStreamRejectsTruncated(t *testing.T) {
-	blob := packState(1, []StateEntry{{Index: idx(0x01), Data: []byte("abcdef")}})
-	noop := func([32]byte, []byte) error { return nil }
-	if _, _, err := unpackStateStream(bytes.NewReader(blob[:len(blob)-3]), noop); !errors.Is(err, errPack) {
-		t.Errorf("truncated data: err = %v, want errPack", err)
-	}
-	if _, _, err := unpackStateStream(bytes.NewReader(blob[:8]), noop); !errors.Is(err, errPack) {
-		t.Errorf("truncated header: err = %v, want errPack", err)
-	}
-}
-
-// TestUnpackStateStreamPropagatesCallbackError verifies a callback failure stops
-// the decode and surfaces unchanged (not wrapped as a pack error).
-func TestUnpackStateStreamPropagatesCallbackError(t *testing.T) {
-	blob := packState(1, []StateEntry{
-		{Index: idx(0x01), Data: []byte("a")},
-		{Index: idx(0x02), Data: []byte("b")},
+func FuzzIndexLedgerPack(f *testing.F) {
+	_, seed := ledgerFixtureForFuzz()
+	f.Add(seed)
+	f.Add([]byte(packMagic))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = indexLedgerPack(data)
 	})
-	sentinel := errors.New("boom")
-	calls := 0
-	_, _, err := unpackStateStream(bytes.NewReader(blob), func([32]byte, []byte) error {
-		calls++
-		return sentinel
+}
+
+func ledgerFixtureForFuzz() (*LedgerSnapshot, []byte) {
+	return nil, []byte{packMagic[0], packMagic[1], packMagic[2], packMagic[3], packVersion, kindLedger}
+}
+
+func FuzzUnpackStateStream(f *testing.F) {
+	seed := encodeStatePack(1, nil)
+	f.Add(seed, uint32(0), int64(len(seed)))
+	f.Add([]byte(packMagic), uint32(math.MaxUint32), int64(packEnvelopeLen))
+	f.Fuzz(func(t *testing.T, data []byte, count uint32, size int64) {
+		_ = unpackStateStream(context.Background(), bytes.NewReader(data), statePackExpectation{seq: 1, count: count, size: size}, func([32]byte, []byte) error { return nil })
 	})
-	if !errors.Is(err, sentinel) {
-		t.Errorf("err = %v, want sentinel", err)
-	}
-	if calls != 1 {
-		t.Errorf("callback called %d times, want 1 (decode should stop on error)", calls)
-	}
-}
-
-func TestLedgerBatchRoundtripAndOffsets(t *testing.T) {
-	ledgers := []ledgerBlob{
-		{seq: 1000, headerBlob: []byte("H0"), txs: []txRecord{
-			{txHash: idx(0xaa), txBlob: []byte("tx0"), metaBlob: []byte("meta0")},
-			{txHash: idx(0xbb), txBlob: []byte("tx1"), metaBlob: []byte("meta1")},
-		}},
-		{seq: 1001, headerBlob: []byte("H1")},
-		{seq: 1002, headerBlob: []byte("H2"), txs: []txRecord{
-			{txHash: idx(0xcc), txBlob: []byte("tx2"), metaBlob: []byte("meta2")},
-		}},
-	}
-	blob, offsets := packLedgerBatch(1000, ledgers)
-
-	// Seek straight to one ledger at its manifest-recorded offset.
-	one, err := readLedgerAt(blob, offsets[1002])
-	if err != nil {
-		t.Fatalf("readLedgerAt(1002): %v", err)
-	}
-	if one.seq != 1002 {
-		t.Errorf("seq = %d, want 1002", one.seq)
-	}
-	if len(one.txs) != 1 || !bytes.Equal(one.txs[0].metaBlob, []byte("meta2")) {
-		t.Errorf("ledger 1002 txs = %+v, want one tx with meta2", one.txs)
-	}
-
-	mid, err := readLedgerAt(blob, offsets[1000])
-	if err != nil {
-		t.Fatalf("readLedgerAt(1000): %v", err)
-	}
-	if len(mid.txs) != 2 || !bytes.Equal(mid.txs[1].txBlob, []byte("tx1")) {
-		t.Errorf("ledger 1000 second tx = %+v, want tx1", mid.txs)
-	}
-
-	empty, err := readLedgerAt(blob, offsets[1001])
-	if err != nil {
-		t.Fatalf("readLedgerAt(1001): %v", err)
-	}
-	if len(empty.txs) != 0 {
-		t.Errorf("ledger 1001 txs = %d, want 0", len(empty.txs))
-	}
-}
-
-func TestUnpackStateRejectsBadMagicAndKind(t *testing.T) {
-	if _, _, err := unpackState([]byte("NOTAPACK" + "\x00\x00\x00\x00")); !errors.Is(err, errPack) {
-		t.Errorf("bad magic: err = %v, want errPack", err)
-	}
-	// A LEDGER pack must not decode as a STATE pack.
-	lblob, _ := packLedgerBatch(1, nil)
-	if _, _, err := unpackState(lblob); !errors.Is(err, errPack) {
-		t.Errorf("kind mismatch: err = %v, want errPack", err)
-	}
-}
-
-func TestUnpackStateRejectsTruncated(t *testing.T) {
-	blob := packState(1, []StateEntry{{Index: idx(0x01), Data: []byte("abcdef")}})
-	if _, _, err := unpackState(blob[:len(blob)-3]); !errors.Is(err, errPack) {
-		t.Errorf("truncated: err = %v, want errPack", err)
-	}
-}
-
-func TestReadLedgerAtOutOfRange(t *testing.T) {
-	blob, _ := packLedgerBatch(1, []ledgerBlob{{seq: 1, headerBlob: []byte("H")}})
-	if _, err := readLedgerAt(blob, len(blob)+1); !errors.Is(err, errPack) {
-		t.Errorf("offset past end: err = %v, want errPack", err)
-	}
-	if _, err := readLedgerAt(blob, 0); !errors.Is(err, errPack) {
-		t.Errorf("offset inside header: err = %v, want errPack", err)
-	}
 }

--- a/internal/tx/serialize.go
+++ b/internal/tx/serialize.go
@@ -375,7 +375,7 @@ func TransactionIndexFromMetadata(metaData []byte) (uint32, bool) {
 	if len(metaData) == 0 {
 		return 0, false
 	}
-	meta, err := binarycodec.Decode(hex.EncodeToString(metaData))
+	meta, err := binarycodec.DecodeBytes(metaData)
 	if err != nil {
 		return 0, false
 	}

--- a/shamap/backend/nodestore.go
+++ b/shamap/backend/nodestore.go
@@ -54,11 +54,26 @@ func NewMemory() *NodeStore {
 // blockCacheMB sizes Pebble's block cache in MiB. nodeCacheItems bounds the
 // decoded-node cache by entry count.
 func OpenPebble(path string, blockCacheMB, nodeCacheItems int) (*NodeStore, error) {
+	return openPebble(path, blockCacheMB, nodeCacheItems, false)
+}
+
+// OpenPebbleReadOnly opens an existing persistent Pebble-backed NodeStore for
+// concurrent readers.
+func OpenPebbleReadOnly(path string, blockCacheMB, nodeCacheItems int) (*NodeStore, error) {
+	return openPebble(path, blockCacheMB, nodeCacheItems, true)
+}
+
+func openPebble(path string, blockCacheMB, nodeCacheItems int, readOnly bool) (*NodeStore, error) {
 	options, err := kvpebble.OptionsFromMiB(int64(blockCacheMB), kvpebble.DefaultMaxOpenFiles)
 	if err != nil {
 		return nil, err
 	}
-	store, err := kvpebble.New(path, options)
+	var store *kvpebble.Store
+	if readOnly {
+		store, err = kvpebble.NewReadOnly(path, options)
+	} else {
+		store, err = kvpebble.New(path, options)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/shamap/backend/nodestore.go
+++ b/shamap/backend/nodestore.go
@@ -149,6 +149,11 @@ func (f *NodeStore) StoreBatch(ctx context.Context, entries []shamap.FlushEntry)
 	return f.db.StoreBatch(ctx, nodes)
 }
 
+// Sync persists all preceding writes to stable storage.
+func (f *NodeStore) Sync(ctx context.Context) error {
+	return f.db.Sync(ctx)
+}
+
 // SetMinimumLedgerSeq waits for older writes to finish, then rejects new
 // writes below the online-delete boundary.
 func (f *NodeStore) SetMinimumLedgerSeq(seq uint32) {

--- a/storage/kvstore/pebble/pebble.go
+++ b/storage/kvstore/pebble/pebble.go
@@ -35,12 +35,32 @@ func New(path string, options Options) (*Store, error) {
 	return newWithCache(path, pebbleCache, resolved)
 }
 
+// NewReadOnly opens an existing Pebble store without taking its exclusive
+// writer lock.
+func NewReadOnly(path string, options Options) (*Store, error) {
+	resolved, err := options.Resolve()
+	if err != nil {
+		return nil, err
+	}
+	pebbleCache := pebble.NewCache(resolved.BlockCacheBytes)
+	defer pebbleCache.Unref()
+	return openWithCache(path, pebbleCache, resolved, true)
+}
+
 func newWithCache(path string, pebbleCache *pebble.Cache, options Options) (*Store, error) {
-	if err := os.MkdirAll(path, 0755); err != nil {
-		return nil, fmt.Errorf("kvstore/pebble: failed to create directory %s: %w", path, err)
+	return openWithCache(path, pebbleCache, options, false)
+}
+
+func openWithCache(path string, pebbleCache *pebble.Cache, options Options, readOnly bool) (*Store, error) {
+	if !readOnly {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			return nil, fmt.Errorf("kvstore/pebble: failed to create directory %s: %w", path, err)
+		}
 	}
 
-	db, err := pebble.Open(path, makePebbleOptions(options, pebbleCache))
+	pebbleOptions := makePebbleOptions(options, pebbleCache)
+	pebbleOptions.ReadOnly = readOnly
+	db, err := pebble.Open(path, pebbleOptions)
 	if err != nil {
 		return nil, fmt.Errorf("kvstore/pebble: failed to open %s: %w", path, err)
 	}

--- a/storage/kvstore/pebble/pebble.go
+++ b/storage/kvstore/pebble/pebble.go
@@ -4,11 +4,13 @@ package pebble
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"sync"
 
 	"github.com/LeJamon/go-xrpl/storage/kvstore"
 	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/vfs"
 )
 
 // Store is a thin wrapper around CockroachDB/Pebble that implements kvstore.KeyValueStore.
@@ -19,10 +21,21 @@ import (
 // bare atomic flag — checked, then acted on — leaves a window where a racing
 // Close turns the panic loose. The RWMutex closes that window.
 type Store struct {
-	mu     sync.RWMutex
-	db     *pebble.DB
-	closed bool
+	mu       sync.RWMutex
+	db       *pebble.DB
+	closed   bool
+	readOnly bool
 }
+
+// readOnlyFS suppresses Pebble's exclusive database lock. Callers may use it
+// only for immutable stores that were closed before publication.
+type readOnlyFS struct{ vfs.FS }
+
+type noOpCloser struct{}
+
+func (noOpCloser) Close() error { return nil }
+
+func (readOnlyFS) Lock(string) (io.Closer, error) { return noOpCloser{}, nil }
 
 // New opens a Pebble database at the given path.
 func New(path string, options Options) (*Store, error) {
@@ -60,12 +73,15 @@ func openWithCache(path string, pebbleCache *pebble.Cache, options Options, read
 
 	pebbleOptions := makePebbleOptions(options, pebbleCache)
 	pebbleOptions.ReadOnly = readOnly
+	if readOnly {
+		pebbleOptions.FS = readOnlyFS{FS: vfs.Default}
+	}
 	db, err := pebble.Open(path, pebbleOptions)
 	if err != nil {
 		return nil, fmt.Errorf("kvstore/pebble: failed to open %s: %w", path, err)
 	}
 
-	return &Store{db: db}, nil
+	return &Store{db: db, readOnly: readOnly}, nil
 }
 
 // Get retrieves the value for the given key.
@@ -180,6 +196,9 @@ func (s *Store) Sync() error {
 	if s.closed {
 		return kvstore.ErrClosed
 	}
+	if s.readOnly {
+		return nil
+	}
 	return s.db.LogData(nil, pebble.Sync)
 }
 
@@ -196,6 +215,9 @@ func (s *Store) Close() error {
 		return nil // already closed
 	}
 	s.closed = true
+	if s.readOnly {
+		return s.db.Close()
+	}
 	flushErr := s.db.Flush()
 	return errors.Join(flushErr, s.db.Close())
 }

--- a/storage/kvstore/pebble/pebble_test.go
+++ b/storage/kvstore/pebble/pebble_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/LeJamon/go-xrpl/storage/kvstore"
 	"github.com/LeJamon/go-xrpl/storage/kvstore/kvstoretest"
 	"github.com/LeJamon/go-xrpl/storage/kvstore/pebble"
+	cockroachpebble "github.com/cockroachdb/pebble"
 )
 
 // The ledger-persist fsync path depends on the store exposing a real Sync;
@@ -56,6 +57,41 @@ func TestStorePersistence(t *testing.T) {
 	}
 	if !bytes.Equal(got, []byte("value")) {
 		t.Fatalf("Get after reopen = %q, want %q", got, "value")
+	}
+}
+
+func TestReadOnlyStoreSupportsConcurrentOpens(t *testing.T) {
+	dir := t.TempDir()
+	writable, err := pebble.New(dir, pebble.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writable.Put([]byte("key"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writable.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := pebble.NewReadOnly(dir, pebble.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+	second, err := pebble.NewReadOnly(dir, pebble.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Close()
+
+	for _, store := range []*pebble.Store{first, second} {
+		value, err := store.Get([]byte("key"))
+		if err != nil || string(value) != "value" {
+			t.Fatalf("Get = %q, %v", value, err)
+		}
+		if err := store.Put([]byte("key"), []byte("changed")); !errors.Is(err, cockroachpebble.ErrReadOnly) {
+			t.Fatalf("Put error = %v, want read-only", err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- bound STATE and LEDGER pack parsing using manifest/object limits, validate complete envelopes and offsets, and confine local/S3 blob access to canonical producer keys
- verify raw ledger headers, manifest identity, transaction counts and hashes, contiguous metadata indices, and the reconstructed transaction SHAMap root before replay data is returned
- preserve cancellation and byte ownership, harden configuration/range edges, and publish root-verified checkpoint nodestores through an atomic staged build

## Test plan

- `go test -count=1 ./...`
- `go test -shuffle=on -count=10 ./internal/statecompare ./internal/replaytool`
- `go test -race -count=1 ./internal/statecompare ./internal/replaytool`
- `go test ./internal/statecompare -run '^$' -fuzz '^FuzzIndexLedgerPack$' -fuzztime=5s`
- `go test ./internal/statecompare -run '^$' -fuzz '^FuzzUnpackStateStream$' -fuzztime=5s`
- `just vet`
- `golangci-lint run --config .golangci.yml`
- `just lint`
- `just build`

Fixes #1491
