### PR TITLE
fix: freeze RPC admission contracts (#1490)

### DIFF
--- a/internal/cli/rpc_test.go
+++ b/internal/cli/rpc_test.go
@@ -37,8 +37,10 @@ func specByMethod(t *testing.T, method string) rpcCommandSpec {
 }
 
 func TestRPCCommandSpecsAreRegisteredHandlers(t *testing.T) {
-	registry := rpctypes.NewMethodRegistry()
-	handlers.RegisterAll(registry)
+	registry, err := handlers.BuildRegistry()
+	if err != nil {
+		t.Fatalf("build registry: %v", err)
+	}
 
 	seen := make(map[string]struct{}, len(rpcCommandSpecs))
 	for _, spec := range rpcCommandSpecs {

--- a/internal/rpc/admin_credentials_test.go
+++ b/internal/rpc/admin_credentials_test.go
@@ -74,8 +74,12 @@ func TestHTTPBatchAdminCredentialsArePerElement(t *testing.T) {
 }
 
 func TestWebSocketAdminCredentials(t *testing.T) {
-	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 2 * time.Second})
-	ws.methodRegistry.Register("stop", &stubHandler{role: types.RoleAdmin})
+	ws := NewWebSocketServer(WebSocketServerOptions{
+		Timeout: 2 * time.Second,
+		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+			"stop": &stubHandler{role: types.RoleAdmin},
+		}),
+	})
 	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ws.ServeHTTP(w, r.WithContext(WithPortContext(r.Context(), credentialedAdminPort())))
 	}))

--- a/internal/rpc/admin_forbidden_test.go
+++ b/internal/rpc/admin_forbidden_test.go
@@ -108,12 +108,13 @@ func TestHTTPAdminDenialChargesFeeMalformed(t *testing.T) {
 // elements are unaffected.
 func TestHTTPBatchAdminDenialForbidden(t *testing.T) {
 	srv := &Server{
-		registry: types.NewMethodRegistry(),
+		registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+			"stop": &stubHandler{role: types.RoleAdmin},
+			"ping": echoHandler(),
+		}),
 		timeout:  time.Second,
 		services: types.NewServiceContainer(nil),
 	}
