### PR TITLE
fix: derive RPC privileges from role (#1490)

### DIFF
--- a/internal/rpc/account_offers_test.go
+++ b/internal/rpc/account_offers_test.go
@@ -589,7 +589,6 @@ func TestAccountOffersMarkerPagination(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
-		IsAdmin:    true,
 		Services:   services,
 	}
 

--- a/internal/rpc/amendment_warnings_test.go
+++ b/internal/rpc/amendment_warnings_test.go
@@ -62,10 +62,13 @@ func serverInfoWarnings(t *testing.T, mock *mockServerInfoWarnings, isAdmin bool
 	t.Helper()
 	services := &types.ServiceContainer{Ledger: mock, NodePublicKey: testNodePublicKey()}
 	method := &handlers.ServerInfoMethod{}
+	role := types.RoleGuest
+	if isAdmin {
+		role = types.RoleAdmin
+	}
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
-		Role:       types.RoleGuest,
-		IsAdmin:    isAdmin,
+		Role:       role,
 		ApiVersion: types.ApiVersion1,
 		Services:   services,
 	}

--- a/internal/rpc/book_offers_test.go
+++ b/internal/rpc/book_offers_test.go
@@ -1616,8 +1616,8 @@ func TestBookOffersNilOffersArray(t *testing.T) {
 // TestBookOffersLimitClampingConformance pins the rippled
 // `readLimitField(rmin=0, rdefault=60, rmax=100)` semantics from
 // RPCHelpers.cpp:703-712, exercised by Book_test.cpp testBookOfferLimits.
-// Non-admin (Unlimited=false) callers see the value clamped into [0, 100];
-// admin/unlimited callers (Unlimited=true) bypass the upper bound entirely.
+// Non-admin callers see the value clamped into [0, 100]; admin/unlimited
+// callers bypass the upper bound entirely.
 // The existing TestBookOffersLimitParameter covers the lower end (0 / default
 // / small values); this case nails down the upper-bound clamp and the
 // asAdmin=true bypass — the part of testBookOfferLimits that varies behaviour
@@ -1636,7 +1636,6 @@ func TestBookOffersLimitClampingConformance(t *testing.T) {
 	tests := []struct {
 		name          string
 		role          types.Role
-		unlimited     bool
 		limit         any
 		expectedLimit uint32
 	}{
@@ -1645,7 +1644,6 @@ func TestBookOffersLimitClampingConformance(t *testing.T) {
 			// for non-admin callers (asAdmin=false branch).
 			name:          "rmax+1 clamps to rmax for guest",
 			role:          types.RoleGuest,
-			unlimited:     false,
 			limit:         101,
 			expectedLimit: 100,
 		},
@@ -1654,7 +1652,6 @@ func TestBookOffersLimitClampingConformance(t *testing.T) {
 			// (asAdmin=true branch).
 			name:          "rmax+1 passes through for admin",
 			role:          types.RoleAdmin,
-			unlimited:     true,
 			limit:         101,
 			expectedLimit: 101,
 		},
@@ -1663,7 +1660,6 @@ func TestBookOffersLimitClampingConformance(t *testing.T) {
 			// is unconditional, not a "soft" hint.
 			name:          "large limit clamps to rmax for guest",
 			role:          types.RoleGuest,
-			unlimited:     false,
 			limit:         100000,
 			expectedLimit: 100,
 		},
@@ -1672,7 +1668,6 @@ func TestBookOffersLimitClampingConformance(t *testing.T) {
 			// for either role.
 			name:          "omitted limit yields default for admin",
 			role:          types.RoleAdmin,
-			unlimited:     true,
 			limit:         nil,
 			expectedLimit: 60,
 		},
@@ -1684,7 +1679,6 @@ func TestBookOffersLimitClampingConformance(t *testing.T) {
 			ctx := &types.RpcContext{
 				Context:    context.Background(),
 				Role:       tc.role,
-				Unlimited:  tc.unlimited,
 				ApiVersion: types.ApiVersion1,
 				Services:   services,
 			}
@@ -1715,7 +1709,6 @@ func TestBookOffersLimitClampingConformance(t *testing.T) {
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
-			Unlimited:  true,
 			ApiVersion: types.ApiVersion1,
 			Services:   services,
 		}

--- a/internal/rpc/feature_test.go
+++ b/internal/rpc/feature_test.go
@@ -24,7 +24,6 @@ func TestFeatureNoParams(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
-		IsAdmin:    true,
 		ApiVersion: types.ApiVersion1,
 		Services:   services,
 	}
@@ -90,7 +89,6 @@ func TestFeatureNoParamsEmptyObject(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
-		IsAdmin:    true,
 		ApiVersion: types.ApiVersion1,
 		Services:   services,
 	}
@@ -124,7 +122,6 @@ func TestFeatureSingleLookupByName(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
-		IsAdmin:    true,
 		ApiVersion: types.ApiVersion1,
 		Services:   services,
 	}
@@ -179,7 +176,6 @@ func TestFeatureSingleLookupByHexID(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
-		IsAdmin:    true,
 		ApiVersion: types.ApiVersion1,
 		Services:   services,
 	}
@@ -234,7 +230,6 @@ func TestFeatureInvalidName(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
-		IsAdmin:    true,
 		ApiVersion: types.ApiVersion1,
 		Services:   services,
 	}
@@ -277,7 +272,6 @@ func TestFeatureResponseStructure(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
-		IsAdmin:    true,
 		ApiVersion: types.ApiVersion1,
 		Services:   services,
 	}

--- a/internal/rpc/handlers/account_channels.go
+++ b/internal/rpc/handlers/account_channels.go
@@ -38,7 +38,7 @@ func (m *AccountChannelsMethod) Handle(ctx *types.RpcContext, params json.RawMes
 		return nil, types.RpcErrorActMalformed("Account malformed.")
 	}
 
-	limit, limitErr := readLimitField(params, limitAccountChannels, ctx.Unlimited)
+	limit, limitErr := readLimitField(params, limitAccountChannels, ctx.Role.IsUnlimited())
 	if limitErr != nil {
 		return nil, limitErr
 	}

--- a/internal/rpc/handlers/account_lines.go
+++ b/internal/rpc/handlers/account_lines.go
@@ -38,7 +38,7 @@ func (m *AccountLinesMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		return nil, types.RpcErrorActMalformed("Account malformed.").WithExtra(ledgerFields)
 	}
 
-	limit, limitErr := readLimitField(params, limitAccountLines, ctx.Unlimited)
+	limit, limitErr := readLimitField(params, limitAccountLines, ctx.Role.IsUnlimited())
 	if limitErr != nil {
 		return nil, limitErr
 	}

--- a/internal/rpc/handlers/account_nfts.go
+++ b/internal/rpc/handlers/account_nfts.go
@@ -30,7 +30,7 @@ func (m *AccountNftsMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		return nil, selErr
 	}
 
-	limit, limitErr := readLimitField(params, limitAccountNFTokens, ctx.Unlimited)
+	limit, limitErr := readLimitField(params, limitAccountNFTokens, ctx.Role.IsUnlimited())
 	if limitErr != nil {
 		return nil, limitErr
 	}

--- a/internal/rpc/handlers/account_objects.go
+++ b/internal/rpc/handlers/account_objects.go
@@ -111,7 +111,7 @@ func (m *AccountObjectsMethod) Handle(ctx *types.RpcContext, params json.RawMess
 			return nil, typeErr
 		}
 	}
-	limit, limitErr := readLimitField(params, limitAccountObjects, ctx.Unlimited)
+	limit, limitErr := readLimitField(params, limitAccountObjects, ctx.Role.IsUnlimited())
 	if limitErr != nil {
 		return nil, limitErr
 	}

--- a/internal/rpc/handlers/account_offers.go
+++ b/internal/rpc/handlers/account_offers.go
@@ -25,7 +25,7 @@ func (m *AccountOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		return nil, selErr
 	}
 
-	limit, limitErr := readLimitField(params, limitAccountOffers, ctx.Unlimited)
+	limit, limitErr := readLimitField(params, limitAccountOffers, ctx.Role.IsUnlimited())
 	if limitErr != nil {
 		return nil, limitErr
 	}

--- a/internal/rpc/handlers/account_tx.go
+++ b/internal/rpc/handlers/account_tx.go
@@ -49,7 +49,7 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		}
 	}
 
-	limit, limitErr := readLimitField(params, limitAccountTx, ctx.Unlimited)
+	limit, limitErr := readLimitField(params, limitAccountTx, ctx.Role.IsUnlimited())
 	if limitErr != nil {
 		return nil, limitErr
 	}

--- a/internal/rpc/handlers/book_offers.go
+++ b/internal/rpc/handlers/book_offers.go
@@ -153,7 +153,7 @@ func (m *BookOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		return nil, types.RpcErrorBadMarket()
 	}
 
-	limit, limitErr := readLimitField(params, limitBookOffers, ctx.Unlimited)
+	limit, limitErr := readLimitField(params, limitBookOffers, ctx.Role.IsUnlimited())
 	if limitErr != nil {
 		return nil, limitErr
 	}

--- a/internal/rpc/handlers/feature.go
+++ b/internal/rpc/handlers/feature.go
@@ -53,7 +53,7 @@ func (m *FeatureMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 		features := make(map[string]any, len(allFeatures))
 		for _, f := range allFeatures {
 			hexID := strings.ToUpper(hex.EncodeToString(f.ID[:]))
-			features[hexID] = buildFeatureInfo(f, enabledSet, majorities, tbl, lastVote, ctx.IsAdmin)
+			features[hexID] = buildFeatureInfo(f, enabledSet, majorities, tbl, lastVote, ctx.Role.IsAdmin())
 		}
 		return map[string]any{
 			"features": features,
@@ -67,7 +67,7 @@ func (m *FeatureMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 
 	// Admin vote mutation: set or clear a veto on a specific amendment.
 	if request.Vetoed.present {
-		if !ctx.IsAdmin {
+		if !ctx.Role.IsAdmin() {
 			return nil, types.RpcErrorNoPermission("feature")
 		}
 		if ctrl == nil || tbl == nil {
@@ -78,13 +78,13 @@ func (m *FeatureMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 		}
 		hexID := strings.ToUpper(hex.EncodeToString(f.ID[:]))
 		return map[string]any{
-			hexID: buildFeatureInfo(f, enabledSet, majorities, tbl, lastVote, ctx.IsAdmin),
+			hexID: buildFeatureInfo(f, enabledSet, majorities, tbl, lastVote, ctx.Role.IsAdmin()),
 		}, nil
 	}
 
 	hexID := strings.ToUpper(hex.EncodeToString(f.ID[:]))
 	return map[string]any{
-		hexID: buildFeatureInfo(f, enabledSet, majorities, tbl, lastVote, ctx.IsAdmin),
+		hexID: buildFeatureInfo(f, enabledSet, majorities, tbl, lastVote, ctx.Role.IsAdmin()),
 	}, nil
 }
 

--- a/internal/rpc/handlers/fetch_info_test.go
+++ b/internal/rpc/handlers/fetch_info_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestFetchInfoMethod_EmptyWhenNotAcquiring(t *testing.T) {
 	m := &handlers.FetchInfoMethod{}
-	ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, IsAdmin: true}
+	ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin}
 
 	result, rpcErr := m.Handle(ctx, json.RawMessage(`{}`))
 	require.Nil(t, rpcErr)
@@ -39,7 +39,6 @@ func TestFetchInfoMethod_PassesThroughSnapshot(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context: context.Background(),
 		Role:    types.RoleAdmin,
-		IsAdmin: true,
 		Services: &types.ServiceContainer{
 			FetchInfo: func() map[string]any { return snap },
 		},
@@ -58,7 +57,6 @@ func TestFetchInfoMethod_ClearInvokesResetAndEchoes(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context: context.Background(),
 		Role:    types.RoleAdmin,
-		IsAdmin: true,
 		Services: &types.ServiceContainer{
 			FetchInfo:      func() map[string]any { return map[string]any{} },
 			FetchInfoClear: func() { cleared = true },

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -104,7 +104,7 @@ func RequirePathSearch(ctx *types.RpcContext) *types.RpcError {
 // unlimited (admin/identified) — mirroring rippled's isUnlimited(role)
 // carve-out at RPCHandler.cpp:132 and LegacyPathFind.cpp:32-37.
 func shedCheck(ctx *types.RpcContext) *types.ClientLoadShedder {
-	if ctx == nil || ctx.Unlimited || ctx.Services == nil {
+	if ctx == nil || ctx.Role.IsUnlimited() || ctx.Services == nil {
 		return nil
 	}
 	return ctx.Services.ClientLoad
@@ -154,7 +154,7 @@ func acquirePathfind(ctx *types.RpcContext) (release func(), rpcErr *types.RpcEr
 	}
 	services := ctx.Services
 	s := services.ClientLoad
-	if ctx.Unlimited {
+	if ctx.Role.IsUnlimited() {
 		if s == nil {
 			return func() {}, nil
 		}

--- a/internal/rpc/handlers/ledger.go
+++ b/internal/rpc/handlers/ledger.go
@@ -67,7 +67,7 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 	}
 
 	if request.Full || request.Accounts {
-		if !ctx.Unlimited {
+		if !ctx.Role.IsUnlimited() {
 			return nil, types.RpcErrorNoPermission("ledger")
 		}
 		if request.Binary {

--- a/internal/rpc/handlers/ledger_data.go
+++ b/internal/rpc/handlers/ledger_data.go
@@ -62,7 +62,7 @@ func (m *LedgerDataMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		}
 	}
 
-	limit, limitErr := ledgerDataLimit(fields, binaryMode, ctx.Unlimited)
+	limit, limitErr := ledgerDataLimit(fields, binaryMode, ctx.Role.IsUnlimited())
 	if limitErr != nil {
 		return nil, limitErr
 	}

--- a/internal/rpc/handlers/load_shed_test.go
+++ b/internal/rpc/handlers/load_shed_test.go
@@ -10,9 +10,8 @@ import (
 
 func unlimitedCtx(s *types.ClientLoadShedder) *types.RpcContext {
 	return &types.RpcContext{
-		Role:      types.RoleAdmin,
-		Unlimited: true,
-		Services:  &types.ServiceContainer{ClientLoad: s},
+		Role:     types.RoleAdmin,
+		Services: &types.ServiceContainer{ClientLoad: s},
 	}
 }
 
@@ -142,7 +141,7 @@ func TestAcquirePathfind_LocalLoadGateWithoutClientCounter(t *testing.T) {
 func TestAcquirePathfind_UnlimitedBypassesLocalLoad(t *testing.T) {
 	s := types.NewClientLoadShedder()
 	ctx := &types.RpcContext{
-		Unlimited: true,
+		Role: types.RoleAdmin,
 		Services: &types.ServiceContainer{
 			ClientLoad:    s,
 			IsLoadedLocal: func() bool { return true },

--- a/internal/rpc/handlers/nft_buy_offers.go
+++ b/internal/rpc/handlers/nft_buy_offers.go
@@ -62,7 +62,7 @@ func handleNFTOffers(ctx *types.RpcContext, params json.RawMessage, fetch func(c
 
 	// Apply rippled's readLimitField with nftOffers tuning (NFTOffers.cpp:69):
 	// absent limit -> default, explicit 0 -> invalidParams, else clamp.
-	limit, limitErr := readLimitField(params, limitNFTOffers, ctx.Unlimited)
+	limit, limitErr := readLimitField(params, limitNFTOffers, ctx.Role.IsUnlimited())
 	if limitErr != nil {
 		return nil, limitErr
 	}

--- a/internal/rpc/handlers/noripple_check.go
+++ b/internal/rpc/handlers/noripple_check.go
@@ -35,7 +35,7 @@ func (m *NoRippleCheckMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		return nil, types.RpcErrorInvalidField("role")
 	}
 
-	limit, limitErr := readLimitField(params, limitNoRippleCheck, ctx.Unlimited)
+	limit, limitErr := readLimitField(params, limitNoRippleCheck, ctx.Role.IsUnlimited())
 	if limitErr != nil {
 		return nil, limitErr
 	}

--- a/internal/rpc/handlers/peers_test.go
+++ b/internal/rpc/handlers/peers_test.go
@@ -22,7 +22,7 @@ func (f *fakePeerSource) PeerCount() int              { return len(f.peers) }
 
 func TestPeersMethod_NilSourceReturnsEmptyList(t *testing.T) {
 	m := &handlers.PeersMethod{}
-	ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, IsAdmin: true}
+	ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin}
 
 	result, rpcErr := m.Handle(ctx, json.RawMessage(`{}`))
 	require.Nil(t, rpcErr)
@@ -47,7 +47,6 @@ func TestPeersMethod_PassesThroughSource(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
-		IsAdmin:    true,
 		PeerSource: src,
 	}
 
@@ -83,7 +82,6 @@ func TestPeersMethod_RelaysClusterMap(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
-		IsAdmin:    true,
 		PeerSource: src,
 	}
 

--- a/internal/rpc/handlers/request_object_test.go
+++ b/internal/rpc/handlers/request_object_test.go
@@ -60,7 +60,7 @@ func TestStrictRequestObjects(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := &types.RpcContext{Context: context.Background(), IsAdmin: true}
+			ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin}
 			result, rpcErr := test.handler.Handle(ctx, test.params)
 			require.Nil(t, result)
 			require.NotNil(t, rpcErr)
@@ -74,7 +74,7 @@ func TestStrictRequestObjects(t *testing.T) {
 func TestDecodeRejectionDoesNotInvokeCallbacks(t *testing.T) {
 	controller := &requestRejectAmendmentController{table: amendment.NewTable()}
 	_, rpcErr := (&FeatureMethod{}).Handle(
-		&types.RpcContext{Context: context.Background(), IsAdmin: true, Services: &types.ServiceContainer{Ledger: controller}},
+		&types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, Services: &types.ServiceContainer{Ledger: controller}},
 		json.RawMessage(`{"feature":1,"vetoed":true}`),
 	)
 	require.NotNil(t, rpcErr)
@@ -123,7 +123,7 @@ func TestRequestObjectJsonCppCoercions(t *testing.T) {
 
 	controller := &requestRejectAmendmentController{table: amendment.NewTable()}
 	_, rpcErr = (&FeatureMethod{}).Handle(
-		&types.RpcContext{Context: context.Background(), IsAdmin: true, Services: &types.ServiceContainer{Ledger: controller}},
+		&types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, Services: &types.ServiceContainer{Ledger: controller}},
 		json.RawMessage(`{"feature":"fixMasterKeyAsRegularKey","vetoed":"true"}`),
 	)
 	require.Nil(t, rpcErr)
@@ -131,7 +131,7 @@ func TestRequestObjectJsonCppCoercions(t *testing.T) {
 
 	controller = &requestRejectAmendmentController{table: amendment.NewTable()}
 	result, rpcErr = (&FeatureMethod{}).Handle(
-		&types.RpcContext{Context: context.Background(), IsAdmin: true, Services: &types.ServiceContainer{Ledger: controller}},
+		&types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, Services: &types.ServiceContainer{Ledger: controller}},
 		json.RawMessage(`{"vetoed":true}`),
 	)
 	require.Nil(t, rpcErr)

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -152,7 +152,7 @@ func (m *ServerInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 	if serverCountersRequested(params) {
 		addServerDiagnostics(info, ctx.Services)
 	}
-	if warnings := buildServerWarnings(ctx.Services, ctx.IsAdmin); len(warnings) > 0 {
+	if warnings := buildServerWarnings(ctx.Services, ctx.Role.IsAdmin()); len(warnings) > 0 {
 		info["warnings"] = warnings
 	}
 	return map[string]any{"info": info}, nil
@@ -315,7 +315,7 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 	}
 	if serverInfo.Standalone {
 		serverState = "standalone"
-	} else if !ctx.IsAdmin && (serverState == "proposing" || serverState == "validating") {
+	} else if !ctx.Role.IsAdmin() && (serverState == "proposing" || serverState == "validating") {
 		serverState = "full"
 	}
 
@@ -347,11 +347,11 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 		"state_accounting":         accounting.modes,
 	}
 
-	info["ports"] = buildServerInfoPorts(configSnapshot.Ports, ctx.IsAdmin)
+	info["ports"] = buildServerInfoPorts(configSnapshot.Ports, ctx.Role.IsAdmin())
 	if configSnapshot.ServerDomain != "" {
 		info["server_domain"] = configSnapshot.ServerDomain
 	}
-	if ctx.IsAdmin {
+	if ctx.Role.IsAdmin() {
 		nodeSize := configSnapshot.NodeSize
 		if nodeSize == "" {
 			nodeSize = "medium"
@@ -380,7 +380,7 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 	// Emits the configured validator's MASTER public key (base58 NodePublic),
 	// or "none" when the node is not a validator. Present in both server_info
 	// (human) and server_state (machine) like rippled's shared getServerInfo.
-	if ctx.IsAdmin {
+	if ctx.Role.IsAdmin() {
 		info["pubkey_validator"] = resolveValidatorPubKey(services)
 		validatorList := resolveValidatorListSnapshot(services, now)
 		if human {
@@ -392,7 +392,7 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 
 	// hostid: only in human mode (server_info), matching rippled
 	if human {
-		info["hostid"] = serverHostID(services, ctx.IsAdmin)
+		info["hostid"] = serverHostID(services, ctx.Role.IsAdmin())
 	}
 
 	info["time"] = formatServerTime(now)
@@ -446,7 +446,7 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 		// Mirror rippled NetworkOPs.cpp:2887-2901: admin-only emission
 		// of load_factor_{local,net,cluster}, each gated on the fee
 		// differing from loadBase.
-		if ctx.IsAdmin {
+		if ctx.Role.IsAdmin() {
 			if uint64(loadFactorFees.Local) != loadBase {
 				info["load_factor_local"] = float64(loadFactorFees.Local) / float64(loadBase)
 			}
@@ -463,7 +463,7 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 		//     && (admin || loadFactorFeeEscalation != loadFactor)
 		// and the queue field on
 		//   minProcessingFeeLevel != referenceFeeLevel.
-		if feeEscalation != feeReference && (ctx.IsAdmin || loadFactorFeeEscalation != loadFactor) {
+		if feeEscalation != feeReference && (ctx.Role.IsAdmin() || loadFactorFeeEscalation != loadFactor) {
 			info["load_factor_fee_escalation"] = float64(feeEscalation) / float64(feeReference)
 		}
 		if feeQueue != feeReference {

--- a/internal/rpc/handlers/server_state.go
+++ b/internal/rpc/handlers/server_state.go
@@ -19,7 +19,7 @@ func (m *ServerStateMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 	if serverCountersRequested(params) {
 		addServerDiagnostics(state, ctx.Services)
 	}
-	if warnings := buildServerWarnings(ctx.Services, ctx.IsAdmin); len(warnings) > 0 {
+	if warnings := buildServerWarnings(ctx.Services, ctx.Role.IsAdmin()); len(warnings) > 0 {
 		state["warnings"] = warnings
 	}
 	return map[string]any{"state": state}, nil

--- a/internal/rpc/handlers/sign_authorization_test.go
+++ b/internal/rpc/handlers/sign_authorization_test.go
@@ -94,7 +94,6 @@ func TestSigningCapabilityGuardPrecedesParsingAndLoad(t *testing.T) {
 			loadedCalled := false
 			ctx := &types.RpcContext{
 				Role:       types.RoleIdentified,
-				Unlimited:  true,
 				ApiVersion: types.ApiVersion2,
 				Services: &types.ServiceContainer{IsLoadedCluster: func() bool {
 					loadedCalled = true

--- a/internal/rpc/handlers/sign_for.go
+++ b/internal/rpc/handlers/sign_for.go
@@ -114,7 +114,7 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (r
 	if rpcErr := rejectOnlineSigningWithoutCurrentLedger(ctx.Services, request.Offline, ctx.ApiVersion); rpcErr != nil {
 		return nil, rpcErr
 	}
-	if rpcErr := rejectSigningWhenLoaded(ctx.Services, ctx.Unlimited); rpcErr != nil {
+	if rpcErr := rejectSigningWhenLoaded(ctx.Services, ctx.Role.IsUnlimited()); rpcErr != nil {
 		return nil, rpcErr
 	}
 	if rpcErr := validateSignForPreConflict(txMap, params); rpcErr != nil {

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -184,7 +184,7 @@ func formatSignResult(result signResult, apiVersion int) map[string]any {
 }
 
 func rejectDisabledSigning(ctx *types.RpcContext) *types.RpcError {
-	if ctx != nil && ctx.Role == types.RoleAdmin {
+	if ctx != nil && ctx.Role.IsAdmin() {
 		return nil
 	}
 	if ctx != nil && ctx.Services != nil && ctx.Services.Capabilities.SigningEnabled {
@@ -483,7 +483,7 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 	if rpcErr := rejectOnlineSigningWithoutCurrentLedger(services, offline, apiVersion); rpcErr != nil {
 		return nil, rpcErr
 	}
-	if rpcErr := rejectSigningWhenLoaded(services, rpcCtx.Unlimited); rpcErr != nil {
+	if rpcErr := rejectSigningWhenLoaded(services, rpcCtx.Role.IsUnlimited()); rpcErr != nil {
 		return nil, rpcErr
 	}
 	srcAddress := txAccount
@@ -548,7 +548,7 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 			if mErr != nil {
 				return nil, rpcInternalError("sign: fee probe marshaling failed", mErr)
 			}
-			fee, feeErr := services.Ledger.GetAutofillFee(probe, rpcCtx.Unlimited, feeOpts.Mult, feeOpts.Div)
+			fee, feeErr := services.Ledger.GetAutofillFee(probe, rpcCtx.Role.IsUnlimited(), feeOpts.Mult, feeOpts.Div)
 			if feeErr != nil {
 				var hfe *svcerr.HighFeeError
 				if errors.As(feeErr, &hfe) {

--- a/internal/rpc/handlers/signing_load_admission_test.go
+++ b/internal/rpc/handlers/signing_load_admission_test.go
@@ -289,8 +289,8 @@ func TestSigningLoadAdmissionUnlimitedExemption(t *testing.T) {
 	t.Run("sign", func(t *testing.T) {
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
+			Role:       types.RoleAdmin,
 			ApiVersion: 2,
-			Unlimited:  true,
 			Services:   &types.ServiceContainer{IsLoadedCluster: loaded},
 		}
 		result, rpcErr := (&SignMethod{}).Handle(signingEnabledHandlerContext(ctx), signingLoadParams(true))
@@ -306,8 +306,8 @@ func TestSigningLoadAdmissionUnlimitedExemption(t *testing.T) {
 		params := json.RawMessage(`{"account":"` + loadAdmissionSigningAccount + `","seed_hex":"` + loadAdmissionSeedHex + `","key_type":"ed25519","tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Sequence":1,"Fee":"10","SigningPubKey":""}}`)
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
+			Role:       types.RoleAdmin,
 			ApiVersion: 2,
-			Unlimited:  true,
 			Services:   &types.ServiceContainer{IsLoadedCluster: loaded},
 		}
 		_, rpcErr := (&SignForMethod{}).Handle(signingEnabledHandlerContext(ctx), params)
@@ -320,8 +320,8 @@ func TestSigningLoadAdmissionUnlimitedExemption(t *testing.T) {
 		params := json.RawMessage(`{"tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Sequence":1,"Fee":"10","SigningPubKey":""}}`)
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
+			Role:       types.RoleAdmin,
 			ApiVersion: 2,
-			Unlimited:  true,
 			Services: &types.ServiceContainer{
 				Ledger:          &loadAdmissionLedger{},
 				IsLoadedCluster: loaded,

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -123,7 +123,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		// rippled's simulate autofill uses the default fee_mult_max /
 		// fee_div_max (getCurrentNetworkFee default arguments).
 		feeOpts := defaultFeeOptions()
-		fee, feeErr := ctx.Services.Ledger.GetAutofillFee(probe, ctx.Unlimited, feeOpts.Mult, feeOpts.Div)
+		fee, feeErr := ctx.Services.Ledger.GetAutofillFee(probe, ctx.Role.IsUnlimited(), feeOpts.Mult, feeOpts.Div)
 		if feeErr != nil {
 			var hfe *svcerr.HighFeeError
 			if errors.As(feeErr, &hfe) {

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -69,7 +69,7 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 	if rpcErr := validateSigningTxJSONShape(txMap); rpcErr != nil {
 		return nil, rpcErr
 	}
-	if rpcErr := rejectSigningWhenLoaded(ctx.Services, ctx.Unlimited); rpcErr != nil {
+	if rpcErr := rejectSigningWhenLoaded(ctx.Services, ctx.Role.IsUnlimited()); rpcErr != nil {
 		return nil, rpcErr
 	}
 

--- a/internal/rpc/ledger_data_test.go
+++ b/internal/rpc/ledger_data_test.go
@@ -278,8 +278,9 @@ func TestLedgerDataLimitClamping(t *testing.T) {
 	}
 
 	t.Run("Limit above signed 32-bit range is rejected", func(t *testing.T) {
-		ctx.Unlimited = true
-		t.Cleanup(func() { ctx.Unlimited = false })
+		originalRole := ctx.Role
+		ctx.Role = types.RoleAdmin
+		t.Cleanup(func() { ctx.Role = originalRole })
 		result, rpcErr := method.Handle(ctx, json.RawMessage(`{"ledger_index":"current","limit":2147483648}`))
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)

--- a/internal/rpc/ledger_header_test.go
+++ b/internal/rpc/ledger_header_test.go
@@ -480,7 +480,6 @@ func TestLedgerHeaderProductionOpenRootsAndFlags(t *testing.T) {
 	require.Zero(t, decoded.CloseFlags)
 
 	ctx.Role = types.RoleAdmin
-	ctx.Unlimited = true
 	result, rpcErr = (&handlers.LedgerMethod{}).Handle(ctx, json.RawMessage(`{"ledger_index":"current","full":true}`))
 	require.Nil(t, rpcErr)
 	ledgerResult := result.(map[string]any)["ledger"].(map[string]any)

--- a/internal/rpc/ledger_test.go
+++ b/internal/rpc/ledger_test.go
@@ -308,7 +308,6 @@ func TestLedgerBasicRequest(t *testing.T) {
 
 	t.Run("Open full response omits closed", func(t *testing.T) {
 		ctx.Role = types.RoleAdmin
-		ctx.Unlimited = true
 		result, rpcErr := method.Handle(ctx, json.RawMessage(`{"ledger_index":"current","full":true}`))
 		require.Nil(t, rpcErr)
 		closeTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(currentReader.CloseTime()) * time.Second)
@@ -333,7 +332,6 @@ func TestLedgerBasicRequest(t *testing.T) {
 			"validated":            false,
 		}, resultToMap(t, result))
 		ctx.Role = types.RoleGuest
-		ctx.Unlimited = false
 	})
 
 	t.Run("Deprecated type field emits warning", func(t *testing.T) {
@@ -756,7 +754,6 @@ func TestLedgerAccountsOption(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
-		Unlimited:  true,
 		Services:   services,
 	}
 	result, rpcErr := method.Handle(adminCtx, paramsJSON)

--- a/internal/rpc/peers_server_info_parity_test.go
+++ b/internal/rpc/peers_server_info_parity_test.go
@@ -40,7 +40,6 @@ func TestPeersAndServerInfoShareSource(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.DefaultApiVersion,
-		IsAdmin:    true,
 		PeerSource: src,
 		Services:   services,
 	}
@@ -66,7 +65,6 @@ func TestPeersAndServerInfoBothEmptyWithoutSource(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.DefaultApiVersion,
-		IsAdmin:    true,
 		Services:   services,
 	}
 

--- a/internal/rpc/role_authority_test.go
+++ b/internal/rpc/role_authority_test.go
@@ -1,0 +1,173 @@
+package rpc
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRolePrivilegeMatrix(t *testing.T) {
+	tests := []struct {
+		name      string
+		role      types.Role
+		isAdmin   bool
+		unlimited bool
+	}{
+		{name: "guest", role: types.RoleGuest},
+		{name: "user", role: types.RoleUser},
+		{name: "admin", role: types.RoleAdmin, isAdmin: true, unlimited: true},
+		{name: "identified", role: types.RoleIdentified, unlimited: true},
+		{name: "proxy", role: types.RoleProxy},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.isAdmin, test.role.IsAdmin())
+			require.Equal(t, test.unlimited, test.role.IsUnlimited())
+		})
+	}
+}
+
+func TestHTTPRoleContextCarriesDerivedPrivileges(t *testing.T) {
+	tests := []struct {
+		name      string
+		port      *PortContext
+		xUser     string
+		want      types.Role
+		isAdmin   bool
+		unlimited bool
+	}{
+		{
+			name: "guest",
+			want: types.RoleGuest,
+		},
+		{
+			name: "admin",
+			port: &PortContext{AdminNets: []net.IPNet{mustParseCIDR("127.0.0.0/8")}},
+			want: types.RoleAdmin, isAdmin: true, unlimited: true,
+		},
+		{
+			name:      "identified",
+			port:      &PortContext{SecureGatewayNets: []net.IPNet{mustParseCIDR("127.0.0.0/8")}},
+			xUser:     "alice",
+			want:      types.RoleIdentified,
+			unlimited: true,
+		},
+		{
+			name: "proxy",
+			port: &PortContext{SecureGatewayNets: []net.IPNet{mustParseCIDR("127.0.0.0/8")}},
+			want: types.RoleProxy,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			observed := make(chan *types.RpcContext, 1)
+			srv := newHardeningServer(t, time.Second, "ping", &stubHandler{
+				handle: func(ctx *types.RpcContext, _ json.RawMessage) (any, *types.RpcError) {
+					observed <- ctx
+					return map[string]any{"ok": true}, nil
+				},
+			})
+			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"method":"ping","params":[{}]}`))
+			req.RemoteAddr = "127.0.0.1:1234"
+			if test.xUser != "" {
+				req.Header.Set("X-User", test.xUser)
+			}
+			if test.port != nil {
+				req = req.WithContext(WithPortContext(req.Context(), test.port))
+			}
+			rr := httptest.NewRecorder()
+			srv.ServeHTTP(rr, req)
+			require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+			ctx := <-observed
+			require.Equal(t, test.want, ctx.Role)
+			require.Equal(t, test.isAdmin, ctx.Role.IsAdmin())
+			require.Equal(t, test.unlimited, ctx.Role.IsUnlimited())
+		})
+	}
+}
+
+func TestWebSocketRoleContextCarriesDerivedPrivileges(t *testing.T) {
+	tests := []struct {
+		name      string
+		port      *PortContext
+		xUser     string
+		want      types.Role
+		isAdmin   bool
+		unlimited bool
+	}{
+		{
+			name:      "admin",
+			port:      &PortContext{AdminNets: []net.IPNet{mustParseCIDR("127.0.0.0/8")}},
+			want:      types.RoleAdmin,
+			isAdmin:   true,
+			unlimited: true,
+		},
+		{
+			name:      "identified",
+			port:      &PortContext{SecureGatewayNets: []net.IPNet{mustParseCIDR("127.0.0.0/8")}},
+			xUser:     "alice",
+			want:      types.RoleIdentified,
+			unlimited: true,
+		},
+		{
+			name: "proxy",
+			port: &PortContext{SecureGatewayNets: []net.IPNet{mustParseCIDR("127.0.0.0/8")}},
+			want: types.RoleProxy,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			observed := make(chan *types.RpcContext, 1)
+			ws := NewWebSocketServer(WebSocketServerOptions{
+				Timeout: time.Second,
+				Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+					"ping": &stubHandler{
+						handle: func(ctx *types.RpcContext, _ json.RawMessage) (any, *types.RpcError) {
+							observed <- ctx
+							return map[string]any{"ok": true}, nil
+						},
+					},
+				}),
+			})
+			httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				ws.ServeHTTP(w, r.WithContext(WithPortContext(r.Context(), test.port)))
+			}))
+			t.Cleanup(func() {
+				httpServer.Close()
+				_ = ws.Close(t.Context())
+			})
+
+			headers := http.Header{}
+			if test.xUser != "" {
+				headers.Set("X-User", test.xUser)
+			}
+			conn, response, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(httpServer.URL, "http"), headers)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusSwitchingProtocols, response.StatusCode)
+			t.Cleanup(func() { _ = conn.Close() })
+			require.NoError(t, conn.WriteJSON(map[string]any{"command": "ping", "id": 1}))
+			require.NoError(t, conn.SetReadDeadline(time.Now().Add(time.Second)))
+			var responseBody map[string]any
+			require.NoError(t, conn.ReadJSON(&responseBody))
+			require.Equal(t, "success", responseBody["status"])
+
+			select {
+			case ctx := <-observed:
+				require.Equal(t, test.want, ctx.Role)
+				require.Equal(t, test.isAdmin, ctx.Role.IsAdmin())
+				require.Equal(t, test.unlimited, ctx.Role.IsUnlimited())
+			case <-time.After(time.Second):
+				t.Fatal("WebSocket handler did not observe a request context")
+			}
+		})
+	}
+}

--- a/internal/rpc/rpcsub_test.go
+++ b/internal/rpc/rpcsub_test.go
@@ -110,7 +110,6 @@ func newRPCSubTestServerWithProvider(t *testing.T, provider types.LedgerInfoProv
 func adminCtx(services *types.ServiceContainer) *types.RpcContext {
 	return &types.RpcContext{
 		Role:       types.RoleAdmin,
-		IsAdmin:    true,
 		ApiVersion: types.ApiVersion1,
 		Services:   services,
 	}

--- a/internal/rpc/server_diagnostics_test.go
+++ b/internal/rpc/server_diagnostics_test.go
@@ -52,7 +52,7 @@ func TestServerDiagnosticsWireShape(t *testing.T) {
 		{name: "server_state", method: &handlers.ServerStateMethod{}, root: "state"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, IsAdmin: true, ApiVersion: 1, Services: services}
+			ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, ApiVersion: 1, Services: services}
 			result, rpcErr := test.method.Handle(ctx, json.RawMessage(`{"counters":"yes"}`))
 			if rpcErr != nil {
 				t.Fatalf("Handle: %v", rpcErr)

--- a/internal/rpc/server_dispatch.go
+++ b/internal/rpc/server_dispatch.go
@@ -22,15 +22,12 @@ func (s *Server) withTimeout(parent context.Context) (context.Context, context.C
 	return context.WithTimeout(parent, s.timeout)
 }
 
-// newRpcContext assembles an RpcContext, deriving IsAdmin / Unlimited from the
-// role so every HTTP/WS dispatch site computes them identically.
+// newRpcContext assembles an RpcContext with the request's authorization role.
 func newRpcContext(ctx context.Context, role types.Role, apiVersion int, clientIP string, peers types.PeerSource, services *types.ServiceContainer) *types.RpcContext {
 	return &types.RpcContext{
 		Context:    ctx,
 		Role:       role,
 		ApiVersion: apiVersion,
-		IsAdmin:    role == types.RoleAdmin,
-		Unlimited:  role.IsUnlimited(),
 		ClientIP:   clientIP,
 		ResourceIP: clientIP,
 		PeerSource: peers,
@@ -413,7 +410,7 @@ func gateLoad(manager *resource.Manager, ctx *types.RpcContext, method string, l
 	var result resource.Disposition
 	if ctx.ResourceConsumer != nil {
 		admission, result = ctx.ResourceConsumer.Admit(resource.FeeReferenceRPC())
-	} else if ctx.Unlimited {
+	} else if ctx.Role.IsUnlimited() {
 		admission, result = manager.AdmitUnlimited(ctx.ResourceIP)
 	} else {
 		admission, result = manager.AdmitInbound(ctx.ClientIP, resource.FeeReferenceRPC())

--- a/internal/rpc/server_dispatch.go
+++ b/internal/rpc/server_dispatch.go
@@ -22,7 +22,6 @@ func (s *Server) withTimeout(parent context.Context) (context.Context, context.C
 	return context.WithTimeout(parent, s.timeout)
 }
 
-// newRpcContext assembles an RpcContext with the request's authorization role.
 func newRpcContext(ctx context.Context, role types.Role, apiVersion int, clientIP string, peers types.PeerSource, services *types.ServiceContainer) *types.RpcContext {
 	return &types.RpcContext{
 		Context:    ctx,

--- a/internal/rpc/server_hardening_test.go
+++ b/internal/rpc/server_hardening_test.go
@@ -409,7 +409,7 @@ func TestSecureGatewayPromotesToIdentifiedWithUser(t *testing.T) {
 	_, gateway, _ := net.ParseCIDR("203.0.113.0/24")
 	pc := &PortContext{SecureGatewayNets: []net.IPNet{*gateway}}
 
-	// With X-User → Identified, Unlimited=true, IsAdmin=false.
+	// With X-User → Identified, unlimited but not admin.
 	req := httptest.NewRequest("POST", "/", strings.NewReader(`{"method":"ping","params":[{}]}`))
 	req.RemoteAddr = "203.0.113.5:1234"
 	req.Header.Set("X-User", "alice")
@@ -419,12 +419,11 @@ func TestSecureGatewayPromotesToIdentifiedWithUser(t *testing.T) {
 	if observed.Role != types.RoleIdentified {
 		t.Fatalf("with X-User: expected RoleIdentified, got %v", observed.Role)
 	}
-	if observed.IsAdmin || !observed.Unlimited {
-		t.Fatalf("with X-User: expected IsAdmin=false, Unlimited=true; got IsAdmin=%v Unlimited=%v",
-			observed.IsAdmin, observed.Unlimited)
+	if observed.Role.IsAdmin() || !observed.Role.IsUnlimited() {
+		t.Fatalf("with X-User: expected non-admin unlimited role; got role=%v", observed.Role)
 	}
 
-	// Without X-User → Proxy, Unlimited=false.
+	// Without X-User → Proxy, not unlimited.
 	req = httptest.NewRequest("POST", "/", strings.NewReader(`{"method":"ping","params":[{}]}`))
 	req.RemoteAddr = "203.0.113.5:1234"
 	req = req.WithContext(WithPortContext(req.Context(), pc))
@@ -433,8 +432,8 @@ func TestSecureGatewayPromotesToIdentifiedWithUser(t *testing.T) {
 	if observed.Role != types.RoleProxy {
 		t.Fatalf("without X-User: expected RoleProxy, got %v", observed.Role)
 	}
-	if observed.Unlimited {
-		t.Fatalf("RoleProxy must not be Unlimited")
+	if observed.Role.IsUnlimited() {
+		t.Fatalf("RoleProxy must not be unlimited")
 	}
 }
 

--- a/internal/rpc/server_info_test.go
+++ b/internal/rpc/server_info_test.go
@@ -99,7 +99,11 @@ func TestServerInfoRoleAliasesAreAdminOnly(t *testing.T) {
 				{name: "admin", admin: true, want: state},
 			} {
 				t.Run(tc.name, func(t *testing.T) {
-					ctx := &types.RpcContext{Context: t.Context(), Services: services, IsAdmin: tc.admin}
+					role := types.RoleGuest
+					if tc.admin {
+						role = types.RoleAdmin
+					}
+					ctx := &types.RpcContext{Context: t.Context(), Role: role, Services: services}
 					infoResult, rpcErr := (&handlers.ServerInfoMethod{}).Handle(ctx, nil)
 					require.Nil(t, rpcErr)
 					assert.Equal(t, tc.want, infoResult.(map[string]any)["info"].(map[string]any)["server_state"])
@@ -125,8 +129,8 @@ func TestServerInfoHostIDPrivacy(t *testing.T) {
 
 	admin := callServerStatus(t, &types.RpcContext{
 		Context:  t.Context(),
+		Role:     types.RoleAdmin,
 		Services: services,
-		IsAdmin:  true,
 	}, true)
 	hostname, err := os.Hostname()
 	if err != nil || hostname == "" {
@@ -136,8 +140,8 @@ func TestServerInfoHostIDPrivacy(t *testing.T) {
 
 	state := callServerStatus(t, &types.RpcContext{
 		Context:  t.Context(),
+		Role:     types.RoleAdmin,
 		Services: services,
-		IsAdmin:  true,
 	}, false)
 	assert.NotContains(t, state, "hostid")
 
@@ -233,7 +237,6 @@ func TestServerStatusRuntimeFields(t *testing.T) {
 					ctx := &types.RpcContext{
 						Context:  t.Context(),
 						Role:     role,
-						IsAdmin:  tc.admin,
 						Services: services,
 					}
 					info := callServerStatus(t, ctx, human)
@@ -265,7 +268,6 @@ func TestServerStatusRuntimeFieldOmissions(t *testing.T) {
 		ctx := &types.RpcContext{
 			Context:  t.Context(),
 			Role:     types.RoleAdmin,
-			IsAdmin:  true,
 			Services: services,
 		}
 		info := callServerStatus(t, ctx, human)
@@ -1373,13 +1375,12 @@ func TestServerInfo_DynamicMetrics_FromHooks(t *testing.T) {
 	}
 
 	method := &handlers.ServerInfoMethod{}
-	// IsAdmin=true so load_factor_fee_escalation is emitted even when
+	// An Admin role makes load_factor_fee_escalation emit even when
 	// loadFactorFeeEscalation == loadFactor; mirrors rippled's
 	// NetworkOPs.cpp:2902-2907 (admin || loadFactorFeeEscalation != loadFactor).
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
-		IsAdmin:    true,
 		ApiVersion: types.ApiVersion1,
 		Services:   services,
 	}
@@ -1708,12 +1709,15 @@ func TestServerInfo_HumanMode_LoadFactorLocalNetCluster_AdminGate(t *testing.T) 
 		if withHook {
 			services.LoadFactorFees = feesHook
 		}
+		role := types.RoleGuest
+		if admin {
+			role = types.RoleAdmin
+		}
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
-			Role:       types.RoleGuest,
+			Role:       role,
 			ApiVersion: types.ApiVersion1,
 			Services:   services,
-			IsAdmin:    admin,
 		}
 		result, rpcErr := method.Handle(ctx, nil)
 		require.Nil(t, rpcErr)
@@ -1848,12 +1852,15 @@ func TestServerInfoPubkeyValidator(t *testing.T) {
 		services := servicesForServerInfo(mock)
 		services.ValidatorPublicKey = pk
 		services.Manifests = manifests
+		role := types.RoleGuest
+		if admin {
+			role = types.RoleAdmin
+		}
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
-			Role:       types.RoleGuest,
+			Role:       role,
 			ApiVersion: types.ApiVersion1,
 			Services:   services,
-			IsAdmin:    admin,
 		}
 		result, rpcErr := infoMethod.Handle(ctx, nil)
 		require.Nil(t, rpcErr)
@@ -1912,10 +1919,9 @@ func TestServerInfoPubkeyValidator(t *testing.T) {
 		services.ValidatorPublicKey = signing
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
-			Role:       types.RoleGuest,
+			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
 			Services:   services,
-			IsAdmin:    true,
 		}
 		result, rpcErr := (&handlers.ServerStateMethod{}).Handle(ctx, nil)
 		require.Nil(t, rpcErr)
@@ -1943,12 +1949,15 @@ func TestServerInfoValidatorListVisibility(t *testing.T) {
 
 	infoFor := func(t *testing.T, admin bool) map[string]any {
 		t.Helper()
+		role := types.RoleGuest
+		if admin {
+			role = types.RoleAdmin
+		}
 		result, rpcErr := (&handlers.ServerInfoMethod{}).Handle(&types.RpcContext{
 			Context:    context.Background(),
-			Role:       types.RoleGuest,
+			Role:       role,
 			ApiVersion: types.ApiVersion1,
 			Services:   services,
-			IsAdmin:    admin,
 		}, nil)
 		require.Nil(t, rpcErr)
 		return result.(map[string]any)["info"].(map[string]any)
@@ -1964,12 +1973,15 @@ func TestServerInfoValidatorListVisibility(t *testing.T) {
 
 	stateFor := func(t *testing.T, admin bool) map[string]any {
 		t.Helper()
+		role := types.RoleGuest
+		if admin {
+			role = types.RoleAdmin
+		}
 		result, rpcErr := (&handlers.ServerStateMethod{}).Handle(&types.RpcContext{
 			Context:    context.Background(),
-			Role:       types.RoleGuest,
+			Role:       role,
 			ApiVersion: types.ApiVersion1,
 			Services:   services,
-			IsAdmin:    admin,
 		}, nil)
 		require.Nil(t, rpcErr)
 		return result.(map[string]any)["state"].(map[string]any)

--- a/internal/rpc/subscription_contracts_test.go
+++ b/internal/rpc/subscription_contracts_test.go
@@ -315,7 +315,6 @@ func TestAccountHistoryURLSubscriptionRetention(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:    requestContext,
 		Role:       types.RoleAdmin,
-		IsAdmin:    true,
 		ApiVersion: types.DefaultApiVersion,
 		Services:   services,
 	}
@@ -366,7 +365,6 @@ func TestAccountHistoryURLValidationIsOrderedAndAtomic(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
-		IsAdmin:    true,
 		ApiVersion: types.DefaultApiVersion,
 		Services:   services,
 	}
@@ -440,7 +438,6 @@ func TestAccountHistoryHTTPURLMethods(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
-		IsAdmin:    true,
 		ApiVersion: types.DefaultApiVersion,
 		Services:   services,
 	}

--- a/internal/rpc/subscription_server_ack_test.go
+++ b/internal/rpc/subscription_server_ack_test.go
@@ -42,7 +42,7 @@ func TestServerSubscriptionInitialAcknowledgement(t *testing.T) {
 	require.Equal(t, testNodePublicKey(), guest["pubkey_node"])
 	require.NotContains(t, guest, "stand_alone")
 
-	admin := ws.buildSubscribeAck(&types.RpcContext{Services: services, IsAdmin: true}, request)
+	admin := ws.buildSubscribeAck(&types.RpcContext{Services: services, Role: types.RoleAdmin}, request)
 	require.Equal(t, "validating", admin["server_status"])
 	require.NotEmpty(t, admin["hostid"])
 	require.NotEqual(t, guest["random"], admin["random"])
@@ -82,7 +82,7 @@ func TestServerSubscriptionStateIsSampledBeforeRegistration(t *testing.T) {
 				return types.LoadFactorFees{Local: factor, Net: factor, Cluster: factor}
 			}
 			ws = NewWebSocketServer(WebSocketServerOptions{Services: services})
-			ctx := &types.RpcContext{Services: services, IsAdmin: true}
+			ctx := &types.RpcContext{Services: services, Role: types.RoleAdmin}
 			var ack map[string]any
 			if transport == "websocket" {
 				connection := subscription.NewConnection("ack-order", make(chan []byte, 1))

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -56,7 +56,6 @@ func (r Role) IsUnlimited() bool {
 	return r == RoleAdmin || r == RoleIdentified
 }
 
-// IsAdmin reports whether the role has administrator privileges.
 func (r Role) IsAdmin() bool {
 	return r == RoleAdmin
 }

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -56,6 +56,11 @@ func (r Role) IsUnlimited() bool {
 	return r == RoleAdmin || r == RoleIdentified
 }
 
+// IsAdmin reports whether the role has administrator privileges.
+func (r Role) IsAdmin() bool {
+	return r == RoleAdmin
+}
+
 // Condition represents the preconditions required by an RPC method.
 // Matches rippled's Condition enum in Handler.h.
 // When the server is amendment-blocked, methods with any condition
@@ -89,12 +94,6 @@ type RpcContext struct {
 	Context    context.Context
 	Role       Role
 	ApiVersion int
-	// IsAdmin gates admin-only commands. True iff Role == RoleAdmin.
-	IsAdmin bool
-	// Unlimited skips per-request resource limits (page sizes, etc.).
-	// True for RoleAdmin and RoleIdentified, matching rippled
-	// isUnlimited() in Role.cpp.
-	Unlimited  bool
 	ClientIP   string
 	ResourceIP string
 	PeerSource PeerSource

--- a/internal/rpc/websocket_subscribe.go
+++ b/internal/rpc/websocket_subscribe.go
@@ -25,7 +25,7 @@ func (ws *WebSocketServer) executeSubscribe(wsConn *websocketConnection, ctx *ty
 	// url requests are server-to-server (RPCSub) subscriptions: events go
 	// to the url's subscriber, not to this WebSocket connection.
 	if request.HasURL() {
-		if !ctx.IsAdmin {
+		if !ctx.Role.IsAdmin() {
 			return nil, types.RpcErrorNoPermission("subscribe")
 		}
 		result, rpcErr := ws.urlSubs.Subscribe(ctx, request)
@@ -43,7 +43,7 @@ func (ws *WebSocketServer) executeSubscribe(wsConn *websocketConnection, ctx *ty
 	}
 	prefix.ApiVersion = ctx.ApiVersion
 	scope := ws.subscriptionManager.NewRequestScope()
-	if rpcErr := ws.subscriptionManager.HandleSubscribeScoped(wsConn.registration, scope, prefix, ctx.IsAdmin); rpcErr != nil {
+	if rpcErr := ws.subscriptionManager.HandleSubscribeScoped(wsConn.registration, scope, prefix, ctx.Role.IsAdmin()); rpcErr != nil {
 		return nil, rpcErr
 	}
 	historyWarning, rpcErr := applyAccountHistorySubscribe(ctx, wsConn.Connection, request)
@@ -52,7 +52,7 @@ func (ws *WebSocketServer) executeSubscribe(wsConn *websocketConnection, ctx *ty
 	}
 	if rpcErr := applyRequestBooks(request, func(bookRequest types.SubscriptionRequest) *types.RpcError {
 		bookRequest.ApiVersion = ctx.ApiVersion
-		if rpcErr := ws.subscriptionManager.HandleSubscribeScoped(wsConn.registration, scope, bookRequest, ctx.IsAdmin); rpcErr != nil {
+		if rpcErr := ws.subscriptionManager.HandleSubscribeScoped(wsConn.registration, scope, bookRequest, ctx.Role.IsAdmin()); rpcErr != nil {
 			return rpcErr
 		}
 		setSubscriptionLoadCost(ctx, bookRequest)
@@ -180,7 +180,7 @@ func (ws *WebSocketServer) executeUnsubscribe(wsConn *websocketConnection, ctx *
 	}
 	// See handleSubscribe: url requests target the RPCSub registry.
 	if request.HasURL() {
-		if !ctx.IsAdmin {
+		if !ctx.Role.IsAdmin() {
 			return nil, types.RpcErrorNoPermission("unsubscribe")
 		}
 		result, rpcErr := ws.urlSubs.Unsubscribe(ctx, request)
@@ -215,7 +215,7 @@ func sampleServerSubscriptionState(ctx *types.RpcContext, request types.Subscrip
 	if !slices.Contains(request.Streams, types.SubServer) {
 		return nil
 	}
-	return handlers.ServerSubscriptionState(ctx.Services, ctx.IsAdmin)
+	return handlers.ServerSubscriptionState(ctx.Services, ctx.Role.IsAdmin())
 }
 
 func (ws *WebSocketServer) buildSubscribeAck(ctx *types.RpcContext, request types.SubscriptionRequest) map[string]any {

--- a/internal/testing/rpcenv/rpcenv.go
+++ b/internal/testing/rpcenv/rpcenv.go
@@ -128,8 +128,6 @@ func (e *Env) RPCAs(method string, params any, role types.Role, apiVersion int) 
 		Context:    context.Background(),
 		Role:       role,
 		ApiVersion: apiVersion,
-		IsAdmin:    role == types.RoleAdmin,
-		Unlimited:  role.IsUnlimited(),
 		Services:   e.services,
 	}
 	return handler.Handle(ctx, raw)


### PR DESCRIPTION
## Summary

- remove cached admin and unlimited flags from request contexts
- derive authorization and resource privileges exclusively from the canonical role
- cover HTTP, WebSocket, batch, proxy, and handler authorization parity

This is layer 3 of 7 and depends on #1603.

Part of #1490.

## Test plan

- `go test -count=1 ./internal/rpc/... ./internal/node ./internal/testing/rpcenv`
- `go test -race -count=1 ./internal/rpc/handlers ./internal/rpc ./internal/node`
- `go vet ./internal/rpc/... ./internal/node ./internal/testing/rpcenv`
- `golangci-lint run`