### PR TITLE
fix: canonicalize RPC error projection (#1490)

### DIFF
--- a/internal/rpc/handlers/account_info.go
+++ b/internal/rpc/handlers/account_info.go
@@ -74,24 +74,18 @@ func (m *AccountInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 	lookupFields := ledgerEntryResponseFields(ledger, lookupValidated)
 	_, accountID, decodeErr := addresscodec.DecodeClassicAddressToAccountID(account)
 	if decodeErr != nil {
-		rpcErr := types.RpcErrorActMalformed("Account malformed.")
-		rpcErr.Extra = lookupFields
-		return nil, rpcErr
+		return nil, types.RpcErrorActMalformed("Account malformed.").WithExtra(lookupFields)
 	}
 	canonicalAccount, encodeErr := addresscodec.EncodeAccountIDToClassicAddress(accountID)
 	if encodeErr != nil {
-		rpcErr := types.RpcErrorActMalformed("Account malformed.")
-		rpcErr.Extra = lookupFields
-		return nil, rpcErr
+		return nil, types.RpcErrorActMalformed("Account malformed.").WithExtra(lookupFields)
 	}
 
 	info, err := ctx.Services.Ledger.GetAccountInfo(ctx.Context, canonicalAccount, ledgerIndex)
 	if err != nil {
 		if errors.Is(err, svcerr.ErrAccountNotFound) {
 			lookupFields["account"] = canonicalAccount
-			rpcErr := types.RpcErrorActNotFound("Account not found.")
-			rpcErr.Extra = lookupFields
-			return nil, rpcErr
+			return nil, types.RpcErrorActNotFound("Account not found.").WithExtra(lookupFields)
 		}
 		if errors.Is(err, svcerr.ErrLedgerNotFound) {
 			return nil, types.RpcErrorLgrNotFound("Ledger not found.")
@@ -104,9 +98,7 @@ func (m *AccountInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		queue = jsonCppBoolRaw(queueRaw)
 	}
 	if queue && ledger.IsClosed() {
-		rpcErr := types.RpcErrorInvalidParams("Invalid parameters.")
-		rpcErr.Extra = lookupFields
-		return nil, rpcErr
+		return nil, types.RpcErrorInvalidParams("Invalid parameters.").WithExtra(lookupFields)
 	}
 
 	signerLists := false
@@ -164,9 +156,7 @@ func (m *AccountInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 
 	if signerListsRaw, ok := rawFields["signer_lists"]; ctx.ApiVersion > 1 && ok {
 		if _, valid := rawJSONBool(signerListsRaw); !valid {
-			rpcErr := types.RpcErrorInvalidParams("Invalid parameters.")
-			rpcErr.Extra = response
-			return nil, rpcErr
+			return nil, types.RpcErrorInvalidParams("Invalid parameters.").WithExtra(response)
 		}
 	}
 

--- a/internal/rpc/handlers/internal_error_test.go
+++ b/internal/rpc/handlers/internal_error_test.go
@@ -627,7 +627,7 @@ func isRpcErrorStructShape(structure *gotypes.Struct) bool {
 	}{
 		{name: "Code", kind: gotypes.Int, tag: `json:"error_code"`},
 		{name: "ErrorString", kind: gotypes.String, tag: `json:"error"`},
-		{name: "Type", kind: gotypes.String, tag: `json:"type"`},
+		{name: "Type", kind: gotypes.String, tag: `json:"-"`},
 		{name: "Message", kind: gotypes.String, tag: `json:"error_message,omitempty"`},
 		{name: "ErrorException", kind: gotypes.String, tag: `json:"error_exception,omitempty"`},
 		{name: "Extra", tag: `json:"-"`, mapType: true},

--- a/internal/rpc/server_response.go
+++ b/internal/rpc/server_response.go
@@ -29,17 +29,8 @@ func buildXrplResponseBody(request any, result any, rpcErr *types.RpcError, opts
 
 	var resultObj map[string]any
 	if rpcErr != nil {
-		resultObj = map[string]any{
-			"status": "error",
-			"error":  rpcErr.ErrorString,
-		}
-		maps.Copy(resultObj, rpcErr.Extra)
-		if rpcErr.ErrorException != "" {
-			resultObj["error_exception"] = rpcErr.ErrorException
-		} else if !rpcErr.IsBareToken() {
-			resultObj["error_code"] = rpcErr.Code
-			resultObj["error_message"] = rpcErr.Message
-		}
+		resultObj = rpcErr.ResponseFields()
+		resultObj["status"] = "error"
 	} else if resultMap, ok := result.(map[string]any); ok {
 		resultObj = make(map[string]any, len(resultMap)+1)
 		maps.Copy(resultObj, resultMap)
@@ -120,46 +111,5 @@ func writeJSONRPCBody(w io.Writer, response any) error {
 	return err
 }
 func rpcErrorHTTPStatus(code int) int {
-	switch code {
-	case types.RpcLGR_NOT_VALIDATED:
-		return http.StatusAccepted
-	case types.RpcHIGH_FEE:
-		return http.StatusPaymentRequired
-	case types.RpcBAD_SECRET, types.RpcBAD_SEED, types.RpcFORBIDDEN, types.RpcMASTER_DISABLED:
-		return http.StatusForbidden
-	case types.RpcBAD_MARKET, types.RpcDST_ACT_NOT_FOUND, types.RpcLGR_NOT_FOUND,
-		types.RpcNO_PF_REQUEST, types.RpcOBJECT_NOT_FOUND, types.RpcSRC_ACT_NOT_FOUND,
-		types.RpcDELEGATE_ACT_NOT_FOUND, types.RpcTXN_NOT_FOUND:
-		return http.StatusNotFound
-	case types.RpcNO_EVENTS, types.RpcMETHOD_NOT_FOUND:
-		return http.StatusMethodNotAllowed
-	case types.RpcSLOW_DOWN:
-		return http.StatusTooManyRequests
-	case types.RpcNO_PERMISSION:
-		return http.StatusUnauthorized
-	case types.RpcDB_DESERIALIZATION:
-		return http.StatusBadGateway
-	case types.RpcNOT_ENABLED, types.RpcNOT_IMPL, types.RpcNOT_SUPPORTED:
-		return http.StatusNotImplemented
-	case types.RpcAMENDMENT_BLOCKED, types.RpcEXPIRED_VALIDATOR_LIST, types.RpcNOT_READY,
-		types.RpcNO_CLOSED, types.RpcNO_CURRENT, types.RpcNOT_SYNCED, types.RpcNO_NETWORK,
-		types.RpcWRONG_NETWORK, types.RpcTOO_BUSY:
-		return http.StatusServiceUnavailable
-	case types.RpcBAD_FEATURE, types.RpcINTERNAL, types.RpcJSON_RPC:
-		return http.StatusInternalServerError
-	case types.RpcATX_DEPRECATED, types.RpcBAD_KEY_TYPE, types.RpcBAD_ISSUER,
-		types.RpcBAD_SYNTAX, types.RpcCHANNEL_MALFORMED, types.RpcCHANNEL_AMT_MALFORMED,
-		types.RpcMISSING_COMMAND, types.RpcDST_ACT_MALFORMED, types.RpcDST_ACT_MISSING,
-		types.RpcDST_AMT_MALFORMED, types.RpcDST_AMT_MISSING, types.RpcDST_ISR_MALFORMED,
-		types.RpcEXCESSIVE_LGR_RANGE, types.RpcINVALID_LGR_RANGE, types.RpcINVALID_PARAMS,
-		types.RpcINVALID_HOTWALLET, types.RpcISSUE_MALFORMED, types.RpcLGR_IDXS_INVALID,
-		types.RpcLGR_IDX_MALFORMED, types.RpcPUBLIC_MALFORMED, types.RpcSENDMAX_MALFORMED,
-		types.RpcSIGNING_MALFORMED, types.RpcSRC_ACT_MALFORMED, types.RpcSRC_ACT_MISSING,
-		types.RpcSRC_CUR_MALFORMED, types.RpcSRC_ISR_MALFORMED, types.RpcSTREAM_MALFORMED,
-		types.RpcORACLE_MALFORMED, types.RpcBAD_CREDENTIALS, types.RpcTX_SIGNED,
-		types.RpcDOMAIN_MALFORMED:
-		return http.StatusBadRequest
-	default:
-		return http.StatusOK
-	}
+	return types.RpcErrorHTTPStatus(code)
 }

--- a/internal/rpc/transport_conformance_test.go
+++ b/internal/rpc/transport_conformance_test.go
@@ -85,6 +85,11 @@ func TestHTTPRipplerpcV3StatusMapping(t *testing.T) {
 		{name: "v3 too busy", version: "3.0", rpcErr: types.RpcErrorTooBusy(), status: http.StatusServiceUnavailable},
 		{name: "v3 database deserialization", version: "3.0", rpcErr: types.RpcErrorDBDeserialization(), status: http.StatusBadGateway},
 		{name: "v3 invalid params", version: "3.0", rpcErr: types.RpcErrorInvalidParams("Invalid parameters."), status: http.StatusBadRequest},
+		{name: "v3 bad issuer", version: "3.0", rpcErr: types.RpcErrorBadIssuer(), status: http.StatusBadRequest},
+		{name: "v3 entry not found", version: "3.0", rpcErr: types.RpcErrorEntryNotFound(""), status: http.StatusBadRequest},
+		{name: "v3 unexpected ledger type", version: "3.0", rpcErr: types.RpcErrorUnexpectedLedgerType(), status: http.StatusBadRequest},
+		{name: "v2 entry not found remains 200", version: "2.0", rpcErr: types.RpcErrorEntryNotFound(""), status: http.StatusOK},
+		{name: "v2 unexpected ledger type remains 200", version: "2.0", rpcErr: types.RpcErrorUnexpectedLedgerType(), status: http.StatusOK},
 	}
 
 	for _, test := range tests {
@@ -97,6 +102,83 @@ func TestHTTPRipplerpcV3StatusMapping(t *testing.T) {
 			recorder := postTransportRequest(t, server, `{"method":"fail","params":[{"ripplerpc":"`+test.version+`"}]}`)
 			if recorder.Code != test.status {
 				t.Fatalf("status = %d, want %d; body: %s", recorder.Code, test.status, recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestHTTPErrorProjectorPreservesExtrasAndCanonicalFields(t *testing.T) {
+	fields := map[string]any{
+		"error":           "spoofed",
+		"status":          "spoofed",
+		"error_code":      999,
+		"error_message":   "spoofed",
+		"error_exception": "spoofed",
+		"code":            999,
+		"message":         "spoofed",
+		"type":            "spoofed",
+		"index":           7,
+	}
+	rpcErr := types.RpcErrorInvalidParams("").WithExtra(fields)
+	fields["index"] = 8
+
+	for _, version := range []string{"1.0", "2.0", "3.0"} {
+		t.Run(version, func(t *testing.T) {
+			server := newHardeningServer(t, time.Second, "fail", &stubHandler{
+				handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
+					return nil, rpcErr
+				},
+			})
+			recorder := postTransportRequest(t, server, `{"method":"fail","params":[{"ripplerpc":"`+version+`"}]}`)
+			wantStatus := http.StatusOK
+			if version == "3.0" {
+				wantStatus = http.StatusBadRequest
+			}
+			if recorder.Code != wantStatus {
+				t.Fatalf("status = %d, want %d; body: %s", recorder.Code, wantStatus, recorder.Body.String())
+			}
+
+			var response map[string]any
+			if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+				t.Fatal(err)
+			}
+			var projected map[string]any
+			if version == "1.0" {
+				projected, _ = response["result"].(map[string]any)
+			} else {
+				projected, _ = response["error"].(map[string]any)
+			}
+			if projected == nil {
+				t.Fatalf("missing projected error: %#v", response)
+			}
+			if projected["error"] != "invalidParams" || projected["index"] != float64(7) {
+				t.Fatalf("projected canonical/extras = %#v", projected)
+			}
+			if _, ok := projected["type"]; ok {
+				t.Fatalf("internal type leaked: %#v", projected)
+			}
+			for _, key := range []string{"error_exception", "status"} {
+				if key == "status" {
+					if projected[key] != "error" {
+						t.Errorf("status = %v, want error", projected[key])
+					}
+					continue
+				}
+				if _, ok := projected[key]; ok {
+					t.Errorf("reserved extra %q was projected: %#v", key, projected)
+				}
+			}
+			if version == "1.0" {
+				if projected["error_code"] != float64(types.RpcINVALID_PARAMS) || projected["error_message"] != "Invalid parameters." {
+					t.Fatalf("v1 canonical fields = %#v", projected)
+				}
+			} else {
+				if projected["code"] != float64(types.RpcINVALID_PARAMS) || projected["message"] != "Invalid parameters." {
+					t.Fatalf("v2+ canonical fields = %#v", projected)
+				}
+				if _, ok := projected["error_message"]; ok {
+					t.Fatalf("v2+ retained error_message: %#v", projected)
+				}
 			}
 		})
 	}

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -25,7 +25,7 @@ import "fmt"
 type RpcError struct {
 	Code           int    `json:"error_code"`
 	ErrorString    string `json:"error"`
-	Type           string `json:"type"`
+	Type           string `json:"-"`
 	Message        string `json:"error_message,omitempty"`
 	ErrorException string `json:"error_exception,omitempty"`
 
@@ -69,7 +69,14 @@ func (e *RpcError) WithExtra(fields map[string]any) *RpcError {
 		return nil
 	}
 	cp := *e
-	cp.Extra = fields
+	if fields == nil {
+		cp.Extra = nil
+		return &cp
+	}
+	cp.Extra = make(map[string]any, len(fields))
+	for key, value := range fields {
+		cp.Extra[key] = value
+	}
 	return &cp
 }
 
@@ -135,15 +142,32 @@ func (e RpcError) ErrorObject() map[string]any {
 
 // ResponseFields returns the error fields used in XRPL response envelopes.
 func (e RpcError) ResponseFields() map[string]any {
-	fields := map[string]any{"error": e.ErrorString}
-	if !e.IsBareToken() {
+	fields := make(map[string]any, len(e.Extra)+3)
+	for key, value := range e.Extra {
+		if isReservedErrorResponseField(key) {
+			continue
+		}
+		fields[key] = value
+	}
+	fields["error"] = e.ErrorString
+	if e.ErrorException != "" {
+		fields["error_exception"] = e.ErrorException
+	} else if !e.IsBareToken() {
 		fields["error_code"] = e.Code
 		fields["error_message"] = e.Message
 	}
-	for key, value := range e.Extra {
-		fields[key] = value
-	}
 	return fields
+}
+
+func isReservedErrorResponseField(key string) bool {
+	switch key {
+	case "type", "status", "error", "error_code", "error_message", "error_exception",
+		"code", "message", "request", "id", "jsonrpc", "ripplerpc", "api_version",
+		"warning", "warnings", "forwarded":
+		return true
+	default:
+		return false
+	}
 }
 
 // rippled error_code_i enum, mirrored 1:1 by value (ErrorCodes.h:42-160).
@@ -252,6 +276,111 @@ const (
 	RpcUNEXPECTED_LEDGER_TYPE = 99
 )
 
+// rpcErrorInfo is the canonical metadata for an XRPL RPC error code. It
+// mirrors rippled's RPC::ErrorInfo table in ErrorCodes.cpp.
+type rpcErrorInfo struct {
+	Code       int
+	Token      string
+	Message    string
+	HTTPStatus int
+}
+
+var rpcErrorInfos = map[int]rpcErrorInfo{
+	RpcACT_MALFORMED:          {RpcACT_MALFORMED, "actMalformed", "Account malformed.", 200},
+	RpcACT_NOT_FOUND:          {RpcACT_NOT_FOUND, "actNotFound", "Account not found.", 200},
+	RpcALREADY_MULTISIG:       {RpcALREADY_MULTISIG, "alreadyMultisig", "Already multisigned.", 200},
+	RpcALREADY_SINGLE_SIG:     {RpcALREADY_SINGLE_SIG, "alreadySingleSig", "Already single-signed.", 200},
+	RpcAMENDMENT_BLOCKED:      {RpcAMENDMENT_BLOCKED, "amendmentBlocked", "Amendment blocked, need upgrade.", 503},
+	RpcEXPIRED_VALIDATOR_LIST: {RpcEXPIRED_VALIDATOR_LIST, "unlBlocked", "Validator list expired.", 503},
+	RpcATX_DEPRECATED:         {RpcATX_DEPRECATED, "deprecated", "Use the new API or specify a ledger range.", 400},
+	RpcBAD_KEY_TYPE:           {RpcBAD_KEY_TYPE, "badKeyType", "Bad key type.", 400},
+	RpcBAD_FEATURE:            {RpcBAD_FEATURE, "badFeature", "Feature unknown or invalid.", 500},
+	RpcBAD_ISSUER:             {RpcBAD_ISSUER, "badIssuer", "Issuer account malformed.", 400},
+	RpcBAD_MARKET:             {RpcBAD_MARKET, "badMarket", "No such market.", 404},
+	RpcBAD_SECRET:             {RpcBAD_SECRET, "badSecret", "Secret does not match account.", 403},
+	RpcBAD_SEED:               {RpcBAD_SEED, "badSeed", "Disallowed seed.", 403},
+	RpcBAD_SYNTAX:             {RpcBAD_SYNTAX, "badSyntax", "Syntax error.", 400},
+	RpcCHANNEL_MALFORMED:      {RpcCHANNEL_MALFORMED, "channelMalformed", "Payment channel is malformed.", 400},
+	RpcCHANNEL_AMT_MALFORMED:  {RpcCHANNEL_AMT_MALFORMED, "channelAmtMalformed", "Payment channel amount is malformed.", 400},
+	RpcMISSING_COMMAND:        {RpcMISSING_COMMAND, "commandMissing", "Missing command entry.", 400},
+	RpcDB_DESERIALIZATION:     {RpcDB_DESERIALIZATION, "dbDeserialization", "Database deserialization error.", 502},
+	RpcDST_ACT_MALFORMED:      {RpcDST_ACT_MALFORMED, "dstActMalformed", "Destination account is malformed.", 400},
+	RpcDST_ACT_MISSING:        {RpcDST_ACT_MISSING, "dstActMissing", "Destination account not provided.", 400},
+	RpcDST_ACT_NOT_FOUND:      {RpcDST_ACT_NOT_FOUND, "dstActNotFound", "Destination account not found.", 404},
+	RpcDST_AMT_MALFORMED:      {RpcDST_AMT_MALFORMED, "dstAmtMalformed", "Destination amount/currency/issuer is malformed.", 400},
+	RpcDST_AMT_MISSING:        {RpcDST_AMT_MISSING, "dstAmtMissing", "Destination amount/currency/issuer is missing.", 400},
+	RpcDST_ISR_MALFORMED:      {RpcDST_ISR_MALFORMED, "dstIsrMalformed", "Destination issuer is malformed.", 400},
+	RpcEXCESSIVE_LGR_RANGE:    {RpcEXCESSIVE_LGR_RANGE, "excessiveLgrRange", "Ledger range exceeds 1000.", 400},
+	RpcFORBIDDEN:              {RpcFORBIDDEN, "forbidden", "Bad credentials.", 403},
+	RpcHIGH_FEE:               {RpcHIGH_FEE, "highFee", "Current transaction fee exceeds your limit.", 402},
+	RpcINTERNAL:               {RpcINTERNAL, "internal", "Internal error.", 500},
+	RpcINVALID_LGR_RANGE:      {RpcINVALID_LGR_RANGE, "invalidLgrRange", "Ledger range is invalid.", 400},
+	RpcINVALID_PARAMS:         {RpcINVALID_PARAMS, "invalidParams", "Invalid parameters.", 400},
+	RpcINVALID_HOTWALLET:      {RpcINVALID_HOTWALLET, "invalidHotWallet", "Invalid hotwallet.", 400},
+	RpcISSUE_MALFORMED:        {RpcISSUE_MALFORMED, "issueMalformed", "Issue is malformed.", 400},
+	RpcJSON_RPC:               {RpcJSON_RPC, "json_rpc", "JSON-RPC transport error.", 500},
+	RpcLGR_IDXS_INVALID:       {RpcLGR_IDXS_INVALID, "lgrIdxsInvalid", "Ledger indexes invalid.", 400},
+	RpcLGR_IDX_MALFORMED:      {RpcLGR_IDX_MALFORMED, "lgrIdxMalformed", "Ledger index malformed.", 400},
+	RpcLGR_NOT_FOUND:          {RpcLGR_NOT_FOUND, "lgrNotFound", "Ledger not found.", 404},
+	RpcLGR_NOT_VALIDATED:      {RpcLGR_NOT_VALIDATED, "lgrNotValidated", "Ledger not validated.", 202},
+	RpcMASTER_DISABLED:        {RpcMASTER_DISABLED, "masterDisabled", "Master key is disabled.", 403},
+	RpcNOT_ENABLED:            {RpcNOT_ENABLED, "notEnabled", "Not enabled in configuration.", 501},
+	RpcNOT_IMPL:               {RpcNOT_IMPL, "notImpl", "Not implemented.", 501},
+	RpcNOT_READY:              {RpcNOT_READY, "notReady", "Not ready to handle this request.", 503},
+	RpcNOT_SUPPORTED:          {RpcNOT_SUPPORTED, "notSupported", "Operation not supported.", 501},
+	RpcNO_CLOSED:              {RpcNO_CLOSED, "noClosed", "Closed ledger is unavailable.", 503},
+	RpcNO_CURRENT:             {RpcNO_CURRENT, "noCurrent", "Current ledger is unavailable.", 503},
+	RpcNOT_SYNCED:             {RpcNOT_SYNCED, "notSynced", "Not synced to the network.", 503},
+	RpcNO_EVENTS:              {RpcNO_EVENTS, "noEvents", "Current transport does not support events.", 405},
+	RpcNO_NETWORK:             {RpcNO_NETWORK, "noNetwork", "Not synced to the network.", 503},
+	RpcWRONG_NETWORK:          {RpcWRONG_NETWORK, "wrongNetwork", "Wrong network.", 503},
+	RpcNO_PERMISSION:          {RpcNO_PERMISSION, "noPermission", "You don't have permission for this command.", 401},
+	RpcNO_PF_REQUEST:          {RpcNO_PF_REQUEST, "noPathRequest", "No pathfinding request in progress.", 404},
+	RpcOBJECT_NOT_FOUND:       {RpcOBJECT_NOT_FOUND, "objectNotFound", "The requested object was not found.", 404},
+	RpcPUBLIC_MALFORMED:       {RpcPUBLIC_MALFORMED, "publicMalformed", "Public key is malformed.", 400},
+	RpcSENDMAX_MALFORMED:      {RpcSENDMAX_MALFORMED, "sendMaxMalformed", "SendMax amount malformed.", 400},
+	RpcSIGNING_MALFORMED:      {RpcSIGNING_MALFORMED, "signingMalformed", "Signing of transaction is malformed.", 400},
+	RpcSLOW_DOWN:              {RpcSLOW_DOWN, "slowDown", "You are placing too much load on the server.", 429},
+	RpcSRC_ACT_MALFORMED:      {RpcSRC_ACT_MALFORMED, "srcActMalformed", "Source account is malformed.", 400},
+	RpcSRC_ACT_MISSING:        {RpcSRC_ACT_MISSING, "srcActMissing", "Source account not provided.", 400},
+	RpcSRC_ACT_NOT_FOUND:      {RpcSRC_ACT_NOT_FOUND, "srcActNotFound", "Source account not found.", 404},
+	RpcDELEGATE_ACT_NOT_FOUND: {RpcDELEGATE_ACT_NOT_FOUND, "delegateActNotFound", "Delegate account not found.", 404},
+	RpcSRC_CUR_MALFORMED:      {RpcSRC_CUR_MALFORMED, "srcCurMalformed", "Source currency is malformed.", 400},
+	RpcSRC_ISR_MALFORMED:      {RpcSRC_ISR_MALFORMED, "srcIsrMalformed", "Source issuer is malformed.", 400},
+	RpcSTREAM_MALFORMED:       {RpcSTREAM_MALFORMED, "malformedStream", "Stream malformed.", 400},
+	RpcTOO_BUSY:               {RpcTOO_BUSY, "tooBusy", "The server is too busy to help you now.", 503},
+	RpcTXN_NOT_FOUND:          {RpcTXN_NOT_FOUND, "txnNotFound", "Transaction not found.", 404},
+	RpcMETHOD_NOT_FOUND:       {RpcMETHOD_NOT_FOUND, "unknownCmd", "Unknown method.", 405},
+	RpcORACLE_MALFORMED:       {RpcORACLE_MALFORMED, "oracleMalformed", "Oracle request is malformed.", 400},
+	RpcBAD_CREDENTIALS:        {RpcBAD_CREDENTIALS, "badCredentials", "Credentials do not exist, are not accepted, or have expired.", 400},
+	RpcTX_SIGNED:              {RpcTX_SIGNED, "transactionSigned", "Transaction should not be signed.", 400},
+	RpcDOMAIN_MALFORMED:       {RpcDOMAIN_MALFORMED, "domainMalformed", "Domain is malformed.", 400},
+	RpcENTRY_NOT_FOUND:        {RpcENTRY_NOT_FOUND, "entryNotFound", "Entry not found.", 400},
+	RpcUNEXPECTED_LEDGER_TYPE: {RpcUNEXPECTED_LEDGER_TYPE, "unexpectedLedgerType", "Unexpected ledger type.", 400},
+}
+
+var unknownRpcErrorInfo = rpcErrorInfo{
+	Code:       RpcUNKNOWN,
+	Token:      "unknown",
+	Message:    "An unknown error code.",
+	HTTPStatus: 200,
+}
+
+// rpcErrorInfoForCode returns rippled's metadata for code, or its unknown-code
+// defaults when code is outside the canonical table.
+func rpcErrorInfoForCode(code int) rpcErrorInfo {
+	if info, ok := rpcErrorInfos[code]; ok {
+		return info
+	}
+	return unknownRpcErrorInfo
+}
+
+// RpcErrorHTTPStatus returns the HTTP status associated with a canonical RPC
+// error code. Unknown and reserved codes retain rippled's default of 200.
+func RpcErrorHTTPStatus(code int) int {
+	return rpcErrorInfoForCode(code).HTTPStatus
+}
+
 // go-xrpl-specific error codes for conditions rippled does not assign an
 // error_code_i slot. These deliberately avoid colliding with any rippled code.
 const (
@@ -285,6 +414,9 @@ func RpcErrorUnknown(message string) *RpcError {
 }
 
 func RpcErrorInvalidParams(message string) *RpcError {
+	if message == "" {
+		message = rpcErrorInfoForCode(RpcINVALID_PARAMS).Message
+	}
 	return NewRpcError(RpcINVALID_PARAMS, "invalidParams", "invalidParams", message)
 }
 

--- a/internal/rpc/types/errors_test.go
+++ b/internal/rpc/types/errors_test.go
@@ -1,6 +1,9 @@
 package types
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 // rippledEnum is rippled's error_code_i enum (ErrorCodes.h:42-160), the source
 // of truth for the numeric error_code field on the wire. Every go-xrpl constant
@@ -267,6 +270,190 @@ func TestEntryNotFoundDefaultMessage(t *testing.T) {
 	}
 	if got := RpcErrorEntryNotFound("custom").Message; got != "custom" {
 		t.Errorf("explicit message = %q, want %q", got, "custom")
+	}
+}
+
+var rippledErrorInfos = []rpcErrorInfo{
+	{RpcACT_MALFORMED, "actMalformed", "Account malformed.", 200},
+	{RpcACT_NOT_FOUND, "actNotFound", "Account not found.", 200},
+	{RpcALREADY_MULTISIG, "alreadyMultisig", "Already multisigned.", 200},
+	{RpcALREADY_SINGLE_SIG, "alreadySingleSig", "Already single-signed.", 200},
+	{RpcAMENDMENT_BLOCKED, "amendmentBlocked", "Amendment blocked, need upgrade.", 503},
+	{RpcEXPIRED_VALIDATOR_LIST, "unlBlocked", "Validator list expired.", 503},
+	{RpcATX_DEPRECATED, "deprecated", "Use the new API or specify a ledger range.", 400},
+	{RpcBAD_KEY_TYPE, "badKeyType", "Bad key type.", 400},
+	{RpcBAD_FEATURE, "badFeature", "Feature unknown or invalid.", 500},
+	{RpcBAD_ISSUER, "badIssuer", "Issuer account malformed.", 400},
+	{RpcBAD_MARKET, "badMarket", "No such market.", 404},
+	{RpcBAD_SECRET, "badSecret", "Secret does not match account.", 403},
+	{RpcBAD_SEED, "badSeed", "Disallowed seed.", 403},
+	{RpcBAD_SYNTAX, "badSyntax", "Syntax error.", 400},
+	{RpcCHANNEL_MALFORMED, "channelMalformed", "Payment channel is malformed.", 400},
+	{RpcCHANNEL_AMT_MALFORMED, "channelAmtMalformed", "Payment channel amount is malformed.", 400},
+	{RpcMISSING_COMMAND, "commandMissing", "Missing command entry.", 400},
+	{RpcDB_DESERIALIZATION, "dbDeserialization", "Database deserialization error.", 502},
+	{RpcDST_ACT_MALFORMED, "dstActMalformed", "Destination account is malformed.", 400},
+	{RpcDST_ACT_MISSING, "dstActMissing", "Destination account not provided.", 400},
+	{RpcDST_ACT_NOT_FOUND, "dstActNotFound", "Destination account not found.", 404},
+	{RpcDST_AMT_MALFORMED, "dstAmtMalformed", "Destination amount/currency/issuer is malformed.", 400},
+	{RpcDST_AMT_MISSING, "dstAmtMissing", "Destination amount/currency/issuer is missing.", 400},
+	{RpcDST_ISR_MALFORMED, "dstIsrMalformed", "Destination issuer is malformed.", 400},
+	{RpcEXCESSIVE_LGR_RANGE, "excessiveLgrRange", "Ledger range exceeds 1000.", 400},
+	{RpcFORBIDDEN, "forbidden", "Bad credentials.", 403},
+	{RpcHIGH_FEE, "highFee", "Current transaction fee exceeds your limit.", 402},
+	{RpcINTERNAL, "internal", "Internal error.", 500},
+	{RpcINVALID_LGR_RANGE, "invalidLgrRange", "Ledger range is invalid.", 400},
+	{RpcINVALID_PARAMS, "invalidParams", "Invalid parameters.", 400},
+	{RpcINVALID_HOTWALLET, "invalidHotWallet", "Invalid hotwallet.", 400},
+	{RpcISSUE_MALFORMED, "issueMalformed", "Issue is malformed.", 400},
+	{RpcJSON_RPC, "json_rpc", "JSON-RPC transport error.", 500},
+	{RpcLGR_IDXS_INVALID, "lgrIdxsInvalid", "Ledger indexes invalid.", 400},
+	{RpcLGR_IDX_MALFORMED, "lgrIdxMalformed", "Ledger index malformed.", 400},
+	{RpcLGR_NOT_FOUND, "lgrNotFound", "Ledger not found.", 404},
+	{RpcLGR_NOT_VALIDATED, "lgrNotValidated", "Ledger not validated.", 202},
+	{RpcMASTER_DISABLED, "masterDisabled", "Master key is disabled.", 403},
+	{RpcNOT_ENABLED, "notEnabled", "Not enabled in configuration.", 501},
+	{RpcNOT_IMPL, "notImpl", "Not implemented.", 501},
+	{RpcNOT_READY, "notReady", "Not ready to handle this request.", 503},
+	{RpcNOT_SUPPORTED, "notSupported", "Operation not supported.", 501},
+	{RpcNO_CLOSED, "noClosed", "Closed ledger is unavailable.", 503},
+	{RpcNO_CURRENT, "noCurrent", "Current ledger is unavailable.", 503},
+	{RpcNOT_SYNCED, "notSynced", "Not synced to the network.", 503},
+	{RpcNO_EVENTS, "noEvents", "Current transport does not support events.", 405},
+	{RpcNO_NETWORK, "noNetwork", "Not synced to the network.", 503},
+	{RpcWRONG_NETWORK, "wrongNetwork", "Wrong network.", 503},
+	{RpcNO_PERMISSION, "noPermission", "You don't have permission for this command.", 401},
+	{RpcNO_PF_REQUEST, "noPathRequest", "No pathfinding request in progress.", 404},
+	{RpcOBJECT_NOT_FOUND, "objectNotFound", "The requested object was not found.", 404},
+	{RpcPUBLIC_MALFORMED, "publicMalformed", "Public key is malformed.", 400},
+	{RpcSENDMAX_MALFORMED, "sendMaxMalformed", "SendMax amount malformed.", 400},
+	{RpcSIGNING_MALFORMED, "signingMalformed", "Signing of transaction is malformed.", 400},
+	{RpcSLOW_DOWN, "slowDown", "You are placing too much load on the server.", 429},
+	{RpcSRC_ACT_MALFORMED, "srcActMalformed", "Source account is malformed.", 400},
+	{RpcSRC_ACT_MISSING, "srcActMissing", "Source account not provided.", 400},
+	{RpcSRC_ACT_NOT_FOUND, "srcActNotFound", "Source account not found.", 404},
+	{RpcDELEGATE_ACT_NOT_FOUND, "delegateActNotFound", "Delegate account not found.", 404},
+	{RpcSRC_CUR_MALFORMED, "srcCurMalformed", "Source currency is malformed.", 400},
+	{RpcSRC_ISR_MALFORMED, "srcIsrMalformed", "Source issuer is malformed.", 400},
+	{RpcSTREAM_MALFORMED, "malformedStream", "Stream malformed.", 400},
+	{RpcTOO_BUSY, "tooBusy", "The server is too busy to help you now.", 503},
+	{RpcTXN_NOT_FOUND, "txnNotFound", "Transaction not found.", 404},
+	{RpcMETHOD_NOT_FOUND, "unknownCmd", "Unknown method.", 405},
+	{RpcORACLE_MALFORMED, "oracleMalformed", "Oracle request is malformed.", 400},
+	{RpcBAD_CREDENTIALS, "badCredentials", "Credentials do not exist, are not accepted, or have expired.", 400},
+	{RpcTX_SIGNED, "transactionSigned", "Transaction should not be signed.", 400},
+	{RpcDOMAIN_MALFORMED, "domainMalformed", "Domain is malformed.", 400},
+	{RpcENTRY_NOT_FOUND, "entryNotFound", "Entry not found.", 400},
+	{RpcUNEXPECTED_LEDGER_TYPE, "unexpectedLedgerType", "Unexpected ledger type.", 400},
+}
+
+func TestRpcErrorInfoTableCoversRippledCodes(t *testing.T) {
+	for _, want := range rippledErrorInfos {
+		info, ok := rpcErrorInfos[want.Code]
+		if !ok {
+			t.Errorf("missing metadata for rippled error code %d", want.Code)
+			continue
+		}
+		if info != want {
+			t.Errorf("metadata[%d] = %#v, want %#v", want.Code, info, want)
+		}
+	}
+	if len(rpcErrorInfos) != len(rippledErrorInfos) {
+		t.Errorf("metadata rows = %d, want %d rippled rows", len(rpcErrorInfos), len(rippledErrorInfos))
+	}
+	unknown := rpcErrorInfoForCode(0)
+	if unknown != unknownRpcErrorInfo {
+		t.Errorf("unknown metadata = %#v, want %#v", unknown, unknownRpcErrorInfo)
+	}
+	if info := rpcErrorInfoForCode(RpcREPORTING_UNSUPPORTED); info != unknownRpcErrorInfo {
+		t.Errorf("deprecated unlisted metadata = %#v, want %#v", info, unknownRpcErrorInfo)
+	}
+}
+
+func TestRpcErrorInvalidParamsDefaultMessage(t *testing.T) {
+	if got := RpcErrorInvalidParams("").Message; got != "Invalid parameters." {
+		t.Fatalf("default message = %q, want %q", got, "Invalid parameters.")
+	}
+	if got := RpcErrorInvalidParams("custom").Message; got != "custom" {
+		t.Fatalf("explicit message = %q, want %q", got, "custom")
+	}
+}
+
+func TestRpcErrorWithExtraProjectsCanonicalFields(t *testing.T) {
+	fields := map[string]any{
+		"error":           "spoofed",
+		"status":          "spoofed",
+		"error_code":      999,
+		"error_message":   "spoofed",
+		"error_exception": "spoofed",
+		"code":            999,
+		"message":         "spoofed",
+		"type":            "spoofed",
+		"index":           7,
+	}
+	err := RpcErrorInvalidParams("").WithExtra(fields)
+	fields["index"] = 8
+	got := err.ResponseFields()
+	if got["index"] != 7 {
+		t.Fatalf("WithExtra retained caller map mutation: index = %v, want 7", got["index"])
+	}
+	if got["error"] != "invalidParams" || got["error_code"] != RpcINVALID_PARAMS || got["error_message"] != "Invalid parameters." {
+		t.Fatalf("canonical fields = %#v", got)
+	}
+	for _, key := range []string{"status", "error_exception", "code", "message", "type"} {
+		if _, ok := got[key]; ok {
+			t.Errorf("reserved extra %q was projected: %#v", key, got)
+		}
+	}
+
+	bare := RpcErrorEntryNotFoundBare("").WithExtra(map[string]any{
+		"error_code":    999,
+		"error_message": "spoofed",
+		"index":         9,
+	})
+	bareFields := bare.ResponseFields()
+	if _, ok := bareFields["error_code"]; ok {
+		t.Errorf("bare error projected error_code: %#v", bareFields)
+	}
+	if _, ok := bareFields["error_message"]; ok {
+		t.Errorf("bare error projected error_message: %#v", bareFields)
+	}
+	if bareFields["index"] != 9 {
+		t.Errorf("bare error lost non-reserved extra: %#v", bareFields)
+	}
+
+	exception := RpcErrorInvalidTransaction("decode failed").WithExtra(map[string]any{
+		"error":           "spoofed",
+		"error_code":      999,
+		"error_message":   "spoofed",
+		"error_exception": "spoofed",
+		"index":           10,
+	})
+	exceptionFields := exception.ResponseFields()
+	if exceptionFields["error"] != "invalidTransaction" || exceptionFields["error_exception"] != "decode failed" || exceptionFields["index"] != 10 {
+		t.Fatalf("exception fields = %#v", exceptionFields)
+	}
+	for _, key := range []string{"error_code", "error_message"} {
+		if _, ok := exceptionFields[key]; ok {
+			t.Errorf("exception error projected %q: %#v", key, exceptionFields)
+		}
+	}
+}
+
+func TestRpcErrorJSONOmitsInternalType(t *testing.T) {
+	data, err := json.Marshal(RpcErrorInvalidParams("custom"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var object map[string]any
+	if err := json.Unmarshal(data, &object); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := object["type"]; ok {
+		t.Fatalf("internal Type leaked from default JSON: %s", data)
+	}
+	if object["error"] != "invalidParams" || object["error_code"] != float64(RpcINVALID_PARAMS) {
+		t.Fatalf("canonical JSON fields = %#v", object)
 	}
 }
 

--- a/internal/rpc/websocket_dispatch.go
+++ b/internal/rpc/websocket_dispatch.go
@@ -331,19 +331,11 @@ func (ws *WebSocketServer) sendCommandError(wsConn *websocketConnection, rpcErr 
 	ws.sendErrorResponse(wsConn, rpcErr, cmd.ID, nil, cmd.Request)
 }
 func (ws *WebSocketServer) sendErrorResponse(wsConn *websocketConnection, rpcErr *types.RpcError, id any, opts *types.WebSocketResponseOptions, request map[string]any) {
-	response := map[string]any{
-		"type":   "response",
-		"status": "error",
-		"error":  rpcErr.ErrorString,
-	}
+	response := rpcErr.ResponseFields()
+	response["type"] = "response"
+	response["status"] = "error"
 	if id != nil {
 		response["id"] = id
-	}
-	if rpcErr.ErrorException != "" {
-		response["error_exception"] = rpcErr.ErrorException
-	} else if !rpcErr.IsBareToken() {
-		response["error_code"] = rpcErr.Code
-		response["error_message"] = rpcErr.Message
 	}
 
 	if opts != nil {

--- a/internal/rpc/websocket_test.go
+++ b/internal/rpc/websocket_test.go
@@ -672,6 +672,83 @@ func TestWebSocketSubscribeErrorWireEnvelope(t *testing.T) {
 	}
 }
 
+func TestWebSocketErrorProjectorPreservesExtrasAndCanonicalFields(t *testing.T) {
+	outbound := make(chan []byte, 3)
+	wsConn := &websocketConnection{Connection: subscription.NewConnection("error-projector", outbound)}
+	ws := &WebSocketServer{}
+	fields := map[string]any{
+		"error":           "spoofed",
+		"status":          "spoofed",
+		"error_code":      999,
+		"error_message":   "spoofed",
+		"error_exception": "spoofed",
+		"code":            999,
+		"message":         "spoofed",
+		"type":            "spoofed",
+		"index":           7,
+	}
+	ws.sendErrorResponse(wsConn, types.RpcErrorInvalidParams("").WithExtra(fields), 1, nil, nil)
+
+	var response map[string]any
+	if err := json.Unmarshal(<-outbound, &response); err != nil {
+		t.Fatal(err)
+	}
+	if response["status"] != "error" || response["error"] != "invalidParams" || response["error_code"] != float64(types.RpcINVALID_PARAMS) || response["error_message"] != "Invalid parameters." {
+		t.Fatalf("canonical WS error = %#v", response)
+	}
+	if response["index"] != float64(7) {
+		t.Fatalf("non-reserved extra missing: %#v", response)
+	}
+	if response["type"] != "response" {
+		t.Fatalf("response type = %v, want response", response["type"])
+	}
+	for _, key := range []string{"error_exception", "code", "message"} {
+		if _, ok := response[key]; ok {
+			t.Errorf("reserved extra %q was projected: %#v", key, response)
+		}
+	}
+
+	bare := types.RpcErrorEntryNotFoundBare("").WithExtra(map[string]any{
+		"error_code":    999,
+		"error_message": "spoofed",
+		"index":         9,
+	})
+	ws.sendErrorResponse(wsConn, bare, 2, nil, nil)
+	response = nil
+	if err := json.Unmarshal(<-outbound, &response); err != nil {
+		t.Fatal(err)
+	}
+	if response["error"] != "entryNotFound" || response["index"] != float64(9) {
+		t.Fatalf("bare WS error = %#v", response)
+	}
+	for _, key := range []string{"error_code", "error_message"} {
+		if _, ok := response[key]; ok {
+			t.Errorf("bare error projected %q: %#v", key, response)
+		}
+	}
+
+	exception := types.RpcErrorInvalidTransaction("decode failed").WithExtra(map[string]any{
+		"error":           "spoofed",
+		"error_code":      999,
+		"error_message":   "spoofed",
+		"error_exception": "spoofed",
+		"index":           10,
+	})
+	ws.sendErrorResponse(wsConn, exception, 3, nil, nil)
+	response = nil
+	if err := json.Unmarshal(<-outbound, &response); err != nil {
+		t.Fatal(err)
+	}
+	if response["error"] != "invalidTransaction" || response["error_exception"] != "decode failed" || response["index"] != float64(10) {
+		t.Fatalf("exception WS error = %#v", response)
+	}
+	for _, key := range []string{"error_code", "error_message"} {
+		if _, ok := response[key]; ok {
+			t.Errorf("exception error projected %q: %#v", key, response)
+		}
+	}
+}
+
 func TestWebSocketHandlerPanicWireEnvelope(t *testing.T) {
 	const panicCause = "websocket panic must stay private"
 	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})


### PR DESCRIPTION
## Summary

- align the RPC error table, default tokens, messages, and HTTP statuses with rippled v3.2.0
- project errors without leaking internal fields or allowing extension keys to overwrite canonical response fields
- add table-driven metadata and transport regressions

This is layer 1 of 7 in the #1490 stack.

Part of #1490.

## Test plan

- `go test -count=1 ./internal/rpc/... ./internal/node ./internal/testing/rpcenv`
- `go test -race -count=1 ./internal/rpc/types ./internal/rpc/handlers ./internal/rpc ./internal/node`
- `go vet ./internal/rpc/... ./internal/node ./internal/testing/rpcenv`
- `golangci-lint run`