-	srv.registry.Register("stop", &stubHandler{role: types.RoleAdmin})
-	srv.registry.Register("ping", echoHandler())
 
 	body := `{"method":"batch","params":[
 		{"method":"stop","value":7},
@@ -168,8 +169,12 @@ func TestHTTPBatchAdminDenialForbidden(t *testing.T) {
 // i.e. the "forbidden" token with code 3. A non-admin role is forced by
 // configuring AdminNets that exclude the loopback test peer.
 func TestWSAdminDenialForbidden(t *testing.T) {
-	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 2 * time.Second})
-	ws.methodRegistry.Register("stop", &stubHandler{role: types.RoleAdmin})
+	ws := NewWebSocketServer(WebSocketServerOptions{
+		Timeout: 2 * time.Second,
+		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+			"stop": &stubHandler{role: types.RoleAdmin},
+		}),
+	})
 
 	_, adminNet, _ := net.ParseCIDR("10.0.0.0/8")
 	pc := &PortContext{AdminNets: []net.IPNet{*adminNet}}

--- a/internal/rpc/admin_role_test.go
+++ b/internal/rpc/admin_role_test.go
@@ -40,8 +40,8 @@ func TestMethodDescriptorCatalogue(t *testing.T) {
 	assert.Equal(t, 40, roleCounts[types.RoleGuest])
 	assert.Equal(t, 10, roleCounts[types.RoleUser])
 
-	registry := types.NewMethodRegistry()
-	handlers.RegisterAll(registry)
+	registry, err := handlers.BuildRegistry()
+	assert.NoError(t, err)
 	assert.ElementsMatch(t, registry.List(), mapKeys(seen))
 	for _, descriptor := range descriptors {
 		registered, ok := registry.Get(descriptor.Name)

--- a/internal/rpc/admin_transport_test.go
+++ b/internal/rpc/admin_transport_test.go
@@ -27,14 +27,14 @@ func transportTestPort() *PortContext {
 
 func transportTestServer(t *testing.T, calls *atomic.Int32) *Server {
 	t.Helper()
-	srv := NewServer(ServerOptions{Timeout: time.Second, Services: types.NewServiceContainer(nil)})
-	srv.registry.Register("stop", &stubHandler{
-		role: types.RoleGuest,
-		handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
-			calls.Add(1)
-			return map[string]any{"stopped": true}, nil
-		},
-	})
+	srv := NewServer(ServerOptions{Timeout: time.Second, Services: types.NewServiceContainer(nil), Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+		"stop": &stubHandler{
+			role: types.RoleGuest,
+			handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
+				calls.Add(1)
+				return map[string]any{"stopped": true}, nil
+			},
+		}})})
 	return srv
 }
 
@@ -138,8 +138,12 @@ func TestHTTPTransportNoOriginCLI(t *testing.T) {
 
 func wsTransportServer(t *testing.T, pc *PortContext) (*httptest.Server, *WebSocketServer) {
 	t.Helper()
-	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second})
-	ws.methodRegistry.Register("ping", &stubHandler{role: types.RoleGuest})
+	ws := NewWebSocketServer(WebSocketServerOptions{
+		Timeout: time.Second,
+		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+			"ping": &stubHandler{role: types.RoleGuest},
+		}),
+	})
 	httpSrv := httptest.NewServer(PortMiddleware(pc, http.HandlerFunc(ws.ServeHTTP)))
 	t.Cleanup(func() {
 		httpSrv.Close()

--- a/internal/rpc/amendment_blocked_test.go
+++ b/internal/rpc/amendment_blocked_test.go
@@ -77,9 +77,8 @@ var unblockedMethods = []string{
 // newTestServer creates a Server with all methods registered for testing
 func newTestServer() *Server {
 	server := &Server{
-		registry: types.NewMethodRegistry(),
+		registry: defaultMethodRegistry(),
 	}
-	server.registerAllMethods()
 	return server
 }
 

--- a/internal/rpc/api_version_gate_test.go
+++ b/internal/rpc/api_version_gate_test.go
@@ -19,17 +19,18 @@ import (
 func versionEchoServer(t *testing.T, beta bool) *Server {
 	t.Helper()
 	srv := &Server{
-		registry: types.NewMethodRegistry(),
+		registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+			"ping": &stubHandler{
+				apiVers: []int{types.ApiVersion1, types.ApiVersion2, types.ApiVersion3},
+				handle: func(ctx *types.RpcContext, _ json.RawMessage) (any, *types.RpcError) {
+					return map[string]any{"api_version": ctx.ApiVersion}, nil
+				},
+			},
+		}),
 		timeout:  time.Second,
 		services: types.NewServiceContainer(nil),
 	}
 	srv.services.BetaRPCAPI = beta
-	srv.registry.Register("ping", &stubHandler{
-		apiVers: []int{types.ApiVersion1, types.ApiVersion2, types.ApiVersion3},
-		handle: func(ctx *types.RpcContext, _ json.RawMessage) (any, *types.RpcError) {
-			return map[string]any{"api_version": ctx.ApiVersion}, nil
-		},
-	})
 	return srv
 }
 
@@ -178,14 +179,19 @@ func TestApiVersion_BatchV3RejectedWithoutBeta(t *testing.T) {
 // given beta flag.
 func versionEchoWSServer(t *testing.T, beta bool) *WebSocketServer {
 	t.Helper()
-	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second, Services: types.NewServiceContainer(nil)})
-	ws.services.BetaRPCAPI = beta
-	ws.methodRegistry.Register("ping", &stubHandler{
-		apiVers: []int{types.ApiVersion1, types.ApiVersion2, types.ApiVersion3},
-		handle: func(ctx *types.RpcContext, _ json.RawMessage) (any, *types.RpcError) {
-			return map[string]any{"api_version": ctx.ApiVersion}, nil
-		},
+	ws := NewWebSocketServer(WebSocketServerOptions{
+		Timeout:  30 * time.Second,
+		Services: types.NewServiceContainer(nil),
+		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+			"ping": &stubHandler{
+				apiVers: []int{types.ApiVersion1, types.ApiVersion2, types.ApiVersion3},
+				handle: func(ctx *types.RpcContext, _ json.RawMessage) (any, *types.RpcError) {
+					return map[string]any{"api_version": ctx.ApiVersion}, nil
+				},
+			},
+		}),
 	})
+	ws.services.BetaRPCAPI = beta
 	return ws
 }
 

--- a/internal/rpc/batch_test.go
+++ b/internal/rpc/batch_test.go
@@ -29,12 +29,13 @@ func echoHandler() *stubHandler {
 func newBatchServer(t *testing.T) *Server {
 	t.Helper()
 	srv := &Server{
-		registry: types.NewMethodRegistry(),
+		registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+			"ping":         echoHandler(),
+			"account_info": echoHandler(),
+		}),
 		timeout:  time.Second,
 		services: types.NewServiceContainer(nil),
 	}
-	srv.registry.Register("ping", echoHandler())
-	srv.registry.Register("account_info", echoHandler())
 	return srv
 }
 

--- a/internal/rpc/dispatch_gate_order_test.go
+++ b/internal/rpc/dispatch_gate_order_test.go
@@ -32,10 +32,11 @@ func saturatedShedder() *types.ClientLoadShedder {
 // does not serve the requested (in-range) api_version resolves to unknown-
 // command — matching rippled's getHandler returning null — not invalid_API_version.
 func TestDispatchGateOrder(t *testing.T) {
-	reg := types.NewMethodRegistry()
-	reg.Register("stop", &stubHandler{role: types.RoleAdmin})                                      // admin-only
-	reg.Register("ping", &stubHandler{role: types.RoleGuest})                                      // open
-	reg.Register("v1only", &stubHandler{role: types.RoleGuest, apiVers: []int{types.ApiVersion1}}) // known, v1-only
+	reg := mustTestMethodRegistry(t, map[string]types.MethodHandler{
+		"stop":   &stubHandler{role: types.RoleAdmin},                                    // admin-only
+		"ping":   &stubHandler{role: types.RoleGuest},                                    // open
+		"v1only": &stubHandler{role: types.RoleGuest, apiVers: []int{types.ApiVersion1}}, // known, v1-only
+	})
 
 	cases := []struct {
 		name       string
@@ -103,8 +104,13 @@ func TestDispatchGateOrder(t *testing.T) {
 func TestHTTPForbiddenBeatsBusy(t *testing.T) {
 	services := types.NewServiceContainer(nil)
 	services.ClientLoad = types.NewClientLoadShedder()
-	srv := NewServer(ServerOptions{Timeout: time.Second, Services: services})
-	srv.registry.Register("stop", &stubHandler{role: types.RoleAdmin})
+	srv := NewServer(ServerOptions{
+		Timeout:  time.Second,
+		Services: services,
+		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+			"stop": &stubHandler{role: types.RoleAdmin},
+		}),
+	})
 
 	for i := int64(0); i <= types.MaxJobQueueClients; i++ {
 		services.ClientLoad.Begin()
@@ -147,8 +153,13 @@ func TestHTTPForbiddenBeatsBusy(t *testing.T) {
 // invalid_API_version bare token.
 func TestHTTPKnownMethodUnsupportedVersionIsUnknownCommand(t *testing.T) {
 	services := types.NewServiceContainer(nil)
-	srv := NewServer(ServerOptions{Timeout: time.Second, Services: services})
-	srv.registry.Register("v1only", &stubHandler{role: types.RoleGuest, apiVers: []int{types.ApiVersion1}})
+	srv := NewServer(ServerOptions{
+		Timeout:  time.Second,
+		Services: services,
+		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+			"v1only": &stubHandler{role: types.RoleGuest, apiVers: []int{types.ApiVersion1}},
+		}),
+	})
 
 	post := func(body string) *httptest.ResponseRecorder {
 		req := httptest.NewRequest("POST", "/", strings.NewReader(body))

--- a/internal/rpc/dispatch_parity_test.go
+++ b/internal/rpc/dispatch_parity_test.go
@@ -31,8 +31,9 @@ func (h *condStubHandler) RequiredCondition() types.Condition { return h.cond }
 // (used by BOTH the HTTP and WebSocket transports) runs conditionMet, so a
 // not-synced node refuses a condition-requiring method on either transport.
 func TestDispatchMethodEnforcesConditionMet(t *testing.T) {
-	reg := types.NewMethodRegistry()
-	reg.Register("gated", &condStubHandler{cond: types.NeedsNetworkConnection})
+	reg := mustTestMethodRegistry(t, map[string]types.MethodHandler{
+		"gated": &condStubHandler{cond: types.NeedsNetworkConnection},
+	})
 
 	t.Run("not synced is refused", func(t *testing.T) {
 		ctx := &types.RpcContext{
@@ -134,8 +135,12 @@ func TestLoadWarningNestedInResultOnHTTP(t *testing.T) {
 // alias for `command`, and an unresolvable command yields a bare missingCommand
 // token that echoes the request and id (ServerHandler.cpp:446-468).
 func TestWSCommandAliasAndMissingCommand(t *testing.T) {
-	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 2 * time.Second})
-	ws.methodRegistry.Register("ping", &stubHandler{})
+	ws := NewWebSocketServer(WebSocketServerOptions{
+		Timeout: 2 * time.Second,
+		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+			"ping": &stubHandler{},
+		}),
+	})
 
 	httpSrv := httptest.NewServer(http.HandlerFunc(ws.ServeHTTP))
 	defer httpSrv.Close()

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -158,8 +158,7 @@ func acquirePathfind(ctx *types.RpcContext) (release func(), rpcErr *types.RpcEr
 		if s == nil {
 			return func() {}, nil
 		}
-		s.AcquirePathfindUnlimited()
-		return s.ReleasePathfind, nil
+		return s.AcquirePathfindUnlimited(), nil
 	}
 	if services.IsLoadedLocal != nil && services.IsLoadedLocal() {
 		return nil, types.RpcErrorTooBusy()
@@ -170,10 +169,11 @@ func acquirePathfind(ctx *types.RpcContext) (release func(), rpcErr *types.RpcEr
 	if s.InFlight() > types.MaxPathfindClients {
 		return nil, types.RpcErrorTooBusy()
 	}
-	if !s.AcquirePathfind() {
+	release, acquired := s.AcquirePathfind()
+	if !acquired {
 		return nil, types.RpcErrorTooBusy()
 	}
-	return s.ReleasePathfind, nil
+	return release, nil
 }
 
 // waitPathfind queues a default-ledger request behind the bounded path-finding
@@ -182,10 +182,11 @@ func waitPathfind(ctx *types.RpcContext) (release func(), rpcErr *types.RpcError
 	if ctx == nil || ctx.Services == nil || ctx.Services.ClientLoad == nil {
 		return func() {}, nil
 	}
-	if !ctx.Services.ClientLoad.WaitPathfind(ctx.Context) {
+	release, acquired := ctx.Services.ClientLoad.WaitPathfind(ctx.Context)
+	if !acquired {
 		return nil, types.RpcErrorTooBusy()
 	}
-	return ctx.Services.ClientLoad.ReleasePathfind, nil
+	return release, nil
 }
 
 // parseParams unmarshals JSON params into dest, returning an RpcError on failure.

--- a/internal/rpc/handlers/load_shed_test.go
+++ b/internal/rpc/handlers/load_shed_test.go
@@ -227,9 +227,14 @@ func TestWaitPathfindWaitsForRelease(t *testing.T) {
 		t.Fatalf("second acquire should succeed: %v", err2)
 	}
 
-	acquired := make(chan bool, 1)
+	type waitResult struct {
+		release func()
+		ok      bool
+	}
+	acquired := make(chan waitResult, 1)
 	go func() {
-		acquired <- s.WaitPathfind(context.Background())
+		release, ok := s.WaitPathfind(context.Background())
+		acquired <- waitResult{release: release, ok: ok}
 	}()
 
 	select {
@@ -240,15 +245,15 @@ func TestWaitPathfindWaitsForRelease(t *testing.T) {
 
 	r1()
 	select {
-	case ok := <-acquired:
-		if !ok {
+	case result := <-acquired:
+		if !result.ok {
 			t.Fatal("waiting pathfind should acquire the released slot")
 		}
+		result.release()
 	case <-time.After(time.Second):
 		t.Fatal("waiting pathfind did not acquire the released slot")
 	}
 
-	s.ReleasePathfind()
 	r2()
 	if got := s.PathfindActive(); got != 0 {
 		t.Fatalf("PathfindActive leaked after wait: %d", got)
@@ -257,14 +262,14 @@ func TestWaitPathfindWaitsForRelease(t *testing.T) {
 
 func TestWaitPathfindHonorsCancellation(t *testing.T) {
 	s := types.NewClientLoadShedder()
-	s.AcquirePathfindUnlimited()
-	s.AcquirePathfindUnlimited()
+	r1 := s.AcquirePathfindUnlimited()
+	r2 := s.AcquirePathfindUnlimited()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	if s.WaitPathfind(ctx) {
+	if _, ok := s.WaitPathfind(ctx); ok {
 		t.Fatal("canceled pathfind wait should fail")
 	}
-	s.ReleasePathfind()
-	s.ReleasePathfind()
+	r1()
+	r2()
 }

--- a/internal/rpc/handlers/registry.go
+++ b/internal/rpc/handlers/registry.go
@@ -180,15 +180,79 @@ func (method registeredMethod) RequiredCondition() types.Condition {
 	return method.descriptor.Condition
 }
 
-// RegisterAll wires the same immutable method catalogue into every transport.
-func RegisterAll(registry *types.MethodRegistry) {
+// RegisterAll adds the immutable method catalogue to a builder. The caller
+// must build the registry before publishing it to a transport.
+func RegisterAll(registry *types.MethodRegistryBuilder) error {
+	if registry == nil {
+		return fmt.Errorf("RPC method registry builder is nil")
+	}
 	seen := make(map[string]struct{}, len(methodDescriptors))
 	for _, descriptor := range methodDescriptors {
 		if _, duplicate := seen[descriptor.Name]; duplicate {
-			panic(fmt.Sprintf("duplicate RPC method descriptor %q", descriptor.Name))
+			return fmt.Errorf("duplicate RPC method descriptor %q", descriptor.Name)
 		}
 		seen[descriptor.Name] = struct{}{}
 		descriptor.Handler = newHandlerOfSameType(descriptor.Handler)
-		registry.Register(descriptor.Name, registeredMethod{descriptor: descriptor})
+		if err := registry.Register(descriptor.Name, registeredMethod{descriptor: descriptor}); err != nil {
+			return fmt.Errorf("register RPC method %q: %w", descriptor.Name, err)
+		}
+	}
+	return nil
+}
+
+// BuildRegistry returns a freshly built copy of the production RPC method
+// catalogue.
+func BuildRegistry() (*types.MethodRegistry, error) {
+	builder := types.NewMethodRegistryBuilder()
+	if err := RegisterAll(builder); err != nil {
+		return nil, err
+	}
+	return builder.Build()
+}
+
+// BuildRegistryWithOverrides builds a pre-publication registry for transport
+// tests that need to replace or add a small number of handlers. The returned
+// registry remains immutable once built.
+func BuildRegistryWithOverrides(overrides map[string]types.MethodHandler) (*types.MethodRegistry, error) {
+	builder := types.NewMethodRegistryBuilder()
+	seen := make(map[string]struct{}, len(methodDescriptors)+len(overrides))
+	for _, descriptor := range methodDescriptors {
+		if _, duplicate := seen[descriptor.Name]; duplicate {
+			return nil, fmt.Errorf("duplicate RPC method descriptor %q", descriptor.Name)
+		}
+		seen[descriptor.Name] = struct{}{}
+		if override, ok := overrides[descriptor.Name]; ok {
+			if methodHandlerIsNil(override) {
+				return nil, fmt.Errorf("RPC method %q has a nil override", descriptor.Name)
+			}
+			descriptor.Handler = override
+		} else {
+			descriptor.Handler = newHandlerOfSameType(descriptor.Handler)
+		}
+		if err := builder.Register(descriptor.Name, registeredMethod{descriptor: descriptor}); err != nil {
+			return nil, fmt.Errorf("register RPC method %q: %w", descriptor.Name, err)
+		}
+	}
+	for name, handler := range overrides {
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		if err := builder.Register(name, handler); err != nil {
+			return nil, fmt.Errorf("register RPC method %q: %w", name, err)
+		}
+	}
+	return builder.Build()
+}
+
+func methodHandlerIsNil(handler types.MethodHandler) bool {
+	if handler == nil {
+		return true
+	}
+	value := reflect.ValueOf(handler)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
 	}
 }

--- a/internal/rpc/json_proxy_regression_test.go
+++ b/internal/rpc/json_proxy_regression_test.go
@@ -17,26 +17,31 @@ import (
 func TestJSONProxyUsesSingleDispatchAccounting(t *testing.T) {
 	services := types.NewServiceContainer(nil)
 	services.ClientLoad = types.NewClientLoadShedder()
-	server := NewServer(ServerOptions{Timeout: time.Second, Services: services})
+	var targetCalls int
+	server := NewServer(ServerOptions{
+		Timeout:  time.Second,
+		Services: services,
+		Registry: mustTestMethodRegistryWithOverrides(t, map[string]types.MethodHandler{
+			"json_proxy_target": &stubHandler{
+				handle: func(ctx *types.RpcContext, _ json.RawMessage) (any, *types.RpcError) {
+					targetCalls++
+					assert.Equal(t, types.MaxJobQueueClients, services.ClientLoad.InFlight())
+					ctx.LoadCost = uint32(resource.FeeHeavyBurdenRPC().Cost())
+					return map[string]any{"proxied": true}, nil
+				},
+			},
+		}),
+	})
 	services.Dispatcher = server
 
+	leases := make([]func(), 0, types.MaxJobQueueClients-1)
 	for range types.MaxJobQueueClients - 1 {
-		services.ClientLoad.Begin()
+		leases = append(leases, services.ClientLoad.Begin())
 	}
 	t.Cleanup(func() {
-		for range types.MaxJobQueueClients - 1 {
-			services.ClientLoad.End()
+		for i := len(leases) - 1; i >= 0; i-- {
+			leases[i]()
 		}
-	})
-
-	var targetCalls int
-	server.registry.Register("json_proxy_target", &stubHandler{
-		handle: func(ctx *types.RpcContext, _ json.RawMessage) (any, *types.RpcError) {
-			targetCalls++
-			assert.Equal(t, types.MaxJobQueueClients, services.ClientLoad.InFlight())
-			ctx.LoadCost = uint32(resource.FeeHeavyBurdenRPC().Cost())
-			return map[string]any{"proxied": true}, nil
-		},
 	})
 
 	request := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(
@@ -114,16 +119,21 @@ func TestHTTPStructuredIDRedactionAcrossDispatchShapes(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			services := types.NewServiceContainer(nil)
-			server := NewServer(ServerOptions{Timeout: time.Second, Services: services})
-			services.Dispatcher = server
-			server.registry.Register("capture", &stubHandler{
-				handle: func(_ *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
-					var received map[string]any
-					require.NoError(t, json.Unmarshal(params, &received))
-					assertMaskedStructuredID(t, received["id"])
-					return map[string]any{"received": received}, nil
-				},
+			server := NewServer(ServerOptions{
+				Timeout:  time.Second,
+				Services: services,
+				Registry: mustTestMethodRegistryWithOverrides(t, map[string]types.MethodHandler{
+					"capture": &stubHandler{
+						handle: func(_ *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
+							var received map[string]any
+							require.NoError(t, json.Unmarshal(params, &received))
+							assertMaskedStructuredID(t, received["id"])
+							return map[string]any{"received": received}, nil
+						},
+					},
+				}),
 			})
+			services.Dispatcher = server
 
 			response := postTransportRegressionRequest(t, server, test.body)
 			require.Equal(t, http.StatusOK, response.Code)
@@ -148,8 +158,13 @@ func TestURLUserinfoIsRedactedAcrossTransportEchoes(t *testing.T) {
 			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 		},
 	}
-	httpServer := NewServer(ServerOptions{Timeout: time.Second, Services: types.NewServiceContainer(nil)})
-	httpServer.registry.Register("userinfo_fail", fail)
+	httpServer := NewServer(ServerOptions{
+		Timeout:  time.Second,
+		Services: types.NewServiceContainer(nil),
+		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+			"userinfo_fail": fail,
+		}),
+	})
 
 	urls := []struct {
 		name  string
@@ -179,8 +194,12 @@ func TestURLUserinfoIsRedactedAcrossTransportEchoes(t *testing.T) {
 			}
 
 			t.Run("WebSocket", func(t *testing.T) {
-				server := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second})
-				server.methodRegistry.Register("userinfo_fail", fail)
+				server := NewWebSocketServer(WebSocketServerOptions{
+					Timeout: time.Second,
+					Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+						"userinfo_fail": fail,
+					}),
+				})
 				body := wsRawRoundTrip(t, server,
 					`{"command":"userinfo_fail","url":"`+testURL.value+`"}`,
 				)

--- a/internal/rpc/load_shed_http_test.go
+++ b/internal/rpc/load_shed_http_test.go
@@ -24,8 +24,13 @@ func TestNewServerLeavesServiceContainerUntouched(t *testing.T) {
 func TestRpcTooBusyUsesLegacyHTTP200(t *testing.T) {
 	services := types.NewServiceContainer(nil)
 	services.ClientLoad = types.NewClientLoadShedder()
-	srv := NewServer(ServerOptions{Timeout: time.Second, Services: services})
-	srv.registry.Register("book_offers", &handlers.BookOffersMethod{})
+	srv := NewServer(ServerOptions{
+		Timeout:  time.Second,
+		Services: services,
+		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+			"book_offers": &handlers.BookOffersMethod{},
+		}),
+	})
 
 	for i := int64(0); i <= types.MaxJobQueueClients; i++ {
 		services.ClientLoad.Begin()
@@ -67,8 +72,13 @@ func TestRpcTooBusyUsesLegacyHTTP200(t *testing.T) {
 func TestRequestUnderThresholdReturnsHTTP200(t *testing.T) {
 	services := types.NewServiceContainer(nil)
 	services.ClientLoad = types.NewClientLoadShedder()
-	srv := NewServer(ServerOptions{Timeout: time.Second, Services: services})
-	srv.registry.Register("book_offers", &handlers.BookOffersMethod{})
+	srv := NewServer(ServerOptions{
+		Timeout:  time.Second,
+		Services: services,
+		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+			"book_offers": &handlers.BookOffersMethod{},
+		}),
+	})
 
 	body := `{"method":"book_offers","params":[{}]}`
 	req := httptest.NewRequest("POST", "/", strings.NewReader(body))

--- a/internal/rpc/methods.go
+++ b/internal/rpc/methods.go
@@ -2,8 +2,13 @@ package rpc
 
 import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
-func (s *Server) registerAllMethods() {
-	handlers.RegisterAll(s.registry)
+func defaultMethodRegistry() *types.MethodRegistry {
+	registry, err := handlers.BuildRegistry()
+	if err != nil {
+		panic(err)
+	}
+	return registry
 }

--- a/internal/rpc/overload_gate_test.go
+++ b/internal/rpc/overload_gate_test.go
@@ -185,13 +185,14 @@ func TestHTTPApiVersionPrecedesOverload(t *testing.T) {
 // element and an ordinary element — never the forbidden (-32605) object.
 func TestHTTPBatchOverloadElement(t *testing.T) {
 	srv := &Server{
-		registry:        types.NewMethodRegistry(),
+		registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+			"stop": &stubHandler{role: types.RoleAdmin},
+			"ping": echoHandler(),
+		}),
 		timeout:         time.Second,
 		services:        types.NewServiceContainer(nil),
 		resourceManager: resource.NewManager(nil, nil),
 	}
-	srv.registry.Register("stop", &stubHandler{role: types.RoleAdmin})
-	srv.registry.Register("ping", echoHandler())
 	pushOverDropThreshold(t, srv.resourceManager, "10.0.0.1") // postBatch posts from 10.0.0.1
 
 	body := `{"method":"batch","params":[
@@ -247,8 +248,13 @@ func TestWSOverloadClosesBeforeRequestValidation(t *testing.T) {
 	for _, request := range tests {
 		t.Run(request, func(t *testing.T) {
 			manager := resource.NewManager(nil, nil)
-			ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 2 * time.Second, ResourceManager: manager})
-			ws.methodRegistry.Register("stop", &stubHandler{role: types.RoleAdmin})
+			ws := NewWebSocketServer(WebSocketServerOptions{
+				Timeout:         2 * time.Second,
+				ResourceManager: manager,
+				Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+					"stop": &stubHandler{role: types.RoleAdmin},
+				}),
+			})
 			pushOverDropThreshold(t, manager, "127.0.0.1")
 
 			_, adminNet, _ := net.ParseCIDR("10.0.0.0/8")

--- a/internal/rpc/path_find_refresh.go
+++ b/internal/rpc/path_find_refresh.go
@@ -341,8 +341,8 @@ func (m *pathFindRefreshManager) waitForPathfindAdmission(job pathFindRefreshJob
 		if !m.jobCurrent(job) {
 			return nil, false
 		}
-		if shedder.AcquirePathfind() {
-			return shedder.ReleasePathfind, true
+		if release, acquired := shedder.AcquirePathfind(); acquired {
+			return release, true
 		}
 		timer := time.NewTimer(pathFindRefreshRetryInterval)
 		select {

--- a/internal/rpc/print_wire_test.go
+++ b/internal/rpc/print_wire_test.go
@@ -37,8 +37,9 @@ func printTestServer(t *testing.T) *Server {
 		cluster:                map[string]any{},
 		criticalFailuresLocal:  4,
 		criticalFailuresShared: 2,
-	}})
-	srv.registry.Register("print", &handlers.PrintMethod{})
+	}, Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+		"print": &handlers.PrintMethod{},
+	})})
 	return srv
 }
 

--- a/internal/rpc/registry_regression_test.go
+++ b/internal/rpc/registry_regression_test.go
@@ -9,8 +9,10 @@ import (
 )
 
 func TestRemovedShardMethodsAreUnknownCommands(t *testing.T) {
-	registry := types.NewMethodRegistry()
-	handlers.RegisterAll(registry)
+	registry, err := handlers.BuildRegistry()
+	if err != nil {
+		t.Fatalf("build registry: %v", err)
+	}
 	for _, name := range []string{"download_shard", "crawl_shards"} {
 		if _, ok := registry.Get(name); ok {
 			t.Fatalf("removed RPC method %q is still registered", name)

--- a/internal/rpc/registry_test_helpers_test.go
+++ b/internal/rpc/registry_test_helpers_test.go
@@ -1,0 +1,32 @@
+package rpc
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+)
+
+func mustTestMethodRegistry(t testing.TB, methods map[string]types.MethodHandler) *types.MethodRegistry {
+	t.Helper()
+	builder := types.NewMethodRegistryBuilder()
+	for name, handler := range methods {
+		if err := builder.Register(name, handler); err != nil {
+			t.Fatalf("register test RPC method %q: %v", name, err)
+		}
+	}
+	registry, err := builder.Build()
+	if err != nil {
+		t.Fatalf("build test RPC method registry: %v", err)
+	}
+	return registry
+}
+
+func mustTestMethodRegistryWithOverrides(t testing.TB, methods map[string]types.MethodHandler) *types.MethodRegistry {
+	t.Helper()
+	registry, err := handlers.BuildRegistryWithOverrides(methods)
+	if err != nil {
+		t.Fatalf("build test RPC method registry with overrides: %v", err)
+	}
+	return registry
+}

--- a/internal/rpc/resource_integration_test.go
+++ b/internal/rpc/resource_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,8 +21,10 @@ func TestUnifiedResourceManagerGossipsWebSocketLoadIntoHTTPAdmission(t *testing.
 	ws := NewWebSocketServer(WebSocketServerOptions{
 		Timeout:         time.Second,
 		ResourceManager: managerA,
+		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+			"heavy": &heavyStub{stubHandler: stubHandler{}},
+		}),
 	})
-	ws.methodRegistry.Register("heavy", &heavyStub{stubHandler: stubHandler{}})
 
 	_, gateway, err := net.ParseCIDR("127.0.0.0/8")
 	require.NoError(t, err)

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -46,6 +46,7 @@ type ServerOptions struct {
 	Services        *types.ServiceContainer
 	ResourceManager *resource.Manager
 	PeerSource      types.PeerSource
+	Registry        *types.MethodRegistry
 }
 
 var _ types.MethodDispatcher = (*Server)(nil)
@@ -79,14 +80,15 @@ func NewServer(options ServerOptions) *Server {
 		manager = resource.NewManager(nil, nil)
 	}
 	server := &Server{
-		registry:        types.NewMethodRegistry(),
+		registry:        options.Registry,
 		timeout:         options.Timeout,
 		services:        options.Services,
 		resourceManager: manager,
 	}
+	if server.registry == nil {
+		server.registry = defaultMethodRegistry()
+	}
 	server.setPeerSource(options.PeerSource)
-
-	server.registerAllMethods()
 
 	return server
 }

--- a/internal/rpc/server_dispatch.go
+++ b/internal/rpc/server_dispatch.go
@@ -191,8 +191,8 @@ func dispatchResolvedMethod(
 	}
 
 	if services != nil && services.ClientLoad != nil {
-		services.ClientLoad.Begin()
-		defer services.ClientLoad.End()
+		release := services.ClientLoad.Begin()
+		defer release()
 	}
 	finishDiagnostics := startRPCDiagnostics(services, method)
 	result, rpcErr, recovered := invokeHandler(resolution.handler, ctx, params, method, log)

--- a/internal/rpc/server_hardening_test.go
+++ b/internal/rpc/server_hardening_test.go
@@ -48,11 +48,10 @@ func (s *stubHandler) RequiredCondition() types.Condition { return types.NoCondi
 func newHardeningServer(t *testing.T, timeout time.Duration, method string, h types.MethodHandler) *Server {
 	t.Helper()
 	srv := &Server{
-		registry: types.NewMethodRegistry(),
+		registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{method: h}),
 		timeout:  timeout,
 		services: types.NewServiceContainer(nil),
 	}
-	srv.registry.Register(method, h)
 	return srv
 }
 

--- a/internal/rpc/transport_regression_test.go
+++ b/internal/rpc/transport_regression_test.go
@@ -29,12 +29,19 @@ func postTransportRegressionRequest(t *testing.T, server *Server, body string) *
 
 func newTransportRegressionServer(t *testing.T) *Server {
 	t.Helper()
-	server := newHardeningServer(t, time.Second, "ping", &stubHandler{})
-	server.registry.Register("stop", &stubHandler{role: types.RoleAdmin})
-	server.registry.Register("fail", &stubHandler{
-		handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
-			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
-		},
+	server := NewServer(ServerOptions{
+		Timeout:  time.Second,
+		Services: types.NewServiceContainer(nil),
+		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+			"ping": &stubHandler{},
+			"stop": &stubHandler{role: types.RoleAdmin},
+			"fail": &stubHandler{
+				handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
+					return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+				},
+			},
+			"gated": &condStubHandler{cond: types.NeedsNetworkConnection},
+		}),
 	})
 	server.resourceManager = resource.NewManager(nil, nil)
 	return server
@@ -283,7 +290,6 @@ func TestHTTPEarlyDispatchErrorsChargeReferenceAndWarn(t *testing.T) {
 			method: "gated",
 			token:  "noNetwork",
 			setup: func(server *Server) {
-				server.registry.Register("gated", &condStubHandler{cond: types.NeedsNetworkConnection})
 				server.services.Ledger = newMockLedgerService()
 			},
 		},

--- a/internal/rpc/types/registry_test.go
+++ b/internal/rpc/types/registry_test.go
@@ -1,0 +1,102 @@
+package types
+
+import (
+	"encoding/json"
+	"reflect"
+	"sync"
+	"testing"
+)
+
+type registryTestHandler struct{}
+
+func (registryTestHandler) Handle(*RpcContext, json.RawMessage) (any, *RpcError) { return nil, nil }
+func (registryTestHandler) RequiredRole() Role                                   { return RoleGuest }
+func (registryTestHandler) SupportedApiVersions() []int                          { return nil }
+func (registryTestHandler) RequiredCondition() Condition                         { return NoCondition }
+
+func TestMethodRegistryBuilderValidationAndPublication(t *testing.T) {
+	var builder MethodRegistryBuilder
+	handler := registryTestHandler{}
+	var typedNil *registryTestHandler
+	for _, test := range []struct {
+		name    string
+		handler MethodHandler
+	}{
+		{name: "", handler: handler},
+		{name: " ", handler: handler},
+		{name: " rpc", handler: handler},
+		{name: "rpc ", handler: handler},
+		{name: "nil", handler: nil},
+		{name: "typed nil", handler: typedNil},
+	} {
+		if err := builder.Register(test.name, test.handler); err == nil {
+			t.Errorf("Register(%q, %T) unexpectedly succeeded", test.name, test.handler)
+		}
+	}
+	if err := builder.Register("zeta", handler); err != nil {
+		t.Fatalf("register zeta: %v", err)
+	}
+	if err := builder.Register("alpha", handler); err != nil {
+		t.Fatalf("register alpha: %v", err)
+	}
+	if err := builder.Register("alpha", handler); err == nil {
+		t.Fatal("duplicate registration unexpectedly succeeded")
+	}
+	registry, err := builder.Build()
+	if err != nil {
+		t.Fatalf("build registry: %v", err)
+	}
+	if err := builder.Register("late", handler); err == nil {
+		t.Fatal("registration after build unexpectedly succeeded")
+	}
+	if _, err := builder.Build(); err == nil {
+		t.Fatal("second build unexpectedly succeeded")
+	}
+
+	want := []string{"alpha", "zeta"}
+	if got := registry.List(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("List() = %v, want sorted %v", got, want)
+	}
+	listed := registry.List()
+	listed[0] = "changed"
+	if got := registry.List(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("List() exposed internal storage: %v", got)
+	}
+	if got, ok := registry.Get("alpha"); !ok || got != handler {
+		t.Fatalf("Get(alpha) = (%T, %v), want registered handler", got, ok)
+	}
+}
+
+func TestMethodRegistryNilReceiversAndConcurrentReads(t *testing.T) {
+	var nilBuilder *MethodRegistryBuilder
+	if err := nilBuilder.Register("rpc", registryTestHandler{}); err == nil {
+		t.Fatal("nil builder Register unexpectedly succeeded")
+	}
+	if registry, err := nilBuilder.Build(); err == nil || registry != nil {
+		t.Fatalf("nil builder Build = (%v, %v), want nil/error", registry, err)
+	}
+	var nilRegistry *MethodRegistry
+	if handler, ok := nilRegistry.Get("rpc"); ok || handler != nil {
+		t.Fatalf("nil registry Get = (%v, %v), want (nil, false)", handler, ok)
+	}
+	if got := nilRegistry.List(); got != nil {
+		t.Fatalf("nil registry List = %v, want nil", got)
+	}
+
+	registry, err := (&MethodRegistryBuilder{}).Build()
+	if err != nil {
+		t.Fatalf("build empty registry: %v", err)
+	}
+	var readers sync.WaitGroup
+	for range 16 {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for range 100 {
+				registry.Get("rpc")
+				registry.List()
+			}
+		}()
+	}
+	readers.Wait()
+}

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -727,13 +727,15 @@ const (
 // ClientLoadShedder is the shared in-flight RPC counter plus a
 // dedicated concurrent-path-find counter. See ServiceContainer.ClientLoad.
 //
-// Begin()/End() bracket each RPC dispatch (HTTP and WebSocket). Handlers
+// Begin returns an ownership-bound release function for each RPC dispatch
+// (HTTP and WebSocket). Handlers
 // consult InFlight() against the rippled-faithful tier constants
 // (MaxJobQueueClients, MaxBookOffersClients, MaxPathfindClients).
 //
-// AcquirePathfind/ReleasePathfind manage the second counter, capped at
-// MaxPathfindsInProgress to mirror rippled's LegacyPathFind ctor
-// (LegacyPathFind.cpp:30-60).
+// AcquirePathfind and AcquirePathfindUnlimited return ownership-bound
+// release functions for the second counter, which is capped at
+// MaxPathfindsInProgress for bounded callers. A release function is safe to
+// invoke more than once.
 type ClientLoadShedder struct {
 	inFlight       atomic.Int64
 	pathfindActive atomic.Int64
@@ -752,21 +754,34 @@ func (s *ClientLoadShedder) pathfindSignal() chan struct{} {
 	return s.pathfindReady
 }
 
-// Begin records the start of a client-RPC dispatch.
-func (s *ClientLoadShedder) Begin() {
+func noOpLoadShedRelease() {}
+
+func (s *ClientLoadShedder) release(counter *atomic.Int64, signal bool) func() {
 	if s == nil {
-		return
+		return noOpLoadShedRelease
 	}
-	s.inFlight.Add(1)
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			counter.Add(-1)
+			if signal {
+				select {
+				case s.pathfindSignal() <- struct{}{}:
+				default:
+				}
+			}
+		})
+	}
 }
 
-// End records completion of a client-RPC dispatch. Safe to call from a
-// defer alongside Begin().
-func (s *ClientLoadShedder) End() {
+// Begin records the start of a client-RPC dispatch and returns its release
+// function.
+func (s *ClientLoadShedder) Begin() func() {
 	if s == nil {
-		return
+		return noOpLoadShedRelease
 	}
-	s.inFlight.Add(-1)
+	s.inFlight.Add(1)
+	return s.release(&s.inFlight, false)
 }
 
 // InFlight returns the current in-flight RPC count. Gates compare it
@@ -779,61 +794,55 @@ func (s *ClientLoadShedder) InFlight() int64 {
 }
 
 // AcquirePathfind attempts to enter the path-finding critical section.
-// Returns true on success (caller MUST pair with ReleasePathfind), false
-// when already at MaxPathfindsInProgress. CAS-loop matches rippled's
-// LegacyPathFind ctor at LegacyPathFind.cpp:44-58.
-func (s *ClientLoadShedder) AcquirePathfind() bool {
+// It returns an ownership-bound release function and true on success, or a
+// nil release function and false when already at MaxPathfindsInProgress.
+// CAS-loop matches rippled's LegacyPathFind ctor at LegacyPathFind.cpp:44-58.
+func (s *ClientLoadShedder) AcquirePathfind() (func(), bool) {
 	if s == nil {
-		return true
+		return noOpLoadShedRelease, true
 	}
 	for {
 		prev := s.pathfindActive.Load()
 		if prev >= MaxPathfindsInProgress {
-			return false
+			return nil, false
 		}
 		if s.pathfindActive.CompareAndSwap(prev, prev+1) {
-			return true
+			return s.release(&s.pathfindActive, true), true
 		}
 	}
 }
 
 // WaitPathfind blocks until a bounded path-finding slot is available or the
-// request is canceled.
-func (s *ClientLoadShedder) WaitPathfind(ctx context.Context) bool {
+// request is canceled. It returns the acquired slot's release function and
+// true on success, or a nil release function and false on cancellation.
+func (s *ClientLoadShedder) WaitPathfind(ctx context.Context) (func(), bool) {
 	if s == nil {
-		return true
+		return noOpLoadShedRelease, true
 	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	for !s.AcquirePathfind() {
+	for {
+		release, acquired := s.AcquirePathfind()
+		if acquired {
+			return release, true
+		}
 		select {
 		case <-ctx.Done():
-			return false
+			return nil, false
 		case <-s.pathfindSignal():
 		}
 	}
-	return true
 }
 
 // AcquirePathfindUnlimited enters the path-finding critical section without
-// enforcing the non-admin concurrency cap.
-func (s *ClientLoadShedder) AcquirePathfindUnlimited() {
+// enforcing the non-admin concurrency cap and returns its release function.
+func (s *ClientLoadShedder) AcquirePathfindUnlimited() func() {
 	if s == nil {
-		return
+		return noOpLoadShedRelease
 	}
 	s.pathfindActive.Add(1)
-}
-
-func (s *ClientLoadShedder) ReleasePathfind() {
-	if s == nil {
-		return
-	}
-	s.pathfindActive.Add(-1)
-	select {
-	case s.pathfindSignal() <- struct{}{}:
-	default:
-	}
+	return s.release(&s.pathfindActive, true)
 }
 
 // PathfindActive returns the current concurrent-path-find count.

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -774,8 +774,6 @@ func (s *ClientLoadShedder) release(counter *atomic.Int64, signal bool) func() {
 	}
 }
 
-// Begin records the start of a client-RPC dispatch and returns its release
-// function.
 func (s *ClientLoadShedder) Begin() func() {
 	if s == nil {
 		return noOpLoadShedRelease

--- a/internal/rpc/types/services_test.go
+++ b/internal/rpc/types/services_test.go
@@ -1,0 +1,106 @@
+package types
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestClientLoadShedderReleaseOwnership(t *testing.T) {
+	var shedder ClientLoadShedder
+	end := shedder.Begin()
+	var dispatchReleases sync.WaitGroup
+	for range 8 {
+		dispatchReleases.Add(1)
+		go func() {
+			defer dispatchReleases.Done()
+			end()
+		}()
+	}
+	dispatchReleases.Wait()
+	if got := shedder.InFlight(); got != 0 {
+		t.Fatalf("in-flight after repeated release = %d, want 0", got)
+	}
+
+	first, ok := shedder.AcquirePathfind()
+	if !ok {
+		t.Fatal("first bounded acquire failed")
+	}
+	second, ok := shedder.AcquirePathfind()
+	if !ok {
+		t.Fatal("second bounded acquire failed")
+	}
+	if _, ok := shedder.AcquirePathfind(); ok {
+		t.Fatal("third bounded acquire exceeded the cap")
+	}
+
+	var releases sync.WaitGroup
+	for range 8 {
+		releases.Add(1)
+		go func() {
+			defer releases.Done()
+			first()
+		}()
+	}
+	releases.Wait()
+	if got := shedder.PathfindActive(); got != 1 {
+		t.Fatalf("active after repeated release = %d, want 1", got)
+	}
+
+	third, ok := shedder.AcquirePathfind()
+	if !ok {
+		t.Fatal("release should make a bounded slot available")
+	}
+	second()
+	third()
+	third()
+	if got := shedder.PathfindActive(); got != 0 {
+		t.Fatalf("active after all releases = %d, want 0", got)
+	}
+
+	unlimited := shedder.AcquirePathfindUnlimited()
+	bounded, ok := shedder.AcquirePathfind()
+	if !ok {
+		t.Fatal("unlimited acquisition should not poison bounded ownership")
+	}
+	bounded()
+	unlimited()
+	if got := shedder.PathfindActive(); got != 0 {
+		t.Fatalf("active after mixed release = %d, want 0", got)
+	}
+}
+
+func TestClientLoadShedderWaitCancellationAndZeroValues(t *testing.T) {
+	var shedder ClientLoadShedder
+	first := shedder.AcquirePathfindUnlimited()
+	second := shedder.AcquirePathfindUnlimited()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if release, ok := shedder.WaitPathfind(ctx); ok || release != nil {
+		t.Fatalf("canceled wait = (%T, %v), want (nil, false)", release, ok)
+	}
+	first()
+	second()
+
+	if release, ok := shedder.WaitPathfind(nil); !ok || release == nil {
+		t.Fatalf("nil-context wait = (%T, %v), want successful owned release", release, ok)
+	} else {
+		release()
+	}
+	if got := shedder.PathfindActive(); got != 0 {
+		t.Fatalf("zero-value shedder leaked pathfind slot: %d", got)
+	}
+
+	var nilShedder *ClientLoadShedder
+	nilShedder.Begin()()
+	if release, ok := nilShedder.AcquirePathfind(); !ok || release == nil {
+		t.Fatalf("nil bounded acquire = (%T, %v), want no-op success", release, ok)
+	} else {
+		release()
+	}
+	if release := nilShedder.AcquirePathfindUnlimited(); release == nil {
+		t.Fatal("nil unlimited acquire returned nil release")
+	} else {
+		release()
+	}
+}

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -143,7 +143,6 @@ type MethodRegistryBuilder struct {
 	built   bool
 }
 
-// NewMethodRegistryBuilder returns an empty method registry builder.
 func NewMethodRegistryBuilder() *MethodRegistryBuilder {
 	return &MethodRegistryBuilder{}
 }

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"sort"
+	"strings"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
@@ -126,31 +129,100 @@ type MethodHandler interface {
 	RequiredCondition() Condition
 }
 
-// Method registry for dynamic method registration
+// MethodRegistry is the immutable, published RPC method catalogue. Use a
+// MethodRegistryBuilder to construct one before handing it to a transport.
 type MethodRegistry struct {
 	methods map[string]MethodHandler
+	names   []string
 }
 
-func NewMethodRegistry() *MethodRegistry {
-	return &MethodRegistry{
-		methods: make(map[string]MethodHandler),
+// MethodRegistryBuilder collects RPC methods before publication. Its zero
+// value is ready for use.
+type MethodRegistryBuilder struct {
+	methods map[string]MethodHandler
+	built   bool
+}
+
+// NewMethodRegistryBuilder returns an empty method registry builder.
+func NewMethodRegistryBuilder() *MethodRegistryBuilder {
+	return &MethodRegistryBuilder{}
+}
+
+// Register adds a method to the builder. Names must be non-empty and have no
+// surrounding whitespace. Handlers must be non-nil, including when an
+// interface contains a typed nil value. Registration is rejected after Build.
+func (b *MethodRegistryBuilder) Register(name string, handler MethodHandler) error {
+	if b == nil {
+		return fmt.Errorf("method registry builder is nil")
+	}
+	if b.built {
+		return fmt.Errorf("method registry is already built")
+	}
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" || trimmed != name {
+		return fmt.Errorf("invalid RPC method name %q", name)
+	}
+	if methodHandlerIsNil(handler) {
+		return fmt.Errorf("RPC method %q has a nil handler", name)
+	}
+	if b.methods == nil {
+		b.methods = make(map[string]MethodHandler)
+	}
+	if _, exists := b.methods[name]; exists {
+		return fmt.Errorf("RPC method %q is already registered", name)
+	}
+	b.methods[name] = handler
+	return nil
+}
+
+// Build publishes an immutable method registry. The builder cannot be reused
+// for further registration after publication.
+func (b *MethodRegistryBuilder) Build() (*MethodRegistry, error) {
+	if b == nil {
+		return nil, fmt.Errorf("method registry builder is nil")
+	}
+	if b.built {
+		return nil, fmt.Errorf("method registry is already built")
+	}
+	methods := make(map[string]MethodHandler, len(b.methods))
+	names := make([]string, 0, len(b.methods))
+	for name, handler := range b.methods {
+		methods[name] = handler
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	registry := &MethodRegistry{methods: methods, names: names}
+	b.built = true
+	return registry, nil
+}
+
+func methodHandlerIsNil(handler MethodHandler) bool {
+	if handler == nil {
+		return true
+	}
+	value := reflect.ValueOf(handler)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
 	}
 }
 
-func (r *MethodRegistry) Register(name string, handler MethodHandler) {
-	r.methods[name] = handler
-}
-
 func (r *MethodRegistry) Get(name string) (MethodHandler, bool) {
+	if r == nil {
+		return nil, false
+	}
 	handler, exists := r.methods[name]
 	return handler, exists
 }
 
 func (r *MethodRegistry) List() []string {
-	methods := make([]string, 0, len(r.methods))
-	for name := range r.methods {
-		methods = append(methods, name)
+	if r == nil {
+		return nil
 	}
+	methods := make([]string, len(r.names))
+	copy(methods, r.names)
 	return methods
 }
 

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
-	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/subscription"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
@@ -76,6 +75,7 @@ type WebSocketServerOptions struct {
 	Services            *types.ServiceContainer
 	ResourceManager     *resource.Manager
 	PeerSource          types.PeerSource
+	Registry            *types.MethodRegistry
 	PingInterval        time.Duration
 	LedgerInfoProvider  types.LedgerInfoProvider
 	SubscriptionManager *subscription.Manager
@@ -130,7 +130,7 @@ func NewWebSocketServer(options WebSocketServerOptions) *WebSocketServer {
 			// Don't require specific subprotocol - xrpl.js doesn't use one
 		},
 		subscriptionManager: manager,
-		methodRegistry:      types.NewMethodRegistry(),
+		methodRegistry:      options.Registry,
 		connections:         make(map[string]*websocketConnection),
 		timeout:             options.Timeout,
 		services:            options.Services,
@@ -139,6 +139,9 @@ func NewWebSocketServer(options WebSocketServerOptions) *WebSocketServer {
 		ledgerInfoProvider:  options.LedgerInfoProvider,
 		closeDone:           make(chan struct{}),
 		forceDone:           make(chan struct{}),
+	}
+	if ws.methodRegistry == nil {
+		ws.methodRegistry = defaultMethodRegistry()
 	}
 	ws.pathFindRefresh = newPathFindRefreshManager(ws)
 	if ws.services != nil {
@@ -149,7 +152,6 @@ func NewWebSocketServer(options WebSocketServerOptions) *WebSocketServer {
 	// composition installs the returned service on the shared container.
 	ws.urlSubs = newURLSubscriptionRegistry(ws)
 	ws.setPeerSource(options.PeerSource)
-	ws.registerAllMethods()
 	return ws
 }
 
@@ -240,10 +242,6 @@ func (ws *WebSocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		defer ws.wg.Done()
 		ws.pingLoop(wsConn)
 	}()
-}
-
-func (ws *WebSocketServer) registerAllMethods() {
-	handlers.RegisterAll(ws.methodRegistry)
 }
 
 // SubscriptionManager returns the subscription manager for event publishing

--- a/internal/rpc/websocket_dispatch.go
+++ b/internal/rpc/websocket_dispatch.go
@@ -162,8 +162,8 @@ func (ws *WebSocketServer) handleSpecialCommand(wsConn *websocketConnection, ctx
 
 	result, rpcErr, recovered := func() (any, *types.RpcError, bool) {
 		if ws.services != nil && ws.services.ClientLoad != nil {
-			ws.services.ClientLoad.Begin()
-			defer ws.services.ClientLoad.End()
+			release := ws.services.ClientLoad.Begin()
+			defer release()
 		}
 		finishDiagnostics := startRPCDiagnostics(ws.services, cmd.Command)
 		result, rpcErr, recovered := invokeWSSpecial(handler, wsConn, ctx, cmd)

--- a/internal/rpc/websocket_special_dispatch_test.go
+++ b/internal/rpc/websocket_special_dispatch_test.go
@@ -22,9 +22,15 @@ func newSpecialDispatchHarness(t *testing.T) (*WebSocketServer, *websocketConnec
 		Capabilities:   types.RPCCapabilities{PathSearchMax: 3},
 	}
 	manager := resource.NewManager(nil, nil)
-	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second, Services: services, ResourceManager: manager})
-	ws.methodRegistry.Register("subscribe", &stubHandler{})
-	ws.methodRegistry.Register("path_find", &stubHandler{})
+	ws := NewWebSocketServer(WebSocketServerOptions{
+		Timeout:         time.Second,
+		Services:        services,
+		ResourceManager: manager,
+		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+			"subscribe": &stubHandler{},
+			"path_find": &stubHandler{},
+		}),
+	})
 	send := make(chan []byte, 1)
 	conn := &websocketConnection{
 		Connection: subscription.NewConnectionWithContext(context.Background(), "special-dispatch", send),

--- a/internal/rpc/websocket_test.go
+++ b/internal/rpc/websocket_test.go
@@ -751,12 +751,12 @@ func TestWebSocketErrorProjectorPreservesExtrasAndCanonicalFields(t *testing.T) 
 
 func TestWebSocketHandlerPanicWireEnvelope(t *testing.T) {
 	const panicCause = "websocket panic must stay private"
-	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
-	ws.methodRegistry.Register("panic", &stubHandler{
-		handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
-			panic(panicCause)
-		},
-	})
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second, Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+		"panic": &stubHandler{
+			handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
+				panic(panicCause)
+			},
+		}})})
 
 	httpSrv := httptest.NewServer(http.HandlerFunc(ws.ServeHTTP))
 	defer httpSrv.Close()
@@ -797,12 +797,12 @@ func TestWebSocketHandlerPanicWireEnvelope(t *testing.T) {
 }
 
 func TestWebSocketOrdinaryErrorWireEnvelope(t *testing.T) {
-	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
-	ws.methodRegistry.Register("fail", &stubHandler{
-		handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
-			return nil, rpcInternalError()
-		},
-	})
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second, Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+		"fail": &stubHandler{
+			handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
+				return nil, rpcInternalError()
+			},
+		}})})
 
 	body := wsRawRoundTrip(t, ws, `{"command":"fail","id":7,"jsonrpc":"2.0","ripplerpc":"1.0","api_version":2,"secret":"private seed"}`)
 	const want = `{"api_version":2,"error":"internal","error_code":73,"error_message":"Internal error.","id":7,"jsonrpc":"2.0","request":{"api_version":2,"command":"fail","id":7,"jsonrpc":"2.0","ripplerpc":"1.0","secret":"<masked>"},"ripplerpc":"1.0","status":"error","type":"response"}`
@@ -813,13 +813,13 @@ func TestWebSocketOrdinaryErrorWireEnvelope(t *testing.T) {
 
 func TestWebSocketRedactsIDAndPreservesItInHandlerParams(t *testing.T) {
 	received := make(chan json.RawMessage, 1)
-	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
-	ws.methodRegistry.Register("capture", &stubHandler{
-		handle: func(_ *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
-			received <- append(json.RawMessage(nil), params...)
-			return map[string]any{"ok": true}, nil
-		},
-	})
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second, Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+		"capture": &stubHandler{
+			handle: func(_ *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
+				received <- append(json.RawMessage(nil), params...)
+				return map[string]any{"ok": true}, nil
+			},
+		}})})
 
 	body := wsRawRoundTrip(t, ws, `{"command":"capture","method":"capture","api_version":1,"id":{"SeCrEt":"private-id"},"payload":"kept"}`)
 	const want = `{"api_version":1,"id":{"SeCrEt":"<masked>"},"result":{"ok":true},"status":"success","type":"response"}`
@@ -938,8 +938,9 @@ func TestWebSocketSpecialCommandDecodeErrorsAreFixed(t *testing.T) {
 }
 
 func TestWebSocketRejectsTrailingJSON(t *testing.T) {
-	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
-	ws.methodRegistry.Register("ping", &stubHandler{})
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second, Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+		"ping": &stubHandler{},
+	})})
 
 	body := wsRawRoundTrip(t, ws, `{"command":"ping","id":7}{"command":"ping","id":8}`)
 	const want = `{"error":"jsonInvalid","type":"error","value":"<redacted>"}`
@@ -975,8 +976,9 @@ func TestWebSocketJSONInvalidWireEnvelope(t *testing.T) {
 }
 
 func TestWebSocketJSONIntegerBounds(t *testing.T) {
-	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
-	ws.methodRegistry.Register("ping", &stubHandler{})
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second, Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+		"ping": &stubHandler{},
+	})})
 
 	for _, request := range []string{
 		`{"command":"ping","id":4294967296}`,
@@ -1015,12 +1017,12 @@ func TestWebSocketJSONIntegerBounds(t *testing.T) {
 }
 
 func TestWebSocketErrorExceptionWireEnvelope(t *testing.T) {
-	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
-	ws.methodRegistry.Register("simulate", &stubHandler{
-		handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
-			return nil, types.RpcErrorInvalidTransaction("invalid transaction detail")
-		},
-	})
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second, Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+		"simulate": &stubHandler{
+			handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
+				return nil, types.RpcErrorInvalidTransaction("invalid transaction detail")
+			},
+		}})})
 
 	body := wsRawRoundTrip(t, ws, `{"command":"simulate","id":9}`)
 	const want = `{"error":"invalidTransaction","error_exception":"invalid transaction detail","id":9,"request":{"command":"simulate","id":9},"status":"error","type":"response"}`

--- a/internal/testing/rpcenv/rpcenv.go
+++ b/internal/testing/rpcenv/rpcenv.go
@@ -36,8 +36,10 @@ func New(t testing.TB) *Env {
 // with custom genesis, TxQ, etc.
 func Wrap(t testing.TB, env *jtx.TestEnv) *Env {
 	t.Helper()
-	registry := types.NewMethodRegistry()
-	handlers.RegisterAll(registry)
+	registry, err := handlers.BuildRegistry()
+	if err != nil {
+		t.Fatalf("build RPC registry: %v", err)
+	}
 	adapter := newLedgerAdapter(env)
 	services := types.NewServiceContainer(adapter)
 	services.Capabilities.PathSearchMax = 3


### PR DESCRIPTION
## Summary

- bind every load-admission release closure to one successful acquisition
- make rejected, unmatched, and repeated releases safe under concurrency
- validate method definitions and publish an immutable registry before transports start

This is layer 2 of 7 and depends on #1602.

Part of #1490.

## Test plan

- `go test -count=1 ./internal/rpc/... ./internal/node ./internal/testing/rpcenv`
- `go test -race -count=1 ./internal/rpc/handlers ./internal/rpc ./internal/node`
- `go vet ./internal/rpc/... ./internal/node ./internal/testing/rpcenv`
- `golangci-lint run`