### PR TITLE
refactor: publish immutable RPC service graph (#1490)

### DIFF
--- a/internal/cli/rpc_test.go
+++ b/internal/cli/rpc_test.go
@@ -769,11 +769,11 @@ func TestRPCStopUsesAdminCredentialsWithRPCServer(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			shutdown := make(chan struct{}, 1)
-			services := &rpctypes.ServiceContainer{
-				ShutdownFunc: func() {
+			services := rpctypes.NewTestServiceGraph(&rpctypes.ServiceContainer{
+				Shutdown: rpctypes.ShutdownFunc(func() {
 					shutdown <- struct{}{}
-				},
-			}
+				}),
+			})
 			server := rpcserver.NewServer(rpcserver.ServerOptions{Timeout: time.Second, Services: services})
 			_, adminNet, err := net.ParseCIDR("127.0.0.0/8")
 			if err != nil {

--- a/internal/node/identity_test.go
+++ b/internal/node/identity_test.go
@@ -15,7 +15,7 @@ func TestConfigureStandaloneNodeIdentityPersists(t *testing.T) {
 		runtime := &nodeRuntime{
 			appConfig:  &config.Config{DatabasePath: dir},
 			standalone: standalone,
-			services:   &types.ServiceContainer{},
+			services:   types.NewServiceGraphBuilder(nil),
 		}
 		err := runtime.configureStandaloneNodeIdentity()
 		return runtime.services.NodePublicKey, err

--- a/internal/node/lifecycle_test.go
+++ b/internal/node/lifecycle_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 	"github.com/LeJamon/go-xrpl/internal/rpc"
+	rpcadapter "github.com/LeJamon/go-xrpl/internal/rpc/adapter"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 	"github.com/LeJamon/go-xrpl/storage/nodestore"
@@ -27,23 +28,20 @@ import (
 func TestBindRPCWiresExplicitSharedServices(t *testing.T) {
 	runtime := &nodeRuntime{
 		appConfig:  &config.Config{},
-		services:   types.NewServiceContainer(nil),
+		services:   newRPCServiceContainer(rpcadapter.NewLedgerServiceAdapter(nil), &config.Config{}),
 		serverLog:  xrpllog.Discard(),
 		shutdownCh: make(chan struct{}, 1),
+		shutdowner: types.ShutdownFunc(func() {}),
 	}
-	runtime.services.ClientLoad = types.NewClientLoadShedder()
 	if err := runtime.bindRPC(); err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = runtime.wsServer.Close(context.Background()) }()
 
-	if runtime.services.Dispatcher != runtime.httpServer {
-		t.Fatal("bindRPC did not install the HTTP dispatcher")
+	if runtime.httpServer == nil || runtime.wsServer == nil || runtime.wsServer.URLSubscriptionService() == nil {
+		t.Fatal("bindRPC did not publish complete transport dependencies")
 	}
-	if runtime.services.URLSubscriptions != runtime.wsServer.URLSubscriptionService() {
-		t.Fatal("bindRPC did not install the WebSocket URL subscription service")
-	}
-	if runtime.services.ClientLoad == nil {
+	if runtime.serviceGraph == nil || runtime.serviceGraph.ClientLoad() == nil {
 		t.Fatal("bindRPC lost the configured client-load shedder")
 	}
 	if runtime.resourceManager == nil || !runtime.ownsResourceManager {
@@ -52,7 +50,7 @@ func TestBindRPCWiresExplicitSharedServices(t *testing.T) {
 	consumer := runtime.resourceManager.NewInboundEndpoint("192.0.2.25")
 	consumer.Charge(resource.NewCharge(resource.WarningThreshold*resource.DecayWindowSeconds, "test"), "")
 	defer consumer.Release()
-	if got := runtime.services.ResourceBlacklist(nil); got["IP Address: 192.0.2.25"] == nil {
+	if got := runtime.serviceGraph.ResourceBlacklist()(nil); got["IP Address: 192.0.2.25"] == nil {
 		t.Fatalf("standalone resource blacklist = %+v", got)
 	}
 }

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -97,8 +97,8 @@ func rpcCapabilities(cfg *config.Config) types.RPCCapabilities {
 	}
 }
 
-func newRPCServiceContainer(ledger types.LedgerService, cfg *config.Config) *types.ServiceContainer {
-	services := types.NewServiceContainer(ledger)
+func newRPCServiceContainer(ledger types.LedgerService, cfg *config.Config) *types.ServiceGraphBuilder {
+	services := types.NewServiceGraphBuilder(ledger)
 	services.ClientLoad = types.NewClientLoadShedder()
 	services.RPCDiagnostics = rpc.NewRPCDiagnostics()
 	services.ServerInfoConfig = serverInfoConfigSnapshot(cfg)

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -60,7 +60,8 @@ type nodeRuntime struct {
 	resourceManager      *resource.Manager
 	ownsResourceManager  bool
 
-	services      *types.ServiceContainer
+	services      *types.ServiceGraphBuilder
+	serviceGraph  *types.ServiceGraph
 	ledgerAdapter *rpcadapter.LedgerServiceAdapter
 	httpServer    *rpc.Server
 	wsServer      *rpc.WebSocketServer
@@ -71,6 +72,7 @@ type nodeRuntime struct {
 	networkID      uint32
 	retentionFloor func() uint32
 	shutdownCh     chan struct{}
+	shutdowner     types.Shutdowner
 	stopSampler    func()
 	stopWatchdog   func()
 }
@@ -85,6 +87,7 @@ func newNodeRuntime(
 	options RunOptions,
 ) *nodeRuntime {
 	runtimeCtx, cancel := context.WithCancelCause(ctx)
+	shutdownCh := make(chan struct{}, 1)
 	return &nodeRuntime{
 		ctx:        runtimeCtx,
 		cancel:     cancel,
@@ -95,7 +98,24 @@ func newNodeRuntime(
 		rootLogger: rootLogger,
 		serverLog:  serverLog,
 		options:    options,
-		shutdownCh: make(chan struct{}, 1),
+		shutdownCh: shutdownCh,
+		shutdowner: &shutdownController{log: serverLog, ch: shutdownCh},
+	}
+}
+
+type shutdownController struct {
+	log xrpllog.Logger
+	ch  chan<- struct{}
+}
+
+func (c *shutdownController) RequestShutdown() {
+	if c == nil {
+		return
+	}
+	c.log.Info("Shutdown requested via RPC stop command")
+	select {
+	case c.ch <- struct{}{}:
+	default:
 	}
 }
 
@@ -863,35 +883,47 @@ func (r *nodeRuntime) bindRPC() error {
 		r.resourceManager = resource.NewManager(nil, nil)
 		r.ownsResourceManager = true
 	}
+	if r.services == nil {
+		return errors.New("bind RPC: service graph builder is unavailable")
+	}
 	r.services.ResourceBlacklist = r.resourceManager.BlacklistJSON
 	var peerSource types.PeerSource
 	if r.consensus != nil && r.consensus.Overlay != nil {
 		peerSource = r.consensus.Overlay
 	}
 	manager := subscription.NewManager()
+	r.services.Shutdown = r.shutdowner
+	r.services.SubscriptionMetrics = manager.Metrics
+	ledgerInfo := &ledgerInfoAdapter{ledgerService: r.ledger}
+	graph, err := r.services.Build()
+	if err != nil {
+		return fmt.Errorf("build RPC service graph: %w", err)
+	}
+	r.serviceGraph = graph
+	urlSubscriptions := rpc.NewURLSubscriptionService(manager, graph, ledgerInfo)
 
 	// Create HTTP JSON-RPC server. The dispatch timeout stays strictly below
 	// the transport WriteTimeout (see httpWriteTimeout) so a timed-out request
 	// can still serialize its error envelope.
 	r.httpServer = rpc.NewServer(rpc.ServerOptions{
-		Timeout:         rpcDispatchTimeout,
-		Services:        r.services,
-		ResourceManager: r.resourceManager,
-		PeerSource:      peerSource,
+		Timeout:          rpcDispatchTimeout,
+		Services:         graph,
+		ResourceManager:  r.resourceManager,
+		PeerSource:       peerSource,
+		URLSubscriptions: urlSubscriptions,
 	})
-	r.services.Dispatcher = r.httpServer
 
 	pingInterval := time.Duration(r.appConfig.WebsocketPingFrequency) * time.Second
 	r.wsServer = rpc.NewWebSocketServer(rpc.WebSocketServerOptions{
 		Timeout:             rpcDispatchTimeout,
-		Services:            r.services,
+		Services:            graph,
 		ResourceManager:     r.resourceManager,
 		PeerSource:          peerSource,
 		PingInterval:        pingInterval,
-		LedgerInfoProvider:  &ledgerInfoAdapter{ledgerService: r.ledger},
+		LedgerInfoProvider:  ledgerInfo,
 		SubscriptionManager: manager,
+		URLSubscriptions:    urlSubscriptions,
 	})
-	r.services.URLSubscriptions = r.wsServer.URLSubscriptionService()
 
 	r.publisher = rpc.NewPublisher(r.wsServer.SubscriptionManager())
 	return nil
@@ -947,7 +979,7 @@ func (r *nodeRuntime) bindStreams() error {
 		)
 	})
 
-	serverStatus := newServerStatusPublisher(r.services, r.publisher)
+	serverStatus := newServerStatusPublisher(r.serviceGraph, r.publisher)
 	r.ledger.SetServerStatusCallback(serverStatus.publish)
 	if feeTrack := r.ledger.FeeTrack(); feeTrack != nil {
 		feeTrack.SetOnChange(func() {
@@ -1011,7 +1043,7 @@ func (r *nodeRuntime) bindStreams() error {
 		serverStatus.publish(nil)
 
 		r.wsServer.UpdatePathFindSessions(func() (types.LedgerStateView, error) {
-			return r.services.Ledger.GetClosedLedgerView()
+			return r.serviceGraph.Ledger().GetClosedLedgerView()
 		})
 
 		r.serverLog.Debug("Broadcasted ledger",
@@ -1058,13 +1090,6 @@ func (r *nodeRuntime) configureWatchdog() error {
 
 func (r *nodeRuntime) bindTransports() error {
 	ctx := r.ctx
-	r.services.ShutdownFunc = func() {
-		r.serverLog.Info("Shutdown requested via RPC stop command")
-		select {
-		case r.shutdownCh <- struct{}{}:
-		default:
-		}
-	}
 
 	if err := context.Cause(ctx); err != nil {
 		return err

--- a/internal/node/server_status.go
+++ b/internal/node/server_status.go
@@ -31,7 +31,7 @@ type serverStatusEventPublisher interface {
 
 type serverStatusPublisher struct {
 	mu        sync.Mutex
-	services  *types.ServiceContainer
+	services  *types.ServiceGraph
 	publisher serverStatusEventPublisher
 	haveLast  bool
 	last      serverStatusSnapshot
@@ -39,7 +39,7 @@ type serverStatusPublisher struct {
 	mode      string
 }
 
-func newServerStatusPublisher(services *types.ServiceContainer, publisher serverStatusEventPublisher) *serverStatusPublisher {
+func newServerStatusPublisher(services *types.ServiceGraph, publisher serverStatusEventPublisher) *serverStatusPublisher {
 	return &serverStatusPublisher{services: services, publisher: publisher}
 }
 
@@ -62,7 +62,7 @@ func (p *serverStatusPublisher) modePublication(mode string) service.ServerStatu
 	return p.statusPublication(&mode)
 }
 func (p *serverStatusPublisher) capture(mode *string) (serverStatusSnapshot, *rpc.ServerStatusEvent) {
-	if p == nil || p.services == nil || p.services.Ledger == nil || p.publisher == nil {
+	if p == nil || p.services == nil || p.services.Ledger() == nil || p.publisher == nil {
 		return serverStatusSnapshot{}, nil
 	}
 	p.mu.Lock()
@@ -76,13 +76,13 @@ func (p *serverStatusPublisher) capture(mode *string) (serverStatusSnapshot, *rp
 	} else if p.haveMode {
 		serverStatus = p.mode
 	} else {
-		if info := p.services.Ledger.GetServerInfo(); info.ServerState != "" {
+		if info := p.services.Ledger().GetServerInfo(); info.ServerState != "" {
 			serverStatus = info.ServerState
 		}
 		p.mode = serverStatus
 		p.haveMode = true
 	}
-	baseFee, _, _ := p.services.Ledger.GetCurrentFees()
+	baseFee, _, _ := p.services.Ledger().GetCurrentFees()
 	load := handlers.ComputeServerLoad(p.services)
 	snapshot := serverStatusSnapshot{
 		baseFee:                 baseFee,

--- a/internal/node/server_status_test.go
+++ b/internal/node/server_status_test.go
@@ -40,7 +40,7 @@ func (r *serverStatusRecorder) count() int {
 	return len(r.events)
 }
 
-func serverStatusTestServices(svc *service.Service) *types.ServiceContainer {
+func serverStatusTestServices(svc *service.Service) *types.ServiceGraph {
 	services := types.NewServiceContainer(rpcadapter.NewLedgerServiceAdapter(svc))
 	services.TxQMetrics = func() types.TxQServerMetrics {
 		metrics := svc.TxQMetrics()
@@ -58,7 +58,7 @@ func serverStatusTestServices(svc *service.Service) *types.ServiceContainer {
 			Cluster: fees.ClusterFee(),
 		}
 	}
-	return services
+	return types.NewTestServiceGraph(services)
 }
 
 func waitForServerStatus(t *testing.T, recorder *serverStatusRecorder) *rpc.ServerStatusEvent {
@@ -204,7 +204,7 @@ func TestServerStatusPublisherClipsSaturatedTxQLoad(t *testing.T) {
 		t.Fatalf("Start service: %v", err)
 	}
 	t.Cleanup(svc.Stop)
-	services := serverStatusTestServices(svc)
+	services := types.NewServiceContainer(rpcadapter.NewLedgerServiceAdapter(svc))
 	services.TxQMetrics = func() types.TxQServerMetrics {
 		return types.TxQServerMetrics{
 			ReferenceFeeLevel:     256,
@@ -212,8 +212,9 @@ func TestServerStatusPublisherClipsSaturatedTxQLoad(t *testing.T) {
 			OpenLedgerFeeLevel:    math.MaxUint64,
 		}
 	}
+	servicesGraph := types.NewTestServiceGraph(services)
 	recorder := newServerStatusRecorder()
-	status := newServerStatusPublisher(services, recorder)
+	status := newServerStatusPublisher(servicesGraph, recorder)
 	status.publish(nil)
 
 	event := waitForServerStatus(t, recorder)

--- a/internal/rpc/account_channels_test.go
+++ b/internal/rpc/account_channels_test.go
@@ -174,8 +174,8 @@ func (m *mockAccountChannelsLedgerService) GetClosedLedgerView() (types.LedgerSt
 }
 
 // newAccountChannelsTestServices builds a *types.ServiceContainer wrapping the mock.
-func newAccountChannelsTestServices(mock *mockAccountChannelsLedgerService) *types.ServiceContainer {
-	return &types.ServiceContainer{Ledger: mock}
+func newAccountChannelsTestServices(mock *mockAccountChannelsLedgerService) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 }
 
 // TestAccountChannelsErrorValidation tests error handling for invalid inputs

--- a/internal/rpc/account_currencies_test.go
+++ b/internal/rpc/account_currencies_test.go
@@ -176,8 +176,8 @@ func (m *mockAccountCurrenciesLedgerService) GetClosedLedgerView() (types.Ledger
 }
 
 // newAccountCurrenciesTestServices builds a *types.ServiceContainer wrapping the mock.
-func newAccountCurrenciesTestServices(mock *mockAccountCurrenciesLedgerService) *types.ServiceContainer {
-	return &types.ServiceContainer{Ledger: mock}
+func newAccountCurrenciesTestServices(mock *mockAccountCurrenciesLedgerService) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 }
 
 // TestAccountCurrenciesBadInput tests error handling for invalid inputs

--- a/internal/rpc/account_info_test.go
+++ b/internal/rpc/account_info_test.go
@@ -220,8 +220,8 @@ func (m *mockLedgerService) GetClosedLedgerView() (types.LedgerStateView, error)
 
 // newTestServices builds a *types.ServiceContainer wrapping the given LedgerService.
 // Accepts any type that implements types.LedgerService.
-func newTestServices(mock types.LedgerService) *types.ServiceContainer {
-	return &types.ServiceContainer{Ledger: mock}
+func newTestServices(mock types.LedgerService) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 }
 
 // TestAccountInfoErrorValidation tests error handling for invalid inputs
@@ -1146,7 +1146,7 @@ func TestAccountInfoServiceNilLedger(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: nil},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: nil}),
 	}
 
 	params := map[string]any{

--- a/internal/rpc/account_lines_test.go
+++ b/internal/rpc/account_lines_test.go
@@ -170,8 +170,8 @@ func (m *mockAccountLinesLedgerService) GetClosedLedgerView() (types.LedgerState
 }
 
 // newAccountLinesTestServices builds a *types.ServiceContainer wrapping the mock.
-func newAccountLinesTestServices(mock *mockAccountLinesLedgerService) *types.ServiceContainer {
-	return &types.ServiceContainer{Ledger: mock}
+func newAccountLinesTestServices(mock *mockAccountLinesLedgerService) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 }
 
 // TestAccountLinesErrorValidation tests error handling for invalid inputs
@@ -1257,7 +1257,7 @@ func TestAccountLinesServiceNilLedger(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: nil},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: nil}),
 	}
 
 	params := map[string]any{

--- a/internal/rpc/account_nfts_test.go
+++ b/internal/rpc/account_nfts_test.go
@@ -182,8 +182,8 @@ func (m *mockAccountNFTsLedgerService) GetClosedLedgerView() (types.LedgerStateV
 }
 
 // newAccountNFTsTestServices builds a *types.ServiceContainer wrapping the mock.
-func newAccountNFTsTestServices(mock *mockAccountNFTsLedgerService) *types.ServiceContainer {
-	return &types.ServiceContainer{Ledger: mock}
+func newAccountNFTsTestServices(mock *mockAccountNFTsLedgerService) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 }
 
 // TestAccountNFTsErrorValidation tests error handling for invalid inputs

--- a/internal/rpc/account_objects_test.go
+++ b/internal/rpc/account_objects_test.go
@@ -37,8 +37,8 @@ func newAccountObjectsMock() *accountObjectsMock {
 }
 
 // newAccountObjectsTestServices builds a *types.ServiceContainer wrapping the mock.
-func newAccountObjectsTestServices(mock *accountObjectsMock) *types.ServiceContainer {
-	return &types.ServiceContainer{Ledger: mock}
+func newAccountObjectsTestServices(mock *accountObjectsMock) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 }
 
 // Test: Error cases – missing / invalid / malformed account
@@ -962,7 +962,7 @@ func TestAccountObjectsServiceUnavailable(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: nil},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: nil}),
 		}
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)

--- a/internal/rpc/account_offers_test.go
+++ b/internal/rpc/account_offers_test.go
@@ -41,8 +41,8 @@ func (m *accountOffersMock) GetAccountOffers(_ context.Context, account string, 
 }
 
 // newAccountOffersTestServices builds a *types.ServiceContainer wrapping the mock.
-func newAccountOffersTestServices(mock *accountOffersMock) *types.ServiceContainer {
-	return &types.ServiceContainer{Ledger: mock}
+func newAccountOffersTestServices(mock *accountOffersMock) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 }
 
 // TestAccountOffersErrorValidation tests error handling for invalid inputs
@@ -964,7 +964,7 @@ func TestAccountOffersServiceUnavailable(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: nil},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: nil}),
 		}
 
 		params := map[string]any{

--- a/internal/rpc/account_page_precedence_test.go
+++ b/internal/rpc/account_page_precedence_test.go
@@ -18,7 +18,7 @@ type accountPageMethod interface {
 	Handle(*types.RpcContext, json.RawMessage) (any, *types.RpcError)
 }
 
-func accountPageContext(services *types.ServiceContainer) *types.RpcContext {
+func accountPageContext(services *types.ServiceGraph) *types.RpcContext {
 	return &types.RpcContext{
 		Context: context.Background(), ApiVersion: types.ApiVersion1,
 		Role: types.RoleGuest, Services: services,

--- a/internal/rpc/account_tx_test.go
+++ b/internal/rpc/account_tx_test.go
@@ -53,8 +53,8 @@ func (m *accountTxMock) GetLedgerByHash(hash [32]byte) (types.LedgerReader, erro
 }
 
 // newTestServicesAccountTx builds a *types.ServiceContainer wrapping the mock.
-func newTestServicesAccountTx(mock *accountTxMock) *types.ServiceContainer {
-	return &types.ServiceContainer{Ledger: mock}
+func newTestServicesAccountTx(mock *accountTxMock) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 }
 
 func TestAccountTxDeliveredAmountHistoricalContext(t *testing.T) {
@@ -1479,7 +1479,7 @@ func TestAccountTxServiceUnavailable(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: nil},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: nil}),
 		}
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)

--- a/internal/rpc/account_validation_order_test.go
+++ b/internal/rpc/account_validation_order_test.go
@@ -87,7 +87,7 @@ func TestAccountHandlerValidationOrder(t *testing.T) {
 				Context:    context.Background(),
 				Role:       types.RoleGuest,
 				ApiVersion: types.ApiVersion2,
-				Services:   &types.ServiceContainer{Ledger: newMockLedgerService()},
+				Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: newMockLedgerService()}),
 			}
 			result, rpcErr := tc.method.Handle(ctx, json.RawMessage(tc.params))
 			assert.Nil(t, result)
@@ -110,7 +110,7 @@ func TestAccountInfoQueueAndSignerValidationFollowAccountLookup(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion2,
-			Services:   &types.ServiceContainer{Ledger: service},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: service}),
 		}
 	}
 
@@ -181,7 +181,7 @@ func TestAccountHandlerOptionalValidationFollowsAccountSLE(t *testing.T) {
 				Context:    context.Background(),
 				Role:       types.RoleGuest,
 				ApiVersion: types.ApiVersion2,
-				Services:   &types.ServiceContainer{Ledger: service},
+				Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: service}),
 			}
 			result, rpcErr := tc.method.Handle(ctx, json.RawMessage(tc.params))
 			assert.Nil(t, result)

--- a/internal/rpc/admin_forbidden_test.go
+++ b/internal/rpc/admin_forbidden_test.go
@@ -113,7 +113,7 @@ func TestHTTPBatchAdminDenialForbidden(t *testing.T) {
 			"ping": echoHandler(),
 		}),
 		timeout:  time.Second,
-		services: types.NewServiceContainer(nil),
+		services: types.NewTestServiceGraph(types.NewServiceContainer(nil)),
 	}
 
 	body := `{"method":"batch","params":[

--- a/internal/rpc/admin_transport_test.go
+++ b/internal/rpc/admin_transport_test.go
@@ -27,7 +27,7 @@ func transportTestPort() *PortContext {
 
 func transportTestServer(t *testing.T, calls *atomic.Int32) *Server {
 	t.Helper()
-	srv := NewServer(ServerOptions{Timeout: time.Second, Services: types.NewServiceContainer(nil), Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
+	srv := NewServer(ServerOptions{Timeout: time.Second, Services: types.NewTestServiceGraph(types.NewServiceContainer(nil)), Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
 		"stop": &stubHandler{
 			role: types.RoleGuest,
 			handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {

--- a/internal/rpc/amendment_warnings_test.go
+++ b/internal/rpc/amendment_warnings_test.go
@@ -70,7 +70,7 @@ func serverInfoWarnings(t *testing.T, mock *mockServerInfoWarnings, isAdmin bool
 		Context:    context.Background(),
 		Role:       role,
 		ApiVersion: types.ApiVersion1,
-		Services:   services,
+		Services:   types.NewTestServiceGraph(services),
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)
@@ -207,7 +207,7 @@ func TestFeatureMajorityFieldEndToEnd(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest, // majority is emitted to all callers, not admin-gated
 		ApiVersion: types.ApiVersion1,
-		Services:   services,
+		Services:   types.NewTestServiceGraph(services),
 	}
 
 	didHex := strings.ToUpper(hex.EncodeToString(did.ID[:]))

--- a/internal/rpc/api_version_gate_test.go
+++ b/internal/rpc/api_version_gate_test.go
@@ -18,6 +18,8 @@ import (
 // versions; the dispatch-layer cap, not the handler set, is what gates v3.
 func versionEchoServer(t *testing.T, beta bool) *Server {
 	t.Helper()
+	services := types.NewServiceContainer(nil)
+	services.BetaRPCAPI = beta
 	srv := &Server{
 		registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
 			"ping": &stubHandler{
@@ -28,9 +30,8 @@ func versionEchoServer(t *testing.T, beta bool) *Server {
 			},
 		}),
 		timeout:  time.Second,
-		services: types.NewServiceContainer(nil),
+		services: types.NewTestServiceGraph(services),
 	}
-	srv.services.BetaRPCAPI = beta
 	return srv
 }
 
@@ -179,9 +180,11 @@ func TestApiVersion_BatchV3RejectedWithoutBeta(t *testing.T) {
 // given beta flag.
 func versionEchoWSServer(t *testing.T, beta bool) *WebSocketServer {
 	t.Helper()
+	services := types.NewServiceContainer(nil)
+	services.BetaRPCAPI = beta
 	ws := NewWebSocketServer(WebSocketServerOptions{
 		Timeout:  30 * time.Second,
-		Services: types.NewServiceContainer(nil),
+		Services: types.NewTestServiceGraph(services),
 		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
 			"ping": &stubHandler{
 				apiVers: []int{types.ApiVersion1, types.ApiVersion2, types.ApiVersion3},
@@ -191,7 +194,6 @@ func versionEchoWSServer(t *testing.T, beta bool) *WebSocketServer {
 			},
 		}),
 	})
-	ws.services.BetaRPCAPI = beta
 	return ws
 }
 

--- a/internal/rpc/batch_test.go
+++ b/internal/rpc/batch_test.go
@@ -34,7 +34,7 @@ func newBatchServer(t *testing.T) *Server {
 			"account_info": echoHandler(),
 		}),
 		timeout:  time.Second,
-		services: types.NewServiceContainer(nil),
+		services: types.NewTestServiceGraph(types.NewServiceContainer(nil)),
 	}
 	return srv
 }

--- a/internal/rpc/book_changes_test.go
+++ b/internal/rpc/book_changes_test.go
@@ -163,8 +163,8 @@ func (m *mockLedgerServiceBC) addLedger(lr *mockLedgerReaderBC) {
 }
 
 // newTestServicesBC builds a *types.ServiceContainer wrapping the mock.
-func newTestServicesBC(mock *mockLedgerServiceBC) *types.ServiceContainer {
-	return &types.ServiceContainer{Ledger: mock}
+func newTestServicesBC(mock *mockLedgerServiceBC) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 }
 
 // Tests
@@ -543,7 +543,7 @@ func TestBookChangesServiceUnavailable(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: nil},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: nil}),
 		}
 
 		params := map[string]any{

--- a/internal/rpc/book_offers_test.go
+++ b/internal/rpc/book_offers_test.go
@@ -43,8 +43,8 @@ func newBookOffersMock() *bookOffersMock {
 }
 
 // newBookOffersTestServices builds a *types.ServiceContainer wrapping the mock.
-func newBookOffersTestServices(mock *bookOffersMock) *types.ServiceContainer {
-	return &types.ServiceContainer{Ledger: mock}
+func newBookOffersTestServices(mock *bookOffersMock) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 }
 
 // TestBookOffersErrorValidation tests error handling for invalid inputs
@@ -1285,7 +1285,7 @@ func TestBookOffersServiceUnavailable(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: nil},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: nil}),
 		}
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)

--- a/internal/rpc/channel_authorize_test.go
+++ b/internal/rpc/channel_authorize_test.go
@@ -20,15 +20,15 @@ import (
 func channelAuthorizeTestContext(apiVersion int) *types.RpcContext {
 	return &types.RpcContext{
 		ApiVersion: apiVersion,
-		Services: &types.ServiceContainer{
+		Services: types.NewTestServiceGraph(&types.ServiceContainer{
 			Capabilities: types.RPCCapabilities{SigningEnabled: true},
-		},
+		}),
 	}
 }
 
 func TestChannelAuthorizeSigningDisabledPrecedesValidation(t *testing.T) {
 	_, rpcErr := (&handlers.ChannelAuthorizeMethod{}).Handle(
-		&types.RpcContext{ApiVersion: types.ApiVersion2, Services: &types.ServiceContainer{}},
+		&types.RpcContext{ApiVersion: types.ApiVersion2, Services: types.NewTestServiceGraph(&types.ServiceContainer{})},
 		json.RawMessage(`{}`),
 	)
 	require.NotNil(t, rpcErr)

--- a/internal/rpc/condition_met_test.go
+++ b/internal/rpc/condition_met_test.go
@@ -15,7 +15,7 @@ import (
 func ctxWith(apiVersion int, mock *mockLedgerService) *types.RpcContext {
 	return &types.RpcContext{
 		ApiVersion: apiVersion,
-		Services:   &types.ServiceContainer{Ledger: mock},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 	}
 }
 
@@ -113,7 +113,7 @@ func TestConditionMet_UNLBlocked(t *testing.T) {
 	m := syncedStandalone()
 	ctx := &types.RpcContext{
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: m, UNLBlocked: func() bool { return true }},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: m, UNLBlocked: func() bool { return true }}),
 	}
 	rpcErr := conditionMet(types.NeedsCurrentLedger, ctx)
 	require.NotNil(t, rpcErr)
@@ -125,7 +125,7 @@ func TestConditionMet_UNLNotBlockedPasses(t *testing.T) {
 	m := syncedStandalone()
 	ctx := &types.RpcContext{
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: m, UNLBlocked: func() bool { return false }},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: m, UNLBlocked: func() bool { return false }}),
 	}
 	assert.Nil(t, conditionMet(types.NeedsCurrentLedger, ctx))
 }
@@ -135,7 +135,7 @@ func TestConditionMet_AmendmentBlockedBeatsUNL(t *testing.T) {
 	m.amendmentBlocked = true
 	ctx := &types.RpcContext{
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: m, UNLBlocked: func() bool { return true }},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: m, UNLBlocked: func() bool { return true }}),
 	}
 	rpcErr := conditionMet(types.NeedsCurrentLedger, ctx)
 	require.NotNil(t, rpcErr)

--- a/internal/rpc/deposit_authorized_test.go
+++ b/internal/rpc/deposit_authorized_test.go
@@ -216,10 +216,10 @@ func (m *mockDepositAuthorizedLedgerService) GetClosedLedgerView() (types.Ledger
 }
 
 // newDepositAuthorizedTestServices builds a per-test ServiceContainer wrapping mock.
-func newDepositAuthorizedTestServices(mock *mockDepositAuthorizedLedgerService) *types.ServiceContainer {
-	return &types.ServiceContainer{
+func newDepositAuthorizedTestServices(mock *mockDepositAuthorizedLedgerService) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{
 		Ledger: mock,
-	}
+	})
 }
 
 // Error Validation Tests

--- a/internal/rpc/diagnostics_test.go
+++ b/internal/rpc/diagnostics_test.go
@@ -87,22 +87,23 @@ func (diagnosticTestHandler) RequiredCondition() types.Condition { return types.
 func TestDispatchDiagnosticsTreatsRPCResultsAsFinished(t *testing.T) {
 	diagnostics := NewRPCDiagnostics()
 	services := &types.ServiceContainer{RPCDiagnostics: diagnostics}
+	graph := types.NewTestServiceGraph(services)
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
-		Services:   services,
+		Services:   graph,
 	}
 
 	resolution := methodResolution{handler: diagnosticTestHandler{rpcErr: types.RpcErrorInvalidParams("bad request")}, resolved: true}
-	_, _ = dispatchResolvedMethod(nil, services, ctx, "normal_error", nil, resolution, rpcLog())
+	_, _ = dispatchResolvedMethod(nil, graph, ctx, "normal_error", nil, resolution, rpcLog())
 	stats := diagnostics.Snapshot().Methods["normal_error"]
 	if stats.Finished != 1 || stats.Errored != 0 {
 		t.Fatalf("ordinary RPC error stats = %#v", stats)
 	}
 
 	resolution = methodResolution{handler: diagnosticTestHandler{panicValue: "boom"}, resolved: true}
-	_, _ = dispatchResolvedMethod(nil, services, ctx, "panic", nil, resolution, rpcLog())
+	_, _ = dispatchResolvedMethod(nil, graph, ctx, "panic", nil, resolution, rpcLog())
 	stats = diagnostics.Snapshot().Methods["panic"]
 	if stats.Finished != 0 || stats.Errored != 1 {
 		t.Fatalf("panic stats = %#v", stats)

--- a/internal/rpc/dispatch_gate_order_test.go
+++ b/internal/rpc/dispatch_gate_order_test.go
@@ -76,13 +76,14 @@ func TestDispatchGateOrder(t *testing.T) {
 			if c.saturated {
 				services.ClientLoad = saturatedShedder()
 			}
+			graph := types.NewTestServiceGraph(services)
 			ctx := &types.RpcContext{
 				ApiVersion: c.apiVersion,
 				Role:       types.RoleGuest, // non-admin caller
-				Services:   services,
+				Services:   graph,
 			}
 
-			result, rpcErr := dispatchMethod(reg, nil, services, ctx, c.method, nil, types.RpcErrorForbidden, rpcLog())
+			result, rpcErr := dispatchMethod(reg, nil, graph, ctx, c.method, nil, types.RpcErrorForbidden, rpcLog())
 
 			if !c.wantErr {
 				require.Nil(t, rpcErr)
@@ -104,9 +105,10 @@ func TestDispatchGateOrder(t *testing.T) {
 func TestHTTPForbiddenBeatsBusy(t *testing.T) {
 	services := types.NewServiceContainer(nil)
 	services.ClientLoad = types.NewClientLoadShedder()
+	graph := types.NewTestServiceGraph(services)
 	srv := NewServer(ServerOptions{
 		Timeout:  time.Second,
-		Services: services,
+		Services: graph,
 		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
 			"stop": &stubHandler{role: types.RoleAdmin},
 		}),
@@ -153,9 +155,10 @@ func TestHTTPForbiddenBeatsBusy(t *testing.T) {
 // invalid_API_version bare token.
 func TestHTTPKnownMethodUnsupportedVersionIsUnknownCommand(t *testing.T) {
 	services := types.NewServiceContainer(nil)
+	graph := types.NewTestServiceGraph(services)
 	srv := NewServer(ServerOptions{
 		Timeout:  time.Second,
-		Services: services,
+		Services: graph,
 		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
 			"v1only": &stubHandler{role: types.RoleGuest, apiVers: []int{types.ApiVersion1}},
 		}),

--- a/internal/rpc/dispatch_parity_test.go
+++ b/internal/rpc/dispatch_parity_test.go
@@ -38,7 +38,7 @@ func TestDispatchMethodEnforcesConditionMet(t *testing.T) {
 	t.Run("not synced is refused", func(t *testing.T) {
 		ctx := &types.RpcContext{
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: newMockLedgerService()}, // zero serverInfo: disconnected
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: newMockLedgerService()}), // zero serverInfo: disconnected
 		}
 		_, rpcErr := dispatchMethod(reg, nil, ctx.Services, ctx, "gated", nil, types.RpcErrorNoPermission, rpcLog())
 		require.NotNil(t, rpcErr)
@@ -49,7 +49,7 @@ func TestDispatchMethodEnforcesConditionMet(t *testing.T) {
 	t.Run("synced passes", func(t *testing.T) {
 		ctx := &types.RpcContext{
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: syncedStandalone()},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: syncedStandalone()}),
 		}
 		result, rpcErr := dispatchMethod(reg, nil, ctx.Services, ctx, "gated", nil, types.RpcErrorNoPermission, rpcLog())
 		require.Nil(t, rpcErr)

--- a/internal/rpc/fee_test.go
+++ b/internal/rpc/fee_test.go
@@ -17,7 +17,7 @@ func feeRequest(t *testing.T, services *types.ServiceContainer) map[string]any {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
-		Services:   services,
+		Services:   types.NewTestServiceGraph(services),
 	}, nil)
 	require.Nil(t, rpcErr)
 	require.NotNil(t, result)

--- a/internal/rpc/gateway_balances_test.go
+++ b/internal/rpc/gateway_balances_test.go
@@ -174,10 +174,10 @@ func (m *mockGatewayBalancesLedgerService) GetClosedLedgerView() (types.LedgerSt
 }
 
 // newGatewayBalancesTestServices builds a per-test ServiceContainer wrapping mock.
-func newGatewayBalancesTestServices(mock *mockGatewayBalancesLedgerService) *types.ServiceContainer {
-	return &types.ServiceContainer{
+func newGatewayBalancesTestServices(mock *mockGatewayBalancesLedgerService) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{
 		Ledger: mock,
-	}
+	})
 }
 
 // TestGatewayBalancesErrorValidation tests error handling for invalid inputs

--- a/internal/rpc/get_aggregate_price_conformance_test.go
+++ b/internal/rpc/get_aggregate_price_conformance_test.go
@@ -279,7 +279,7 @@ func callAggregatePriceError(t *testing.T, service types.LedgerService, request 
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: service},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: service}),
 	}
 	return (&handlers.GetAggregatePriceMethod{}).Handle(ctx, encoded)
 }
@@ -367,7 +367,7 @@ func TestGetAggregatePriceWalksExactlyThreePriorOracleVersions(t *testing.T) {
 				Context:    context.Background(),
 				Role:       types.RoleGuest,
 				ApiVersion: types.ApiVersion1,
-				Services:   &types.ServiceContainer{Ledger: service},
+				Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: service}),
 			}
 			result, rpcErr := (&handlers.GetAggregatePriceMethod{}).Handle(ctx, encoded)
 			if !test.wantFound {
@@ -392,7 +392,7 @@ func callAggregatePrice(t *testing.T, service types.LedgerService, request map[s
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: service},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: service}),
 	}
 	result, rpcErr := (&handlers.GetAggregatePriceMethod{}).Handle(ctx, encoded)
 	require.Nil(t, rpcErr)

--- a/internal/rpc/handlers/account_channels.go
+++ b/internal/rpc/handlers/account_channels.go
@@ -51,7 +51,7 @@ func (m *AccountChannelsMethod) Handle(ctx *types.RpcContext, params json.RawMes
 			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 		}
 	}
-	result, err := ctx.Services.Ledger.GetAccountChannels(
+	result, err := ctx.Services.Ledger().GetAccountChannels(
 		ctx.Context,
 		account,
 		destinationAccount,

--- a/internal/rpc/handlers/account_currencies.go
+++ b/internal/rpc/handlers/account_currencies.go
@@ -50,7 +50,7 @@ func (m *AccountCurrenciesMethod) Handle(ctx *types.RpcContext, params json.RawM
 	}
 
 	// Get account currencies from the ledger service
-	result, err := ctx.Services.Ledger.GetAccountCurrencies(
+	result, err := ctx.Services.Ledger().GetAccountCurrencies(
 		ctx.Context,
 		account,
 		ledgerIndex,

--- a/internal/rpc/handlers/account_info.go
+++ b/internal/rpc/handlers/account_info.go
@@ -81,7 +81,7 @@ func (m *AccountInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		return nil, types.RpcErrorActMalformed("Account malformed.").WithExtra(lookupFields)
 	}
 
-	info, err := ctx.Services.Ledger.GetAccountInfo(ctx.Context, canonicalAccount, ledgerIndex)
+	info, err := ctx.Services.Ledger().GetAccountInfo(ctx.Context, canonicalAccount, ledgerIndex)
 	if err != nil {
 		if errors.Is(err, svcerr.ErrAccountNotFound) {
 			lookupFields["account"] = canonicalAccount
@@ -263,8 +263,8 @@ func (m *AccountInfoMethod) buildAccountData(info *types.AccountInfo) map[string
 // max_spend_drops and auth_change, plus the aggregate counts, sequence/ticket
 // bounds, auth_change_queued and max_spend_drops_total. An empty (or unwired)
 // queue yields {txn_count: 0}.
-func buildAccountQueueData(services *types.ServiceContainer, account string) map[string]any {
-	if services == nil || services.QueueAccountTxs == nil {
+func buildAccountQueueData(services *types.ServiceGraph, account string) map[string]any {
+	if services == nil || services.QueueAccountTxs() == nil {
 		return map[string]any{"txn_count": 0}
 	}
 
@@ -275,7 +275,7 @@ func buildAccountQueueData(services *types.ServiceContainer, account string) map
 	var accountID [20]byte
 	copy(accountID[:], idBytes)
 
-	txs := services.QueueAccountTxs(accountID)
+	txs := services.QueueAccountTxs()(accountID)
 	if len(txs) == 0 {
 		return map[string]any{"txn_count": 0}
 	}
@@ -353,12 +353,12 @@ func buildAccountQueueData(services *types.ServiceContainer, account string) map
 }
 
 // loadSignerLists retrieves signer list objects for an account
-func (m *AccountInfoMethod) loadSignerLists(ctx context.Context, services *types.ServiceContainer, account string, ledgerIndex string) ([]any, error) {
+func (m *AccountInfoMethod) loadSignerLists(ctx context.Context, services *types.ServiceGraph, account string, ledgerIndex string) ([]any, error) {
 	signerLists := make([]any, 0, 1)
 	marker := ""
 	seenMarkers := make(map[string]struct{})
 	for {
-		result, err := services.Ledger.GetAccountObjects(ctx, account, ledgerIndex, "SignerList", 10, marker)
+		result, err := services.Ledger().GetAccountObjects(ctx, account, ledgerIndex, "SignerList", 10, marker)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/rpc/handlers/account_lines.go
+++ b/internal/rpc/handlers/account_lines.go
@@ -55,7 +55,7 @@ func (m *AccountLinesMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 		}
 	}
-	result, err := ctx.Services.Ledger.GetAccountLines(ctx.Context, account, ledgerIndex, peer, limit, marker)
+	result, err := ctx.Services.Ledger().GetAccountLines(ctx.Context, account, ledgerIndex, peer, limit, marker)
 	if err != nil {
 		if rerr := mapLedgerLookupErr(err); rerr != nil {
 			return nil, rerr

--- a/internal/rpc/handlers/account_nfts.go
+++ b/internal/rpc/handlers/account_nfts.go
@@ -48,7 +48,7 @@ func (m *AccountNftsMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 			}
 		}
 	}
-	result, err := ctx.Services.Ledger.GetAccountNFTs(
+	result, err := ctx.Services.Ledger().GetAccountNFTs(
 		ctx.Context,
 		account,
 		ledgerIndex,

--- a/internal/rpc/handlers/account_objects.go
+++ b/internal/rpc/handlers/account_objects.go
@@ -124,7 +124,7 @@ func (m *AccountObjectsMethod) Handle(ctx *types.RpcContext, params json.RawMess
 		return nil, mErr
 	}
 
-	result, err := ctx.Services.Ledger.GetAccountObjects(ctx.Context, account, ledgerIndex, effectiveType, limit, markerStr)
+	result, err := ctx.Services.Ledger().GetAccountObjects(ctx.Context, account, ledgerIndex, effectiveType, limit, markerStr)
 	if err != nil {
 		if rerr := mapLedgerLookupErr(err); rerr != nil {
 			return nil, rerr

--- a/internal/rpc/handlers/account_offers.go
+++ b/internal/rpc/handlers/account_offers.go
@@ -39,7 +39,7 @@ func (m *AccountOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		}
 	}
 
-	result, err := ctx.Services.Ledger.GetAccountOffers(ctx.Context, account, ledgerIndex, limit, marker)
+	result, err := ctx.Services.Ledger().GetAccountOffers(ctx.Context, account, ledgerIndex, limit, marker)
 	if err != nil {
 		if rerr := mapLedgerLookupErr(err); rerr != nil {
 			return nil, rerr

--- a/internal/rpc/handlers/account_params.go
+++ b/internal/rpc/handlers/account_params.go
@@ -39,7 +39,7 @@ func rawJSONBool(raw json.RawMessage) (bool, bool) {
 }
 
 func requireAccountExists(ctx *types.RpcContext, account, ledgerIndex string) *types.RpcError {
-	_, err := ctx.Services.Ledger.GetAccountInfo(ctx.Context, account, ledgerIndex)
+	_, err := ctx.Services.Ledger().GetAccountInfo(ctx.Context, account, ledgerIndex)
 	if err == nil {
 		return nil
 	}

--- a/internal/rpc/handlers/account_tx.go
+++ b/internal/rpc/handlers/account_tx.go
@@ -93,7 +93,7 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 	}
 
 	setLoadMedium(ctx)
-	result, err := ctx.Services.Ledger.GetAccountTransactions(
+	result, err := ctx.Services.Ledger().GetAccountTransactions(
 		ctx.Context,
 		account,
 		ledgerIndexMin,
@@ -123,7 +123,7 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 			return entry
 		}
 		entry := &ledgerCacheEntry{}
-		if source, ok := ctx.Services.Ledger.(types.LedgerContextReader); ok {
+		if source, ok := ctx.Services.Ledger().(types.LedgerContextReader); ok {
 			ledgerContext, lookupErr := source.GetLedgerContext(ctx.Context, seq)
 			if lookupErr == nil && ledgerContext != nil {
 				entry.hash = ledgerContext.Hash
@@ -133,7 +133,7 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 				return entry
 			}
 		}
-		ledger, lookupErr := ctx.Services.Ledger.GetLedgerBySequence(seq)
+		ledger, lookupErr := ctx.Services.Ledger().GetLedgerBySequence(seq)
 		if lookupErr == nil && ledger != nil {
 			entry.hash = ledger.Hash()
 			entry.closeTimeSec = ledger.CloseTime()
@@ -143,7 +143,7 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		return entry
 	}
 
-	serverInfo := ctx.Services.Ledger.GetServerInfo()
+	serverInfo := ctx.Services.Ledger().GetServerInfo()
 	networkID := serverInfo.NetworkID
 
 	isV2 := ctx.ApiVersion > 1
@@ -365,7 +365,7 @@ func parseAccountTxLedgerSelection(ctx *types.RpcContext, fields map[string]json
 }
 
 func resolveAccountTxLedgerSelection(ctx *types.RpcContext, selection accountTxLedgerSelection) (int64, int64, *types.RpcError) {
-	validatedMin, validatedMax, ok := accountTxValidatedRange(ctx.Services.Ledger.GetServerInfo().CompleteLedgers)
+	validatedMin, validatedMax, ok := accountTxValidatedRange(ctx.Services.Ledger().GetServerInfo().CompleteLedgers)
 	if !ok {
 		if ctx.ApiVersion == types.ApiVersion1 {
 			return 0, 0, types.NewRpcError(types.RpcLGR_IDXS_INVALID, "lgrIdxsInvalid", "lgrIdxsInvalid", "Ledger indexes invalid.")

--- a/internal/rpc/handlers/admin_control.go
+++ b/internal/rpc/handlers/admin_control.go
@@ -34,13 +34,13 @@ type outboundCriticalQueueFailureSource interface {
 }
 
 func (m *PrintMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
-	if ctx.Services == nil || ctx.Services.Ledger == nil {
+	if ctx.Services == nil || ctx.Services.Ledger() == nil {
 		return nil, rpcInternalInvariantError("print: ledger service unavailable")
 	}
 
 	out := map[string]any{}
 
-	info := ctx.Services.Ledger.GetServerInfo()
+	info := ctx.Services.Ledger().GetServerInfo()
 	ledger := map[string]any{
 		"standalone":        info.Standalone,
 		"server_state":      info.ServerState,
@@ -73,28 +73,28 @@ func (m *PrintMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any
 	}
 
 	counters := map[string]any{}
-	if ctx.Services.PeerDisconnects != nil {
-		total, resources := ctx.Services.PeerDisconnects()
+	if ctx.Services.PeerDisconnects() != nil {
+		total, resources := ctx.Services.PeerDisconnects()()
 		counters["peer_disconnects"] = fmt.Sprintf("%d", total)
 		counters["peer_disconnects_resources"] = fmt.Sprintf("%d", resources)
 	}
-	if ctx.Services.JqTransOverflow != nil {
-		counters["jq_trans_overflow"] = fmt.Sprintf("%d", ctx.Services.JqTransOverflow())
+	if ctx.Services.JqTransOverflow() != nil {
+		counters["jq_trans_overflow"] = fmt.Sprintf("%d", ctx.Services.JqTransOverflow()())
 	}
 	if len(counters) > 0 {
 		out["counters"] = counters
 	}
 
-	if ctx.Services.LastCloseInfo != nil {
-		proposers, convergeMs := ctx.Services.LastCloseInfo()
+	if ctx.Services.LastCloseInfo() != nil {
+		proposers, convergeMs := ctx.Services.LastCloseInfo()()
 		out["last_close"] = map[string]any{
 			"proposers":        proposers,
 			"converge_time_ms": convergeMs,
 		}
 	}
 
-	if ctx.Services.StateAccounting != nil {
-		if snap := ctx.Services.StateAccounting(); len(snap.Modes) > 0 {
+	if ctx.Services.StateAccounting() != nil {
+		if snap := ctx.Services.StateAccounting()(); len(snap.Modes) > 0 {
 			states := make(map[string]any, len(snap.Modes))
 			for mode, e := range snap.Modes {
 				states[mode] = map[string]any{
@@ -167,7 +167,7 @@ func (m *CanDeleteMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 	if ctx.Services == nil {
 		return nil, types.RpcErrorNotEnabled("")
 	}
-	store := ctx.Services.AdvisoryDeleteState
+	store := ctx.Services.AdvisoryDeleteState()
 	if store == nil || !store.AdvisoryDelete() {
 		return nil, types.RpcErrorNotEnabled("")
 	}
@@ -235,7 +235,7 @@ func resolveCanDeleteSeq(ctx *types.RpcContext, store types.AdvisoryDeleteStore,
 		if hb, err := hex.DecodeString(str); err == nil {
 			var h [32]byte
 			copy(h[:], hb)
-			lr, lerr := getLedgerByHashContext(ctx.Context, ctx.Services.Ledger, h)
+			lr, lerr := getLedgerByHashContext(ctx.Context, ctx.Services.Ledger(), h)
 			if errors.Is(lerr, svcerr.ErrLedgerNotFound) || (lerr == nil && lr == nil) {
 				return 0, types.RpcErrorLgrNotFound("ledgerNotFound")
 			}
@@ -305,19 +305,19 @@ func uptimeText(d time.Duration) string {
 }
 
 func (m *GetCountsMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
-	if ctx.Services == nil || ctx.Services.Ledger == nil {
+	if ctx.Services == nil || ctx.Services.Ledger() == nil {
 		return nil, rpcInternalInvariantError("get_counts: ledger service unavailable")
 	}
 
 	result := map[string]any{
-		"standalone": ctx.Services.Ledger.GetServerInfo().Standalone,
+		"standalone": ctx.Services.Ledger().GetServerInfo().Standalone,
 	}
 
-	if ctx.Services.GetCounts == nil {
+	if ctx.Services.GetCounts() == nil {
 		return result, nil
 	}
 
-	c := ctx.Services.GetCounts()
+	c := ctx.Services.GetCounts()()
 	result["standalone"] = c.Standalone
 	result["uptime"] = uptimeText(time.Since(serverStartTime))
 

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -135,7 +135,7 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 		ammKey = keylet.AMM(issue1Issuer, issue1Currency, issue2Issuer, issue2Currency).Key
 	}
 
-	ammEntry, err := ctx.Services.Ledger.GetLedgerEntry(ctx.Context, ammKey, ledgerIndex)
+	ammEntry, err := ctx.Services.Ledger().GetLedgerEntry(ctx.Context, ammKey, ledgerIndex)
 	if err != nil {
 		if rerr := mapLedgerLookupErr(err); rerr != nil {
 			return nil, rerr
@@ -525,7 +525,7 @@ func readAccountRoot(ctx *types.RpcContext, ledgerIndex, ident string) ([20]byte
 		return accountID, nil, types.RpcErrorActMalformed("Account malformed.")
 	}
 
-	entry, err := ctx.Services.Ledger.GetLedgerEntry(ctx.Context, keylet.Account(accountID).Key, ledgerIndex)
+	entry, err := ctx.Services.Ledger().GetLedgerEntry(ctx.Context, keylet.Account(accountID).Key, ledgerIndex)
 	if err != nil {
 		if errors.Is(err, svcerr.ErrLedgerNotFound) {
 			return accountID, nil, types.RpcErrorLgrNotFound("Ledger not found.")
@@ -576,7 +576,7 @@ func ammPoolBalanceJSON(ctx *types.RpcContext, ledgerIndex string, ammAccountID 
 // readAMMXRPBalance returns the AMM account's XRP balance in drops, or 0 when
 // the AccountRoot can't be read.
 func readAMMXRPBalance(ctx *types.RpcContext, ledgerIndex string, ammAccountID [20]byte) uint64 {
-	entry, err := ctx.Services.Ledger.GetLedgerEntry(ctx.Context, keylet.Account(ammAccountID).Key, ledgerIndex)
+	entry, err := ctx.Services.Ledger().GetLedgerEntry(ctx.Context, keylet.Account(ammAccountID).Key, ledgerIndex)
 	if err != nil || entry == nil || len(entry.Node) == 0 {
 		return 0
 	}
@@ -594,7 +594,7 @@ func readAMMXRPBalance(ctx *types.RpcContext, ledgerIndex string, ammAccountID [
 // Reference: rippled View.cpp accountHolds() lines 432-455 — balance from the
 // AMM's perspective, with .setIssuer(issuer) applied to the result.
 func readAMMIOUBalance(ctx *types.RpcContext, ledgerIndex string, ammAccountID [20]byte, issue ammIssue) string {
-	entry, err := ctx.Services.Ledger.GetLedgerEntry(ctx.Context, keylet.Line(ammAccountID, issue.Issuer, issue.Currency).Key, ledgerIndex)
+	entry, err := ctx.Services.Ledger().GetLedgerEntry(ctx.Context, keylet.Line(ammAccountID, issue.Issuer, issue.Currency).Key, ledgerIndex)
 	if err != nil || entry == nil || len(entry.Node) == 0 {
 		return "0"
 	}
@@ -625,7 +625,7 @@ func ammIssueFrozen(ctx *types.RpcContext, ledgerIndex string, ammAccountID [20]
 	}
 
 	// Global freeze on the issuer.
-	if issuerEntry, err := ctx.Services.Ledger.GetLedgerEntry(ctx.Context, keylet.Account(issue.Issuer).Key, ledgerIndex); err == nil && issuerEntry != nil && len(issuerEntry.Node) > 0 {
+	if issuerEntry, err := ctx.Services.Ledger().GetLedgerEntry(ctx.Context, keylet.Account(issue.Issuer).Key, ledgerIndex); err == nil && issuerEntry != nil && len(issuerEntry.Node) > 0 {
 		if issuerRoot, perr := state.ParseAccountRoot(issuerEntry.Node); perr == nil && issuerRoot != nil {
 			if (issuerRoot.Flags & state.LsfGlobalFreeze) != 0 {
 				return true
@@ -634,7 +634,7 @@ func ammIssueFrozen(ctx *types.RpcContext, ledgerIndex string, ammAccountID [20]
 	}
 
 	// Individual freeze on the trust line — checked on the issuer's side.
-	lineEntry, err := ctx.Services.Ledger.GetLedgerEntry(ctx.Context, keylet.Line(ammAccountID, issue.Issuer, issue.Currency).Key, ledgerIndex)
+	lineEntry, err := ctx.Services.Ledger().GetLedgerEntry(ctx.Context, keylet.Line(ammAccountID, issue.Issuer, issue.Currency).Key, ledgerIndex)
 	if err != nil || lineEntry == nil || len(lineEntry.Node) == 0 {
 		return false
 	}

--- a/internal/rpc/handlers/book_offers.go
+++ b/internal/rpc/handlers/book_offers.go
@@ -158,7 +158,7 @@ func (m *BookOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		return nil, limitErr
 	}
 
-	result, err := ctx.Services.Ledger.GetBookOffers(ctx.Context, takerGets, takerPays, takerStr, domain, ledgerIndex, limit, "", false)
+	result, err := ctx.Services.Ledger().GetBookOffers(ctx.Context, takerGets, takerPays, takerStr, domain, ledgerIndex, limit, "", false)
 	if err != nil {
 		if errors.Is(err, svcerr.ErrStaleMarker) {
 			return nil, types.RpcErrorInvalidParams("Invalid marker: object pointed to by marker is gone; retry with a pinned ledger_index or ledger_hash.")
@@ -176,7 +176,7 @@ func (m *BookOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 	response := map[string]any{
 		"offers": result.Offers,
 	}
-	fillLedgerFields(response, ledgerIndex, FormatLedgerHash(result.LedgerHash), result.LedgerIndex, ctx.Services.Ledger.GetCurrentLedgerIndex(), result.Validated)
+	fillLedgerFields(response, ledgerIndex, FormatLedgerHash(result.LedgerHash), result.LedgerIndex, ctx.Services.Ledger().GetCurrentLedgerIndex(), result.Validated)
 	return response, nil
 }
 

--- a/internal/rpc/handlers/can_delete_test.go
+++ b/internal/rpc/handlers/can_delete_test.go
@@ -60,7 +60,7 @@ func canDeleteParams(t *testing.T, value any) json.RawMessage {
 func runCanDelete(t *testing.T, svc *types.ServiceContainer, params json.RawMessage) (map[string]any, *types.RpcError) {
 	t.Helper()
 	method := &handlers.CanDeleteMethod{}
-	result, rpcErr := method.Handle(adminCtx(svc), params)
+	result, rpcErr := method.Handle(adminCtx(types.NewTestServiceGraph(svc)), params)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}

--- a/internal/rpc/handlers/consensus_info.go
+++ b/internal/rpc/handlers/consensus_info.go
@@ -17,8 +17,8 @@ type ConsensusInfoMethod struct{ adminHandler }
 
 func (m *ConsensusInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	info := map[string]any{}
-	if ctx.Services != nil && ctx.Services.ConsensusInfo != nil {
-		if live := ctx.Services.ConsensusInfo(true); live != nil {
+	if ctx.Services != nil && ctx.Services.ConsensusInfo() != nil {
+		if live := ctx.Services.ConsensusInfo()(true); live != nil {
 			info = live
 		}
 	}

--- a/internal/rpc/handlers/deposit_authorized.go
+++ b/internal/rpc/handlers/deposit_authorized.go
@@ -64,13 +64,13 @@ func (m *DepositAuthorizedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, lookupErr
 	}
 	lookupExtra := ledgerEntryResponseFields(ledger, validated)
-	if _, err := ctx.Services.Ledger.GetAccountInfo(ctx.Context, sourceAccount, ledgerIndex); err != nil {
+	if _, err := ctx.Services.Ledger().GetAccountInfo(ctx.Context, sourceAccount, ledgerIndex); err != nil {
 		if errors.Is(err, svcerr.ErrAccountNotFound) {
 			return nil, types.RpcErrorSrcActNotFound("Source account not found.").WithExtra(lookupExtra)
 		}
 		return nil, rpcInternalError("deposit_authorized: source account lookup failed", err)
 	}
-	if _, err := ctx.Services.Ledger.GetAccountInfo(ctx.Context, destinationAccount, ledgerIndex); err != nil {
+	if _, err := ctx.Services.Ledger().GetAccountInfo(ctx.Context, destinationAccount, ledgerIndex); err != nil {
 		if errors.Is(err, svcerr.ErrAccountNotFound) {
 			return nil, types.RpcErrorDstActNotFound("Destination account not found.").WithExtra(lookupExtra)
 		}
@@ -89,7 +89,7 @@ func (m *DepositAuthorizedMethod) Handle(ctx *types.RpcContext, params json.RawM
 	// The service performs the ledger-side checks (source/destination
 	// existence, credential existence/acceptance/expiry/ownership/duplicates,
 	// and the direct + credential-based preauth lookups).
-	result, err := ctx.Services.Ledger.GetDepositAuthorized(
+	result, err := ctx.Services.Ledger().GetDepositAuthorized(
 		ctx.Context,
 		sourceAccount,
 		destinationAccount,

--- a/internal/rpc/handlers/feature.go
+++ b/internal/rpc/handlers/feature.go
@@ -103,11 +103,11 @@ func resolveFeature(feature string) *amendment.Feature {
 
 // amendmentController returns the live amendment-vote controller if the wired
 // ledger service exposes one, else nil (e.g. test mocks).
-func amendmentController(services *types.ServiceContainer) amendmentVoteController {
-	if services == nil || services.Ledger == nil {
+func amendmentController(services *types.ServiceGraph) amendmentVoteController {
+	if services == nil || services.Ledger() == nil {
 		return nil
 	}
-	if c, ok := services.Ledger.(amendmentVoteController); ok {
+	if c, ok := services.Ledger().(amendmentVoteController); ok {
 		return c
 	}
 	return nil
@@ -118,12 +118,12 @@ func amendmentController(services *types.ServiceContainer) amendmentVoteControll
 // (amendment hash → close time at which it reached majority, XRPL epoch seconds).
 // Both are nil if the ledger is unavailable, meaning the caller should fall back
 // to deriving enabled status from the registry defaults.
-func (m *FeatureMethod) getAmendmentState(services *types.ServiceContainer) (enabled map[[32]byte]bool, majorities map[[32]byte]uint32) {
-	if services == nil || services.Ledger == nil {
+func (m *FeatureMethod) getAmendmentState(services *types.ServiceGraph) (enabled map[[32]byte]bool, majorities map[[32]byte]uint32) {
+	if services == nil || services.Ledger() == nil {
 		return nil, nil
 	}
 
-	view, err := services.Ledger.GetClosedLedgerView()
+	view, err := services.Ledger().GetClosedLedgerView()
 	if err != nil || view == nil {
 		return nil, nil
 	}

--- a/internal/rpc/handlers/fee.go
+++ b/internal/rpc/handlers/fee.go
@@ -28,10 +28,10 @@ func (m *FeeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, 
 		return nil, err
 	}
 
-	baseFee, _, _ := ctx.Services.Ledger.GetCurrentFees()
-	currentLedgerIndex := ctx.Services.Ledger.GetCurrentLedgerIndex()
+	baseFee, _, _ := ctx.Services.Ledger().GetCurrentFees()
+	currentLedgerIndex := ctx.Services.Ledger().GetCurrentLedgerIndex()
 
-	metrics := snapshotTxQ(ctx.Services, ctx.Services.Ledger.IsStandalone())
+	metrics := snapshotTxQ(ctx.Services, ctx.Services.Ledger().IsStandalone())
 	txCount := metrics.TxCount
 	maxQueue := metrics.TxQMaxSize
 	txInLedger := metrics.TxInLedger
@@ -76,9 +76,9 @@ func (m *FeeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, 
 
 // snapshotTxQ returns the active TxQ metrics, or rippled's idle-state
 // defaults when the TxQ hook isn't wired.
-func snapshotTxQ(services *types.ServiceContainer, standalone bool) types.TxQFeeMetrics {
-	if services != nil && services.TxQFeeMetrics != nil {
-		return services.TxQFeeMetrics()
+func snapshotTxQ(services *types.ServiceGraph, standalone bool) types.TxQFeeMetrics {
+	if services != nil && services.TxQFeeMetrics() != nil {
+		return services.TxQFeeMetrics()()
 	}
 	expected := uint64(feeDefaultExpected)
 	if standalone {

--- a/internal/rpc/handlers/fetch_info_test.go
+++ b/internal/rpc/handlers/fetch_info_test.go
@@ -39,9 +39,9 @@ func TestFetchInfoMethod_PassesThroughSnapshot(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context: context.Background(),
 		Role:    types.RoleAdmin,
-		Services: &types.ServiceContainer{
+		Services: types.NewTestServiceGraph(&types.ServiceContainer{
 			FetchInfo: func() map[string]any { return snap },
-		},
+		}),
 	}
 
 	result, rpcErr := m.Handle(ctx, json.RawMessage(`{}`))
@@ -57,10 +57,10 @@ func TestFetchInfoMethod_ClearInvokesResetAndEchoes(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context: context.Background(),
 		Role:    types.RoleAdmin,
-		Services: &types.ServiceContainer{
+		Services: types.NewTestServiceGraph(&types.ServiceContainer{
 			FetchInfo:      func() map[string]any { return map[string]any{} },
 			FetchInfoClear: func() { cleared = true },
-		},
+		}),
 	}
 
 	result, rpcErr := m.Handle(ctx, json.RawMessage(`{"clear":true}`))

--- a/internal/rpc/handlers/gateway_balances.go
+++ b/internal/rpc/handlers/gateway_balances.go
@@ -102,7 +102,7 @@ func (m *GatewayBalancesMethod) Handle(ctx *types.RpcContext, params json.RawMes
 	}
 
 	// Get gateway balances from the ledger service
-	result, err := ctx.Services.Ledger.GetGatewayBalances(
+	result, err := ctx.Services.Ledger().GetGatewayBalances(
 		ctx.Context,
 		account,
 		hotWallets,

--- a/internal/rpc/handlers/get_aggregate_price.go
+++ b/internal/rpc/handlers/get_aggregate_price.go
@@ -141,7 +141,7 @@ func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawM
 			return nil, types.RpcErrorInvalidParams("Invalid parameters.").WithExtra(lookupFields)
 		}
 
-		entry, err := ctx.Services.Ledger.GetLedgerEntry(ctx.Context, keylet.Oracle(accountID, documentID).Key, ledgerIndex)
+		entry, err := ctx.Services.Ledger().GetLedgerEntry(ctx.Context, keylet.Oracle(accountID, documentID).Key, ledgerIndex)
 		if err != nil {
 			if errors.Is(err, svcerr.ErrLedgerEntryNotFound) {
 				continue
@@ -287,7 +287,7 @@ func iterateAggregatePriceData(ctx *types.RpcContext, initial map[string]any, vi
 		if !ok {
 			return nil
 		}
-		transaction, err := ctx.Services.Ledger.GetTransaction(previousID)
+		transaction, err := ctx.Services.Ledger().GetTransaction(previousID)
 		if err != nil {
 			if errors.Is(err, svcerr.ErrTxnNotFound) || errors.Is(err, svcerr.ErrLedgerNotFound) {
 				return nil

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -66,8 +66,8 @@ func ledgerAmendmentRules(l types.LedgerReader) (*amendment.Rules, error) {
 	return amendment.EmptyRules(), nil
 }
 
-func requireLedgerService(services *types.ServiceContainer) *types.RpcError {
-	if services == nil || services.Ledger == nil {
+func requireLedgerService(services *types.ServiceGraph) *types.RpcError {
+	if services == nil || services.Ledger() == nil {
 		return rpcInternalInvariantError("rpc: ledger service unavailable")
 	}
 	return nil
@@ -79,11 +79,11 @@ func requireLedgerService(services *types.ServiceContainer) *types.RpcError {
 // database answers notEnabled even for otherwise-malformed requests.
 // Services that don't implement types.TxTablesProvider are assumed to
 // have history available.
-func requireTxTables(services *types.ServiceContainer) *types.RpcError {
+func requireTxTables(services *types.ServiceGraph) *types.RpcError {
 	if err := requireLedgerService(services); err != nil {
 		return err
 	}
-	if p, ok := services.Ledger.(types.TxTablesProvider); ok && !p.UseTxTables() {
+	if p, ok := services.Ledger().(types.TxTablesProvider); ok && !p.UseTxTables() {
 		return types.RpcErrorNotEnabled("")
 	}
 	return nil
@@ -93,7 +93,7 @@ func requireTxTables(services *types.ServiceContainer) *types.RpcError {
 // capability. The check belongs at each transport/handler entry point so a
 // disabled server rejects before parsing request parameters or charging load.
 func RequirePathSearch(ctx *types.RpcContext) *types.RpcError {
-	if ctx == nil || ctx.Services == nil || ctx.Services.Capabilities.PathSearchMax == 0 {
+	if ctx == nil || ctx.Services == nil || ctx.Services.Capabilities().PathSearchMax == 0 {
 		return types.RpcErrorNotSupported("")
 	}
 	return nil
@@ -107,7 +107,7 @@ func shedCheck(ctx *types.RpcContext) *types.ClientLoadShedder {
 	if ctx == nil || ctx.Role.IsUnlimited() || ctx.Services == nil {
 		return nil
 	}
-	return ctx.Services.ClientLoad
+	return ctx.Services.ClientLoad()
 }
 
 // RequireNotBusyClient rejects non-admin RPC requests when the client job queue is full.
@@ -153,14 +153,14 @@ func acquirePathfind(ctx *types.RpcContext) (release func(), rpcErr *types.RpcEr
 		return func() {}, nil
 	}
 	services := ctx.Services
-	s := services.ClientLoad
+	s := services.ClientLoad()
 	if ctx.Role.IsUnlimited() {
 		if s == nil {
 			return func() {}, nil
 		}
 		return s.AcquirePathfindUnlimited(), nil
 	}
-	if services.IsLoadedLocal != nil && services.IsLoadedLocal() {
+	if services.IsLoadedLocal() != nil && services.IsLoadedLocal()() {
 		return nil, types.RpcErrorTooBusy()
 	}
 	if s == nil {
@@ -179,10 +179,10 @@ func acquirePathfind(ctx *types.RpcContext) (release func(), rpcErr *types.RpcEr
 // waitPathfind queues a default-ledger request behind the bounded path-finding
 // workers until a slot is available or the request is canceled.
 func waitPathfind(ctx *types.RpcContext) (release func(), rpcErr *types.RpcError) {
-	if ctx == nil || ctx.Services == nil || ctx.Services.ClientLoad == nil {
+	if ctx == nil || ctx.Services == nil || ctx.Services.ClientLoad() == nil {
 		return func() {}, nil
 	}
-	release, acquired := ctx.Services.ClientLoad.WaitPathfind(ctx.Context)
+	release, acquired := ctx.Services.ClientLoad().WaitPathfind(ctx.Context)
 	if !acquired {
 		return nil, types.RpcErrorTooBusy()
 	}
@@ -410,7 +410,7 @@ func preflightAccountPage(
 		}
 		return "", nil, rpcErr
 	}
-	if _, err := ctx.Services.Ledger.GetAccountInfo(ctx.Context, account, ledgerIndex); err != nil {
+	if _, err := ctx.Services.Ledger().GetAccountInfo(ctx.Context, account, ledgerIndex); err != nil {
 		rpcErr := mapAccountQueryErr(err, internalDetail)
 		return "", nil, rpcErr
 	}
@@ -571,7 +571,7 @@ func resolveLedgerSelection(
 	if err := requireLedgerService(ctx.Services); err != nil {
 		return ledgerselector.Result[types.LedgerReader]{}, err
 	}
-	svc := ctx.Services.Ledger
+	svc := ctx.Services.Ledger()
 
 	bySequence := func(sequence uint32) (types.LedgerReader, bool, error) {
 		reader, err := svc.GetLedgerBySequence(sequence)

--- a/internal/rpc/handlers/json.go
+++ b/internal/rpc/handlers/json.go
@@ -28,7 +28,7 @@ func (m *jsonMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any,
 		return nil, types.RpcErrorInvalidParams("Missing required parameter: method")
 	}
 
-	if ctx.Services == nil || ctx.Services.Dispatcher == nil {
+	if ctx == nil || ctx.Dispatcher == nil {
 		return nil, rpcInternalInvariantError("json: method dispatcher unavailable")
 	}
 
@@ -45,5 +45,5 @@ func (m *jsonMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any,
 		}
 	}
 
-	return ctx.Services.Dispatcher.ExecuteMethod(ctx, request.Method, forwardParams)
+	return ctx.Dispatcher.ExecuteMethod(ctx, request.Method, forwardParams)
 }

--- a/internal/rpc/handlers/ledger.go
+++ b/internal/rpc/handlers/ledger.go
@@ -378,11 +378,11 @@ func ledgerRequestHasSelector(params json.RawMessage) (bool, *types.RpcError) {
 }
 
 func ledgerDefaultResponse(ctx *types.RpcContext) (map[string]any, *types.RpcError) {
-	closed, err := ctx.Services.Ledger.GetLedgerBySequence(ctx.Services.Ledger.GetClosedLedgerIndex())
+	closed, err := ctx.Services.Ledger().GetLedgerBySequence(ctx.Services.Ledger().GetClosedLedgerIndex())
 	if err != nil || closed == nil {
 		return nil, types.RpcErrorLgrNotFound("ledgerNotFound")
 	}
-	open, err := ctx.Services.Ledger.GetLedgerBySequence(ctx.Services.Ledger.GetCurrentLedgerIndex())
+	open, err := ctx.Services.Ledger().GetLedgerBySequence(ctx.Services.Ledger().GetCurrentLedgerIndex())
 	if err != nil || open == nil {
 		return nil, types.RpcErrorLgrNotFound("ledgerNotFound")
 	}
@@ -397,7 +397,7 @@ func ledgerDefaultResponse(ctx *types.RpcContext) (map[string]any, *types.RpcErr
 // Missing capabilities, lookup failures, and nil results are operational
 // errors because silently omitting owner_funds would produce a partial reply.
 func ownerFundsLedgerView(ctx *types.RpcContext, l types.LedgerReader) (types.LedgerStateView, error) {
-	src, ok := ctx.Services.Ledger.(types.LedgerViewSource)
+	src, ok := ctx.Services.Ledger().(types.LedgerViewSource)
 	if !ok {
 		return nil, errors.New("ledger service does not expose state views")
 	}
@@ -446,7 +446,7 @@ func (a *ledgerOwnerFundsAnnotator) annotate(txEntry, txJSON map[string]any) (bo
 		a.view = view
 	}
 	if needsReserves && !a.reservesRead {
-		_, fallbackBase, fallbackInc := a.ctx.Services.Ledger.GetCurrentFees()
+		_, fallbackBase, fallbackInc := a.ctx.Services.Ledger().GetCurrentFees()
 		reserveBase, reserveInc, err := reserveSettingsFromLedger(a.view, fallbackBase, fallbackInc)
 		if err != nil {
 			return false, fmt.Errorf("owner_funds reserve lookup: %w", err)
@@ -560,7 +560,7 @@ func dumpAccountState(ctx *types.RpcContext, l types.LedgerReader, binary, expan
 		limit = limitLedgerDataBinary.Default
 	}
 	for {
-		result, err := ctx.Services.Ledger.GetLedgerData(ctx.Context, ledgerIndex, limit, marker)
+		result, err := ctx.Services.Ledger().GetLedgerData(ctx.Context, ledgerIndex, limit, marker)
 		if err != nil {
 			return nil, err
 		}
@@ -591,10 +591,10 @@ func buildLedgerQueueData(
 	binary, expanded bool,
 	ownerFundsAnnotator *ledgerOwnerFundsAnnotator,
 ) ([]any, bool, error) {
-	if ctx.Services == nil || ctx.Services.QueueAllTxs == nil {
+	if ctx.Services == nil || ctx.Services.QueueAllTxs() == nil {
 		return nil, false, nil
 	}
-	txs := ctx.Services.QueueAllTxs()
+	txs := ctx.Services.QueueAllTxs()()
 	if len(txs) == 0 {
 		return nil, false, nil
 	}

--- a/internal/rpc/handlers/ledger_accept.go
+++ b/internal/rpc/handlers/ledger_accept.go
@@ -16,11 +16,11 @@ func (m *LedgerAcceptMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		return nil, err
 	}
 
-	if !ctx.Services.Ledger.IsStandalone() {
+	if !ctx.Services.Ledger().IsStandalone() {
 		return nil, types.RpcErrorNotStandalone("ledger_accept is only available in standalone mode")
 	}
 
-	closedSeq, err := ctx.Services.Ledger.AcceptLedger(ctx.Context)
+	closedSeq, err := ctx.Services.Ledger().AcceptLedger(ctx.Context)
 	if err != nil {
 		return nil, rpcInternalError("ledger_accept: accepting ledger failed", err)
 	}

--- a/internal/rpc/handlers/ledger_cleaner.go
+++ b/internal/rpc/handlers/ledger_cleaner.go
@@ -25,7 +25,7 @@ func (m *LedgerCleanerMethod) RequiredCondition() types.Condition {
 }
 
 func (m *LedgerCleanerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
-	if ctx.Services == nil || ctx.Services.LedgerCleanerConfigure == nil {
+	if ctx.Services == nil || ctx.Services.LedgerCleanerConfigure() == nil {
 		return nil, rpcInternalInvariantError("ledger_cleaner: service unavailable")
 	}
 
@@ -48,13 +48,13 @@ func (m *LedgerCleanerMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 	hasParams := req.Ledger != nil || req.MinLedger != nil || req.MaxLedger != nil ||
 		req.Full != nil || req.CheckNodes != nil || req.FixTxns != nil || req.Stop != nil
 	if !hasParams {
-		if ctx.Services.LedgerCleanerStatusFn != nil {
-			return statusResponse(ctx.Services.LedgerCleanerStatusFn(), false), nil
+		if ctx.Services.LedgerCleanerStatusFn() != nil {
+			return statusResponse(ctx.Services.LedgerCleanerStatusFn()(), false), nil
 		}
 		return statusResponse(types.LedgerCleanerStatus{State: "idle"}, false), nil
 	}
 
-	st := ctx.Services.LedgerCleanerConfigure(types.LedgerCleanerParams{
+	st := ctx.Services.LedgerCleanerConfigure()(types.LedgerCleanerParams{
 		Ledger:     req.Ledger,
 		MinLedger:  req.MinLedger,
 		MaxLedger:  req.MaxLedger,

--- a/internal/rpc/handlers/ledger_closed.go
+++ b/internal/rpc/handlers/ledger_closed.go
@@ -14,12 +14,12 @@ func (m *LedgerClosedMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		return nil, err
 	}
 
-	seq := ctx.Services.Ledger.GetClosedLedgerIndex()
+	seq := ctx.Services.Ledger().GetClosedLedgerIndex()
 	if seq == 0 {
 		return nil, types.RpcErrorLgrNotFound("No closed ledger")
 	}
 
-	ledger, err := ctx.Services.Ledger.GetLedgerBySequence(seq)
+	ledger, err := ctx.Services.Ledger().GetLedgerBySequence(seq)
 	if err != nil {
 		return nil, types.RpcErrorLgrNotFound("Closed ledger not found")
 	}

--- a/internal/rpc/handlers/ledger_current.go
+++ b/internal/rpc/handlers/ledger_current.go
@@ -13,7 +13,7 @@ func (m *ledgerCurrentMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		return nil, err
 	}
 
-	seq := ctx.Services.Ledger.GetCurrentLedgerIndex()
+	seq := ctx.Services.Ledger().GetCurrentLedgerIndex()
 	if seq == 0 {
 		return nil, types.RpcErrorLgrNotFound("No current ledger")
 	}

--- a/internal/rpc/handlers/ledger_data.go
+++ b/internal/rpc/handlers/ledger_data.go
@@ -72,7 +72,7 @@ func (m *LedgerDataMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		return nil, typeErr
 	}
 
-	result, err := ctx.Services.Ledger.GetLedgerData(ctx.Context, ledgerIndex, limit, markerStr)
+	result, err := ctx.Services.Ledger().GetLedgerData(ctx.Context, ledgerIndex, limit, markerStr)
 	if err != nil {
 		if rerr := mapLedgerLookupErr(err); rerr != nil {
 			return nil, rerr

--- a/internal/rpc/handlers/ledger_entry.go
+++ b/internal/rpc/handlers/ledger_entry.go
@@ -472,7 +472,7 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 	computedIndex := strings.ToUpper(hex.EncodeToString(entryKey[:]))
 	response["index"] = computedIndex
 
-	result, err := ctx.Services.Ledger.GetLedgerEntry(ctx.Context, entryKey, ledgerIndex)
+	result, err := ctx.Services.Ledger().GetLedgerEntry(ctx.Context, entryKey, ledgerIndex)
 	if err != nil {
 		if errors.Is(err, svcerr.ErrLedgerEntryNotFound) {
 			return nil, types.RpcErrorEntryNotFound("").WithExtra(response)

--- a/internal/rpc/handlers/ledger_range.go
+++ b/internal/rpc/handlers/ledger_range.go
@@ -39,7 +39,7 @@ func (m *LedgerRangeMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		return nil, err
 	}
 
-	result, err := ctx.Services.Ledger.GetLedgerRange(ctx.Context, request.StartLedger, request.StopLedger)
+	result, err := ctx.Services.Ledger().GetLedgerRange(ctx.Context, request.StartLedger, request.StopLedger)
 	if err != nil {
 		return nil, rpcInternalError("ledger_range: ledger query failed", err)
 	}

--- a/internal/rpc/handlers/ledger_request.go
+++ b/internal/rpc/handlers/ledger_request.go
@@ -90,7 +90,7 @@ func (m *LedgerRequestMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		}
 		copy(targetHash[:], hb)
 
-		l, err := getLedgerByHashContext(ctx.Context, ctx.Services.Ledger, targetHash)
+		l, err := getLedgerByHashContext(ctx.Context, ctx.Services.Ledger(), targetHash)
 		if err == nil && l != nil {
 			return ledgerRequestSuccess(l), nil
 		}
@@ -107,7 +107,7 @@ func (m *LedgerRequestMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		// resolve the sequence to a hash (rippled's getValidatedLedger gate).
 		// rippled distinguishes API v1 (rpcNO_CURRENT) from later versions
 		// (rpcNOT_SYNCED) here — RPCHelpers.cpp:1060-1062.
-		validatedSeq := ctx.Services.Ledger.GetValidatedLedgerIndex()
+		validatedSeq := ctx.Services.Ledger().GetValidatedLedgerIndex()
 		if validatedSeq == 0 {
 			if ctx.ApiVersion == types.ApiVersion1 {
 				return nil, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent",
@@ -126,7 +126,7 @@ func (m *LedgerRequestMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		}
 		targetSeq = uint32(idx)
 
-		if l, err := ctx.Services.Ledger.GetLedgerBySequence(targetSeq); err == nil && l != nil {
+		if l, err := ctx.Services.Ledger().GetLedgerBySequence(targetSeq); err == nil && l != nil {
 			return ledgerRequestSuccess(l), nil
 		}
 	}
@@ -134,8 +134,8 @@ func (m *LedgerRequestMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 	// Not local — trigger (or join) a generic acquisition from peers. When no
 	// acquisition subsystem is wired (standalone / RPC-only) the ledger is
 	// simply reported as not found, matching rippled's standalone fallback.
-	if ctx.Services.RequestLedger != nil {
-		if acquiring, started, reference := ctx.Services.RequestLedger(targetHash, targetSeq); started {
+	if ctx.Services.RequestLedger() != nil {
+		if acquiring, started, reference := ctx.Services.RequestLedger()(targetHash, targetSeq); started {
 			if reference {
 				// Acquiring a reference ledger only to learn the target's hash:
 				// rippled wraps the snapshot as lgrNotFound + acquiring

--- a/internal/rpc/handlers/load_shed_test.go
+++ b/internal/rpc/handlers/load_shed_test.go
@@ -11,12 +11,12 @@ import (
 func unlimitedCtx(s *types.ClientLoadShedder) *types.RpcContext {
 	return &types.RpcContext{
 		Role:     types.RoleAdmin,
-		Services: &types.ServiceContainer{ClientLoad: s},
+		Services: types.NewTestServiceGraph(&types.ServiceContainer{ClientLoad: s}),
 	}
 }
 
 func gatedCtx(s *types.ClientLoadShedder) *types.RpcContext {
-	return &types.RpcContext{Services: &types.ServiceContainer{ClientLoad: s}}
+	return &types.RpcContext{Services: types.NewTestServiceGraph(&types.ServiceContainer{ClientLoad: s})}
 }
 
 func loadInFlight(s *types.ClientLoadShedder, n int64) {
@@ -29,7 +29,7 @@ func TestGates_NilOrUnwiredIsNoOp(t *testing.T) {
 	for _, ctx := range []*types.RpcContext{
 		nil,
 		{},
-		{Services: &types.ServiceContainer{}},
+		{Services: types.NewTestServiceGraph(&types.ServiceContainer{})},
 	} {
 		if rpcErr := RequireNotBusyClient(ctx); rpcErr != nil {
 			t.Fatalf("RequireNotBusyClient(%v) = %v, want nil", ctx, rpcErr)
@@ -130,9 +130,9 @@ func TestAcquirePathfind_JobCountGate(t *testing.T) {
 }
 
 func TestAcquirePathfind_LocalLoadGateWithoutClientCounter(t *testing.T) {
-	ctx := &types.RpcContext{Services: &types.ServiceContainer{
+	ctx := &types.RpcContext{Services: types.NewTestServiceGraph(&types.ServiceContainer{
 		IsLoadedLocal: func() bool { return true },
-	}}
+	})}
 	if _, rpcErr := acquirePathfind(ctx); rpcErr == nil || rpcErr.ErrorString != "tooBusy" {
 		t.Fatalf("local load should shed without ClientLoad, got %v", rpcErr)
 	}
@@ -142,10 +142,10 @@ func TestAcquirePathfind_UnlimitedBypassesLocalLoad(t *testing.T) {
 	s := types.NewClientLoadShedder()
 	ctx := &types.RpcContext{
 		Role: types.RoleAdmin,
-		Services: &types.ServiceContainer{
+		Services: types.NewTestServiceGraph(&types.ServiceContainer{
 			ClientLoad:    s,
 			IsLoadedLocal: func() bool { return true },
-		},
+		}),
 	}
 	release, rpcErr := acquirePathfind(ctx)
 	if rpcErr != nil {

--- a/internal/rpc/handlers/loadkinds_test.go
+++ b/internal/rpc/handlers/loadkinds_test.go
@@ -37,7 +37,7 @@ func TestLoadCostEarlyErrorTiming(t *testing.T) {
 			ctx := &types.RpcContext{
 				Context:  context.Background(),
 				LoadCost: uint32(resource.FeeReferenceRPC().Cost()),
-				Services: &types.ServiceContainer{Capabilities: types.RPCCapabilities{SigningEnabled: true}},
+				Services: types.NewTestServiceGraph(&types.ServiceContainer{Capabilities: types.RPCCapabilities{SigningEnabled: true}}),
 			}
 			_, rpcErr := test.handler.Handle(ctx, test.params)
 			if rpcErr == nil {
@@ -58,11 +58,11 @@ func TestRipplePathFindBusyAdmissionIsHeavy(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:  context.Background(),
 		LoadCost: uint32(resource.FeeReferenceRPC().Cost()),
-		Services: &types.ServiceContainer{
+		Services: types.NewTestServiceGraph(&types.ServiceContainer{
 			Ledger:       &loadAdmissionLedger{serverInfo: &types.LedgerServerInfo{Standalone: true}},
 			ClientLoad:   shedder,
 			Capabilities: types.RPCCapabilities{PathSearchMax: 3},
-		},
+		}),
 	}
 
 	_, rpcErr := (&ripplePathFindMethod{}).Handle(ctx, json.RawMessage(`{}`))

--- a/internal/rpc/handlers/manifest.go
+++ b/internal/rpc/handlers/manifest.go
@@ -59,10 +59,10 @@ func (m *ManifestMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	// Manifest cache isn't wired in standalone / pre-consensus setups
 	// — return the sparse response so clients can still probe the
 	// method without a 500.
-	if ctx.Services == nil || ctx.Services.Manifests == nil {
+	if ctx.Services == nil || ctx.Services.Manifests() == nil {
 		return resp, nil
 	}
-	cache := ctx.Services.Manifests
+	cache := ctx.Services.Manifests()
 
 	// Callers may pass EITHER the master key or its ephemeral signing
 	// key. GetMasterKey collapses both into the master; if the input

--- a/internal/rpc/handlers/manifest_test.go
+++ b/internal/rpc/handlers/manifest_test.go
@@ -93,11 +93,11 @@ func deterministicEd25519KeypairRPC(seed byte) ([]byte, []byte) {
 
 // servicesForCache builds a per-test ServiceContainer wired to the given
 // manifest cache.
-func servicesForCache(cache types.ManifestLookup) *types.ServiceContainer {
-	return &types.ServiceContainer{Manifests: cache}
+func servicesForCache(cache types.ManifestLookup) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{Manifests: cache})
 }
 
-func callManifestRPC(t *testing.T, services *types.ServiceContainer, publicKey string) (map[string]any, *types.RpcError) {
+func callManifestRPC(t *testing.T, services *types.ServiceGraph, publicKey string) (map[string]any, *types.RpcError) {
 	t.Helper()
 	var params json.RawMessage
 	if publicKey != "" {

--- a/internal/rpc/handlers/network_control.go
+++ b/internal/rpc/handlers/network_control.go
@@ -33,15 +33,15 @@ func (m *FetchInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 	response := make(map[string]any)
 
 	if request.Clear.value {
-		if ctx.Services != nil && ctx.Services.FetchInfoClear != nil {
-			ctx.Services.FetchInfoClear()
+		if ctx.Services != nil && ctx.Services.FetchInfoClear() != nil {
+			ctx.Services.FetchInfoClear()()
 		}
 		response["clear"] = true
 	}
 
 	info := map[string]any{}
-	if ctx.Services != nil && ctx.Services.FetchInfo != nil {
-		if snap := ctx.Services.FetchInfo(); snap != nil {
+	if ctx.Services != nil && ctx.Services.FetchInfo() != nil {
+		if snap := ctx.Services.FetchInfo()(); snap != nil {
 			info = snap
 		}
 	}
@@ -62,8 +62,8 @@ type TxReduceRelayMethod struct{ baseHandler }
 
 func (m *TxReduceRelayMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	var metrics types.TxReduceRelayMetrics
-	if ctx.Services != nil && ctx.Services.TxReduceRelayMetrics != nil {
-		metrics = ctx.Services.TxReduceRelayMetrics()
+	if ctx.Services != nil && ctx.Services.TxReduceRelayMetrics() != nil {
+		metrics = ctx.Services.TxReduceRelayMetrics()()
 	}
 	return metrics.JSON(), nil
 }
@@ -80,10 +80,10 @@ func (m *ConnectMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 	// The ledger invariant and standalone guard intentionally precede request
 	// decoding. This preserves rippled's notSynced result for every standalone
 	// request, including malformed parameters.
-	if ctx.Services == nil || ctx.Services.Ledger == nil {
+	if ctx.Services == nil || ctx.Services.Ledger() == nil {
 		return nil, rpcInternalInvariantError("connect: ledger service unavailable")
 	}
-	if ctx.Services.Ledger.IsStandalone() {
+	if ctx.Services.Ledger().IsStandalone() {
 		return nil, types.RpcErrorNotSynced("")
 	}
 
@@ -95,12 +95,12 @@ func (m *ConnectMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 	if !ok || ip.IsUnspecified() {
 		return connectMessage(request.ip, request.port), nil
 	}
-	if ctx.Services.PeerConnect == nil {
+	if ctx.Services.PeerConnect() == nil {
 		return nil, types.RpcErrorNotEnabled("")
 	}
 
 	addr := netip.AddrPortFrom(ip, uint16(request.port)).String()
-	if err := ctx.Services.PeerConnect(addr); err != nil {
+	if err := ctx.Services.PeerConnect()(addr); err != nil {
 		switch {
 		case errors.Is(err, types.ErrPeerConnectQueueFull):
 			return nil, types.RpcErrorTooBusy()
@@ -282,8 +282,8 @@ type UnlListMethod struct{ adminHandler }
 
 func (m *UnlListMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	unl := make([]any, 0)
-	if ctx.Services != nil && ctx.Services.ValidatorList != nil {
-		for _, v := range ctx.Services.ValidatorList.ListedValidators() {
+	if ctx.Services != nil && ctx.Services.ValidatorList() != nil {
+		for _, v := range ctx.Services.ValidatorList().ListedValidators() {
 			enc, err := addresscodec.EncodeNodePublicKey(v.MasterKey[:])
 			if err != nil {
 				continue
@@ -317,8 +317,8 @@ func (m *BlackListMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		}
 	}
 
-	if ctx.Services != nil && ctx.Services.ResourceBlacklist != nil {
-		if result := ctx.Services.ResourceBlacklist(request.Threshold); result != nil {
+	if ctx.Services != nil && ctx.Services.ResourceBlacklist() != nil {
+		if result := ctx.Services.ResourceBlacklist()(request.Threshold); result != nil {
 			return result, nil
 		}
 	}

--- a/internal/rpc/handlers/nft_buy_offers.go
+++ b/internal/rpc/handlers/nft_buy_offers.go
@@ -19,7 +19,7 @@ func (m *NftBuyOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 	if err := requireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
-	return handleNFTOffers(ctx, params, ctx.Services.Ledger.GetNFTBuyOffers)
+	return handleNFTOffers(ctx, params, ctx.Services.Ledger().GetNFTBuyOffers)
 }
 
 // handleNFTOffers is the shared nft_buy_offers / nft_sell_offers flow; the only

--- a/internal/rpc/handlers/nft_sell_offers.go
+++ b/internal/rpc/handlers/nft_sell_offers.go
@@ -14,5 +14,5 @@ func (m *NftSellOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 	if err := requireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
-	return handleNFTOffers(ctx, params, ctx.Services.Ledger.GetNFTSellOffers)
+	return handleNFTOffers(ctx, params, ctx.Services.Ledger().GetNFTSellOffers)
 }

--- a/internal/rpc/handlers/noripple_check.go
+++ b/internal/rpc/handlers/noripple_check.go
@@ -76,7 +76,7 @@ func (m *NoRippleCheckMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		return nil, types.RpcErrorActMalformed("Account malformed.").WithExtra(response)
 	}
 
-	result, err := ctx.Services.Ledger.GetNoRippleCheck(
+	result, err := ctx.Services.Ledger().GetNoRippleCheck(
 		ctx.Context,
 		account,
 		role,

--- a/internal/rpc/handlers/owner_info.go
+++ b/internal/rpc/handlers/owner_info.go
@@ -56,7 +56,7 @@ func (m *OwnerInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 	if err := requireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
-	walker, ok := ctx.Services.Ledger.(types.OwnerDirectoryReader)
+	walker, ok := ctx.Services.Ledger().(types.OwnerDirectoryReader)
 	if !ok {
 		return nil, rpcInternalInvariantError("owner_info: ledger service cannot walk owner directories")
 	}

--- a/internal/rpc/handlers/path_find_test.go
+++ b/internal/rpc/handlers/path_find_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func pathFindTestContext(pathSearchMax int) *types.RpcContext {
-	return &types.RpcContext{Services: &types.ServiceContainer{
+	return &types.RpcContext{Services: types.NewTestServiceGraph(&types.ServiceContainer{
 		Capabilities: types.RPCCapabilities{PathSearchMax: pathSearchMax},
-	}}
+	})}
 }
 
 func TestPathFindCapabilityPrecedesValidation(t *testing.T) {
@@ -133,10 +133,10 @@ func TestRipplePathFindStaleDefaultUsesApiVersionError(t *testing.T) {
 			ledger := &pathFindTestLedger{info: types.LedgerServerInfo{}}
 			ctx := &types.RpcContext{
 				ApiVersion: test.api,
-				Services: &types.ServiceContainer{
+				Services: types.NewTestServiceGraph(&types.ServiceContainer{
 					Ledger:       ledger,
 					Capabilities: types.RPCCapabilities{PathSearchMax: 3},
-				},
+				}),
 			}
 			_, rpcErr := (&ripplePathFindMethod{}).Handle(ctx, json.RawMessage(`{}`))
 			if rpcErr == nil || rpcErr.ErrorString != test.want {
@@ -152,17 +152,17 @@ func TestRipplePathFindExplicitHistoricalBypassesStaleDefaultGate(t *testing.T) 
 	ledger := &pathFindTestLedger{info: types.LedgerServerInfo{}, view: view, reader: reader}
 	ctx := &types.RpcContext{
 		ApiVersion: types.ApiVersion2,
-		Services: &types.ServiceContainer{
+		Services: types.NewTestServiceGraph(&types.ServiceContainer{
 			Ledger:       ledger,
 			Capabilities: types.RPCCapabilities{PathSearchMax: 3},
 			ClientLoad:   types.NewClientLoadShedder(),
-		},
+		}),
 	}
 	_, rpcErr := (&ripplePathFindMethod{}).Handle(ctx, json.RawMessage(`{"ledger_index":7}`))
 	if rpcErr == nil || rpcErr.ErrorString != "srcActMissing" {
 		t.Fatalf("explicit historical error = %v, want srcActMissing after lookup", rpcErr)
 	}
-	if got := ctx.Services.ClientLoad.PathfindActive(); got != 0 {
+	if got := ctx.Services.ClientLoad().PathfindActive(); got != 0 {
 		t.Fatalf("pathfind admission leaked after validation error: %d", got)
 	}
 }
@@ -190,10 +190,10 @@ func TestRipplePathFindExistsErrorsAreInternal(t *testing.T) {
 			}
 			view := &pathFindTestView{existsFn: existsFn}
 			ledger := &pathFindTestLedger{info: freshPathFindInfo(), view: view}
-			ctx := &types.RpcContext{Services: &types.ServiceContainer{
+			ctx := &types.RpcContext{Services: types.NewTestServiceGraph(&types.ServiceContainer{
 				Ledger:       ledger,
 				Capabilities: types.RPCCapabilities{PathSearchMax: 3},
-			}}
+			})}
 			params := json.RawMessage(`{"source_account":"` + account + `","destination_account":"` + account + `","destination_amount":"10"}`)
 			_, rpcErr := (&ripplePathFindMethod{}).Handle(ctx, params)
 			if rpcErr == nil || rpcErr.ErrorString != "internal" || rpcErr.Message != "Internal error." {

--- a/internal/rpc/handlers/peers.go
+++ b/internal/rpc/handlers/peers.go
@@ -63,8 +63,8 @@ func (m *PeerReservationsAddMethod) Handle(ctx *types.RpcContext, params json.Ra
 	}
 
 	result := map[string]any{}
-	if ctx.Services != nil && ctx.Services.PeerReservationAdd != nil {
-		prevDesc, replaced, err := ctx.Services.PeerReservationAdd(key, desc)
+	if ctx.Services != nil && ctx.Services.PeerReservationAdd() != nil {
+		prevDesc, replaced, err := ctx.Services.PeerReservationAdd()(key, desc)
 		if err != nil {
 			return nil, rpcInternalError("peer_reservations_add: persisting reservation failed", err)
 		}
@@ -97,8 +97,8 @@ func (m *PeerReservationsDelMethod) Handle(ctx *types.RpcContext, params json.Ra
 	}
 
 	result := map[string]any{}
-	if ctx.Services != nil && ctx.Services.PeerReservationDel != nil {
-		prevDesc, existed, err := ctx.Services.PeerReservationDel(key)
+	if ctx.Services != nil && ctx.Services.PeerReservationDel() != nil {
+		prevDesc, existed, err := ctx.Services.PeerReservationDel()(key)
 		if err != nil {
 			return nil, rpcInternalError("peer_reservations_del: persisting reservation failed", err)
 		}
@@ -116,8 +116,8 @@ type PeerReservationsListMethod struct{ adminHandler }
 
 func (m *PeerReservationsListMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	reservations := make([]any, 0)
-	if ctx.Services != nil && ctx.Services.PeerReservationList != nil {
-		entries := ctx.Services.PeerReservationList()
+	if ctx.Services != nil && ctx.Services.PeerReservationList() != nil {
+		entries := ctx.Services.PeerReservationList()()
 		// Rippled's PeerReservationTable::list() sorts ascending by nodeId
 		// (PeerReservationTable.cpp:57) so the wire order is deterministic.
 		sort.Slice(entries, func(i, j int) bool {

--- a/internal/rpc/handlers/request_object_test.go
+++ b/internal/rpc/handlers/request_object_test.go
@@ -74,7 +74,7 @@ func TestStrictRequestObjects(t *testing.T) {
 func TestDecodeRejectionDoesNotInvokeCallbacks(t *testing.T) {
 	controller := &requestRejectAmendmentController{table: amendment.NewTable()}
 	_, rpcErr := (&FeatureMethod{}).Handle(
-		&types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, Services: &types.ServiceContainer{Ledger: controller}},
+		&types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, Services: types.NewTestServiceGraph(&types.ServiceContainer{Ledger: controller})},
 		json.RawMessage(`{"feature":1,"vetoed":true}`),
 	)
 	require.NotNil(t, rpcErr)
@@ -90,7 +90,7 @@ func TestDecodeRejectionDoesNotInvokeCallbacks(t *testing.T) {
 		},
 	}
 	_, rpcErr = (&FetchInfoMethod{}).Handle(
-		&types.RpcContext{Services: services},
+		&types.RpcContext{Services: types.NewTestServiceGraph(services)},
 		json.RawMessage(`{"clear":true`),
 	)
 	require.NotNil(t, rpcErr)
@@ -99,7 +99,7 @@ func TestDecodeRejectionDoesNotInvokeCallbacks(t *testing.T) {
 
 	store := &requestRejectAdvisory{}
 	_, rpcErr = (&CanDeleteMethod{}).Handle(
-		&types.RpcContext{Context: context.Background(), Services: &types.ServiceContainer{AdvisoryDeleteState: store}},
+		&types.RpcContext{Context: context.Background(), Services: types.NewTestServiceGraph(&types.ServiceContainer{AdvisoryDeleteState: store})},
 		json.RawMessage(`{"can_delete":true}`),
 	)
 	require.NotNil(t, rpcErr)
@@ -114,7 +114,7 @@ func TestRequestObjectJsonCppCoercions(t *testing.T) {
 		FetchInfo:      func() map[string]any { return nil },
 	}
 	result, rpcErr := (&FetchInfoMethod{}).Handle(
-		&types.RpcContext{Services: services},
+		&types.RpcContext{Services: types.NewTestServiceGraph(services)},
 		json.RawMessage(`{"clear":"true"}`),
 	)
 	require.Nil(t, rpcErr)
@@ -123,7 +123,7 @@ func TestRequestObjectJsonCppCoercions(t *testing.T) {
 
 	controller := &requestRejectAmendmentController{table: amendment.NewTable()}
 	_, rpcErr = (&FeatureMethod{}).Handle(
-		&types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, Services: &types.ServiceContainer{Ledger: controller}},
+		&types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, Services: types.NewTestServiceGraph(&types.ServiceContainer{Ledger: controller})},
 		json.RawMessage(`{"feature":"fixMasterKeyAsRegularKey","vetoed":"true"}`),
 	)
 	require.Nil(t, rpcErr)
@@ -131,7 +131,7 @@ func TestRequestObjectJsonCppCoercions(t *testing.T) {
 
 	controller = &requestRejectAmendmentController{table: amendment.NewTable()}
 	result, rpcErr = (&FeatureMethod{}).Handle(
-		&types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, Services: &types.ServiceContainer{Ledger: controller}},
+		&types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, Services: types.NewTestServiceGraph(&types.ServiceContainer{Ledger: controller})},
 		json.RawMessage(`{"vetoed":true}`),
 	)
 	require.Nil(t, rpcErr)
@@ -188,7 +188,7 @@ func TestJsonCppRequestFields(t *testing.T) {
 
 func TestCanDeleteNotEnabledPrecedesDecode(t *testing.T) {
 	_, rpcErr := (&CanDeleteMethod{}).Handle(
-		&types.RpcContext{Services: &types.ServiceContainer{}},
+		&types.RpcContext{Services: types.NewTestServiceGraph(&types.ServiceContainer{})},
 		json.RawMessage(`{"can_delete":`),
 	)
 	require.NotNil(t, rpcErr)
@@ -208,7 +208,7 @@ func TestCanDeleteStrictRequestObjects(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			store := &requestRejectAdvisory{}
 			_, rpcErr := (&CanDeleteMethod{}).Handle(
-				&types.RpcContext{Context: context.Background(), Services: &types.ServiceContainer{AdvisoryDeleteState: store}},
+				&types.RpcContext{Context: context.Background(), Services: types.NewTestServiceGraph(&types.ServiceContainer{AdvisoryDeleteState: store})},
 				test.params,
 			)
 			require.NotNil(t, rpcErr)

--- a/internal/rpc/handlers/ripple_path_find.go
+++ b/internal/rpc/handlers/ripple_path_find.go
@@ -72,8 +72,8 @@ func (m *ripplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 	var view types.LedgerStateView
 	var meta *pathFindLedgerMeta
 	var rpcErr *types.RpcError
-	standalone := ctx != nil && ctx.Services != nil && ctx.Services.Ledger != nil &&
-		ctx.Services.Ledger.GetServerInfo().Standalone
+	standalone := ctx != nil && ctx.Services != nil && ctx.Services.Ledger() != nil &&
+		ctx.Services.Ledger().GetServerInfo().Standalone
 	usesLookup := hasLedgerSelector || standalone
 	if usesLookup {
 		view, meta, rpcErr = resolvePathFindLedger(ctx, ledgerSpec, true)
@@ -86,7 +86,7 @@ func (m *ripplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 		}
 		defer release()
 	} else {
-		if types.ValidatedLedgerStale(ctx.Services.Ledger.GetServerInfo()) {
+		if types.ValidatedLedgerStale(ctx.Services.Ledger().GetServerInfo()) {
 			if ctx.ApiVersion == types.ApiVersion1 {
 				return nil, types.RpcErrorNoNetwork("")
 			}
@@ -432,7 +432,7 @@ func resolvePathFindLedger(
 	hasSelector bool,
 ) (types.LedgerStateView, *pathFindLedgerMeta, *types.RpcError) {
 	if !hasSelector {
-		view, err := ctx.Services.Ledger.GetClosedLedgerView()
+		view, err := ctx.Services.Ledger().GetClosedLedgerView()
 		if err != nil {
 			return nil, nil, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent", "Current ledger is unavailable.")
 		}
@@ -443,7 +443,7 @@ func resolvePathFindLedger(
 		return nil, nil, rpcErr
 	}
 
-	source, ok := ctx.Services.Ledger.(types.LedgerViewSource)
+	source, ok := ctx.Services.Ledger().(types.LedgerViewSource)
 	if !ok {
 		return nil, nil, types.RpcErrorLgrNotFound("ledgerNotFound")
 	}
@@ -458,7 +458,7 @@ func resolvePathFindLedger(
 		return selected, view != nil && reader != nil, err
 	}
 	validated := func() (selectedPathFindLedger, bool, error) {
-		sequence := ctx.Services.Ledger.GetValidatedLedgerIndex()
+		sequence := ctx.Services.Ledger().GetValidatedLedgerIndex()
 		if sequence == 0 {
 			return selectedPathFindLedger{}, false, nil
 		}
@@ -466,10 +466,10 @@ func resolvePathFindLedger(
 	}
 	resolved, err := ledgerselector.Resolve(selection, ledgerselector.Callbacks[selectedPathFindLedger]{
 		Current: func() (selectedPathFindLedger, bool, error) {
-			return bySequence(ctx.Services.Ledger.GetCurrentLedgerIndex())
+			return bySequence(ctx.Services.Ledger().GetCurrentLedgerIndex())
 		},
 		Closed: func() (selectedPathFindLedger, bool, error) {
-			return bySequence(ctx.Services.Ledger.GetClosedLedgerIndex())
+			return bySequence(ctx.Services.Ledger().GetClosedLedgerIndex())
 		},
 		Validated:  validated,
 		BySequence: bySequence,

--- a/internal/rpc/handlers/ripple_path_find_mpt_test.go
+++ b/internal/rpc/handlers/ripple_path_find_mpt_test.go
@@ -42,10 +42,10 @@ func TestRipplePathFindRejectsMPTWithZeroIssuer(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, rpcErr := (&ripplePathFindMethod{}).Handle(&types.RpcContext{
-				Services: &types.ServiceContainer{
+				Services: types.NewTestServiceGraph(&types.ServiceContainer{
 					Ledger:       &pathFindTestLedger{info: freshPathFindInfo(), view: &pathFindTestView{}},
 					Capabilities: types.RPCCapabilities{PathSearchMax: 3},
-				},
+				}),
 			}, test.params)
 			require.NotNil(t, rpcErr)
 			require.Equal(t, test.token, rpcErr.ErrorString)

--- a/internal/rpc/handlers/selector_endpoints_test.go
+++ b/internal/rpc/handlers/selector_endpoints_test.go
@@ -123,7 +123,7 @@ func newSelectorEndpointService(t *testing.T) (*selectorEndpointService, string)
 func TestResolvePathFindLedgerSelectors(t *testing.T) {
 	t.Run("omitted uses closed view without metadata", func(t *testing.T) {
 		service, _ := newSelectorEndpointService(t)
-		ctx := &types.RpcContext{Services: &types.ServiceContainer{Ledger: service}}
+		ctx := &types.RpcContext{Services: types.NewTestServiceGraph(&types.ServiceContainer{Ledger: service})}
 		view, meta, rpcErr := resolvePathFindLedger(ctx, types.LedgerSpecifier{}, false)
 		if rpcErr != nil || view != service.closedView || meta != nil {
 			t.Fatalf("view=%#v meta=%#v error=%#v", view, meta, rpcErr)
@@ -152,7 +152,7 @@ func TestResolvePathFindLedgerSelectors(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			service, hash := newSelectorEndpointService(t)
-			ctx := &types.RpcContext{Services: &types.ServiceContainer{Ledger: service}}
+			ctx := &types.RpcContext{Services: types.NewTestServiceGraph(&types.ServiceContainer{Ledger: service})}
 			spec, hasSelector, parseErr := parseLedgerSpecifier(json.RawMessage(test.probe(hash)))
 			if parseErr != nil {
 				t.Fatal(parseErr)
@@ -186,7 +186,7 @@ func TestAMMInfoResolvesSelectorBeforeParameters(t *testing.T) {
 	t.Run("missing ledger outranks invalid AMM parameters", func(t *testing.T) {
 		service, _ := newSelectorEndpointService(t)
 		delete(service.readersBySeq, service.current)
-		ctx := &types.RpcContext{Services: &types.ServiceContainer{Ledger: service}}
+		ctx := &types.RpcContext{Services: types.NewTestServiceGraph(&types.ServiceContainer{Ledger: service})}
 		_, rpcErr := method.Handle(ctx, json.RawMessage(`{}`))
 		if rpcErr == nil || rpcErr.ErrorString != "noNetwork" {
 			t.Fatalf("error = %#v", rpcErr)
@@ -198,7 +198,7 @@ func TestAMMInfoResolvesSelectorBeforeParameters(t *testing.T) {
 
 	t.Run("valid selector is resolved once before parameter error", func(t *testing.T) {
 		service, _ := newSelectorEndpointService(t)
-		ctx := &types.RpcContext{Services: &types.ServiceContainer{Ledger: service}}
+		ctx := &types.RpcContext{Services: types.NewTestServiceGraph(&types.ServiceContainer{Ledger: service})}
 		_, rpcErr := method.Handle(ctx, json.RawMessage(`{}`))
 		if rpcErr == nil || rpcErr.ErrorString != "invalidParams" {
 			t.Fatalf("error = %#v", rpcErr)

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -80,12 +80,12 @@ func resolveHostID() string {
 	return "go-xrpl"
 }
 
-func serverHostID(services *types.ServiceContainer, admin bool) string {
+func serverHostID(services *types.ServiceGraph, admin bool) string {
 	if admin {
 		return cachedHostID
 	}
 	if services != nil {
-		key, err := addresscodec.DecodeNodePublicKey(services.NodePublicKey)
+		key, err := addresscodec.DecodeNodePublicKey(services.NodePublicKey())
 		if err == nil && len(key) == addresscodec.NodePublicKeyLength {
 			return rfc1751.WordFromBlob(key)
 		}
@@ -93,14 +93,14 @@ func serverHostID(services *types.ServiceContainer, admin bool) string {
 	return "go-xrpl"
 }
 
-func ServerSubscriptionState(services *types.ServiceContainer, admin bool) map[string]any {
+func ServerSubscriptionState(services *types.ServiceGraph, admin bool) map[string]any {
 	random := make([]byte, 32)
 	_, _ = rand.Read(random)
 	load := ComputeServerLoad(services)
 	status := "full"
 	standalone := false
-	if services != nil && services.Ledger != nil {
-		info := services.Ledger.GetServerInfo()
+	if services != nil && services.Ledger() != nil {
+		info := services.Ledger().GetServerInfo()
 		standalone = info.Standalone
 		if info.ServerState != "" {
 			status = info.ServerState
@@ -120,7 +120,7 @@ func ServerSubscriptionState(services *types.ServiceContainer, admin bool) map[s
 		"pubkey_node":   "",
 	}
 	if services != nil {
-		result["pubkey_node"] = services.NodePublicKey
+		result["pubkey_node"] = services.NodePublicKey()
 	}
 	if standalone {
 		result["stand_alone"] = true
@@ -128,9 +128,9 @@ func ServerSubscriptionState(services *types.ServiceContainer, admin bool) map[s
 	return result
 }
 
-func serverSystemTime(services *types.ServiceContainer) time.Time {
-	if services != nil && services.SystemTime != nil {
-		return services.SystemTime()
+func serverSystemTime(services *types.ServiceGraph) time.Time {
+	if services != nil && services.SystemTime() != nil {
+		return services.SystemTime()()
 	}
 	return time.Now()
 }
@@ -169,11 +169,11 @@ func serverCountersRequested(params json.RawMessage) bool {
 	return jsonCppBoolRaw(object["counters"])
 }
 
-func addServerDiagnostics(info map[string]any, services *types.ServiceContainer) {
+func addServerDiagnostics(info map[string]any, services *types.ServiceGraph) {
 	rpcCounters := make(map[string]any)
 	var snapshot types.RPCDiagnosticsSnapshot
-	if services != nil && services.RPCDiagnostics != nil {
-		snapshot = services.RPCDiagnostics.Snapshot()
+	if services != nil && services.RPCDiagnostics() != nil {
+		snapshot = services.RPCDiagnostics().Snapshot()
 	}
 	methods := make([]map[string]any, 0, len(snapshot.Current))
 
@@ -199,8 +199,8 @@ func addServerDiagnostics(info map[string]any, services *types.ServiceContainer)
 	}
 
 	nodeStore := make(map[string]any)
-	if services != nil && services.GetCounts != nil {
-		if counts := services.GetCounts().NodeStore; counts != nil {
+	if services != nil && services.GetCounts() != nil {
+		if counts := services.GetCounts()().NodeStore; counts != nil {
 			nodeStore["node_writes"] = strconv.FormatUint(counts.Writes, 10)
 			nodeStore["node_reads_total"] = strconv.FormatUint(counts.Reads, 10)
 			nodeStore["node_reads_hit"] = strconv.FormatUint(counts.FetchHits, 10)
@@ -214,8 +214,8 @@ func addServerDiagnostics(info map[string]any, services *types.ServiceContainer)
 		"job_queue": map[string]any{},
 		"nodestore": nodeStore,
 	}
-	if services != nil && services.SubscriptionMetrics != nil {
-		metrics := services.SubscriptionMetrics()
+	if services != nil && services.SubscriptionMetrics() != nil {
+		metrics := services.SubscriptionMetrics()()
 		counters["subscriptions"] = map[string]any{
 			"connections":                 strconv.FormatUint(metrics.Connections, 10),
 			"items":                       strconv.FormatUint(metrics.Items, 10),
@@ -243,20 +243,20 @@ func rpcDiagnosticsJSON(stats types.RPCMethodDiagnostics) map[string]any {
 	}
 }
 
-func buildServerWarnings(services *types.ServiceContainer, isAdmin bool) []types.WarningObject {
-	if services == nil || services.Ledger == nil {
+func buildServerWarnings(services *types.ServiceGraph, isAdmin bool) []types.WarningObject {
+	if services == nil || services.Ledger() == nil {
 		return nil
 	}
 
 	var warnings []types.WarningObject
-	blocked := services.Ledger.IsAmendmentBlocked()
+	blocked := services.Ledger().IsAmendmentBlocked()
 	if blocked {
 		warnings = append(warnings, types.WarningObject{
 			ID:      types.WarningAmendmentBlocked,
 			Message: "This server is amendment blocked, and must be updated to be able to stay in sync with the network.",
 		})
 	}
-	if services.ValidatorList != nil && services.ValidatorList.IsUNLBlocked() {
+	if services.ValidatorList() != nil && services.ValidatorList().IsUNLBlocked() {
 		warnings = append(warnings, types.WarningObject{
 			ID:      types.WarningExpiredValidatorList,
 			Message: "This server has an expired validator list. validators.txt may be incorrectly configured or some [validator_list_sites] may be unreachable.",
@@ -264,7 +264,7 @@ func buildServerWarnings(services *types.ServiceContainer, isAdmin bool) []types
 	}
 
 	if isAdmin && !blocked {
-		if p, ok := services.Ledger.(interface {
+		if p, ok := services.Ledger().(interface {
 			Table() *amendment.Table
 		}); ok {
 			if tbl := p.Table(); tbl != nil {
@@ -290,9 +290,9 @@ func buildServerWarnings(services *types.ServiceContainer, isAdmin bool) []types
 func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 	services := ctx.Services
 	now := serverSystemTime(services)
-	serverInfo := services.Ledger.GetServerInfo()
-	configSnapshot := services.ServerInfoConfig
-	baseFee, reserveBase, reserveIncrement := services.Ledger.GetCurrentFees()
+	serverInfo := services.Ledger().GetServerInfo()
+	configSnapshot := services.ServerInfoConfig()
+	baseFee, reserveBase, reserveIncrement := services.Ledger().GetCurrentFees()
 
 	// Uptime in seconds
 	uptimeDuration := time.Since(serverStartTime)
@@ -329,7 +329,7 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 		"build_version":     BuildVersion,
 		"complete_ledgers":  completeLedgers,
 		"io_latency_ms":     observability.SchedLatencyMs(),
-		"pubkey_node":       services.NodePublicKey,
+		"pubkey_node":       services.NodePublicKey(),
 		"server_state":      serverState,
 		"uptime":            uptime,
 		"validation_quorum": resolveValidationQuorum(services),
@@ -361,8 +361,8 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 			info["git"] = map[string]any{"hash": configSnapshot.GitHash}
 		}
 	}
-	if services.FetchPackCacheSize != nil {
-		if size := services.FetchPackCacheSize(); size != 0 {
+	if services.FetchPackCacheSize() != nil {
+		if size := services.FetchPackCacheSize()(); size != 0 {
 			info["fetch_pack"] = size
 		}
 	}
@@ -400,8 +400,8 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 	// last_close: converge_time_s (float seconds) for human, converge_time (int ms) for machine
 	proposers := 0
 	convergeTimeMs := 0
-	if services.LastCloseInfo != nil {
-		proposers, convergeTimeMs = services.LastCloseInfo()
+	if services.LastCloseInfo() != nil {
+		proposers, convergeTimeMs = services.LastCloseInfo()()
 	}
 	if human {
 		info["last_close"] = map[string]any{
@@ -425,8 +425,8 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 		loadFactorFeeEscalation = mulDivSaturating(feeEscalation, loadBase, feeReference)
 	}
 	var loadFactorFees types.LoadFactorFees
-	if services != nil && services.LoadFactorFees != nil {
-		loadFactorFees = services.LoadFactorFees()
+	if services != nil && services.LoadFactorFees() != nil {
+		loadFactorFees = services.LoadFactorFees()()
 	} else {
 		// Tracker unwired (older test fixtures): treat as no load so
 		// loadFactorServer collapses to loadBase, matching a fresh
@@ -527,8 +527,8 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 			// preserving the two's-complement bit pattern — so a negative
 			// offset surfaces as a large positive number. Match that wire
 			// shape rather than emit a signed value.
-			if services != nil && services.CloseTimeOffset != nil {
-				offset := services.CloseTimeOffset()
+			if services != nil && services.CloseTimeOffset() != nil {
+				offset := services.CloseTimeOffset()()
 				abs := offset
 				if abs < 0 {
 					abs = -abs
@@ -573,7 +573,7 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 	}
 
 	// amendment_blocked: rippled only includes this when true
-	if services.Ledger.IsAmendmentBlocked() {
+	if services.Ledger().IsAmendmentBlocked() {
 		info["amendment_blocked"] = true
 	}
 
@@ -631,9 +631,9 @@ func getPeerCount(ctx *types.RpcContext) int {
 // consensus subsystem hasn't been wired (standalone or pre-startup).
 // Rippled exposes the runtime quorum here; previously goxrpl hardcoded
 // 1, which made network-mode soaks misleading (#451).
-func resolveValidationQuorum(services *types.ServiceContainer) uint32 {
-	if services != nil && services.ValidationQuorum != nil {
-		if q := services.ValidationQuorum(); q > 0 {
+func resolveValidationQuorum(services *types.ServiceGraph) uint32 {
+	if services != nil && services.ValidationQuorum() != nil {
+		if q := services.ValidationQuorum()(); q > 0 {
 			return validationQuorumForRPC(q)
 		}
 	}
@@ -654,15 +654,15 @@ func resolveValidationQuorum(services *types.ServiceContainer) uint32 {
 // identity != nil) is the faithful single-term equivalent for every state the
 // node can reach; the two-term form only matters if a separable
 // manifest-revocation path is added later.
-func resolveValidatorPubKey(services *types.ServiceContainer) string {
-	if services == nil || len(services.ValidatorPublicKey) != 33 {
+func resolveValidatorPubKey(services *types.ServiceGraph) string {
+	if services == nil || len(services.ValidatorPublicKey()) != 33 {
 		return "none"
 	}
 	var signing [33]byte
-	copy(signing[:], services.ValidatorPublicKey)
+	copy(signing[:], services.ValidatorPublicKey())
 	master := signing
-	if services.Manifests != nil {
-		master = services.Manifests.GetMasterKey(signing)
+	if services.Manifests() != nil {
+		master = services.Manifests().GetMasterKey(signing)
 	}
 	enc, err := addresscodec.EncodeNodePublicKey(master[:])
 	if err != nil {
@@ -676,15 +676,15 @@ func resolveValidatorPubKey(services *types.ServiceContainer) string {
 // so server_info still produces a complete shape. overflow sources
 // from the overlay's TMTransaction-refusal counter (the rippled-shape
 // jq_trans_overflow signal at PeerImp.cpp:1353).
-func resolveDisconnectCounters(services *types.ServiceContainer) (overflow, peerDisc, peerDiscRes uint64) {
+func resolveDisconnectCounters(services *types.ServiceGraph) (overflow, peerDisc, peerDiscRes uint64) {
 	if services == nil {
 		return 0, 0, 0
 	}
-	if services.JqTransOverflow != nil {
-		overflow = services.JqTransOverflow()
+	if services.JqTransOverflow() != nil {
+		overflow = services.JqTransOverflow()()
 	}
-	if services.PeerDisconnects != nil {
-		peerDisc, peerDiscRes = services.PeerDisconnects()
+	if services.PeerDisconnects() != nil {
+		peerDisc, peerDiscRes = services.PeerDisconnects()()
 	}
 	return overflow, peerDisc, peerDiscRes
 }
@@ -695,11 +695,11 @@ func resolveDisconnectCounters(services *types.ServiceContainer) (overflow, peer
 // gates collapse to "absent". Once the hook fires, values pass through
 // unfiltered — a zero from TxQ would be a TxQ bug, not something to
 // paper over here.
-func resolveLoadFactorFees(services *types.ServiceContainer) (escalation, queue, reference uint64) {
-	if services == nil || services.TxQMetrics == nil {
+func resolveLoadFactorFees(services *types.ServiceGraph) (escalation, queue, reference uint64) {
+	if services == nil || services.TxQMetrics() == nil {
 		return loadBase, loadBase, loadBase
 	}
-	m := services.TxQMetrics()
+	m := services.TxQMetrics()()
 	return m.OpenLedgerFeeLevel, m.MinProcessingFeeLevel, m.ReferenceFeeLevel
 }
 
@@ -722,7 +722,7 @@ type ServerLoadSnapshot struct {
 // and returns the rendered triple every server_info / server-stream
 // emit needs. Mirrors the NetworkOPs::getServerStatus computation at
 // rippled NetworkOPs.cpp:2850-2912.
-func ComputeServerLoad(services *types.ServiceContainer) ServerLoadSnapshot {
+func ComputeServerLoad(services *types.ServiceGraph) ServerLoadSnapshot {
 	feeEscalation, feeQueue, feeReference := resolveLoadFactorFees(services)
 	snap := ServerLoadSnapshot{
 		LoadBase:                loadBase,
@@ -739,8 +739,8 @@ func ComputeServerLoad(services *types.ServiceContainer) ServerLoadSnapshot {
 	if feeReference != 0 {
 		scaledFeeEscalation = mulDivSaturating(feeEscalation, loadBase, feeReference)
 	}
-	if services != nil && services.LoadFactorFees != nil {
-		fees := services.LoadFactorFees()
+	if services != nil && services.LoadFactorFees() != nil {
+		fees := services.LoadFactorFees()()
 		if fees.Local > 0 {
 			snap.LoadFactorLocal = uint64(fees.Local)
 		}
@@ -787,7 +787,7 @@ type stateAccountingResolved struct {
 // goxrpl-only deployments (standalone / RPC-only tests) where wiring the
 // real tracker isn't applicable. Production network nodes always take
 // the wired path above.
-func resolveStateAccounting(services *types.ServiceContainer, serverState string, uptimeUs int64) stateAccountingResolved {
+func resolveStateAccounting(services *types.ServiceGraph, serverState string, uptimeUs int64) stateAccountingResolved {
 	out := make(map[string]any, len(stateAccountingModes))
 	for _, m := range stateAccountingModes {
 		out[m] = map[string]any{
@@ -796,8 +796,8 @@ func resolveStateAccounting(services *types.ServiceContainer, serverState string
 		}
 	}
 
-	if services != nil && services.StateAccounting != nil {
-		snap := services.StateAccounting()
+	if services != nil && services.StateAccounting() != nil {
+		snap := services.StateAccounting()()
 		for mode, entry := range snap.Modes {
 			out[mode] = map[string]any{
 				"duration_us": fmt.Sprintf("%d", entry.DurationUs),

--- a/internal/rpc/handlers/server_load_test.go
+++ b/internal/rpc/handlers/server_load_test.go
@@ -35,7 +35,7 @@ func TestComputeServerLoadKeepsRawAndScaledEscalationDistinct(t *testing.T) {
 		},
 	}
 
-	load := ComputeServerLoad(services)
+	load := ComputeServerLoad(types.NewTestServiceGraph(services))
 	if load.LoadFactorFeeEscalation != 256 {
 		t.Fatalf("raw fee escalation = %d, want 256", load.LoadFactorFeeEscalation)
 	}

--- a/internal/rpc/handlers/sign_authorization_test.go
+++ b/internal/rpc/handlers/sign_authorization_test.go
@@ -33,10 +33,10 @@ func signingAuthorizationContext(ledger types.LedgerService) *types.RpcContext {
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion2,
-		Services: &types.ServiceContainer{
+		Services: types.NewTestServiceGraph(&types.ServiceContainer{
 			Ledger:       ledger,
 			Capabilities: types.RPCCapabilities{SigningEnabled: true},
-		},
+		}),
 	}
 }
 
@@ -95,10 +95,10 @@ func TestSigningCapabilityGuardPrecedesParsingAndLoad(t *testing.T) {
 			ctx := &types.RpcContext{
 				Role:       types.RoleIdentified,
 				ApiVersion: types.ApiVersion2,
-				Services: &types.ServiceContainer{IsLoadedCluster: func() bool {
+				Services: types.NewTestServiceGraph(&types.ServiceContainer{IsLoadedCluster: func() bool {
 					loadedCalled = true
 					return true
-				}},
+				}}),
 			}
 			_, rpcErr := method.handle(ctx, json.RawMessage(`{`))
 			if rpcErr == nil || rpcErr.Code != types.RpcNOT_SUPPORTED || rpcErr.Message != "Signing is not supported by this server." {

--- a/internal/rpc/handlers/sign_for.go
+++ b/internal/rpc/handlers/sign_for.go
@@ -73,8 +73,8 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (r
 	// integral NetworkID, else invalidParams. Unlike sign/submit — which autofill
 	// a missing NetworkID — sign_for rejects, so a multisigner cannot sign for the
 	// wrong network. Mirrors rippled checkNetworkID in transactionSignFor.
-	if ctx.Services != nil && ctx.Services.Ledger != nil {
-		if networkID := ctx.Services.Ledger.GetServerInfo().NetworkID; networkID > 1024 {
+	if ctx.Services != nil && ctx.Services.Ledger() != nil {
+		if networkID := ctx.Services.Ledger().GetServerInfo().NetworkID; networkID > 1024 {
 			v, ok := txMap["NetworkID"]
 			if !ok {
 				return nil, types.RpcErrorMissingField("tx_json.NetworkID")

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -187,7 +187,7 @@ func rejectDisabledSigning(ctx *types.RpcContext) *types.RpcError {
 	if ctx != nil && ctx.Role.IsAdmin() {
 		return nil
 	}
-	if ctx != nil && ctx.Services != nil && ctx.Services.Capabilities.SigningEnabled {
+	if ctx != nil && ctx.Services != nil && ctx.Services.Capabilities().SigningEnabled {
 		return nil
 	}
 	return types.RpcErrorNotSupported("Signing is not supported by this server.")
@@ -261,11 +261,11 @@ func checkPayment(txMap map[string]any, params json.RawMessage, doPath bool, rpc
 			"Field 'build_path' not allowed in this context.")
 	}
 	if buildPath && amount.IsMPT() {
-		if rpcCtx == nil || rpcCtx.Services == nil || rpcCtx.Services.Ledger == nil {
+		if rpcCtx == nil || rpcCtx.Services == nil || rpcCtx.Services.Ledger() == nil {
 			return types.RpcErrorInvalidParams(
 				"Field 'build_path' not allowed in this context.")
 		}
-		rulesSource, ok := rpcCtx.Services.Ledger.(types.TransactionRulesSource)
+		rulesSource, ok := rpcCtx.Services.Ledger().(types.TransactionRulesSource)
 		if !ok {
 			return types.RpcErrorInvalidParams(
 				"Field 'build_path' not allowed in this context.")
@@ -314,7 +314,7 @@ func checkPayment(txMap map[string]any, params json.RawMessage, doPath bool, rpc
 			return types.RpcErrorInvalidParams(
 				"Cannot build XRP to XRP paths.")
 		}
-		if rpcCtx == nil || rpcCtx.Services == nil || rpcCtx.Services.Ledger == nil {
+		if rpcCtx == nil || rpcCtx.Services == nil || rpcCtx.Services.Ledger() == nil {
 			return rpcInternalInvariantError("payment: ledger service unavailable for path construction")
 		}
 		release, rpcErr := acquirePathfind(rpcCtx)
@@ -322,7 +322,7 @@ func checkPayment(txMap map[string]any, params json.RawMessage, doPath bool, rpc
 			return rpcErr
 		}
 		defer release()
-		viewSource, ok := rpcCtx.Services.Ledger.(types.OpenLedgerViewSource)
+		viewSource, ok := rpcCtx.Services.Ledger().(types.OpenLedgerViewSource)
 		if !ok {
 			return rpcInternalInvariantError("payment: open ledger view unavailable for path construction")
 		}
@@ -432,7 +432,7 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 
 	// Check if ledger service is available (needed for auto-filling fields)
 	// only after credentials have entered the shared signing preprocessing.
-	if !offline && (services == nil || services.Ledger == nil) {
+	if !offline && (services == nil || services.Ledger() == nil) {
 		return nil, rpcInternalInvariantError("sign: ledger service unavailable")
 	}
 
@@ -496,7 +496,7 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 		// The source account must exist in the current ledger, whether or
 		// not Sequence is supplied (rpcSRC_ACT_NOT_FOUND).
 		var err error
-		sourceAccountInfo, err = services.Ledger.GetAccountInfo(ctx, srcAddress, "current")
+		sourceAccountInfo, err = services.Ledger().GetAccountInfo(ctx, srcAddress, "current")
 		if err != nil {
 			if errors.Is(err, svcerr.ErrAccountNotFound) {
 				return nil, types.RpcErrorSrcActNotFound("Source account not found.")
@@ -508,7 +508,7 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 		// TicketSequence supplies the sequence instead (Sequence = 0).
 		if _, ok := txMap["Sequence"]; !ok {
 			_, hasTicket := txMap["TicketSequence"]
-			seq, err := services.Ledger.GetAutofillSequence(srcAddress, hasTicket)
+			seq, err := services.Ledger().GetAutofillSequence(srcAddress, hasTicket)
 			if err != nil {
 				if errors.Is(err, svcerr.ErrAccountNotFound) {
 					return nil, types.RpcErrorSrcActNotFound("Source account not found.")
@@ -530,7 +530,7 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 		// legacy networks (ID <= 1024) must NOT include NetworkID;
 		// new networks (ID > 1024) require it and it is auto-filled here.
 		if _, ok := txMap["NetworkID"]; !ok {
-			serverInfo := services.Ledger.GetServerInfo()
+			serverInfo := services.Ledger().GetServerInfo()
 			if serverInfo.NetworkID > 1024 {
 				txMap["NetworkID"] = serverInfo.NetworkID
 			}
@@ -548,7 +548,7 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 			if mErr != nil {
 				return nil, rpcInternalError("sign: fee probe marshaling failed", mErr)
 			}
-			fee, feeErr := services.Ledger.GetAutofillFee(probe, rpcCtx.Role.IsUnlimited(), feeOpts.Mult, feeOpts.Div)
+			fee, feeErr := services.Ledger().GetAutofillFee(probe, rpcCtx.Role.IsUnlimited(), feeOpts.Mult, feeOpts.Div)
 			if feeErr != nil {
 				var hfe *svcerr.HighFeeError
 				if errors.As(feeErr, &hfe) {
@@ -651,8 +651,8 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 
 func authorizeSigningKey(ctx *types.RpcContext, account, derivedAccount string, requireAccount bool) *types.RpcError {
 	var accountInfo *types.AccountInfo
-	if ctx != nil && ctx.Services != nil && ctx.Services.Ledger != nil {
-		info, err := ctx.Services.Ledger.GetAccountInfo(ctx.Context, account, "current")
+	if ctx != nil && ctx.Services != nil && ctx.Services.Ledger() != nil {
+		info, err := ctx.Services.Ledger().GetAccountInfo(ctx.Context, account, "current")
 		if err != nil {
 			if !errors.Is(err, svcerr.ErrAccountNotFound) {
 				return rpcInternalError("signing authorization account lookup failed", err)
@@ -687,18 +687,18 @@ func signingKeyAuthorization(account, derivedAccount string, accountInfo *types.
 	return types.RpcErrorBadSecret()
 }
 
-func rejectSigningWhenLoaded(services *types.ServiceContainer, unlimited bool) *types.RpcError {
-	if unlimited || services == nil || services.IsLoadedCluster == nil || !services.IsLoadedCluster() {
+func rejectSigningWhenLoaded(services *types.ServiceGraph, unlimited bool) *types.RpcError {
+	if unlimited || services == nil || services.IsLoadedCluster() == nil || !services.IsLoadedCluster()() {
 		return nil
 	}
 	return types.RpcErrorTooBusy()
 }
 
-func rejectOnlineSigningWithoutCurrentLedger(services *types.ServiceContainer, offline bool, apiVersion int) *types.RpcError {
-	if offline || services == nil || services.Ledger == nil {
+func rejectOnlineSigningWithoutCurrentLedger(services *types.ServiceGraph, offline bool, apiVersion int) *types.RpcError {
+	if offline || services == nil || services.Ledger() == nil {
 		return nil
 	}
-	info := services.Ledger.GetServerInfo()
+	info := services.Ledger().GetServerInfo()
 	if info.Standalone || !types.ValidatedLedgerStale(info) {
 		return nil
 	}

--- a/internal/rpc/handlers/signing_load_admission_test.go
+++ b/internal/rpc/handlers/signing_load_admission_test.go
@@ -20,11 +20,15 @@ const (
 )
 
 func signingEnabledHandlerContext(ctx *types.RpcContext) *types.RpcContext {
-	if ctx.Services == nil {
-		ctx.Services = &types.ServiceContainer{}
-	}
-	ctx.Services.Capabilities.SigningEnabled = true
 	return ctx
+}
+
+func signingEnabledTestGraph(services *types.ServiceContainer) *types.ServiceGraph {
+	if services == nil {
+		services = &types.ServiceContainer{}
+	}
+	services.Capabilities.SigningEnabled = true
+	return types.NewTestServiceGraph(services)
 }
 
 type loadAdmissionLedger struct {
@@ -135,7 +139,7 @@ func TestSignRejectsClusterOnlyAndArmedLocalLoad(t *testing.T) {
 			ctx := &types.RpcContext{
 				Context:    context.Background(),
 				ApiVersion: 2,
-				Services:   &types.ServiceContainer{IsLoadedCluster: track.IsLoadedCluster},
+				Services:   signingEnabledTestGraph(&types.ServiceContainer{IsLoadedCluster: track.IsLoadedCluster}),
 			}
 			_, rpcErr := (&SignMethod{}).Handle(signingEnabledHandlerContext(ctx), signingLoadParams(true))
 			assertTooBusy(t, rpcErr)
@@ -154,7 +158,7 @@ func TestSignRejectsLoadedOnlineAndOfflineBeforeLedgerWork(t *testing.T) {
 			ctx := &types.RpcContext{
 				Context:    context.Background(),
 				ApiVersion: 2,
-				Services:   services,
+				Services:   signingEnabledTestGraph(services),
 			}
 
 			_, rpcErr := (&SignMethod{}).Handle(signingEnabledHandlerContext(ctx), signingLoadParams(offline))
@@ -199,13 +203,13 @@ func TestOnlineSigningRejectsStaleLedgerBeforeLoad(t *testing.T) {
 				ctx := &types.RpcContext{
 					Context:    context.Background(),
 					ApiVersion: api.version,
-					Services: &types.ServiceContainer{
+					Services: signingEnabledTestGraph(&types.ServiceContainer{
 						Ledger: ledger,
 						IsLoadedCluster: func() bool {
 							loadChecks++
 							return true
 						},
-					},
+					}),
 				}
 
 				_, rpcErr := method.handle(signingEnabledHandlerContext(ctx), method.params)
@@ -263,10 +267,10 @@ func TestSigningLoadAdmissionValidatesCredentialsAndShapeFirst(t *testing.T) {
 			ctx := &types.RpcContext{
 				Context:    context.Background(),
 				ApiVersion: 2,
-				Services: &types.ServiceContainer{IsLoadedCluster: func() bool {
+				Services: signingEnabledTestGraph(&types.ServiceContainer{IsLoadedCluster: func() bool {
 					loadChecks++
 					return true
-				}},
+				}}),
 			}
 			_, rpcErr := (&SignMethod{}).Handle(signingEnabledHandlerContext(ctx), test.params)
 			if rpcErr == nil || rpcErr.ErrorString != test.want {
@@ -291,7 +295,7 @@ func TestSigningLoadAdmissionUnlimitedExemption(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: 2,
-			Services:   &types.ServiceContainer{IsLoadedCluster: loaded},
+			Services:   signingEnabledTestGraph(&types.ServiceContainer{IsLoadedCluster: loaded}),
 		}
 		result, rpcErr := (&SignMethod{}).Handle(signingEnabledHandlerContext(ctx), signingLoadParams(true))
 		if rpcErr != nil {
@@ -308,7 +312,7 @@ func TestSigningLoadAdmissionUnlimitedExemption(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: 2,
-			Services:   &types.ServiceContainer{IsLoadedCluster: loaded},
+			Services:   signingEnabledTestGraph(&types.ServiceContainer{IsLoadedCluster: loaded}),
 		}
 		_, rpcErr := (&SignForMethod{}).Handle(signingEnabledHandlerContext(ctx), params)
 		if rpcErr != nil {
@@ -322,10 +326,10 @@ func TestSigningLoadAdmissionUnlimitedExemption(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: 2,
-			Services: &types.ServiceContainer{
+			Services: signingEnabledTestGraph(&types.ServiceContainer{
 				Ledger:          &loadAdmissionLedger{},
 				IsLoadedCluster: loaded,
-			},
+			}),
 		}
 		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
 		if rpcErr != nil && rpcErr.ErrorString == "tooBusy" {
@@ -344,10 +348,10 @@ func TestCredentialedSubmitAndMultisignMethodsRejectLoaded(t *testing.T) {
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
 			ApiVersion: 2,
-			Services: &types.ServiceContainer{
+			Services: signingEnabledTestGraph(&types.ServiceContainer{
 				Ledger:          ledger,
 				IsLoadedCluster: func() bool { return true },
-			},
+			}),
 		}
 		_, rpcErr := (&SubmitMethod{}).Handle(signingEnabledHandlerContext(ctx), signingLoadParams(false))
 		assertTooBusy(t, rpcErr)
@@ -361,7 +365,7 @@ func TestCredentialedSubmitAndMultisignMethodsRejectLoaded(t *testing.T) {
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
 			ApiVersion: 2,
-			Services:   &types.ServiceContainer{IsLoadedCluster: func() bool { return true }},
+			Services:   signingEnabledTestGraph(&types.ServiceContainer{IsLoadedCluster: func() bool { return true }}),
 		}
 		_, rpcErr := (&SignForMethod{}).Handle(signingEnabledHandlerContext(ctx), params)
 		assertTooBusy(t, rpcErr)
@@ -373,10 +377,10 @@ func TestCredentialedSubmitAndMultisignMethodsRejectLoaded(t *testing.T) {
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
 			ApiVersion: 2,
-			Services: &types.ServiceContainer{
+			Services: signingEnabledTestGraph(&types.ServiceContainer{
 				Ledger:          ledger,
 				IsLoadedCluster: func() bool { return true },
-			},
+			}),
 		}
 		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
 		assertTooBusy(t, rpcErr)
@@ -393,10 +397,10 @@ func TestMultisignLoadAdmissionValidationPrecedence(t *testing.T) {
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
 			ApiVersion: 2,
-			Services: &types.ServiceContainer{IsLoadedCluster: func() bool {
+			Services: signingEnabledTestGraph(&types.ServiceContainer{IsLoadedCluster: func() bool {
 				loadChecks++
 				return true
-			}},
+			}}),
 		}
 		_, rpcErr := (&SignForMethod{}).Handle(signingEnabledHandlerContext(ctx), params)
 		if rpcErr == nil || rpcErr.ErrorString != "invalidParams" {
@@ -413,10 +417,10 @@ func TestMultisignLoadAdmissionValidationPrecedence(t *testing.T) {
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
 			ApiVersion: 2,
-			Services: &types.ServiceContainer{IsLoadedCluster: func() bool {
+			Services: signingEnabledTestGraph(&types.ServiceContainer{IsLoadedCluster: func() bool {
 				loadChecks++
 				return true
-			}},
+			}}),
 		}
 		_, rpcErr := (&SignForMethod{}).Handle(signingEnabledHandlerContext(ctx), params)
 		if rpcErr == nil || rpcErr.ErrorString != "invalidParams" {
@@ -433,13 +437,13 @@ func TestMultisignLoadAdmissionValidationPrecedence(t *testing.T) {
 		params := json.RawMessage(`{"tx_json":{"Account":"` + loadAdmissionAccount + `","Sequence":1,"Fee":"10","SigningPubKey":""}}`)
 		ctx := &types.RpcContext{
 			Context: context.Background(),
-			Services: &types.ServiceContainer{
+			Services: signingEnabledTestGraph(&types.ServiceContainer{
 				Ledger: ledger,
 				IsLoadedCluster: func() bool {
 					loadChecks++
 					return true
 				},
-			},
+			}),
 		}
 		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
 		if rpcErr == nil || rpcErr.ErrorString != "invalidParams" {
@@ -455,10 +459,10 @@ func TestMultisignLoadAdmissionValidationPrecedence(t *testing.T) {
 		params := json.RawMessage(`{"tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Sequence":"bad","Fee":"10","SigningPubKey":""}}`)
 		ctx := &types.RpcContext{
 			Context: context.Background(),
-			Services: &types.ServiceContainer{
+			Services: signingEnabledTestGraph(&types.ServiceContainer{
 				Ledger:          ledger,
 				IsLoadedCluster: func() bool { return true },
-			},
+			}),
 		}
 		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
 		assertTooBusy(t, rpcErr)
@@ -474,7 +478,7 @@ func TestSubmitMultisignedUsesCanonicalFieldParsingAfterAdmission(t *testing.T) 
 		params := json.RawMessage(`{"tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Sequence":"1","Fee":50,"SigningPubKey":""}}`)
 		ctx := &types.RpcContext{
 			Context:  context.Background(),
-			Services: &types.ServiceContainer{Ledger: ledger},
+			Services: signingEnabledTestGraph(&types.ServiceContainer{Ledger: ledger}),
 		}
 
 		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
@@ -488,7 +492,7 @@ func TestSubmitMultisignedUsesCanonicalFieldParsingAfterAdmission(t *testing.T) 
 		params := json.RawMessage(`{"tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Sequence":"4294967296","Fee":"10","SigningPubKey":"","TxnSignature":""}}`)
 		ctx := &types.RpcContext{
 			Context:  context.Background(),
-			Services: &types.ServiceContainer{Ledger: ledger},
+			Services: signingEnabledTestGraph(&types.ServiceContainer{Ledger: ledger}),
 		}
 
 		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
@@ -502,7 +506,7 @@ func TestSubmitMultisignedUsesCanonicalFieldParsingAfterAdmission(t *testing.T) 
 		params := json.RawMessage(`{"tx_json":{"TransactionType":3,"Account":"` + loadAdmissionAccount + `","Sequence":1,"Fee":"10","SigningPubKey":""}}`)
 		ctx := &types.RpcContext{
 			Context:  context.Background(),
-			Services: &types.ServiceContainer{Ledger: ledger},
+			Services: signingEnabledTestGraph(&types.ServiceContainer{Ledger: ledger}),
 		}
 
 		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
@@ -516,7 +520,7 @@ func TestSubmitMultisignedUsesCanonicalFieldParsingAfterAdmission(t *testing.T) 
 		params := json.RawMessage(`{"tx_json":{"TransactionType":"3","Account":"` + loadAdmissionAccount + `","Sequence":1,"Fee":"10","SigningPubKey":""}}`)
 		ctx := &types.RpcContext{
 			Context:  context.Background(),
-			Services: &types.ServiceContainer{Ledger: ledger},
+			Services: signingEnabledTestGraph(&types.ServiceContainer{Ledger: ledger}),
 		}
 
 		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
@@ -543,7 +547,7 @@ func TestSubmitMultisignedUsesCanonicalFieldParsingAfterAdmission(t *testing.T) 
 		}
 		ctx := &types.RpcContext{
 			Context:  context.Background(),
-			Services: &types.ServiceContainer{Ledger: ledger},
+			Services: signingEnabledTestGraph(&types.ServiceContainer{Ledger: ledger}),
 		}
 
 		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
@@ -557,7 +561,7 @@ func TestSubmitMultisignedUsesCanonicalFieldParsingAfterAdmission(t *testing.T) 
 		params := json.RawMessage(`{"tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Destination":"` + loadAdmissionSigner + `","Sequence":1,"Fee":"10","SigningPubKey":"","TxnSignature":""}}`)
 		ctx := &types.RpcContext{
 			Context:  context.Background(),
-			Services: &types.ServiceContainer{Ledger: ledger},
+			Services: signingEnabledTestGraph(&types.ServiceContainer{Ledger: ledger}),
 		}
 
 		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
@@ -584,7 +588,7 @@ func TestSubmitMultisignedUsesCanonicalFieldParsingAfterAdmission(t *testing.T) 
 		}
 		ctx := &types.RpcContext{
 			Context:  context.Background(),
-			Services: &types.ServiceContainer{Ledger: ledger},
+			Services: signingEnabledTestGraph(&types.ServiceContainer{Ledger: ledger}),
 		}
 
 		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
@@ -598,7 +602,7 @@ func TestSubmitMultisignedUsesCanonicalFieldParsingAfterAdmission(t *testing.T) 
 		params := json.RawMessage(`{"tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Sequence":1,"Fee":"1/USD/` + loadAdmissionSigner + `","SigningPubKey":"","TxnSignature":""}}`)
 		ctx := &types.RpcContext{
 			Context:  context.Background(),
-			Services: &types.ServiceContainer{Ledger: ledger},
+			Services: signingEnabledTestGraph(&types.ServiceContainer{Ledger: ledger}),
 		}
 
 		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
@@ -641,7 +645,7 @@ func TestSubmitMultisignedUsesCanonicalFieldParsingAfterAdmission(t *testing.T) 
 		}
 		ctx := &types.RpcContext{
 			Context:  context.Background(),
-			Services: &types.ServiceContainer{Ledger: &loadAdmissionLedger{}},
+			Services: signingEnabledTestGraph(&types.ServiceContainer{Ledger: &loadAdmissionLedger{}}),
 		}
 
 		result, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
@@ -686,7 +690,7 @@ func TestSubmitMultisignedUsesCanonicalFieldParsingAfterAdmission(t *testing.T) 
 		}
 		ctx := &types.RpcContext{
 			Context:  context.Background(),
-			Services: &types.ServiceContainer{Ledger: ledger},
+			Services: signingEnabledTestGraph(&types.ServiceContainer{Ledger: ledger}),
 		}
 
 		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
@@ -708,13 +712,13 @@ func TestSubmitWithoutCredentialsDoesNotConsultSigningLoad(t *testing.T) {
 			loadChecks := 0
 			ctx := &types.RpcContext{
 				Context: context.Background(),
-				Services: &types.ServiceContainer{
+				Services: signingEnabledTestGraph(&types.ServiceContainer{
 					Ledger: &loadAdmissionLedger{},
 					IsLoadedCluster: func() bool {
 						loadChecks++
 						return true
 					},
-				},
+				}),
 			}
 			_, rpcErr := (&SubmitMethod{}).Handle(ctx, test.params)
 			if rpcErr != nil && rpcErr.ErrorString == "tooBusy" {

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -62,7 +62,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		return nil, types.RpcErrorInvalidParams("Neither `tx_blob` nor `tx_json` included.")
 	}
 
-	if ctx.Services == nil || ctx.Services.Ledger == nil {
+	if ctx.Services == nil || ctx.Services.Ledger() == nil {
 		return nil, rpcInternalInvariantError("simulate: ledger service unavailable")
 	}
 
@@ -123,7 +123,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		// rippled's simulate autofill uses the default fee_mult_max /
 		// fee_div_max (getCurrentNetworkFee default arguments).
 		feeOpts := defaultFeeOptions()
-		fee, feeErr := ctx.Services.Ledger.GetAutofillFee(probe, ctx.Role.IsUnlimited(), feeOpts.Mult, feeOpts.Div)
+		fee, feeErr := ctx.Services.Ledger().GetAutofillFee(probe, ctx.Role.IsUnlimited(), feeOpts.Mult, feeOpts.Div)
 		if feeErr != nil {
 			var hfe *svcerr.HighFeeError
 			if errors.As(feeErr, &hfe) {
@@ -166,7 +166,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 			return nil, types.RpcErrorInvalidField("tx.Account")
 		}
 		_, hasTicket := txJsonMap["TicketSequence"]
-		seq, seqErr := ctx.Services.Ledger.GetAutofillSequence(accountStr, hasTicket)
+		seq, seqErr := ctx.Services.Ledger().GetAutofillSequence(accountStr, hasTicket)
 		if seqErr != nil {
 			switch {
 			case errors.Is(seqErr, svcerr.ErrAccountMalformed):
@@ -182,7 +182,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 
 	// 6. NetworkID — rippled Simulate.cpp:148-153.
 	if _, ok := txJsonMap["NetworkID"]; !ok {
-		serverInfo := ctx.Services.Ledger.GetServerInfo()
+		serverInfo := ctx.Services.Ledger().GetServerInfo()
 		if serverInfo.NetworkID > 1024 {
 			txJsonMap["NetworkID"] = serverInfo.NetworkID
 		}
@@ -231,7 +231,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		return nil, rpcInternalError("simulate: transaction marshaling failed", err)
 	}
 
-	result, err := ctx.Services.Ledger.SimulateTransaction(txJSON)
+	result, err := ctx.Services.Ledger().SimulateTransaction(txJSON)
 	if err != nil {
 		return nil, rpcInternalError("simulate: transaction simulation failed", err)
 	}

--- a/internal/rpc/handlers/stop.go
+++ b/internal/rpc/handlers/stop.go
@@ -12,12 +12,15 @@ import (
 type StopMethod struct{ adminHandler }
 
 func (m *StopMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
-	if ctx.Services == nil || ctx.Services.ShutdownFunc == nil {
+	if ctx == nil || ctx.Services == nil {
+		return nil, rpcInternalInvariantError("stop: shutdown function unavailable")
+	}
+	shutdown := ctx.Services.Shutdowner()
+	if shutdown == nil {
 		return nil, rpcInternalInvariantError("stop: shutdown function unavailable")
 	}
 
-	// Trigger shutdown asynchronously so the response can be sent first
-	ctx.Services.ShutdownFunc()
+	shutdown.RequestShutdown()
 
 	response := map[string]any{
 		"message": "ripple server stopping",

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -65,9 +65,9 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (re
 
 		signatureReason := ""
 		signatureChecked := false
-		checkSigs := ctx.Services == nil || ctx.Services.Ledger == nil || !ctx.Services.Ledger.IsStandalone()
-		if ctx.Services != nil && ctx.Services.Ledger != nil {
-			if rulesSource, ok := ctx.Services.Ledger.(types.TransactionRulesSource); ok {
+		checkSigs := ctx.Services == nil || ctx.Services.Ledger() == nil || !ctx.Services.Ledger().IsStandalone()
+		if ctx.Services != nil && ctx.Services.Ledger() != nil {
+			if rulesSource, ok := ctx.Services.Ledger().(types.TransactionRulesSource); ok {
 				signatureReason = sign.CheckSTTxSignature(parsed, rulesSource.TransactionRules(), checkSigs)
 				signatureChecked = true
 			}
@@ -144,7 +144,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (re
 	// When the client passed fail_hard:true and the ledger service
 	// implements the FailHardSubmitter surface, route through it so
 	// non-applying submissions are not held or relayed.
-	submitResult, submitErr := submitWithFailHard(ctx.Services.Ledger, txJSON, txBlobHex, failHard)
+	submitResult, submitErr := submitWithFailHard(ctx.Services.Ledger(), txJSON, txBlobHex, failHard)
 	if submitErr != nil {
 		return nil, rpcTransactionSubmissionError("submit: transaction submission failed", submitErr)
 	}

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -81,7 +81,7 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 	// existence, signer weights, and quorum are deliberately not checked
 	// here: rippled leaves them to the engine's checkMultiSign
 	// (tefNOT_MULTI_SIGNING / tefBAD_SIGNATURE / tefBAD_QUORUM).
-	if _, err := ctx.Services.Ledger.GetAccountInfo(ctx.Context, txAccount, "current"); err != nil {
+	if _, err := ctx.Services.Ledger().GetAccountInfo(ctx.Context, txAccount, "current"); err != nil {
 		if errors.Is(err, svcerr.ErrAccountNotFound) {
 			return nil, types.RpcErrorSrcActNotFound("Source account not found.")
 		}
@@ -167,7 +167,7 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 	// Route fail_hard submissions through the optional surface so they
 	// are not held or relayed on non-apply. Mirrors rippled
 	// NetworkOPs.cpp:1685-1689 (`!enforceFailHard`).
-	result, submitErr := submitWithFailHard(ctx.Services.Ledger, txJSON, txBlob, request.FailHard)
+	result, submitErr := submitWithFailHard(ctx.Services.Ledger(), txJSON, txBlob, request.FailHard)
 	if submitErr != nil {
 		return nil, rpcTransactionSubmissionError("submit_multisigned: transaction submission failed", submitErr)
 	}

--- a/internal/rpc/handlers/subscribe.go
+++ b/internal/rpc/handlers/subscribe.go
@@ -33,10 +33,10 @@ func urlSubscriptionRequest(ctx *types.RpcContext, params json.RawMessage, metho
 	if ctx.Role != types.RoleAdmin {
 		return request, nil, types.RpcErrorNoPermission(method)
 	}
-	if ctx.Services == nil || ctx.Services.URLSubscriptions == nil {
+	if ctx == nil || ctx.URLSubscriptions == nil {
 		return request, nil, types.RpcErrorNotSupported("url-based (RPCSub) subscriptions are not supported")
 	}
-	return request, ctx.Services.URLSubscriptions, nil
+	return request, ctx.URLSubscriptions, nil
 }
 
 func (m *SubscribeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {

--- a/internal/rpc/handlers/transaction_entry.go
+++ b/internal/rpc/handlers/transaction_entry.go
@@ -90,7 +90,7 @@ func (m *TransactionEntryMethod) Handle(ctx *types.RpcContext, params json.RawMe
 			}
 		}
 	} else {
-		txInfo, lookupErr = ctx.Services.Ledger.GetTransaction(txHash)
+		txInfo, lookupErr = ctx.Services.Ledger().GetTransaction(txHash)
 	}
 	if lookupErr != nil || txInfo == nil {
 		return nil, types.RpcErrorTransactionNotFound("Transaction not found.").WithExtra(lookupExtra)

--- a/internal/rpc/handlers/transaction_preprocess_test.go
+++ b/internal/rpc/handlers/transaction_preprocess_test.go
@@ -185,7 +185,7 @@ func TestCheckPaymentMPTGatePrecedesLaterValidation(t *testing.T) {
 		"Paths":    []any{},
 		"DomainID": "00",
 	}
-	ctx := &types.RpcContext{Services: &types.ServiceContainer{Ledger: ledger}}
+	ctx := &types.RpcContext{Services: types.NewTestServiceGraph(&types.ServiceContainer{Ledger: ledger})}
 	rpcErr := checkPayment(txMap, json.RawMessage(`{"build_path":true}`), true, ctx)
 	if rpcErr == nil || rpcErr.Message != "Field 'build_path' not allowed in this context." {
 		t.Fatalf("error = %#v", rpcErr)
@@ -277,7 +277,7 @@ func TestSubmitMultisignedRejectsMalformedSignerBeforeBinaryEncoding(t *testing.
 	}
 	ctx := &types.RpcContext{
 		Context:  context.Background(),
-		Services: &types.ServiceContainer{Ledger: &loadAdmissionLedger{}},
+		Services: types.NewTestServiceGraph(&types.ServiceContainer{Ledger: &loadAdmissionLedger{}}),
 	}
 	_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
 	if rpcErr == nil || rpcErr.Message != "Signers array may only contain Signer entries." {

--- a/internal/rpc/handlers/tx.go
+++ b/internal/rpc/handlers/tx.go
@@ -67,7 +67,7 @@ func (m *TxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *
 		if err != nil {
 			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 		}
-		if nodeNet := ctx.Services.Ledger.GetServerInfo().NetworkID; uint32(ctidNetworkID) != nodeNet {
+		if nodeNet := ctx.Services.Ledger().GetServerInfo().NetworkID; uint32(ctidNetworkID) != nodeNet {
 			return nil, types.RpcErrorWrongNetwork(fmt.Sprintf(
 				"Wrong network. You should submit this request to a node running on NetworkID: %d", ctidNetworkID))
 		}
@@ -108,13 +108,13 @@ func (m *TxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *
 	var searched types.TxSearchResult
 	var err error
 	if hasLedgerRange {
-		if ranged, ok := ctx.Services.Ledger.(types.RangedTransactionLookup); ok {
+		if ranged, ok := ctx.Services.Ledger().(types.RangedTransactionLookup); ok {
 			txInfo, searched, err = ranged.GetTransactionWithRange(ctx.Context, txHash, rangeMin, rangeMax)
 		} else {
-			txInfo, err = ctx.Services.Ledger.GetTransaction(txHash)
+			txInfo, err = ctx.Services.Ledger().GetTransaction(txHash)
 		}
 	} else {
-		txInfo, err = ctx.Services.Ledger.GetTransaction(txHash)
+		txInfo, err = ctx.Services.Ledger().GetTransaction(txHash)
 	}
 	if err != nil && !errors.Is(err, svcerr.ErrTxnNotFound) {
 		if errors.Is(err, svcerr.ErrTxnDataCorrupt) {
@@ -137,7 +137,7 @@ func (m *TxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *
 	// Resolve close time from the containing ledger
 	closeTimeSec := txInfo.CloseTime
 	if closeTimeSec == 0 && txInfo.LedgerIndex > 0 {
-		if ledger, err := ctx.Services.Ledger.GetLedgerBySequence(txInfo.LedgerIndex); err == nil {
+		if ledger, err := ctx.Services.Ledger().GetLedgerBySequence(txInfo.LedgerIndex); err == nil {
 			closeTimeSec = ledger.CloseTime()
 		}
 	}
@@ -191,7 +191,7 @@ func (m *TxMethod) buildResponse(
 	closeTimeSec int64,
 	binary bool,
 ) map[string]any {
-	networkID := ctx.Services.Ledger.GetServerInfo().NetworkID
+	networkID := ctx.Services.Ledger().GetServerInfo().NetworkID
 	if ctx.ApiVersion > 1 {
 		return m.buildResponseV2(storedTx, txInfo, hashStr, closeTimeSec, binary, networkID)
 	}
@@ -320,7 +320,7 @@ func (m *TxMethod) buildResponseV2(
 
 // lookupByCTID looks up a transaction using a CTID (Compact Transaction ID)
 func (m *TxMethod) lookupByCTID(ctx *types.RpcContext, ledgerSeq uint32, txIndex uint16, binary bool) (any, *types.RpcError) {
-	ledger, err := ctx.Services.Ledger.GetLedgerBySequence(ledgerSeq)
+	ledger, err := ctx.Services.Ledger().GetLedgerBySequence(ledgerSeq)
 	if err != nil {
 		return nil, types.RpcErrorTxnNotFound("Transaction not found.")
 	}
@@ -377,7 +377,7 @@ func (m *TxMethod) ctidResponse(
 		TxIndex:     uint32(txIndex),
 	}
 
-	networkID := uint16(ctx.Services.Ledger.GetServerInfo().NetworkID)
+	networkID := uint16(ctx.Services.Ledger().GetServerInfo().NetworkID)
 	response := m.buildResponse(ctx, storedTx, txInfo, hashStr, closeTimeSec, binary)
 
 	if binary {

--- a/internal/rpc/handlers/tx_history.go
+++ b/internal/rpc/handlers/tx_history.go
@@ -29,7 +29,7 @@ func (m *TxHistoryMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		return nil, err
 	}
 
-	result, err := ctx.Services.Ledger.GetTransactionHistory(ctx.Context, request.Start)
+	result, err := ctx.Services.Ledger().GetTransactionHistory(ctx.Context, request.Start)
 	if err != nil {
 		if errors.Is(err, svcerr.ErrTxHistoryUnavailable) {
 			return nil, types.RpcErrorNotEnabled("")

--- a/internal/rpc/handlers/validator_info.go
+++ b/internal/rpc/handlers/validator_info.go
@@ -29,11 +29,11 @@ type validatorInfoResponse struct {
 }
 
 func (m *ValidatorInfoMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (any, *types.RpcError) {
-	if ctx.Services == nil || len(ctx.Services.ValidatorPublicKey) == 0 {
+	if ctx.Services == nil || len(ctx.Services.ValidatorPublicKey()) == 0 {
 		return nil, types.RpcErrorInvalidParams("not a validator")
 	}
 
-	validationPK := ctx.Services.ValidatorPublicKey
+	validationPK := ctx.Services.ValidatorPublicKey()
 	if len(validationPK) != 33 {
 		return nil, rpcInternalInvariantError("validator_info: validator public key has invalid length")
 	}
@@ -42,8 +42,8 @@ func (m *ValidatorInfoMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (
 	copy(keyArr[:], validationPK)
 
 	masterKey := keyArr
-	if ctx.Services.Manifests != nil {
-		masterKey = ctx.Services.Manifests.GetMasterKey(keyArr)
+	if ctx.Services.Manifests() != nil {
+		masterKey = ctx.Services.Manifests().GetMasterKey(keyArr)
 	}
 
 	masterB58, err := addresscodec.EncodeNodePublicKey(masterKey[:])
@@ -64,14 +64,14 @@ func (m *ValidatorInfoMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (
 		}
 		resp.EphemeralKey = ephB58
 
-		if manifestBytes, ok := ctx.Services.Manifests.GetManifest(masterKey); ok {
+		if manifestBytes, ok := ctx.Services.Manifests().GetManifest(masterKey); ok {
 			resp.Manifest = base64.StdEncoding.EncodeToString(manifestBytes)
 		}
-		if seq, ok := ctx.Services.Manifests.GetSequence(masterKey); ok {
+		if seq, ok := ctx.Services.Manifests().GetSequence(masterKey); ok {
 			s := seq
 			resp.Seq = &s
 		}
-		if domain, ok := ctx.Services.Manifests.GetDomain(masterKey); ok {
+		if domain, ok := ctx.Services.Manifests().GetDomain(masterKey); ok {
 			resp.Domain = domain
 		}
 	}

--- a/internal/rpc/handlers/validator_info_test.go
+++ b/internal/rpc/handlers/validator_info_test.go
@@ -60,14 +60,14 @@ func makeValidatorPubKey(prefix byte) []byte {
 	return pk
 }
 
-func installServices(pk []byte, manifests types.ManifestLookup) *types.ServiceContainer {
-	return &types.ServiceContainer{
+func installServices(pk []byte, manifests types.ManifestLookup) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{
 		ValidatorPublicKey: pk,
 		Manifests:          manifests,
-	}
+	})
 }
 
-func adminCtx(services *types.ServiceContainer) *types.RpcContext {
+func adminCtx(services *types.ServiceGraph) *types.RpcContext {
 	return &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,

--- a/internal/rpc/handlers/validators.go
+++ b/internal/rpc/handlers/validators.go
@@ -30,7 +30,7 @@ import (
 type ValidatorsMethod struct{ adminHandler }
 
 func (m *ValidatorsMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (any, *types.RpcError) {
-	var services *types.ServiceContainer
+	var services *types.ServiceGraph
 	if ctx != nil {
 		services = ctx.Services
 	}
@@ -41,7 +41,7 @@ func (m *ValidatorsMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (any
 	negativeUNL := []string{}
 
 	if ctx != nil && ctx.Services != nil {
-		if vl := ctx.Services.ValidatorList; vl != nil {
+		if vl := ctx.Services.ValidatorList(); vl != nil {
 			for _, p := range listSnapshot.publishers {
 				entry := map[string]any{
 					"pubkey_publisher": p.PublicKeyHex,
@@ -99,28 +99,28 @@ func (m *ValidatorsMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (any
 				publisherLists = append(publisherLists, entry)
 			}
 		}
-		if fn := ctx.Services.TrustedValidatorKeysBase58; fn != nil {
+		if fn := ctx.Services.TrustedValidatorKeysBase58(); fn != nil {
 			trustedKeys = nonNilStrings(fn())
-		} else if vl := ctx.Services.ValidatorList; vl != nil {
+		} else if vl := ctx.Services.ValidatorList(); vl != nil {
 			for _, mk := range vl.TrustedMasterKeys() {
 				if enc, err := addresscodec.EncodeNodePublicKey(mk[:]); err == nil {
 					trustedKeys = append(trustedKeys, enc)
 				}
 			}
 		}
-		if fn := ctx.Services.SigningKeysBase58; fn != nil {
+		if fn := ctx.Services.SigningKeysBase58(); fn != nil {
 			for master, signing := range fn() {
 				signingKeys[master] = signing
 			}
 		}
-		if fn := ctx.Services.NegativeUNLBase58; fn != nil {
+		if fn := ctx.Services.NegativeUNLBase58(); fn != nil {
 			negativeUNL = nonNilStrings(fn())
 		}
 	}
 
 	quorum := 0
-	if ctx != nil && ctx.Services != nil && ctx.Services.ValidationQuorum != nil {
-		quorum = ctx.Services.ValidationQuorum()
+	if ctx != nil && ctx.Services != nil && ctx.Services.ValidationQuorum() != nil {
+		quorum = ctx.Services.ValidationQuorum()()
 	}
 	quorumRPC := validationQuorumForRPC(quorum)
 
@@ -149,21 +149,21 @@ type validatorListSnapshot struct {
 	expires     uint32
 }
 
-func resolveValidatorListSnapshot(services *types.ServiceContainer, now time.Time) validatorListSnapshot {
+func resolveValidatorListSnapshot(services *types.ServiceGraph, now time.Time) validatorListSnapshot {
 	snapshot := validatorListSnapshot{localStatic: []string{}}
 	if services == nil {
 		snapshot.summary = map[string]any{"count": 0, "status": "unknown", "expiration": "unknown"}
 		return snapshot
 	}
-	if services.LocalStaticTrustedKeysBase58 != nil {
-		snapshot.localStatic = nonNilStrings(services.LocalStaticTrustedKeysBase58())
+	if services.LocalStaticTrustedKeysBase58() != nil {
+		snapshot.localStatic = nonNilStrings(services.LocalStaticTrustedKeysBase58()())
 	}
 
 	publisherCount := 0
-	if services.ValidatorList != nil {
-		publisherCount = services.ValidatorList.PublisherCount()
-		snapshot.threshold = services.ValidatorList.Threshold()
-		snapshot.publishers = services.ValidatorList.Publishers()
+	if services.ValidatorList() != nil {
+		publisherCount = services.ValidatorList().PublisherCount()
+		snapshot.threshold = services.ValidatorList().Threshold()
+		snapshot.publishers = services.ValidatorList().Publishers()
 	}
 
 	listCount := publisherCount
@@ -223,8 +223,8 @@ type validatorListSitesMethod struct{ adminHandler }
 func (m *validatorListSitesMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (any, *types.RpcError) {
 	sites := []map[string]any{}
 
-	if ctx != nil && ctx.Services != nil && ctx.Services.ValidatorList != nil {
-		for _, s := range ctx.Services.ValidatorList.Sites() {
+	if ctx != nil && ctx.Services != nil && ctx.Services.ValidatorList() != nil {
+		for _, s := range ctx.Services.ValidatorList().Sites() {
 			entry := map[string]any{
 				"uri":                  s.URI,
 				"refresh_interval_min": s.RefreshIntervalMin,

--- a/internal/rpc/handlers/vault_info.go
+++ b/internal/rpc/handlers/vault_info.go
@@ -36,7 +36,7 @@ func (m *VaultInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		return nil, parseErr.WithExtra(response)
 	}
 
-	vaultEntry, err := ctx.Services.Ledger.GetLedgerEntry(ctx.Context, vaultKey, ledgerIndex)
+	vaultEntry, err := ctx.Services.Ledger().GetLedgerEntry(ctx.Context, vaultKey, ledgerIndex)
 	if err != nil || vaultEntry == nil {
 		if rerr := mapLedgerLookupErr(err); rerr != nil {
 			return nil, rerr.WithExtra(response)
@@ -58,7 +58,7 @@ func (m *VaultInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 	copy(shareMPTID[:], shareMPTIDBytes)
 	mptIssuanceKey := keylet.MPTIssuance(shareMPTID).Key
 
-	mptIssuanceEntry, mptErr := ctx.Services.Ledger.GetLedgerEntry(ctx.Context, mptIssuanceKey, ledgerIndex)
+	mptIssuanceEntry, mptErr := ctx.Services.Ledger().GetLedgerEntry(ctx.Context, mptIssuanceKey, ledgerIndex)
 	if mptErr != nil || mptIssuanceEntry == nil {
 		if rerr := mapLedgerLookupErr(mptErr); rerr != nil {
 			return nil, rerr.WithExtra(response)

--- a/internal/rpc/handlers/version.go
+++ b/internal/rpc/handlers/version.go
@@ -33,7 +33,7 @@ func (m *VersionMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 		}
 	} else {
 		last := types.MaxSupportedApiVersion
-		if ctx.Services != nil && ctx.Services.BetaRPCAPI {
+		if ctx.Services != nil && ctx.Services.BetaRPCAPI() {
 			last = types.BetaApiVersion
 		}
 		version = map[string]any{

--- a/internal/rpc/hex_case_test.go
+++ b/internal/rpc/hex_case_test.go
@@ -37,7 +37,7 @@ func TestRPCHexCaseRegression(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: mock},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -71,7 +71,7 @@ func TestRPCHexCaseRegression(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: mock},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 		}
 
 		params, err := json.Marshal(map[string]any{"account": validAccount})

--- a/internal/rpc/json_proxy_regression_test.go
+++ b/internal/rpc/json_proxy_regression_test.go
@@ -17,10 +17,11 @@ import (
 func TestJSONProxyUsesSingleDispatchAccounting(t *testing.T) {
 	services := types.NewServiceContainer(nil)
 	services.ClientLoad = types.NewClientLoadShedder()
+	graph := types.NewTestServiceGraph(services)
 	var targetCalls int
 	server := NewServer(ServerOptions{
 		Timeout:  time.Second,
-		Services: services,
+		Services: graph,
 		Registry: mustTestMethodRegistryWithOverrides(t, map[string]types.MethodHandler{
 			"json_proxy_target": &stubHandler{
 				handle: func(ctx *types.RpcContext, _ json.RawMessage) (any, *types.RpcError) {
@@ -32,8 +33,6 @@ func TestJSONProxyUsesSingleDispatchAccounting(t *testing.T) {
 			},
 		}),
 	})
-	services.Dispatcher = server
-
 	leases := make([]func(), 0, types.MaxJobQueueClients-1)
 	for range types.MaxJobQueueClients - 1 {
 		leases = append(leases, services.ClientLoad.Begin())
@@ -119,9 +118,10 @@ func TestHTTPStructuredIDRedactionAcrossDispatchShapes(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			services := types.NewServiceContainer(nil)
+			graph := types.NewTestServiceGraph(services)
 			server := NewServer(ServerOptions{
 				Timeout:  time.Second,
-				Services: services,
+				Services: graph,
 				Registry: mustTestMethodRegistryWithOverrides(t, map[string]types.MethodHandler{
 					"capture": &stubHandler{
 						handle: func(_ *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
@@ -133,8 +133,6 @@ func TestHTTPStructuredIDRedactionAcrossDispatchShapes(t *testing.T) {
 					},
 				}),
 			})
-			services.Dispatcher = server
-
 			response := postTransportRegressionRequest(t, server, test.body)
 			require.Equal(t, http.StatusOK, response.Code)
 			for _, secret := range test.secrets {
@@ -160,7 +158,7 @@ func TestURLUserinfoIsRedactedAcrossTransportEchoes(t *testing.T) {
 	}
 	httpServer := NewServer(ServerOptions{
 		Timeout:  time.Second,
-		Services: types.NewServiceContainer(nil),
+		Services: types.NewTestServiceGraph(types.NewServiceContainer(nil)),
 		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
 			"userinfo_fail": fail,
 		}),

--- a/internal/rpc/ledger_closed_test.go
+++ b/internal/rpc/ledger_closed_test.go
@@ -54,7 +54,7 @@ func TestLedgerClosedBasicSuccess(t *testing.T) {
 		return nil, errors.New("not found")
 	}
 
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerClosedMethod{}
 	ctx := &types.RpcContext{
@@ -113,7 +113,7 @@ func TestLedgerClosedHashFormat(t *testing.T) {
 		return nil, errors.New("not found")
 	}
 
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerClosedMethod{}
 	ctx := &types.RpcContext{
@@ -171,7 +171,7 @@ func TestLedgerClosedServiceUnavailable(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: nil},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: nil}),
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -191,7 +191,7 @@ func TestLedgerClosedServiceUnavailable(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: mock},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -211,7 +211,7 @@ func TestLedgerClosedServiceUnavailable(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: mock},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)

--- a/internal/rpc/ledger_data_test.go
+++ b/internal/rpc/ledger_data_test.go
@@ -77,7 +77,7 @@ func TestLedgerDataCurrentResponseFields(t *testing.T) {
 	}
 	ctx := &types.RpcContext{
 		Context:  context.Background(),
-		Services: &types.ServiceContainer{Ledger: mock},
+		Services: types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 	}
 
 	result, rpcErr := (&handlers.LedgerDataMethod{}).Handle(ctx, json.RawMessage(`{"ledger_index":"current"}`))
@@ -103,7 +103,7 @@ func TestLedgerDataLimitClamping(t *testing.T) {
 		return result, nil
 	}
 
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerDataMethod{}
 	ctx := &types.RpcContext{
@@ -298,7 +298,7 @@ func TestLedgerDataBinaryMode(t *testing.T) {
 		return newDefaultLedgerDataResult(3, false), nil
 	}
 
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerDataMethod{}
 	ctx := &types.RpcContext{
@@ -382,7 +382,7 @@ func TestLedgerDataTypeFilter(t *testing.T) {
 		return result, nil
 	}
 
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerDataMethod{}
 	ctx := &types.RpcContext{
@@ -449,7 +449,7 @@ func TestLedgerDataMarkerPagination(t *testing.T) {
 		return newDefaultLedgerDataResult(3, false), nil
 	}
 
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerDataMethod{}
 	ctx := &types.RpcContext{
@@ -537,7 +537,7 @@ func TestLedgerDataResponseStructure(t *testing.T) {
 		}, nil
 	}
 
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerDataMethod{}
 	ctx := &types.RpcContext{
@@ -615,7 +615,7 @@ func TestLedgerDataServiceUnavailable(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: nil},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: nil}),
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -636,7 +636,7 @@ func TestLedgerDataServiceUnavailable(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: mock},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 		}
 
 		params := map[string]any{
@@ -707,7 +707,7 @@ func TestLedgerDataLedgerHeader(t *testing.T) {
 		return result, nil
 	}
 
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerDataMethod{}
 	ctx := &types.RpcContext{
@@ -791,7 +791,7 @@ func TestLedgerDataEmptyState(t *testing.T) {
 		return newDefaultLedgerDataResult(0, false), nil
 	}
 
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerDataMethod{}
 	ctx := &types.RpcContext{
@@ -831,7 +831,7 @@ func TestLedgerDataMarkerValidation(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: mock},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 		}
 		params := map[string]any{"ledger_index": "current", "marker": "not-a-valid-hash"}
 		paramsJSON, _ := json.Marshal(params)
@@ -854,7 +854,7 @@ func TestLedgerDataMarkerValidation(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: mock},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 		}
 		params := map[string]any{"ledger_index": "current", "marker": 12345}
 		paramsJSON, _ := json.Marshal(params)
@@ -880,7 +880,7 @@ func TestLedgerDataMarkerValidation(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: mock},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 		}
 		params := map[string]any{"ledger_index": "current", "marker": nil}
 		paramsJSON, _ := json.Marshal(params)
@@ -906,7 +906,7 @@ func TestLedgerDataMarkerValidation(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: mock},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 		}
 		params := map[string]any{"ledger_index": "current", "marker": ""}
 		paramsJSON, _ := json.Marshal(params)
@@ -936,7 +936,7 @@ func TestLedgerDataMarkerValidation(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: mock},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 		}
 		params := map[string]any{"ledger_index": "current", "marker": "0"}
 		paramsJSON, _ := json.Marshal(params)

--- a/internal/rpc/ledger_entry_test.go
+++ b/internal/rpc/ledger_entry_test.go
@@ -85,10 +85,10 @@ func (m *mockLedgerEntryService) GetLedgerByHash(hash [32]byte) (types.LedgerRea
 }
 
 // newLedgerEntryTestServices builds a per-test ServiceContainer wrapping mock.
-func newLedgerEntryTestServices(mock *mockLedgerEntryService) *types.ServiceContainer {
-	return &types.ServiceContainer{
+func newLedgerEntryTestServices(mock *mockLedgerEntryService) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{
 		Ledger: mock,
-	}
+	})
 }
 
 // Direct Index Lookup Tests
@@ -1034,7 +1034,7 @@ func TestLedgerEntryServiceUnavailable(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: nil},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: nil}),
 		}
 
 		params := map[string]any{

--- a/internal/rpc/ledger_extensions_test.go
+++ b/internal/rpc/ledger_extensions_test.go
@@ -29,7 +29,7 @@ func TestLedgerAcceptDoesNotExposeCloseTimeControl(t *testing.T) {
 	ledger := &ledgerExtensionsMock{mockLedgerService: newMockLedgerService()}
 	ctx := &types.RpcContext{
 		Context:  context.Background(),
-		Services: &types.ServiceContainer{Ledger: ledger},
+		Services: types.NewTestServiceGraph(&types.ServiceContainer{Ledger: ledger}),
 	}
 
 	result, rpcErr := (&handlers.LedgerAcceptMethod{}).Handle(ctx, json.RawMessage(`{"close_time":1}`))
@@ -54,7 +54,7 @@ func TestLedgerRangeSortsLedgersBySequence(t *testing.T) {
 	}
 	ctx := &types.RpcContext{
 		Context:  context.Background(),
-		Services: &types.ServiceContainer{Ledger: ledger},
+		Services: types.NewTestServiceGraph(&types.ServiceContainer{Ledger: ledger}),
 	}
 
 	for range 20 {

--- a/internal/rpc/ledger_header_test.go
+++ b/internal/rpc/ledger_header_test.go
@@ -47,7 +47,7 @@ func TestLedgerHeaderBasicRequest(t *testing.T) {
 		}
 		return nil, errors.New("ledger not found")
 	}
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerHeaderMethod{}
 	ctx := &types.RpcContext{
@@ -226,7 +226,7 @@ func TestLedgerHeaderBinaryFormat(t *testing.T) {
 	mock.getLedgerBySequenceFn = func(seq uint32) (types.LedgerReader, error) {
 		return reader, nil
 	}
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerHeaderMethod{}
 	ctx := &types.RpcContext{
@@ -310,7 +310,7 @@ func TestLedgerHeaderHashFormat(t *testing.T) {
 	mock.getLedgerBySequenceFn = func(seq uint32) (types.LedgerReader, error) {
 		return reader, nil
 	}
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerHeaderMethod{}
 	ctx := &types.RpcContext{
@@ -353,7 +353,7 @@ func TestLedgerHeaderBadInput(t *testing.T) {
 		}
 		return nil, errors.New("ledger not found")
 	}
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerHeaderMethod{}
 	ctx := &types.RpcContext{
@@ -419,7 +419,7 @@ func TestLedgerHeaderOpenLedger(t *testing.T) {
 		}
 		return nil, errors.New("not found")
 	}
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerHeaderMethod{}
 	ctx := &types.RpcContext{
@@ -466,7 +466,7 @@ func TestLedgerHeaderProductionOpenRootsAndFlags(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: rpcadapter.NewLedgerServiceAdapter(svc)},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: rpcadapter.NewLedgerServiceAdapter(svc)}),
 	}
 	result, rpcErr := (&handlers.LedgerHeaderMethod{}).Handle(ctx, json.RawMessage(`{"ledger_index":"current"}`))
 	require.Nil(t, rpcErr)
@@ -502,7 +502,7 @@ func TestLedgerHeaderCloseTimeEstimated(t *testing.T) {
 	mock.getLedgerBySequenceFn = func(seq uint32) (types.LedgerReader, error) {
 		return reader, nil
 	}
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerHeaderMethod{}
 	ctx := &types.RpcContext{
@@ -564,7 +564,7 @@ func TestLedgerHeaderServiceUnavailable(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: nil},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: nil}),
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)

--- a/internal/rpc/ledger_owner_funds_test.go
+++ b/internal/rpc/ledger_owner_funds_test.go
@@ -134,7 +134,7 @@ func TestLedgerOwnerFunds(t *testing.T) {
 	mock := &ownerFundsLedgerMock{ledgerMock: base, view: view, reader: reader}
 	services := &types.ServiceContainer{Ledger: mock}
 
-	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1, Services: services}
+	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1, Services: types.NewTestServiceGraph(services)}
 	method := &handlers.LedgerMethod{}
 	for _, tc := range []struct {
 		apiVersion int
@@ -204,6 +204,7 @@ func TestLedgerOwnerFunds(t *testing.T) {
 	services.QueueAllTxs = func() []types.QueuedTxInfo {
 		return []types.QueuedTxInfo{{Account: accountID, TxID: [32]byte{0x02}, TxJSON: offerCreate}}
 	}
+	ctx.Services = types.NewTestServiceGraph(services)
 	reader.closed = false
 	base.currentLedgerIndex = 2
 	for _, tc := range []struct {
@@ -312,7 +313,7 @@ func TestLedgerOwnerFundsUsesTargetLedgerReservesIncludingZero(t *testing.T) {
 	}
 
 	services := &types.ServiceContainer{Ledger: &ownerFundsLedgerMock{ledgerMock: base, view: view, reader: reader}}
-	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1, Services: services}
+	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1, Services: types.NewTestServiceGraph(services)}
 	paramsJSON, err := json.Marshal(map[string]any{
 		"ledger_index": 2,
 		"transactions": true,
@@ -533,7 +534,7 @@ func TestTransactionOwnerFundsMPT(t *testing.T) {
 	result, rpcErr := (&handlers.LedgerMethod{}).Handle(&types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
-		Services:   services,
+		Services:   types.NewTestServiceGraph(services),
 	}, paramsJSON)
 	require.Nil(t, rpcErr)
 	txns := resultToMap(t, result)["ledger"].(map[string]any)["transactions"].([]any)
@@ -558,7 +559,7 @@ func TestTransactionOwnerFundsMPT(t *testing.T) {
 	result, rpcErr = (&handlers.LedgerMethod{}).Handle(&types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
-		Services:   services,
+		Services:   types.NewTestServiceGraph(services),
 	}, queueParams)
 	require.Nil(t, result)
 	require.NotNil(t, rpcErr)

--- a/internal/rpc/ledger_request_test.go
+++ b/internal/rpc/ledger_request_test.go
@@ -49,7 +49,7 @@ func TestLedgerRequest_ServesLocalLedgerByHash(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: mock},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 	}
 
 	result, rpcErr := (&handlers.LedgerRequestMethod{}).Handle(ctx,
@@ -80,7 +80,7 @@ func TestLedgerRequest_ServesLocalLedgerByIndex(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: mock},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 	}
 
 	result, rpcErr := (&handlers.LedgerRequestMethod{}).Handle(ctx,
@@ -117,13 +117,13 @@ func TestLedgerRequest_AcquiringTargetReturnsBareSnapshot(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
-		Services: &types.ServiceContainer{
+		Services: types.NewTestServiceGraph(&types.ServiceContainer{
 			Ledger: mock,
 			RequestLedger: func(h [32]byte, seq uint32) (map[string]any, bool, bool) {
 				gotHash = h
 				return acquiring, true, false
 			},
-		},
+		}),
 	}
 
 	result, rpcErr := (&handlers.LedgerRequestMethod{}).Handle(ctx,
@@ -157,12 +157,12 @@ func TestLedgerRequest_AcquiringReferenceReturnsLgrNotFound(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
-		Services: &types.ServiceContainer{
+		Services: types.NewTestServiceGraph(&types.ServiceContainer{
 			Ledger: mock,
 			RequestLedger: func(h [32]byte, seq uint32) (map[string]any, bool, bool) {
 				return acquiring, true, true
 			},
-		},
+		}),
 	}
 
 	result, rpcErr := (&handlers.LedgerRequestMethod{}).Handle(ctx,
@@ -185,7 +185,7 @@ func TestLedgerRequest_NotFoundWithoutSubsystem(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: mock}, // RequestLedger nil
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}), // RequestLedger nil
 	}
 
 	result, rpcErr := (&handlers.LedgerRequestMethod{}).Handle(ctx,

--- a/internal/rpc/ledger_test.go
+++ b/internal/rpc/ledger_test.go
@@ -176,7 +176,7 @@ func TestLedgerBasicRequest(t *testing.T) {
 	mock.getLedgerDataFn = func(string, uint32, string) (*types.LedgerDataResult, error) {
 		return &types.LedgerDataResult{}, nil
 	}
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerMethod{}
 	ctx := &types.RpcContext{
@@ -392,7 +392,7 @@ func TestLedgerBadInput(t *testing.T) {
 		}
 		return nil, errors.New("ledger not found")
 	}
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerMethod{}
 	ctx := &types.RpcContext{
@@ -448,7 +448,7 @@ func TestLedgerCurrentRequest(t *testing.T) {
 		}
 		return nil, errors.New("not found")
 	}
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerMethod{}
 	ctx := &types.RpcContext{
@@ -517,7 +517,7 @@ func TestLedgerFullOption(t *testing.T) {
 		}
 		return nil, errors.New("not found")
 	}
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerMethod{}
 	ctx := &types.RpcContext{
@@ -606,7 +606,7 @@ func TestLedgerExpandedTransactionsStopAtMalformedLeaf(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: mock},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 	}
 
 	result, rpcErr := (&handlers.LedgerMethod{}).Handle(ctx, json.RawMessage(`{"ledger_index":2,"transactions":true,"expand":true}`))
@@ -677,7 +677,7 @@ func TestLedgerExpandedDeliveredAmountHistoricalCloseTime(t *testing.T) {
 					Context:    context.Background(),
 					Role:       types.RoleGuest,
 					ApiVersion: apiVersion,
-					Services:   &types.ServiceContainer{Ledger: mock},
+					Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 				}
 				params := json.RawMessage(`{"ledger_index":4594094,"transactions":true,"expand":true}`)
 
@@ -723,7 +723,7 @@ func TestLedgerAccountsOption(t *testing.T) {
 			},
 		}, nil
 	}
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerMethod{}
 
@@ -829,7 +829,7 @@ func TestLedgerQueueRequiresOpenSelector(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: mock},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 	}
 	method := &handlers.LedgerMethod{}
 
@@ -862,7 +862,7 @@ func TestLedgerLookupByHash(t *testing.T) {
 		}
 		return nil, svcerr.ErrLedgerNotFound
 	}
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerMethod{}
 	ctx := &types.RpcContext{
@@ -954,7 +954,7 @@ func TestLedgerResponseStructure(t *testing.T) {
 		}
 		return nil, errors.New("not found")
 	}
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerMethod{}
 	ctx := &types.RpcContext{
@@ -1021,7 +1021,7 @@ func TestLedgerServiceUnavailable(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: nil},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: nil}),
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -1040,7 +1040,7 @@ func TestLedgerNilLedgerReturned(t *testing.T) {
 	mock.getLedgerBySequenceFn = func(seq uint32) (types.LedgerReader, error) {
 		return nil, errors.New("not found")
 	}
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerMethod{}
 	ctx := &types.RpcContext{
@@ -1092,7 +1092,7 @@ func TestLedgerLookupByIndex(t *testing.T) {
 		}
 		return nil, errors.New("not found")
 	}
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.LedgerMethod{}
 	ctx := &types.RpcContext{

--- a/internal/rpc/load_shed_http_test.go
+++ b/internal/rpc/load_shed_http_test.go
@@ -14,7 +14,8 @@ import (
 
 func TestNewServerLeavesServiceContainerUntouched(t *testing.T) {
 	services := types.NewServiceContainer(nil)
-	_ = NewServer(ServerOptions{Timeout: time.Second, Services: services})
+	graph := types.NewTestServiceGraph(services)
+	_ = NewServer(ServerOptions{Timeout: time.Second, Services: graph})
 
 	if services.ClientLoad != nil {
 		t.Fatal("NewServer mutated services.ClientLoad")
@@ -24,9 +25,10 @@ func TestNewServerLeavesServiceContainerUntouched(t *testing.T) {
 func TestRpcTooBusyUsesLegacyHTTP200(t *testing.T) {
 	services := types.NewServiceContainer(nil)
 	services.ClientLoad = types.NewClientLoadShedder()
+	graph := types.NewTestServiceGraph(services)
 	srv := NewServer(ServerOptions{
 		Timeout:  time.Second,
-		Services: services,
+		Services: graph,
 		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
 			"book_offers": &handlers.BookOffersMethod{},
 		}),
@@ -72,9 +74,10 @@ func TestRpcTooBusyUsesLegacyHTTP200(t *testing.T) {
 func TestRequestUnderThresholdReturnsHTTP200(t *testing.T) {
 	services := types.NewServiceContainer(nil)
 	services.ClientLoad = types.NewClientLoadShedder()
+	graph := types.NewTestServiceGraph(services)
 	srv := NewServer(ServerOptions{
 		Timeout:  time.Second,
-		Services: services,
+		Services: graph,
 		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
 			"book_offers": &handlers.BookOffersMethod{},
 		}),

--- a/internal/rpc/missing_methods_test.go
+++ b/internal/rpc/missing_methods_test.go
@@ -44,10 +44,10 @@ func (m *mockLedgerServiceMissingMethods) GetOwnerInfo(_ context.Context, _ stri
 
 // servicesForMissingMethods builds a per-test ServiceContainer for tests
 // that exercise the "missing methods" handlers.
-func servicesForMissingMethods(mock *mockLedgerServiceMissingMethods) *types.ServiceContainer {
-	return &types.ServiceContainer{
+func servicesForMissingMethods(mock *mockLedgerServiceMissingMethods) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{
 		Ledger: mock,
-	}
+	})
 }
 
 // mockValidatorList is a minimal ValidatorListReader for unl_list tests.
@@ -386,7 +386,7 @@ func TestLedgerRequestMethod(t *testing.T) {
 
 func TestLedgerCleanerMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	services := servicesForMissingMethods(mock)
+	services := types.NewServiceContainer(mock)
 
 	method := &handlers.LedgerCleanerMethod{}
 
@@ -397,7 +397,7 @@ func TestLedgerCleanerMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
-			Services:   services,
+			Services:   types.NewTestServiceGraph(services),
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -426,7 +426,7 @@ func TestLedgerCleanerMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
-			Services:   services,
+			Services:   types.NewTestServiceGraph(services),
 		}
 
 		result, rpcErr := method.Handle(ctx, json.RawMessage(`{"min_ledger":5,"max_ledger":9,"full":true}`))
@@ -455,7 +455,7 @@ func TestLedgerCleanerMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
-			Services:   services,
+			Services:   types.NewTestServiceGraph(services),
 		}
 
 		_, rpcErr := method.Handle(ctx, json.RawMessage(
@@ -560,7 +560,7 @@ func TestTxReduceRelayMethod(t *testing.T) {
 	})
 
 	t.Run("Renders real metrics as txr_* decimal strings when wired", func(t *testing.T) {
-		svc := servicesForMissingMethods(mock)
+		svc := types.NewServiceContainer(mock)
 		svc.TxReduceRelayMetrics = func() types.TxReduceRelayMetrics {
 			return types.TxReduceRelayMetrics{
 				TxCnt:           12,
@@ -576,7 +576,7 @@ func TestTxReduceRelayMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleUser,
 			ApiVersion: types.ApiVersion1,
-			Services:   svc,
+			Services:   types.NewTestServiceGraph(svc),
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -672,7 +672,7 @@ func TestConnectMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
-			Services:   svc,
+			Services:   types.NewTestServiceGraph(svc),
 		}
 
 		result, rpcErr := method.Handle(ctx, json.RawMessage(`{}`))
@@ -701,7 +701,7 @@ func TestConnectMethod(t *testing.T) {
 					t.Fatal("PeerConnect called for unspecified endpoint")
 					return nil
 				}}
-				ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, ApiVersion: types.ApiVersion1, Services: svc}
+				ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, ApiVersion: types.ApiVersion1, Services: types.NewTestServiceGraph(svc)}
 				result, rpcErr := method.Handle(ctx, json.RawMessage(`{"ip":`+tc.rawIP+`}`))
 				require.Nil(t, rpcErr)
 				resultMap := result.(map[string]any)
@@ -716,7 +716,7 @@ func TestConnectMethod(t *testing.T) {
 				t.Fatal("PeerConnect called after failed IP coercion")
 				return nil
 			}}
-			ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, ApiVersion: types.ApiVersion1, Services: svc}
+			ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, ApiVersion: types.ApiVersion1, Services: types.NewTestServiceGraph(svc)}
 			result, rpcErr := method.Handle(ctx, json.RawMessage(`{"ip":`+rawIP+`}`))
 			assert.Nil(t, result)
 			require.NotNil(t, rpcErr)
@@ -737,7 +737,7 @@ func TestConnectMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
-			Services:   svc,
+			Services:   types.NewTestServiceGraph(svc),
 		}
 
 		params := json.RawMessage(`{"ip": "10.0.0.1", "port": 2459}`)
@@ -758,7 +758,7 @@ func TestConnectMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
-			Services:   svc,
+			Services:   types.NewTestServiceGraph(svc),
 		}
 
 		_, rpcErr := method.Handle(ctx, json.RawMessage(`{"ip": "10.0.0.2"}`))
@@ -786,7 +786,7 @@ func TestConnectMethod(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				var got string
 				svc := &types.ServiceContainer{Ledger: mock, PeerConnect: func(addr string) error { got = addr; return nil }}
-				ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, ApiVersion: types.ApiVersion1, Services: svc}
+				ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, ApiVersion: types.ApiVersion1, Services: types.NewTestServiceGraph(svc)}
 				result, rpcErr := method.Handle(ctx, json.RawMessage(fmt.Sprintf(`{"ip":%q,"port":%d}`, tc.ip, tc.port)))
 				require.Nil(t, rpcErr)
 				assert.Equal(t, tc.want, got)
@@ -816,7 +816,7 @@ func TestConnectMethod(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				var got string
 				svc := &types.ServiceContainer{Ledger: mock, PeerConnect: func(addr string) error { got = addr; return nil }}
-				ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, ApiVersion: types.ApiVersion1, Services: svc}
+				ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, ApiVersion: types.ApiVersion1, Services: types.NewTestServiceGraph(svc)}
 				result, rpcErr := method.Handle(ctx, json.RawMessage(fmt.Sprintf(`{"ip":"10.0.0.3","port":%s}`, tc.rawPort)))
 				require.Nil(t, rpcErr)
 				assert.Equal(t, tc.wantAddress, got)
@@ -828,7 +828,7 @@ func TestConnectMethod(t *testing.T) {
 	t.Run("Malformed and out-of-range ports are invalidParams", func(t *testing.T) {
 		for _, rawPort := range []string{`"1"`, "[]", "{}", "2147483648", "-2147483649"} {
 			svc := &types.ServiceContainer{Ledger: mock, PeerConnect: func(string) error { t.Fatal("PeerConnect called for invalid port"); return nil }}
-			ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, ApiVersion: types.ApiVersion1, Services: svc}
+			ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, ApiVersion: types.ApiVersion1, Services: types.NewTestServiceGraph(svc)}
 			_, rpcErr := method.Handle(ctx, json.RawMessage(fmt.Sprintf(`{"ip":"10.0.0.4","port":%s}`, rawPort)))
 			require.NotNil(t, rpcErr, rawPort)
 			assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code, rawPort)
@@ -837,7 +837,7 @@ func TestConnectMethod(t *testing.T) {
 
 	t.Run("Port validation precedes IP conversion", func(t *testing.T) {
 		svc := &types.ServiceContainer{Ledger: mock, PeerConnect: func(string) error { t.Fatal("PeerConnect called for invalid request"); return nil }}
-		ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, ApiVersion: types.ApiVersion1, Services: svc}
+		ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, ApiVersion: types.ApiVersion1, Services: types.NewTestServiceGraph(svc)}
 		_, rpcErr := method.Handle(ctx, json.RawMessage(`{"ip":[],"port":"1"}`))
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
@@ -845,7 +845,7 @@ func TestConnectMethod(t *testing.T) {
 
 	t.Run("Unavailable scheduler returns notEnabled", func(t *testing.T) {
 		ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, ApiVersion: types.ApiVersion1,
-			Services: &types.ServiceContainer{Ledger: mock}}
+			Services: types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})}
 		_, rpcErr := method.Handle(ctx, json.RawMessage(`{"ip":"10.0.0.5"}`))
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcNOT_ENABLED, rpcErr.Code)
@@ -863,7 +863,7 @@ func TestConnectMethod(t *testing.T) {
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				svc := &types.ServiceContainer{Ledger: mock, PeerConnect: func(string) error { return tc.err }}
-				ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, ApiVersion: types.ApiVersion1, Services: svc}
+				ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, ApiVersion: types.ApiVersion1, Services: types.NewTestServiceGraph(svc)}
 				_, rpcErr := method.Handle(ctx, json.RawMessage(`{"ip":"10.0.0.6"}`))
 				require.NotNil(t, rpcErr)
 				assert.Equal(t, tc.code, rpcErr.Code)
@@ -902,7 +902,7 @@ func TestPrintMethod(t *testing.T) {
 	})
 
 	t.Run("Aggregates wired subsystem state", func(t *testing.T) {
-		svc := servicesForMissingMethods(mock)
+		svc := types.NewServiceContainer(mock)
 		svc.PeerDisconnects = func() (uint64, uint64) { return 7, 3 }
 		svc.JqTransOverflow = func() uint64 { return 9 }
 		svc.LastCloseInfo = func() (int, int) { return 5, 1900 }
@@ -918,7 +918,7 @@ func TestPrintMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
-			Services:   svc,
+			Services:   types.NewTestServiceGraph(svc),
 			PeerSource: &stubPeerSource{
 				peers:   []map[string]any{{"address": "192.0.2.1:51235"}},
 				cluster: map[string]any{},
@@ -1299,7 +1299,7 @@ func TestGetCountsMethod(t *testing.T) {
 	})
 
 	t.Run("Emits node store counters when wired", func(t *testing.T) {
-		svc := servicesForMissingMethods(mock)
+		svc := types.NewServiceContainer(mock)
 		svc.GetCounts = func() types.CountsResult {
 			return types.CountsResult{
 				Standalone: true,
@@ -1321,7 +1321,7 @@ func TestGetCountsMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
-			Services:   svc,
+			Services:   types.NewTestServiceGraph(svc),
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -1355,7 +1355,7 @@ func TestGetCountsMethod(t *testing.T) {
 	})
 
 	t.Run("Omits node store block and local_txs when unavailable", func(t *testing.T) {
-		svc := servicesForMissingMethods(mock)
+		svc := types.NewServiceContainer(mock)
 		svc.GetCounts = func() types.CountsResult {
 			return types.CountsResult{Standalone: false, LocalTxs: 0}
 		}
@@ -1363,7 +1363,7 @@ func TestGetCountsMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
-			Services:   svc,
+			Services:   types.NewTestServiceGraph(svc),
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -1522,7 +1522,7 @@ func TestLogRotateMethod(t *testing.T) {
 
 func TestAMMInfoMethod(t *testing.T) {
 	mock := newMockLedgerServiceMissingMethods()
-	services := &types.ServiceContainer{Ledger: &ammInfoTestLedgerService{mock}}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: &ammInfoTestLedgerService{mock}})
 
 	method := &handlers.AMMInfoMethod{}
 
@@ -1775,13 +1775,13 @@ func TestUnlListMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
-			Services: &types.ServiceContainer{
+			Services: types.NewTestServiceGraph(&types.ServiceContainer{
 				Ledger: mock,
 				ValidatorList: &mockValidatorList{listed: []types.ListedValidator{
 					{MasterKey: newKey(0), Trusted: true},
 					{MasterKey: newKey(100), Trusted: false},
 				}},
-			},
+			}),
 		}
 
 		result, rpcErr := method.Handle(ctx, nil)
@@ -1852,7 +1852,7 @@ func TestBlackListMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
-			Services:   svc,
+			Services:   types.NewTestServiceGraph(svc),
 		}
 
 		result, rpcErr := method.Handle(ctx, json.RawMessage(`{"threshold": 100}`))
@@ -1877,7 +1877,7 @@ func TestBlackListMethod(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
 			ApiVersion: types.ApiVersion1,
-			Services:   svc,
+			Services:   types.NewTestServiceGraph(svc),
 		}
 
 		_, rpcErr := method.Handle(ctx, nil)
@@ -1950,7 +1950,7 @@ func TestMissingMethodsNilLedgerService(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: nil},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: nil}),
 	}
 
 	// Methods that depend on ledger service should return RpcINTERNAL when Ledger is nil

--- a/internal/rpc/nft_offers_test.go
+++ b/internal/rpc/nft_offers_test.go
@@ -157,10 +157,10 @@ func (m *mockNFTOffersLedgerService) GetClosedLedgerView() (types.LedgerStateVie
 }
 
 // newNFTOffersTestServices builds a per-test ServiceContainer wrapping mock.
-func newNFTOffersTestServices(mock *mockNFTOffersLedgerService) *types.ServiceContainer {
-	return &types.ServiceContainer{
+func newNFTOffersTestServices(mock *mockNFTOffersLedgerService) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{
 		Ledger: mock,
-	}
+	})
 }
 
 // nft_buy_offers Tests

--- a/internal/rpc/noripple_check_test.go
+++ b/internal/rpc/noripple_check_test.go
@@ -171,10 +171,10 @@ func (m *mockNoRippleCheckLedgerService) GetClosedLedgerView() (types.LedgerStat
 }
 
 // newNoRippleCheckTestServices builds a per-test ServiceContainer wrapping mock.
-func newNoRippleCheckTestServices(mock *mockNoRippleCheckLedgerService) *types.ServiceContainer {
-	return &types.ServiceContainer{
+func newNoRippleCheckTestServices(mock *mockNoRippleCheckLedgerService) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{
 		Ledger: mock,
-	}
+	})
 }
 
 // Error Validation Tests

--- a/internal/rpc/overload_gate_test.go
+++ b/internal/rpc/overload_gate_test.go
@@ -105,7 +105,7 @@ func TestHTTPOverloadAdminUnlimitedBypass(t *testing.T) {
 
 func TestGateLoadKeysUnlimitedHTTPBySocketPeer(t *testing.T) {
 	manager := resource.NewManager(nil, nil)
-	ctx := newRpcContext(context.Background(), types.RoleIdentified, types.DefaultApiVersion, "198.51.100.7", nil, nil)
+	ctx := newRpcContext(context.Background(), types.RoleIdentified, types.DefaultApiVersion, "198.51.100.7", nil, nil, nil, nil)
 	ctx.ResourceIP = "203.0.113.5"
 	if rpcErr := gateLoad(manager, ctx, "ping", rpcLog()); rpcErr != nil {
 		t.Fatal(rpcErr)
@@ -121,7 +121,7 @@ func TestGateLoadKeepsWebSocketConnectionConsumer(t *testing.T) {
 	manager := resource.NewManager(nil, nil)
 	consumer := manager.NewInboundEndpoint("198.51.100.7")
 	defer consumer.Release()
-	ctx := newRpcContext(context.Background(), types.RoleAdmin, types.DefaultApiVersion, "198.51.100.7", nil, nil)
+	ctx := newRpcContext(context.Background(), types.RoleAdmin, types.DefaultApiVersion, "198.51.100.7", nil, nil, nil, nil)
 	ctx.ResourceIP = "203.0.113.5"
 	ctx.ResourceConsumer = consumer
 	if rpcErr := gateLoad(manager, ctx, "stop", rpcLog()); rpcErr != nil {
@@ -190,7 +190,7 @@ func TestHTTPBatchOverloadElement(t *testing.T) {
 			"ping": echoHandler(),
 		}),
 		timeout:         time.Second,
-		services:        types.NewServiceContainer(nil),
+		services:        types.NewTestServiceGraph(types.NewServiceContainer(nil)),
 		resourceManager: resource.NewManager(nil, nil),
 	}
 	pushOverDropThreshold(t, srv.resourceManager, "10.0.0.1") // postBatch posts from 10.0.0.1

--- a/internal/rpc/path_find_refresh.go
+++ b/internal/rpc/path_find_refresh.go
@@ -360,7 +360,7 @@ func (m *pathFindRefreshManager) pathFindShedder() *types.ClientLoadShedder {
 	if m.ws == nil || m.ws.services == nil {
 		return nil
 	}
-	return m.ws.services.ClientLoad
+	return m.ws.services.ClientLoad()
 }
 
 func (m *pathFindRefreshManager) generationCurrent(generation uint64) bool {

--- a/internal/rpc/path_find_refresh_test.go
+++ b/internal/rpc/path_find_refresh_test.go
@@ -447,7 +447,7 @@ func TestPathFindRefreshSharesPathfindAdmissionPerConnection(t *testing.T) {
 	ws, connections := newPathFindRefreshTestServer(t, 1)
 	manager := ws.ensurePathFindRefreshManager()
 	shedder := types.NewClientLoadShedder()
-	ws.services = &types.ServiceContainer{ClientLoad: shedder}
+	ws.services = types.NewTestServiceGraph(&types.ServiceContainer{ClientLoad: shedder})
 	firstStarted := make(chan struct{})
 	latestStarted := make(chan struct{})
 	releaseFirst := make(chan struct{})

--- a/internal/rpc/peer_reservations_test.go
+++ b/internal/rpc/peer_reservations_test.go
@@ -27,9 +27,9 @@ func testNodePublic(t *testing.T, seed byte) string {
 
 // reservationServices builds a ServiceContainer whose peer_reservations_*
 // closures are backed by an in-memory map, standing in for the overlay table.
-func reservationServices() *types.ServiceContainer {
+func reservationServices() *types.ServiceGraph {
 	m := map[string]string{}
-	return &types.ServiceContainer{
+	return types.NewTestServiceGraph(&types.ServiceContainer{
 		PeerReservationAdd: func(key, desc string) (string, bool, error) {
 			prev, ok := m[key]
 			m[key] = desc
@@ -49,12 +49,12 @@ func reservationServices() *types.ServiceContainer {
 			}
 			return out
 		},
-	}
+	})
 }
 
 func TestPeerReservationsAddValidation(t *testing.T) {
 	method := &handlers.PeerReservationsAddMethod{}
-	ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, Services: &types.ServiceContainer{}}
+	ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, Services: types.NewTestServiceGraph(&types.ServiceContainer{})}
 
 	t.Run("missing public_key", func(t *testing.T) {
 		_, rpcErr := method.Handle(ctx, json.RawMessage(`{}`))
@@ -179,11 +179,11 @@ func TestPeerReservationsAddPersistenceError(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context: context.Background(),
 		Role:    types.RoleAdmin,
-		Services: &types.ServiceContainer{
+		Services: types.NewTestServiceGraph(&types.ServiceContainer{
 			PeerReservationAdd: func(string, string) (string, bool, error) {
 				return "", false, errors.New("disk full")
 			},
-		},
+		}),
 	}
 	body, _ := json.Marshal(map[string]any{"public_key": testNodePublic(t, 3)})
 	_, rpcErr := (&handlers.PeerReservationsAddMethod{}).Handle(ctx, body)
@@ -192,7 +192,7 @@ func TestPeerReservationsAddPersistenceError(t *testing.T) {
 }
 
 func TestPeerReservationsEmptyWhenUnwired(t *testing.T) {
-	ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, Services: &types.ServiceContainer{}}
+	ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, Services: types.NewTestServiceGraph(&types.ServiceContainer{})}
 
 	// list returns an empty array, and add is a no-op that reports no previous.
 	resL, rpcErr := (&handlers.PeerReservationsListMethod{}).Handle(ctx, nil)

--- a/internal/rpc/peers_server_info_parity_test.go
+++ b/internal/rpc/peers_server_info_parity_test.go
@@ -41,7 +41,7 @@ func TestPeersAndServerInfoShareSource(t *testing.T) {
 		Role:       types.RoleAdmin,
 		ApiVersion: types.DefaultApiVersion,
 		PeerSource: src,
-		Services:   services,
+		Services:   types.NewTestServiceGraph(services),
 	}
 
 	peersRes, err := (&handlers.PeersMethod{}).Handle(ctx, nil)
@@ -65,7 +65,7 @@ func TestPeersAndServerInfoBothEmptyWithoutSource(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleAdmin,
 		ApiVersion: types.DefaultApiVersion,
-		Services:   services,
+		Services:   types.NewTestServiceGraph(services),
 	}
 
 	peersRes, err := (&handlers.PeersMethod{}).Handle(ctx, nil)

--- a/internal/rpc/print_wire_test.go
+++ b/internal/rpc/print_wire_test.go
@@ -21,7 +21,7 @@ import (
 // output is observed end-to-end.
 func printTestServer(t *testing.T) *Server {
 	t.Helper()
-	svc := servicesForMissingMethods(newMockLedgerServiceMissingMethods())
+	svc := types.NewServiceContainer(newMockLedgerServiceMissingMethods())
 	svc.PeerDisconnects = func() (uint64, uint64) { return 7, 3 }
 	svc.JqTransOverflow = func() uint64 { return 9 }
 	svc.LastCloseInfo = func() (int, int) { return 5, 1900 }
@@ -32,7 +32,8 @@ func printTestServer(t *testing.T) *Server {
 		}
 	}
 
-	srv := NewServer(ServerOptions{Timeout: time.Second, Services: svc, PeerSource: &stubPeerSource{
+	graph := types.NewTestServiceGraph(svc)
+	srv := NewServer(ServerOptions{Timeout: time.Second, Services: graph, PeerSource: &stubPeerSource{
 		peers:                  []map[string]any{{"address": "192.0.2.1:51235"}},
 		cluster:                map[string]any{},
 		criticalFailuresLocal:  4,

--- a/internal/rpc/queue_data_test.go
+++ b/internal/rpc/queue_data_test.go
@@ -66,7 +66,7 @@ func TestAccountInfoQueueData_RealQueue(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
-		Services:   services,
+		Services:   types.NewTestServiceGraph(services),
 	}
 	method := &handlers.AccountInfoMethod{}
 	paramsJSON, err := json.Marshal(map[string]any{
@@ -132,7 +132,7 @@ func TestAccountInfoQueueData_Tickets(t *testing.T) {
 			}
 		},
 	}
-	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1, Services: services}
+	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1, Services: types.NewTestServiceGraph(services)}
 	method := &handlers.AccountInfoMethod{}
 	paramsJSON, _ := json.Marshal(map[string]any{"account": queueTestAccount, "queue": true, "ledger_index": "current"})
 
@@ -189,7 +189,7 @@ func TestLedgerQueueData_RealQueue(t *testing.T) {
 		},
 	}
 
-	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1, Services: services}
+	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1, Services: types.NewTestServiceGraph(services)}
 	method := &handlers.LedgerMethod{}
 	paramsJSON, err := json.Marshal(map[string]any{"ledger_index": "current", "queue": true})
 	require.NoError(t, err)
@@ -284,7 +284,7 @@ func TestLedgerQueueDataRejectsClosedLedger(t *testing.T) {
 	result, rpcErr := (&handlers.LedgerMethod{}).Handle(&types.RpcContext{
 		Context:    context.Background(),
 		ApiVersion: types.ApiVersion1,
-		Services:   services,
+		Services:   types.NewTestServiceGraph(services),
 	}, paramsJSON)
 
 	require.Nil(t, result)
@@ -309,7 +309,7 @@ func TestLedgerQueueData_EmptyOmitted(t *testing.T) {
 		Ledger:      mock,
 		QueueAllTxs: func() []types.QueuedTxInfo { return nil },
 	}
-	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1, Services: services}
+	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1, Services: types.NewTestServiceGraph(services)}
 	method := &handlers.LedgerMethod{}
 	paramsJSON, _ := json.Marshal(map[string]any{"ledger_index": "current", "queue": true})
 

--- a/internal/rpc/rpcsub.go
+++ b/internal/rpc/rpcsub.go
@@ -97,8 +97,10 @@ func (m *rpcSubMetrics) recordDeliveryFailure(endpoint, reason string, details .
 // urlSubscriptionRegistry owns URL-based admin subscriptions. Each URL maps
 // to one subscriber in the shared manager and one delivery goroutine.
 type urlSubscriptionRegistry struct {
-	ws     *WebSocketServer
-	client *http.Client
+	manager            *subscription.Manager
+	services           *types.ServiceGraph
+	ledgerInfoProvider types.LedgerInfoProvider
+	client             *http.Client
 	// ctx cancels in-flight deliveries on Close so shutdown isn't held
 	// hostage by a stalled endpoint.
 	ctx    context.Context
@@ -118,10 +120,12 @@ type urlSubscriptionRegistry struct {
 	closeDone        chan struct{}
 }
 
-func newURLSubscriptionRegistry(ws *WebSocketServer) *urlSubscriptionRegistry {
+func newURLSubscriptionRegistry(manager *subscription.Manager, services *types.ServiceGraph, ledgerInfoProvider types.LedgerInfoProvider) *urlSubscriptionRegistry {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &urlSubscriptionRegistry{
-		ws: ws,
+		manager:            manager,
+		services:           services,
+		ledgerInfoProvider: ledgerInfoProvider,
 		client: &http.Client{
 			Timeout: rpcSubRequestTimeout,
 			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
@@ -138,6 +142,16 @@ func newURLSubscriptionRegistry(ws *WebSocketServer) *urlSubscriptionRegistry {
 		closeDone:        make(chan struct{}),
 		principalWorkers: make(map[string]int),
 	}
+}
+
+// NewURLSubscriptionService constructs the transport-neutral RPCSub registry.
+// It is called before HTTP and WebSocket transports are built so neither
+// transport needs to mutate the application graph.
+func NewURLSubscriptionService(manager *subscription.Manager, services *types.ServiceGraph, ledgerInfoProvider types.LedgerInfoProvider) types.URLSubscriptionService {
+	if manager == nil {
+		manager = subscription.NewManager()
+	}
+	return newURLSubscriptionRegistry(manager, services, ledgerInfoProvider)
 }
 
 func (r *urlSubscriptionRegistry) metricsSnapshot() rpcSubMetricsSnapshot {
@@ -177,8 +191,8 @@ func (r *urlSubscriptionRegistry) Subscribe(ctx *types.RpcContext, request types
 		return nil, rpcErr
 	}
 	prefix := request.WithoutBooks().WithoutAccountHistory()
-	scope := r.ws.subscriptionManager.NewRequestScope()
-	if rpcErr := r.ws.subscriptionManager.HandleSubscribeScoped(lookup.sub.registration, scope, prefix, true); rpcErr != nil {
+	scope := r.manager.NewRequestScope()
+	if rpcErr := r.manager.HandleSubscribeScoped(lookup.sub.registration, scope, prefix, true); rpcErr != nil {
 		return fail(rpcErr)
 	}
 	history, rpcErr := prepareAccountHistorySubscribe(ctx, request)
@@ -191,7 +205,7 @@ func (r *urlSubscriptionRegistry) Subscribe(ctx *types.RpcContext, request types
 	history.apply(lookup.sub.conn)
 	if rpcErr := applyRequestBooks(request, func(bookRequest types.SubscriptionRequest) *types.RpcError {
 		bookRequest.ApiVersion = request.ApiVersion
-		if rpcErr := r.ws.subscriptionManager.HandleSubscribeScoped(lookup.sub.registration, scope, bookRequest, true); rpcErr != nil {
+		if rpcErr := r.manager.HandleSubscribeScoped(lookup.sub.registration, scope, bookRequest, true); rpcErr != nil {
 			return rpcErr
 		}
 		setSubscriptionLoadCost(ctx, bookRequest)
@@ -199,7 +213,7 @@ func (r *urlSubscriptionRegistry) Subscribe(ctx *types.RpcContext, request types
 	}); rpcErr != nil {
 		return fail(rpcErr)
 	}
-	result := r.ws.buildSubscribeAckSampled(ctx, request, serverState)
+	result := buildSubscribeAckSampled(r.ledgerInfoProvider, ctx, request, serverState)
 	if history != nil {
 		result["warning"] = accountHistoryWarning
 	}
@@ -226,8 +240,8 @@ func (r *urlSubscriptionRegistry) Unsubscribe(ctx *types.RpcContext, request typ
 		return map[string]any{}, nil
 	}
 	prefix := request.WithoutBooks().WithoutAccountHistory()
-	scope := r.ws.subscriptionManager.NewRequestScope()
-	if rpcErr := r.ws.subscriptionManager.HandleUnsubscribeScoped(sub.registration, scope, prefix); rpcErr != nil {
+	scope := r.manager.NewRequestScope()
+	if rpcErr := r.manager.HandleUnsubscribeScoped(sub.registration, scope, prefix); rpcErr != nil {
 		r.mu.Unlock()
 		return nil, rpcErr
 	}
@@ -238,7 +252,7 @@ func (r *urlSubscriptionRegistry) Unsubscribe(ctx *types.RpcContext, request typ
 	}
 	history.apply(sub.conn)
 	if rpcErr := applyRequestBooks(request, func(bookRequest types.SubscriptionRequest) *types.RpcError {
-		return r.ws.subscriptionManager.HandleUnsubscribeScoped(sub.registration, scope, bookRequest)
+		return r.manager.HandleUnsubscribeScoped(sub.registration, scope, bookRequest)
 	}); rpcErr != nil {
 		r.mu.Unlock()
 		return nil, rpcErr
@@ -312,7 +326,7 @@ func (r *urlSubscriptionRegistry) findOrCreateLocked(request types.SubscriptionR
 		}
 	})
 	sub.conn.SetDisconnect(func() { go r.retire(sub) })
-	registration, attached := r.ws.subscriptionManager.Attach(sub.conn)
+	registration, attached := r.manager.Attach(sub.conn)
 	if !attached {
 		subCancel()
 		return rpcSubLookup{}, types.RpcErrorInternal()
@@ -340,10 +354,10 @@ func (r *urlSubscriptionRegistry) tryRemoveLocked(key string) *rpcSub {
 	if !ok {
 		return nil
 	}
-	if r.ws.subscriptionManager.HasStreamSubscriptions(sub.registration) {
+	if r.manager.HasStreamSubscriptions(sub.registration) {
 		return nil
 	}
-	if hasAccountHistorySubscriptions(r.ws.services, sub.conn) {
+	if hasAccountHistorySubscriptions(r.services, sub.conn) {
 		return nil
 	}
 	return r.removeLocked(key, sub)
@@ -360,8 +374,8 @@ func (r *urlSubscriptionRegistry) removeLocked(key string, sub *rpcSub) *rpcSub 
 			delete(r.principalCounts, sub.principal)
 		}
 	}
-	r.ws.subscriptionManager.Detach(sub.registration)
-	removeAccountHistoryConnection(r.ws.services, sub.conn)
+	r.manager.Detach(sub.registration)
+	removeAccountHistoryConnection(r.services, sub.conn)
 	sub.stop()
 	return sub
 }
@@ -398,8 +412,8 @@ func (r *urlSubscriptionRegistry) Close() {
 
 	r.cancel()
 	for _, sub := range subs {
-		r.ws.subscriptionManager.Detach(sub.registration)
-		removeAccountHistoryConnection(r.ws.services, sub.conn)
+		r.manager.Detach(sub.registration)
+		removeAccountHistoryConnection(r.services, sub.conn)
 		sub.stop()
 	}
 	for _, sub := range subs {

--- a/internal/rpc/rpcsub_test.go
+++ b/internal/rpc/rpcsub_test.go
@@ -91,37 +91,42 @@ func (s *rpcSubSink) expectNone(t *testing.T) {
 	}
 }
 
-// newRPCSubTestServer builds a WebSocket server whose service container
-// carries the url-subscription registry, plus admin/guest contexts for
-// driving the plain JSON-RPC handlers.
-func newRPCSubTestServer(t *testing.T) (*WebSocketServer, *types.ServiceContainer) {
+type rpcSubTestServices struct {
+	graph *types.ServiceGraph
+	url   types.URLSubscriptionService
+}
+
+// newRPCSubTestServer builds a WebSocket server and the explicit request
+// dependencies used by the plain JSON-RPC handlers.
+func newRPCSubTestServer(t *testing.T) (*WebSocketServer, *rpcSubTestServices) {
 	return newRPCSubTestServerWithProvider(t, nil)
 }
 
-func newRPCSubTestServerWithProvider(t *testing.T, provider types.LedgerInfoProvider) (*WebSocketServer, *types.ServiceContainer) {
+func newRPCSubTestServerWithProvider(t *testing.T, provider types.LedgerInfoProvider) (*WebSocketServer, *rpcSubTestServices) {
 	t.Helper()
-	services := types.NewServiceContainer(nil)
-	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second, Services: services, LedgerInfoProvider: provider})
-	services.URLSubscriptions = ws.URLSubscriptionService()
-	require.NotNil(t, services.URLSubscriptions, "composition must expose the url registry explicitly")
-	return ws, services
+	graph := types.NewTestServiceGraph(types.NewServiceContainer(nil))
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second, Services: graph, LedgerInfoProvider: provider})
+	url := ws.URLSubscriptionService()
+	require.NotNil(t, url, "composition must expose the url registry explicitly")
+	return ws, &rpcSubTestServices{graph: graph, url: url}
 }
 
-func adminCtx(services *types.ServiceContainer) *types.RpcContext {
+func adminCtx(services *rpcSubTestServices) *types.RpcContext {
 	return &types.RpcContext{
-		Role:       types.RoleAdmin,
-		ApiVersion: types.ApiVersion1,
-		Services:   services,
+		Role:             types.RoleAdmin,
+		ApiVersion:       types.ApiVersion1,
+		Services:         services.graph,
+		URLSubscriptions: services.url,
 	}
 }
 
-func subscribeURL(t *testing.T, services *types.ServiceContainer, params string) (any, *types.RpcError) {
+func subscribeURL(t *testing.T, services *rpcSubTestServices, params string) (any, *types.RpcError) {
 	t.Helper()
 	method := &handlers.SubscribeMethod{}
 	return method.Handle(adminCtx(services), json.RawMessage(params))
 }
 
-func unsubscribeURL(t *testing.T, services *types.ServiceContainer, params string) (any, *types.RpcError) {
+func unsubscribeURL(t *testing.T, services *rpcSubTestServices, params string) (any, *types.RpcError) {
 	t.Helper()
 	method := &handlers.UnsubscribeMethod{}
 	return method.Handle(adminCtx(services), json.RawMessage(params))

--- a/internal/rpc/rpcsub_test.go
+++ b/internal/rpc/rpcsub_test.go
@@ -96,8 +96,6 @@ type rpcSubTestServices struct {
 	url   types.URLSubscriptionService
 }
 
-// newRPCSubTestServer builds a WebSocket server and the explicit request
-// dependencies used by the plain JSON-RPC handlers.
 func newRPCSubTestServer(t *testing.T) (*WebSocketServer, *rpcSubTestServices) {
 	return newRPCSubTestServerWithProvider(t, nil)
 }

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -33,20 +33,22 @@ func rpcLog() xrpllog.Logger { return xrpllog.Named(xrpllog.PartitionRPC) }
 
 type Server struct {
 	peerSourceHolder
-	registry        *types.MethodRegistry
-	timeout         time.Duration
-	services        *types.ServiceContainer
-	resourceManager *resource.Manager
+	registry         *types.MethodRegistry
+	timeout          time.Duration
+	services         *types.ServiceGraph
+	urlSubscriptions types.URLSubscriptionService
+	resourceManager  *resource.Manager
 }
 
 // ServerOptions controls construction of an HTTP JSON-RPC server.
 // Services may be nil for routing-only tests; constructors never mutate it.
 type ServerOptions struct {
-	Timeout         time.Duration
-	Services        *types.ServiceContainer
-	ResourceManager *resource.Manager
-	PeerSource      types.PeerSource
-	Registry        *types.MethodRegistry
+	Timeout          time.Duration
+	Services         *types.ServiceGraph
+	ResourceManager  *resource.Manager
+	PeerSource       types.PeerSource
+	Registry         *types.MethodRegistry
+	URLSubscriptions types.URLSubscriptionService
 }
 
 var _ types.MethodDispatcher = (*Server)(nil)
@@ -80,10 +82,11 @@ func NewServer(options ServerOptions) *Server {
 		manager = resource.NewManager(nil, nil)
 	}
 	server := &Server{
-		registry:        options.Registry,
-		timeout:         options.Timeout,
-		services:        options.Services,
-		resourceManager: manager,
+		registry:         options.Registry,
+		timeout:          options.Timeout,
+		services:         options.Services,
+		urlSubscriptions: options.URLSubscriptions,
+		resourceManager:  manager,
 	}
 	if server.registry == nil {
 		server.registry = defaultMethodRegistry()

--- a/internal/rpc/server_batch.go
+++ b/internal/rpc/server_batch.go
@@ -25,7 +25,7 @@ func (s *Server) dispatchBatchElement(el json.RawMessage, baseCtx context.Contex
 			"error":   makeBatchJSONError(rpcMethodNotFoundCode, "Method not found"),
 		}
 	}
-	ctx := newRpcContext(baseCtx, role, types.DefaultApiVersion, clientIP, s.loadPeerSource(), s.services)
+	ctx := newRpcContext(baseCtx, role, types.DefaultApiVersion, clientIP, s.loadPeerSource(), s.services, s, s.urlSubscriptions)
 	ctx.ResourceIP = resourceIP
 	if ver, ok := apiVersionFromBatchElement(el); ok {
 		ctx.ApiVersion = ver

--- a/internal/rpc/server_diagnostics_test.go
+++ b/internal/rpc/server_diagnostics_test.go
@@ -23,7 +23,8 @@ func (d staticRPCDiagnostics) Snapshot() types.RPCDiagnosticsSnapshot {
 }
 
 func TestServerDiagnosticsWireShape(t *testing.T) {
-	services := servicesForServerInfo(newMockLedgerServiceServerInfo())
+	services := types.NewServiceContainer(newMockLedgerServiceServerInfo())
+	services.NodePublicKey = testNodePublicKey()
 	services.RPCDiagnostics = staticRPCDiagnostics{snapshot: types.RPCDiagnosticsSnapshot{
 		Methods: map[string]types.RPCMethodDiagnostics{
 			"account_info": {Started: 3, Finished: 2, Errored: 1, DurationUs: 4500},
@@ -52,7 +53,7 @@ func TestServerDiagnosticsWireShape(t *testing.T) {
 		{name: "server_state", method: &handlers.ServerStateMethod{}, root: "state"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, ApiVersion: 1, Services: services}
+			ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleAdmin, ApiVersion: 1, Services: types.NewTestServiceGraph(services)}
 			result, rpcErr := test.method.Handle(ctx, json.RawMessage(`{"counters":"yes"}`))
 			if rpcErr != nil {
 				t.Fatalf("Handle: %v", rpcErr)

--- a/internal/rpc/server_dispatch.go
+++ b/internal/rpc/server_dispatch.go
@@ -22,15 +22,17 @@ func (s *Server) withTimeout(parent context.Context) (context.Context, context.C
 	return context.WithTimeout(parent, s.timeout)
 }
 
-func newRpcContext(ctx context.Context, role types.Role, apiVersion int, clientIP string, peers types.PeerSource, services *types.ServiceContainer) *types.RpcContext {
+func newRpcContext(ctx context.Context, role types.Role, apiVersion int, clientIP string, peers types.PeerSource, services *types.ServiceGraph, dispatcher types.MethodDispatcher, urlSubscriptions types.URLSubscriptionService) *types.RpcContext {
 	return &types.RpcContext{
-		Context:    ctx,
-		Role:       role,
-		ApiVersion: apiVersion,
-		ClientIP:   clientIP,
-		ResourceIP: clientIP,
-		PeerSource: peers,
-		Services:   services,
+		Context:          ctx,
+		Role:             role,
+		ApiVersion:       apiVersion,
+		ClientIP:         clientIP,
+		ResourceIP:       clientIP,
+		PeerSource:       peers,
+		Services:         services,
+		Dispatcher:       dispatcher,
+		URLSubscriptions: urlSubscriptions,
 	}
 }
 func redactedRequestMap(request map[string]any) map[string]any {
@@ -121,7 +123,7 @@ func resolveMethod(registry *types.MethodRegistry, method string, apiVersion int
 func dispatchMethod(
 	registry *types.MethodRegistry,
 	manager *resource.Manager,
-	services *types.ServiceContainer,
+	services *types.ServiceGraph,
 	ctx *types.RpcContext,
 	method string,
 	params json.RawMessage,
@@ -160,7 +162,7 @@ func admitMethod(
 }
 func dispatchResolvedMethod(
 	manager *resource.Manager,
-	services *types.ServiceContainer,
+	services *types.ServiceGraph,
 	ctx *types.RpcContext,
 	method string,
 	params json.RawMessage,
@@ -186,8 +188,8 @@ func dispatchResolvedMethod(
 		return nil, rpcErr
 	}
 
-	if services != nil && services.ClientLoad != nil {
-		release := services.ClientLoad.Begin()
+	if services != nil && services.ClientLoad() != nil {
+		release := services.ClientLoad().Begin()
 		defer release()
 	}
 	finishDiagnostics := startRPCDiagnostics(services, method)
@@ -200,11 +202,11 @@ func dispatchResolvedMethod(
 	finalizeLoad(manager, ctx, method, fee, log)
 	return result, rpcErr
 }
-func startRPCDiagnostics(services *types.ServiceContainer, method string) func(bool) {
-	if services == nil || services.RPCDiagnostics == nil {
+func startRPCDiagnostics(services *types.ServiceGraph, method string) func(bool) {
+	if services == nil || services.RPCDiagnostics() == nil {
 		return func(bool) {}
 	}
-	return services.RPCDiagnostics.Start(method)
+	return services.RPCDiagnostics().Start(method)
 }
 func dispatchNestedMethod(
 	registry *types.MethodRegistry,
@@ -278,7 +280,7 @@ func redactStructuredID(params json.RawMessage) json.RawMessage {
 // this request. nil-safe: a request without a service container (routing-only
 // tests) is treated as non-beta.
 func betaEnabled(ctx *types.RpcContext) bool {
-	return ctx.Services != nil && ctx.Services.BetaRPCAPI
+	return ctx.Services != nil && ctx.Services.BetaRPCAPI()
 }
 
 // validateApiVersion enforces the accepted api_version range, mirroring
@@ -324,17 +326,17 @@ func conditionMet(cond types.Condition, ctx *types.RpcContext) *types.RpcError {
 	if cond == types.NoCondition {
 		return nil
 	}
-	if ctx.Services == nil || ctx.Services.Ledger == nil {
+	if ctx.Services == nil || ctx.Services.Ledger() == nil {
 		return nil
 	}
-	svc := ctx.Services.Ledger
+	svc := ctx.Services.Ledger()
 
 	if svc.IsAmendmentBlocked() {
 		return types.NewRpcError(types.RpcAMENDMENT_BLOCKED,
 			"amendmentBlocked", "amendmentBlocked", "Amendment blocked, need upgrade.")
 	}
 
-	if ctx.Services.UNLBlocked != nil && ctx.Services.UNLBlocked() {
+	if ctx.Services.UNLBlocked() != nil && ctx.Services.UNLBlocked()() {
 		return types.NewRpcError(types.RpcEXPIRED_VALIDATOR_LIST,
 			"unlBlocked", "unlBlocked", "Validator list expired.")
 	}

--- a/internal/rpc/server_hardening_test.go
+++ b/internal/rpc/server_hardening_test.go
@@ -50,7 +50,7 @@ func newHardeningServer(t *testing.T, timeout time.Duration, method string, h ty
 	srv := &Server{
 		registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{method: h}),
 		timeout:  timeout,
-		services: types.NewServiceContainer(nil),
+		services: types.NewTestServiceGraph(types.NewServiceContainer(nil)),
 	}
 	return srv
 }

--- a/internal/rpc/server_info_test.go
+++ b/internal/rpc/server_info_test.go
@@ -119,7 +119,8 @@ func TestServerInfoRoleAliasesAreAdminOnly(t *testing.T) {
 
 func TestServerInfoHostIDPrivacy(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	services := servicesForServerInfo(mock)
+	container := mutableServicesForServerInfo(mock)
+	services := types.NewTestServiceGraph(container)
 
 	guest := callServerStatus(t, &types.RpcContext{
 		Context:  t.Context(),
@@ -145,7 +146,8 @@ func TestServerInfoHostIDPrivacy(t *testing.T) {
 	}, false)
 	assert.NotContains(t, state, "hostid")
 
-	services.NodePublicKey = "invalid"
+	container.NodePublicKey = "invalid"
+	services = types.NewTestServiceGraph(container)
 	guest = callServerStatus(t, &types.RpcContext{Context: t.Context(), Services: services}, true)
 	assert.Equal(t, "go-xrpl", guest["hostid"])
 }
@@ -170,7 +172,14 @@ func TestServerInfoNetworkLedgerWaiting(t *testing.T) {
 }
 
 // servicesForServerInfo builds a per-test ServiceContainer with a server_info mock.
-func servicesForServerInfo(mock *mockLedgerServiceServerInfo) *types.ServiceContainer {
+func servicesForServerInfo(mock *mockLedgerServiceServerInfo) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{
+		Ledger:        mock,
+		NodePublicKey: testNodePublicKey(),
+	})
+}
+
+func mutableServicesForServerInfo(mock *mockLedgerServiceServerInfo) *types.ServiceContainer {
 	return &types.ServiceContainer{
 		Ledger:        mock,
 		NodePublicKey: testNodePublicKey(),
@@ -192,8 +201,8 @@ func callServerStatus(t *testing.T, ctx *types.RpcContext, human bool) map[strin
 func TestServerStatusRuntimeFields(t *testing.T) {
 	const gitHash = "0123456789abcdef0123456789abcdef01234567"
 	mock := newMockLedgerServiceServerInfo()
-	services := servicesForServerInfo(mock)
-	services.ServerInfoConfig = types.ServerInfoConfigSnapshot{
+	container := mutableServicesForServerInfo(mock)
+	container.ServerInfoConfig = types.ServerInfoConfigSnapshot{
 		Ports: []types.ServerInfoPortSnapshot{
 			{Port: 5005, Protocol: "ws2 http,http ignored"},
 			{Port: 6006, Protocol: "wss2, https", Admin: true},
@@ -203,7 +212,8 @@ func TestServerStatusRuntimeFields(t *testing.T) {
 		NodeSize:     "large",
 		GitHash:      gitHash,
 	}
-	services.FetchPackCacheSize = func() uint32 { return 7 }
+	container.FetchPackCacheSize = func() uint32 { return 7 }
+	services := types.NewTestServiceGraph(container)
 
 	publicPorts := []map[string]any{
 		{"port": "5005", "protocol": []string{"http", "ws2"}},
@@ -261,8 +271,9 @@ func TestServerStatusRuntimeFields(t *testing.T) {
 
 func TestServerStatusRuntimeFieldOmissions(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	services := servicesForServerInfo(mock)
-	services.FetchPackCacheSize = func() uint32 { return 0 }
+	container := mutableServicesForServerInfo(mock)
+	container.FetchPackCacheSize = func() uint32 { return 0 }
+	services := types.NewTestServiceGraph(container)
 
 	for _, human := range []bool{true, false} {
 		ctx := &types.RpcContext{
@@ -582,8 +593,9 @@ func TestServerInfoResponseFields(t *testing.T) {
 
 func TestServerInfoDisabledQuorumUsesRippledWireValue(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	services := servicesForServerInfo(mock)
-	services.ValidationQuorum = func() int { return math.MaxInt }
+	container := mutableServicesForServerInfo(mock)
+	container.ValidationQuorum = func() int { return math.MaxInt }
+	services := types.NewTestServiceGraph(container)
 	method := &handlers.ServerInfoMethod{}
 	ctx := &types.RpcContext{
 		Context: context.Background(), Role: types.RoleGuest,
@@ -898,7 +910,7 @@ func TestServerInfoServiceNilLedger(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: nil},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: nil}),
 	}
 
 	result, rpcErr := method.Handle(ctx, nil)
@@ -1032,10 +1044,11 @@ func TestServerInfoStateAccounting(t *testing.T) {
 // TestServerInfoTimeField tests the time field format
 func TestServerInfoTimeField(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	services := servicesForServerInfo(mock)
-	services.SystemTime = func() time.Time {
+	container := mutableServicesForServerInfo(mock)
+	container.SystemTime = func() time.Time {
 		return time.Date(2026, time.August, 3, 14, 5, 6, 789012345, time.FixedZone("test", 2*60*60))
 	}
+	services := types.NewTestServiceGraph(container)
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
@@ -1350,17 +1363,17 @@ func TestServerInfo_DynamicMetrics_FromHooks(t *testing.T) {
 	mock.serverInfo.ValidatedLedgerCloseTime = closeRippleEpoch
 	mock.serverInfo.ClosedLedgerCloseTime = closeRippleEpoch + 1
 
-	services := servicesForServerInfo(mock)
-	services.TxQMetrics = func() types.TxQServerMetrics {
+	container := mutableServicesForServerInfo(mock)
+	container.TxQMetrics = func() types.TxQServerMetrics {
 		return types.TxQServerMetrics{
 			ReferenceFeeLevel:     256,
 			MinProcessingFeeLevel: 512,
 			OpenLedgerFeeLevel:    1024,
 		}
 	}
-	services.JqTransOverflow = func() uint64 { return 13 }
-	services.PeerDisconnects = func() (uint64, uint64) { return 42, 9 }
-	services.StateAccounting = func() types.StateAccountingSnapshot {
+	container.JqTransOverflow = func() uint64 { return 13 }
+	container.PeerDisconnects = func() (uint64, uint64) { return 42, 9 }
+	container.StateAccounting = func() types.StateAccountingSnapshot {
 		return types.StateAccountingSnapshot{
 			Modes: map[string]types.StateAccountingEntry{
 				"disconnected": {Transitions: 1, DurationUs: 1500},
@@ -1373,6 +1386,7 @@ func TestServerInfo_DynamicMetrics_FromHooks(t *testing.T) {
 			InitialSyncUs:     1234,
 		}
 	}
+	services := types.NewTestServiceGraph(container)
 
 	method := &handlers.ServerInfoMethod{}
 	// An Admin role makes load_factor_fee_escalation emit even when
@@ -1427,14 +1441,15 @@ func TestServerInfo_DynamicMetrics_FromHooks(t *testing.T) {
 // metrics.
 func TestServerInfo_MachineMode_LoadFactorFees(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	services := servicesForServerInfo(mock)
-	services.TxQMetrics = func() types.TxQServerMetrics {
+	container := mutableServicesForServerInfo(mock)
+	container.TxQMetrics = func() types.TxQServerMetrics {
 		return types.TxQServerMetrics{
 			ReferenceFeeLevel:     256,
 			MinProcessingFeeLevel: 768,
 			OpenLedgerFeeLevel:    2048,
 		}
 	}
+	services := types.NewTestServiceGraph(container)
 
 	method := &handlers.ServerStateMethod{}
 	ctx := &types.RpcContext{
@@ -1462,13 +1477,14 @@ func TestServerInfo_MachineMode_LoadFactorFees(t *testing.T) {
 
 func TestServerInfo_LoadFactorEscalationAvoidsIntermediateOverflow(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	services := servicesForServerInfo(mock)
-	services.TxQMetrics = func() types.TxQServerMetrics {
+	container := mutableServicesForServerInfo(mock)
+	container.TxQMetrics = func() types.TxQServerMetrics {
 		return types.TxQServerMetrics{
 			ReferenceFeeLevel:  256,
 			OpenLedgerFeeLevel: 1 << 56,
 		}
 	}
+	services := types.NewTestServiceGraph(container)
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
@@ -1523,14 +1539,15 @@ func TestServerInfo_ValidatedLedgerAge_HighAgeThreshold(t *testing.T) {
 // loadFactorFeeEscalation == loadFactor, so the field is hidden.
 func TestServerInfo_HumanMode_LoadFactorFeeEscalation_NonAdminGate(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	services := servicesForServerInfo(mock)
-	services.TxQMetrics = func() types.TxQServerMetrics {
+	container := mutableServicesForServerInfo(mock)
+	container.TxQMetrics = func() types.TxQServerMetrics {
 		return types.TxQServerMetrics{
 			ReferenceFeeLevel:     256,
 			MinProcessingFeeLevel: 768, // diverges -> _queue still emitted
 			OpenLedgerFeeLevel:    1024,
 		}
 	}
+	services := types.NewTestServiceGraph(container)
 
 	method := &handlers.ServerInfoMethod{}
 	ctx := &types.RpcContext{
@@ -1594,7 +1611,7 @@ func TestServerInfo_ClosedLedgerAge_OmittedOnFutureCloseTime(t *testing.T) {
 // closed ledger. Suppressed entirely when neither is available.
 func TestServerInfo_SingleLedgerEmit(t *testing.T) {
 	method := &handlers.ServerInfoMethod{}
-	newCtx := func(svc *types.ServiceContainer) *types.RpcContext {
+	newCtx := func(svc *types.ServiceGraph) *types.RpcContext {
 		return &types.RpcContext{
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
@@ -1649,13 +1666,14 @@ func TestServerInfo_HumanMode_LoadFactorServer(t *testing.T) {
 
 	t.Run("escalation > loadBase → field present", func(t *testing.T) {
 		mock := newMockLedgerServiceServerInfo()
-		services := servicesForServerInfo(mock)
-		services.TxQMetrics = func() types.TxQServerMetrics {
+		container := mutableServicesForServerInfo(mock)
+		container.TxQMetrics = func() types.TxQServerMetrics {
 			return types.TxQServerMetrics{
 				ReferenceFeeLevel:  256,
 				OpenLedgerFeeLevel: 1024,
 			}
 		}
+		services := types.NewTestServiceGraph(container)
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
@@ -1705,10 +1723,11 @@ func TestServerInfo_HumanMode_LoadFactorLocalNetCluster_AdminGate(t *testing.T) 
 	}
 	build := func(admin bool, withHook bool) map[string]any {
 		mock := newMockLedgerServiceServerInfo()
-		services := servicesForServerInfo(mock)
+		container := mutableServicesForServerInfo(mock)
 		if withHook {
-			services.LoadFactorFees = feesHook
+			container.LoadFactorFees = feesHook
 		}
+		services := types.NewTestServiceGraph(container)
 		role := types.RoleGuest
 		if admin {
 			role = types.RoleAdmin
@@ -1781,9 +1800,10 @@ func TestServerInfo_CloseTimeOffset_Threshold(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mock := newMockLedgerServiceServerInfo()
-			services := servicesForServerInfo(mock)
+			container := mutableServicesForServerInfo(mock)
 			offset := tc.offset
-			services.CloseTimeOffset = func() time.Duration { return offset }
+			container.CloseTimeOffset = func() time.Duration { return offset }
+			services := types.NewTestServiceGraph(container)
 			ctx := &types.RpcContext{
 				Context:    context.Background(),
 				Role:       types.RoleGuest,
@@ -1849,9 +1869,10 @@ func TestServerInfoPubkeyValidator(t *testing.T) {
 	buildInfo := func(t *testing.T, admin bool, pk []byte, manifests types.ManifestLookup) (map[string]any, bool) {
 		t.Helper()
 		mock := newMockLedgerServiceServerInfo()
-		services := servicesForServerInfo(mock)
-		services.ValidatorPublicKey = pk
-		services.Manifests = manifests
+		container := mutableServicesForServerInfo(mock)
+		container.ValidatorPublicKey = pk
+		container.Manifests = manifests
+		services := types.NewTestServiceGraph(container)
 		role := types.RoleGuest
 		if admin {
 			role = types.RoleAdmin
@@ -1915,8 +1936,9 @@ func TestServerInfoPubkeyValidator(t *testing.T) {
 		want, err := addresscodec.EncodeNodePublicKey(signing)
 		require.NoError(t, err)
 		mock := newMockLedgerServiceServerInfo()
-		services := servicesForServerInfo(mock)
-		services.ValidatorPublicKey = signing
+		container := mutableServicesForServerInfo(mock)
+		container.ValidatorPublicKey = signing
+		services := types.NewTestServiceGraph(container)
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
 			Role:       types.RoleAdmin,
@@ -1944,8 +1966,9 @@ func TestServerInfoValidatorListVisibility(t *testing.T) {
 		}},
 	}
 	mock := newMockLedgerServiceServerInfo()
-	services := servicesForServerInfo(mock)
-	services.ValidatorList = validatorList
+	container := mutableServicesForServerInfo(mock)
+	container.ValidatorList = validatorList
+	services := types.NewTestServiceGraph(container)
 
 	infoFor := func(t *testing.T, admin bool) map[string]any {
 		t.Helper()
@@ -1993,8 +2016,9 @@ func TestServerInfoValidatorListVisibility(t *testing.T) {
 
 func TestServerInfoExpiredValidatorListWarningIsPublic(t *testing.T) {
 	mock := newMockLedgerServiceServerInfo()
-	services := servicesForServerInfo(mock)
-	services.ValidatorList = &serverInfoValidatorList{blocked: true}
+	container := mutableServicesForServerInfo(mock)
+	container.ValidatorList = &serverInfoValidatorList{blocked: true}
+	services := types.NewTestServiceGraph(container)
 	result, rpcErr := (&handlers.ServerInfoMethod{}).Handle(&types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleGuest,

--- a/internal/rpc/server_request.go
+++ b/internal/rpc/server_request.go
@@ -107,7 +107,7 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 	if version, present := apiVersionFromSingleParams(request.Params); present {
 		apiVersion = version
 	}
-	versionCtx := newRpcContext(dispatchCtx, role, apiVersion, clientIP, s.loadPeerSource(), s.services)
+	versionCtx := newRpcContext(dispatchCtx, role, apiVersion, clientIP, s.loadPeerSource(), s.services, s, s.urlSubscriptions)
 	versionCtx.ResourceIP = peerIP
 	if rpcErr := validateApiVersion(versionCtx); rpcErr != nil {
 		writeInvalidApiVersionHTTP(w)

--- a/internal/rpc/sign_for_networkid_test.go
+++ b/internal/rpc/sign_for_networkid_test.go
@@ -27,10 +27,10 @@ func TestSignFor_NetworkIDEnforcement(t *testing.T) {
 		return &types.RpcContext{
 			Context:    context.Background(),
 			ApiVersion: types.ApiVersion1,
-			Services: &types.ServiceContainer{
+			Services: types.NewTestServiceGraph(&types.ServiceContainer{
 				Ledger:       mock,
 				Capabilities: types.RPCCapabilities{SigningEnabled: true},
-			},
+			}),
 		}
 	}
 

--- a/internal/rpc/sign_test.go
+++ b/internal/rpc/sign_test.go
@@ -13,11 +13,18 @@ import (
 )
 
 func signingEnabledContext(ctx *types.RpcContext) *types.RpcContext {
-	if ctx.Services == nil {
-		ctx.Services = &types.ServiceContainer{}
+	clone := *ctx
+	var ledger types.LedgerService
+	if ctx.Services != nil {
+		ledger = ctx.Services.Ledger()
 	}
-	ctx.Services.Capabilities.SigningEnabled = true
-	return ctx
+	clone.Services = types.NewTestServiceGraph(&types.ServiceContainer{
+		Ledger: ledger,
+		Capabilities: types.RPCCapabilities{
+			SigningEnabled: true,
+		},
+	})
+	return &clone
 }
 
 // WalletPropose Tests
@@ -262,7 +269,7 @@ func TestWalletPropose_Metadata(t *testing.T) {
 
 func TestSign_MissingTxJson(t *testing.T) {
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
@@ -280,7 +287,7 @@ func TestSign_MissingTxJson(t *testing.T) {
 
 func TestSign_MissingCredentials(t *testing.T) {
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
@@ -430,7 +437,7 @@ func TestSign_LegacySecretRejectsKeyTokens(t *testing.T) {
 
 func TestSign_InvalidKeyType(t *testing.T) {
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
@@ -457,7 +464,7 @@ func TestSign_InvalidKeyType(t *testing.T) {
 
 func TestSign_InvalidSeed(t *testing.T) {
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
@@ -487,7 +494,7 @@ func TestSign_InvalidSeed(t *testing.T) {
 
 func TestSign_AccountMismatch(t *testing.T) {
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
@@ -583,7 +590,7 @@ func TestSign_SrcActNotFound(t *testing.T) {
 	// (TransactionSign.cpp:458-465) -> rpcSRC_ACT_NOT_FOUND.
 	mock := newMockLedgerService()
 	mock.accountInfoErr = svcerr.ErrAccountNotFound
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
@@ -615,7 +622,7 @@ func TestSign_SrcActNotFound(t *testing.T) {
 func TestSign_AutofillSequence(t *testing.T) {
 	// Online signing with Sequence absent auto-fills it from account state.
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
@@ -703,7 +710,7 @@ func TestSign_TicketSequence_AutofillsSequenceZero(t *testing.T) {
 	// A present TicketSequence supplies the sequence: the autofilled
 	// Sequence must be 0 (rippled TransactionSign.cpp:469-483).
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
@@ -754,7 +761,7 @@ func TestSign_FeeMultMax_DefaultAccepted(t *testing.T) {
 	// With default fee_mult_max=10 and fee_div_max=1, a baseFee of 10
 	// should be accepted (10 <= 10*10/1 = 100).
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
@@ -789,7 +796,7 @@ func TestSign_FeeMultMax_ZeroRejects(t *testing.T) {
 	// fee_mult_max=0 means limit = baseFee * 0 / 1 = 0.
 	// Since networkFee (10) > 0, should return rpcHIGH_FEE.
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
@@ -819,7 +826,7 @@ func TestSign_FeeDivMax_LargeRejects(t *testing.T) {
 	// fee_div_max=100 means limit = baseFee * 10 / 100 = 1.
 	// Since networkFee (10) > 1, should return rpcHIGH_FEE.
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
@@ -849,7 +856,7 @@ func TestSign_FeeMultMax_NegativeRejectsInvalidParams(t *testing.T) {
 	// Negative fee_mult_max should return rpcINVALID_PARAMS when Fee is
 	// autofilled. Matches rippled: mult < 0 -> rpcINVALID_PARAMS
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
@@ -881,7 +888,7 @@ func TestSign_FeeDivMax_ZeroRejectsInvalidParams(t *testing.T) {
 	// fee_div_max=0 should return rpcINVALID_PARAMS (not positive) when
 	// Fee is autofilled. Matches rippled: div <= 0 -> rpcINVALID_PARAMS
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
@@ -913,7 +920,7 @@ func TestSign_FeeDivMax_NegativeRejectsInvalidParams(t *testing.T) {
 	// Negative fee_div_max should return rpcINVALID_PARAMS when Fee is
 	// autofilled.
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
@@ -944,7 +951,7 @@ func TestSign_FeeMultMax_FloatRejectsHighFee(t *testing.T) {
 	// Float fee_mult_max should return rpcHIGH_FEE (not rpcINVALID_PARAMS)
 	// when Fee is autofilled. Matches rippled: isInt() false -> rpcHIGH_FEE
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{
@@ -975,7 +982,7 @@ func TestSign_FeeMultMax_FloatRejectsHighFee(t *testing.T) {
 func TestSign_FeeMultMax_StringRejectsHighFee(t *testing.T) {
 	// String fee_mult_max should return rpcHIGH_FEE when Fee is autofilled.
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -97,10 +97,10 @@ func (m *mockLedgerServiceSimulate) GetAutofillSequence(account string, hasTicke
 	return m.autofillSeq, nil
 }
 
-func newSimulateTestServices(mock *mockLedgerServiceSimulate) *types.ServiceContainer {
-	return &types.ServiceContainer{
+func newSimulateTestServices(mock *mockLedgerServiceSimulate) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{
 		Ledger: mock,
-	}
+	})
 }
 
 // validAccountAddress is a well-known XRPL genesis account used in tests.

--- a/internal/rpc/submit_test.go
+++ b/internal/rpc/submit_test.go
@@ -259,10 +259,19 @@ func (m *mockLedgerServiceSubmit) StoreTransaction(txHash [32]byte, txData []byt
 }
 
 // newSubmitTestServices builds a per-test ServiceContainer wrapping mock.
-func newSubmitTestServices(mock *mockLedgerServiceSubmit) *types.ServiceContainer {
-	return &types.ServiceContainer{
+func newSubmitTestServices(mock *mockLedgerServiceSubmit) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{
 		Ledger: mock,
-	}
+	})
+}
+
+func newSubmitSigningTestServices(mock *mockLedgerServiceSubmit) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{
+		Ledger: mock,
+		Capabilities: types.RPCCapabilities{
+			SigningEnabled: true,
+		},
+	})
 }
 
 func rawSubmitParams(t *testing.T, txJSON map[string]any, extra map[string]any) json.RawMessage {
@@ -991,7 +1000,7 @@ func TestSubmitMethodServiceNilLedger(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: nil},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: nil}),
 	}
 
 	paramsJSON := rawSubmitParams(t, map[string]any{
@@ -1229,8 +1238,7 @@ func TestSubmitMethodOptionalParams(t *testing.T) {
 // the key, signs the transaction, and submits the signed blob.
 func TestSubmitMethodSigningCredentials(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	services := newSubmitTestServices(mock)
-	services.Capabilities.SigningEnabled = true
+	services := newSubmitSigningTestServices(mock)
 
 	method := &handlers.SubmitMethod{}
 	ctx := &types.RpcContext{
@@ -1342,8 +1350,7 @@ func TestSubmitMethodSigningCredentials(t *testing.T) {
 
 func TestSubmitMethodEmptyCredentialIsPresent(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	services := newSubmitTestServices(mock)
-	services.Capabilities.SigningEnabled = true
+	services := newSubmitSigningTestServices(mock)
 	params := json.RawMessage(`{
 		"tx_json": {
 			"TransactionType": "Payment",
@@ -1371,8 +1378,7 @@ func TestSubmitMethodEmptyCredentialIsPresent(t *testing.T) {
 
 func TestSubmitMethodMissingTxJSONPreservesCredentialPrecedence(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	services := newSubmitTestServices(mock)
-	services.Capabilities.SigningEnabled = true
+	services := newSubmitSigningTestServices(mock)
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
 		Role:       types.RoleUser,
@@ -1417,8 +1423,7 @@ func TestSubmitMethodMissingTxJSONPreservesCredentialPrecedence(t *testing.T) {
 // API v2 should include "hash" at the root level of the response.
 func TestSubmitMethodApiV2Response(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	services := newSubmitTestServices(mock)
-	services.Capabilities.SigningEnabled = true
+	services := newSubmitSigningTestServices(mock)
 
 	method := &handlers.SubmitMethod{}
 
@@ -1524,8 +1529,7 @@ func TestSubmitMethodApiV2Response(t *testing.T) {
 // For API v2+: Amount is removed, DeliverMax replaces it.
 func TestSubmitMethodDeliverMax(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
-	services := newSubmitTestServices(mock)
-	services.Capabilities.SigningEnabled = true
+	services := newSubmitSigningTestServices(mock)
 
 	method := &handlers.SubmitMethod{}
 

--- a/internal/rpc/subscribe_test.go
+++ b/internal/rpc/subscribe_test.go
@@ -1550,7 +1550,7 @@ func TestWebSocketSnapshot_Single(t *testing.T) {
 			"XRP/": {types.BookOffer{Account: "rOffer1"}, types.BookOffer{Account: "rOffer2"}},
 		},
 	}
-	services := types.NewServiceContainer(mock)
+	services := types.NewTestServiceGraph(types.NewServiceContainer(mock))
 	ws := &WebSocketServer{services: services}
 
 	offers, err := ws.snapshotBook(
@@ -1577,7 +1577,7 @@ func TestWebSocketSnapshot_Both(t *testing.T) {
 			"USD/" + gateway: {types.BookOffer{Account: "rAsk"}},
 		},
 	}
-	services := types.NewServiceContainer(mock)
+	services := types.NewTestServiceGraph(types.NewServiceContainer(mock))
 	ws := &WebSocketServer{services: services}
 	ctx := &types.RpcContext{Context: context.Background(), Services: services}
 
@@ -1596,14 +1596,15 @@ func TestWebSocketSnapshot_Both(t *testing.T) {
 // than constant 256s.
 func TestComputeServerLoad_TracksTxQ(t *testing.T) {
 	mock := newMockLedgerService()
-	services := types.NewServiceContainer(mock)
-	services.TxQMetrics = func() types.TxQServerMetrics {
+	container := types.NewServiceContainer(mock)
+	container.TxQMetrics = func() types.TxQServerMetrics {
 		return types.TxQServerMetrics{
 			ReferenceFeeLevel:     256,
 			MinProcessingFeeLevel: 512,
 			OpenLedgerFeeLevel:    1024,
 		}
 	}
+	services := types.NewTestServiceGraph(container)
 
 	load := handlers.ComputeServerLoad(services)
 	assert.Equal(t, uint64(256), load.LoadBase)
@@ -1618,29 +1619,31 @@ func TestComputeServerLoad_TracksTxQ(t *testing.T) {
 
 func TestComputeServerLoad_UsesServerAndOverallMaxima(t *testing.T) {
 	mock := newMockLedgerService()
-	services := types.NewServiceContainer(mock)
-	services.LoadFactorFees = func() types.LoadFactorFees {
+	container := types.NewServiceContainer(mock)
+	container.LoadFactorFees = func() types.LoadFactorFees {
 		return types.LoadFactorFees{Local: 700, Net: 900, Cluster: 800}
 	}
-	services.TxQMetrics = func() types.TxQServerMetrics {
+	container.TxQMetrics = func() types.TxQServerMetrics {
 		return types.TxQServerMetrics{
 			ReferenceFeeLevel:     256,
 			MinProcessingFeeLevel: 256,
 			OpenLedgerFeeLevel:    600,
 		}
 	}
+	services := types.NewTestServiceGraph(container)
 
 	load := handlers.ComputeServerLoad(services)
 	assert.Equal(t, uint64(900), load.LoadFactorServer)
 	assert.Equal(t, uint64(900), load.LoadFactor)
 
-	services.TxQMetrics = func() types.TxQServerMetrics {
+	container.TxQMetrics = func() types.TxQServerMetrics {
 		return types.TxQServerMetrics{
 			ReferenceFeeLevel:     256,
 			MinProcessingFeeLevel: 256,
 			OpenLedgerFeeLevel:    1200,
 		}
 	}
+	services = types.NewTestServiceGraph(container)
 	load = handlers.ComputeServerLoad(services)
 	assert.Equal(t, uint64(900), load.LoadFactorServer)
 	assert.Equal(t, uint64(1200), load.LoadFactor)

--- a/internal/rpc/subscription_contracts_test.go
+++ b/internal/rpc/subscription_contracts_test.go
@@ -36,6 +36,21 @@ func newHistorySubscriptionProvider() *historySubscriptionProvider {
 	}
 }
 
+func setHistoryServices(ws *WebSocketServer, ctx *types.RpcContext, ledger types.LedgerService, provider types.AccountHistorySubscriptionService) {
+	previous := ctx.Services
+	services := &types.ServiceContainer{
+		Ledger:                      ledger,
+		AccountHistorySubscriptions: provider,
+	}
+	if previous != nil {
+		services.ClientLoad = previous.ClientLoad()
+		services.RPCDiagnostics = previous.RPCDiagnostics()
+		services.Capabilities = previous.Capabilities()
+	}
+	ctx.Services = types.NewTestServiceGraph(services)
+	ws.services = ctx.Services
+}
+
 func (p *historySubscriptionProvider) ValidateSubscribe(conn types.AccountHistorySubscriptionSink, account string) *types.RpcError {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -176,8 +191,7 @@ func TestRTAccountsAliasAndCanonicalPrecedence(t *testing.T) {
 func TestAccountHistorySubscribeCapabilityAndValidation(t *testing.T) {
 	t.Run("transaction table gate precedes nested validation", func(t *testing.T) {
 		ws, conn, ctx := newSpecialDispatchHarness(t)
-		ctx.Services.Ledger = &txTablesOffLedger{newMockLedgerService()}
-		ctx.Services.AccountHistorySubscriptions = newHistorySubscriptionProvider()
+		setHistoryServices(ws, ctx, &txTablesOffLedger{newMockLedgerService()}, newHistorySubscriptionProvider())
 		ctx.LoadCost = uint32(resource.FeeReferenceRPC().Cost())
 
 		_, rpcErr := ws.executeSubscribe(conn, ctx, types.WebSocketCommand{
@@ -191,7 +205,7 @@ func TestAccountHistorySubscribeCapabilityAndValidation(t *testing.T) {
 
 	t.Run("missing replay provider fails closed", func(t *testing.T) {
 		ws, conn, ctx := newSpecialDispatchHarness(t)
-		ctx.Services.Ledger = newMockLedgerService()
+		setHistoryServices(ws, ctx, newMockLedgerService(), nil)
 		_, rpcErr := ws.executeSubscribe(conn, ctx, types.WebSocketCommand{
 			Params: json.RawMessage(`{"account_history_tx_stream":{"account":"` + historyAccountA + `"}}`),
 		})
@@ -202,8 +216,7 @@ func TestAccountHistorySubscribeCapabilityAndValidation(t *testing.T) {
 	t.Run("success sets medium load warning and rejects duplicates", func(t *testing.T) {
 		ws, conn, ctx := newSpecialDispatchHarness(t)
 		provider := newHistorySubscriptionProvider()
-		ctx.Services.Ledger = newMockLedgerService()
-		ctx.Services.AccountHistorySubscriptions = provider
+		setHistoryServices(ws, ctx, newMockLedgerService(), provider)
 		ctx.LoadCost = uint32(resource.FeeReferenceRPC().Cost())
 		command := types.WebSocketCommand{
 			Params: json.RawMessage(`{"account_history_tx_stream":{"account":"` + historyAccountA + `"}}`),
@@ -224,8 +237,7 @@ func TestAccountHistorySubscribeCapabilityAndValidation(t *testing.T) {
 
 	t.Run("bad account is invalidParams after medium charge", func(t *testing.T) {
 		ws, conn, ctx := newSpecialDispatchHarness(t)
-		ctx.Services.Ledger = newMockLedgerService()
-		ctx.Services.AccountHistorySubscriptions = newHistorySubscriptionProvider()
+		setHistoryServices(ws, ctx, newMockLedgerService(), newHistorySubscriptionProvider())
 		ctx.LoadCost = uint32(resource.FeeReferenceRPC().Cost())
 
 		_, rpcErr := ws.executeSubscribe(conn, ctx, types.WebSocketCommand{
@@ -240,8 +252,7 @@ func TestAccountHistorySubscribeCapabilityAndValidation(t *testing.T) {
 func TestAccountHistoryUnsubscribeModesAndCleanup(t *testing.T) {
 	ws, conn, ctx := newSpecialDispatchHarness(t)
 	provider := newHistorySubscriptionProvider()
-	ctx.Services.Ledger = newMockLedgerService()
-	ctx.Services.AccountHistorySubscriptions = provider
+	setHistoryServices(ws, ctx, newMockLedgerService(), provider)
 
 	subscribe := types.WebSocketCommand{
 		Params: json.RawMessage(`{"account_history_tx_stream":{"account":"` + historyAccountA + `"}}`),
@@ -285,7 +296,7 @@ func TestAccountHistoryUnsubscribeModesAndCleanup(t *testing.T) {
 
 func TestAccountHistoryUnsubscribeWithoutProviderIsNoOp(t *testing.T) {
 	ws, conn, ctx := newSpecialDispatchHarness(t)
-	ctx.Services.Ledger = &txTablesOffLedger{newMockLedgerService()}
+	setHistoryServices(ws, ctx, &txTablesOffLedger{newMockLedgerService()}, nil)
 
 	_, rpcErr := ws.executeUnsubscribe(conn, ctx, types.WebSocketCommand{
 		Params: json.RawMessage(`{"account_history_tx_stream":{"account":"not-an-account"}}`),
@@ -305,10 +316,10 @@ func TestAccountHistoryURLSubscriptionRetention(t *testing.T) {
 	defer sink.Close()
 
 	provider := newHistorySubscriptionProvider()
-	services := &types.ServiceContainer{
+	services := types.NewTestServiceGraph(&types.ServiceContainer{
 		Ledger:                      newMockLedgerService(),
 		AccountHistorySubscriptions: provider,
-	}
+	})
 	ws := NewWebSocketServer(WebSocketServerOptions{Services: services})
 	defer ws.urlSubs.Close()
 	requestContext, cancelRequest := context.WithCancel(context.Background())
@@ -335,7 +346,7 @@ func TestAccountHistoryURLSubscriptionRetention(t *testing.T) {
 	}
 	require.NotNil(t, conn)
 
-	services.Ledger = &txTablesOffLedger{newMockLedgerService()}
+	setHistoryServices(ws, ctx, &txTablesOffLedger{newMockLedgerService()}, provider)
 	request.AccountHistory.StopHistoryTxOnly = true
 	_, rpcErr = ws.urlSubs.Unsubscribe(ctx, request)
 	require.Nil(t, rpcErr)
@@ -356,10 +367,10 @@ func TestAccountHistoryURLValidationIsOrderedAndAtomic(t *testing.T) {
 	sink := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	defer sink.Close()
 	provider := newHistorySubscriptionProvider()
-	services := &types.ServiceContainer{
+	services := types.NewTestServiceGraph(&types.ServiceContainer{
 		Ledger:                      newMockLedgerService(),
 		AccountHistorySubscriptions: provider,
-	}
+	})
 	ws := NewWebSocketServer(WebSocketServerOptions{Services: services})
 	defer ws.urlSubs.Close()
 	ctx := &types.RpcContext{
@@ -428,18 +439,18 @@ func TestAccountHistoryHTTPURLMethods(t *testing.T) {
 	sink := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	defer sink.Close()
 	provider := newHistorySubscriptionProvider()
-	services := &types.ServiceContainer{
+	services := types.NewTestServiceGraph(&types.ServiceContainer{
 		Ledger:                      newMockLedgerService(),
 		AccountHistorySubscriptions: provider,
-	}
+	})
 	ws := NewWebSocketServer(WebSocketServerOptions{Services: services})
 	defer ws.urlSubs.Close()
-	services.URLSubscriptions = ws.urlSubs
 	ctx := &types.RpcContext{
-		Context:    context.Background(),
-		Role:       types.RoleAdmin,
-		ApiVersion: types.DefaultApiVersion,
-		Services:   services,
+		Context:          context.Background(),
+		Role:             types.RoleAdmin,
+		ApiVersion:       types.DefaultApiVersion,
+		Services:         services,
+		URLSubscriptions: ws.urlSubs,
 	}
 	params := json.RawMessage(`{
 		"url":"` + sink.URL + `",

--- a/internal/rpc/subscription_history.go
+++ b/internal/rpc/subscription_history.go
@@ -22,13 +22,13 @@ func prepareAccountHistorySubscribe(ctx *types.RpcContext, request types.Subscri
 		return nil, nil
 	}
 	services := rpcServices(ctx)
-	if services == nil || services.Ledger == nil {
+	if services == nil || services.Ledger() == nil {
 		return nil, types.RpcErrorNotEnabled("")
 	}
-	if tables, ok := services.Ledger.(types.TxTablesProvider); ok && !tables.UseTxTables() {
+	if tables, ok := services.Ledger().(types.TxTablesProvider); ok && !tables.UseTxTables() {
 		return nil, types.RpcErrorNotEnabled("")
 	}
-	if services.AccountHistorySubscriptions == nil {
+	if services.AccountHistorySubscriptions() == nil {
 		return nil, types.RpcErrorNotEnabled("")
 	}
 	if ctx != nil {
@@ -39,7 +39,7 @@ func prepareAccountHistorySubscribe(ctx *types.RpcContext, request types.Subscri
 		return nil, rpcErr
 	}
 	return &preparedAccountHistorySubscribe{
-		service: services.AccountHistorySubscriptions,
+		service: services.AccountHistorySubscriptions(),
 		account: account,
 	}, nil
 }
@@ -98,7 +98,7 @@ func prepareAccountHistoryUnsubscribe(ctx *types.RpcContext, request types.Subsc
 	services := rpcServices(ctx)
 	var service types.AccountHistorySubscriptionService
 	if services != nil {
-		service = services.AccountHistorySubscriptions
+		service = services.AccountHistorySubscriptions()
 	}
 	return &preparedAccountHistoryUnsubscribe{
 		service:     service,
@@ -156,19 +156,19 @@ func parseAccountHistoryRequest(request types.SubscriptionRequest, unsubscribe b
 	return account, historyOnly, nil
 }
 
-func rpcServices(ctx *types.RpcContext) *types.ServiceContainer {
+func rpcServices(ctx *types.RpcContext) *types.ServiceGraph {
 	if ctx == nil {
 		return nil
 	}
 	return ctx.Services
 }
 
-func removeAccountHistoryConnection(services *types.ServiceContainer, conn *subscription.Connection) {
-	if services != nil && services.AccountHistorySubscriptions != nil {
-		services.AccountHistorySubscriptions.RemoveConnection(conn)
+func removeAccountHistoryConnection(services *types.ServiceGraph, conn *subscription.Connection) {
+	if services != nil && services.AccountHistorySubscriptions() != nil {
+		services.AccountHistorySubscriptions().RemoveConnection(conn)
 	}
 }
 
-func hasAccountHistorySubscriptions(services *types.ServiceContainer, conn *subscription.Connection) bool {
-	return services != nil && services.AccountHistorySubscriptions != nil && services.AccountHistorySubscriptions.HasSubscriptions(conn)
+func hasAccountHistorySubscriptions(services *types.ServiceGraph, conn *subscription.Connection) bool {
+	return services != nil && services.AccountHistorySubscriptions() != nil && services.AccountHistorySubscriptions().HasSubscriptions(conn)
 }

--- a/internal/rpc/subscription_server_ack_test.go
+++ b/internal/rpc/subscription_server_ack_test.go
@@ -29,7 +29,7 @@ func TestServerSubscriptionInitialAcknowledgement(t *testing.T) {
 	ledger := newMockLedgerServiceServerInfo()
 	ledger.standalone = false
 	ledger.serverState = "validating"
-	services := &types.ServiceContainer{Ledger: ledger, NodePublicKey: testNodePublicKey()}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: ledger, NodePublicKey: testNodePublicKey()})
 	ws := NewWebSocketServer(WebSocketServerOptions{Services: services})
 	request := types.SubscriptionRequest{Streams: []types.SubscriptionType{types.SubServer}}
 
@@ -54,14 +54,14 @@ func TestServerSubscriptionInitialAcknowledgement(t *testing.T) {
 }
 
 func TestServerSubscriptionInitialLoadExcludesTxQEscalation(t *testing.T) {
-	services := &types.ServiceContainer{
+	services := types.NewTestServiceGraph(&types.ServiceContainer{
 		LoadFactorFees: func() types.LoadFactorFees {
 			return types.LoadFactorFees{Local: 256, Net: 256, Cluster: 256}
 		},
 		TxQMetrics: func() types.TxQServerMetrics {
 			return types.TxQServerMetrics{ReferenceFeeLevel: 256, OpenLedgerFeeLevel: 1024}
 		},
-	}
+	})
 	ws := NewWebSocketServer(WebSocketServerOptions{Services: services})
 	request := types.SubscriptionRequest{Streams: []types.SubscriptionType{types.SubServer}}
 	ack := ws.buildSubscribeAck(&types.RpcContext{Services: services}, request)
@@ -72,15 +72,16 @@ func TestServerSubscriptionInitialLoadExcludesTxQEscalation(t *testing.T) {
 func TestServerSubscriptionStateIsSampledBeforeRegistration(t *testing.T) {
 	for _, transport := range []string{"websocket", "url"} {
 		t.Run(transport, func(t *testing.T) {
-			services := &types.ServiceContainer{}
+			container := &types.ServiceContainer{}
 			var ws *WebSocketServer
-			services.LoadFactorFees = func() types.LoadFactorFees {
+			container.LoadFactorFees = func() types.LoadFactorFees {
 				factor := uint32(256)
 				if ws != nil && ws.subscriptionManager.GetSubscriberCount(types.SubServer) != 0 {
 					factor = 512
 				}
 				return types.LoadFactorFees{Local: factor, Net: factor, Cluster: factor}
 			}
+			services := types.NewTestServiceGraph(container)
 			ws = NewWebSocketServer(WebSocketServerOptions{Services: services})
 			ctx := &types.RpcContext{Services: services, Role: types.RoleAdmin}
 			var ack map[string]any
@@ -112,7 +113,7 @@ func TestServerSubscriptionStateIsSampledBeforeRegistration(t *testing.T) {
 
 func TestMPTBookSnapshotPreservesIssuanceID(t *testing.T) {
 	ledger := &mptSnapshotLedger{mockLedgerService: newMockLedgerService()}
-	services := &types.ServiceContainer{Ledger: ledger}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: ledger})
 	ws := NewWebSocketServer(WebSocketServerOptions{Services: services})
 	const mptID = "00000001C4F149B6F2A4B6A4C4A01C1570C4A040A3D9B221"
 	var request types.SubscriptionRequest

--- a/internal/rpc/transaction_entry_test.go
+++ b/internal/rpc/transaction_entry_test.go
@@ -129,10 +129,10 @@ func (m *mockLedgerServiceTE) addLedger(lr *mockLedgerReaderTE) {
 	m.ledgersByHash[lr.hash] = lr
 }
 
-func newTransactionEntryTestServices(mock *mockLedgerServiceTE) *types.ServiceContainer {
-	return &types.ServiceContainer{
+func newTransactionEntryTestServices(mock *mockLedgerServiceTE) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{
 		Ledger: mock,
-	}
+	})
 }
 
 // Tests
@@ -736,7 +736,7 @@ func TestTransactionEntryServiceUnavailable(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleGuest,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: nil},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: nil}),
 		}
 
 		params := map[string]any{

--- a/internal/rpc/transport_regression_test.go
+++ b/internal/rpc/transport_regression_test.go
@@ -31,7 +31,7 @@ func newTransportRegressionServer(t *testing.T) *Server {
 	t.Helper()
 	server := NewServer(ServerOptions{
 		Timeout:  time.Second,
-		Services: types.NewServiceContainer(nil),
+		Services: types.NewTestServiceGraph(types.NewServiceContainer(nil)),
 		Registry: mustTestMethodRegistry(t, map[string]types.MethodHandler{
 			"ping": &stubHandler{},
 			"stop": &stubHandler{role: types.RoleAdmin},
@@ -68,9 +68,10 @@ func TestTransportConstructorsShareInjectedResourceManager(t *testing.T) {
 }
 
 func TestRPCConstructorsUseExplicitDependencies(t *testing.T) {
-	services := types.NewServiceContainer(nil)
+	container := types.NewServiceContainer(nil)
 	clientLoad := types.NewClientLoadShedder()
-	services.ClientLoad = clientLoad
+	container.ClientLoad = clientLoad
+	services := types.NewTestServiceGraph(container)
 	manager := subscription.NewManager()
 	provider := stubLedgerInfoProvider{ledgerAvailable: true}
 	peerSource := &stubPeerSource{}
@@ -91,11 +92,11 @@ func TestRPCConstructorsUseExplicitDependencies(t *testing.T) {
 		SubscriptionManager: manager,
 	})
 
-	if services.ClientLoad != clientLoad || services.Dispatcher != nil || services.URLSubscriptions != nil {
+	if container.ClientLoad != clientLoad {
 		t.Fatal("RPC constructors mutated the service container")
 	}
 	clientLoad.Begin()
-	if httpServer.services.ClientLoad.InFlight() != 1 || wsServer.services.ClientLoad.InFlight() != 1 {
+	if httpServer.services.ClientLoad().InFlight() != 1 || wsServer.services.ClientLoad().InFlight() != 1 {
 		t.Fatal("HTTP and WebSocket servers did not observe the shared client-load shedder")
 	}
 	if wsServer.SubscriptionManager() != manager {
@@ -281,7 +282,7 @@ func TestHTTPEarlyDispatchErrorsChargeReferenceAndWarn(t *testing.T) {
 			method: "ping",
 			token:  "tooBusy",
 			setup: func(server *Server) {
-				server.services.ClientLoad = saturatedShedder()
+				server.services = types.NewTestServiceGraph(&types.ServiceContainer{ClientLoad: saturatedShedder()})
 			},
 		},
 		{name: "unknown", method: "does_not_exist", token: "unknownCmd", setup: func(*Server) {}},
@@ -290,7 +291,7 @@ func TestHTTPEarlyDispatchErrorsChargeReferenceAndWarn(t *testing.T) {
 			method: "gated",
 			token:  "noNetwork",
 			setup: func(server *Server) {
-				server.services.Ledger = newMockLedgerService()
+				server.services = types.NewTestServiceGraph(&types.ServiceContainer{Ledger: newMockLedgerService()})
 			},
 		},
 	}

--- a/internal/rpc/tx_history_test.go
+++ b/internal/rpc/tx_history_test.go
@@ -41,10 +41,10 @@ func (m *mockLedgerServiceTxHistory) GetTransactionHistory(ctx context.Context, 
 	}, nil
 }
 
-func newTxHistoryTestServices(mock *mockLedgerServiceTxHistory) *types.ServiceContainer {
-	return &types.ServiceContainer{
+func newTxHistoryTestServices(mock *mockLedgerServiceTxHistory) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{
 		Ledger: mock,
-	}
+	})
 }
 
 // Tests
@@ -297,7 +297,7 @@ func TestTxHistoryServiceUnavailable(t *testing.T) {
 			Context:    context.Background(),
 			Role:       types.RoleUser,
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: nil},
+			Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: nil}),
 		}
 
 		params := map[string]any{

--- a/internal/rpc/tx_tables_gate_test.go
+++ b/internal/rpc/tx_tables_gate_test.go
@@ -22,7 +22,7 @@ func newTxTablesOffContext() *types.RpcContext {
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: &txTablesOffLedger{newMockLedgerService()}},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: &txTablesOffLedger{newMockLedgerService()}}),
 	}
 }
 

--- a/internal/rpc/tx_test.go
+++ b/internal/rpc/tx_test.go
@@ -113,10 +113,10 @@ func (m *mockLedgerServiceTx) GetLedgerRange(ctx context.Context, minSeq, maxSeq
 }
 
 // servicesForTx builds a per-test ServiceContainer with a tx mock.
-func servicesForTx(mock *mockLedgerServiceTx) *types.ServiceContainer {
-	return &types.ServiceContainer{
+func servicesForTx(mock *mockLedgerServiceTx) *types.ServiceGraph {
+	return types.NewTestServiceGraph(&types.ServiceContainer{
 		Ledger: mock,
-	}
+	})
 }
 
 func TestTxDeliveredAmountHistoricalContext(t *testing.T) {
@@ -1587,7 +1587,7 @@ func TestTxMethodServiceNilLedger(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: nil},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: nil}),
 	}
 
 	params := map[string]any{
@@ -2037,7 +2037,7 @@ func TestTxMethodCTIDLookupUsesMetadataTransactionIndex(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: service},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: service}),
 	}
 
 	result, rpcErr := (&handlers.TxMethod{}).Handle(ctx, params)
@@ -2063,7 +2063,7 @@ func TestTxMethodCTIDLookupSkipsMalformedLeaf(t *testing.T) {
 		}
 		return nil, errors.New("ledger not found")
 	}
-	services := &types.ServiceContainer{Ledger: service}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: service})
 	params, err := json.Marshal(map[string]any{
 		"ctid":   "C000006400000000",
 		"binary": true,
@@ -2288,7 +2288,7 @@ func TestTxMethodCTIDCorruptedStoredData(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: mock},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 	}
 	ctid, ok := handlers.EncodeCTID(ledger.sequence, 0, 0)
 	require.True(t, ok)
@@ -2334,7 +2334,7 @@ func TestTxMethodCTIDStoredDataWithoutMetadata(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: mock},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 	}
 	ctid, ok := handlers.EncodeCTID(ledger.sequence, 0, 0)
 	require.True(t, ok)

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -19,6 +21,22 @@ import (
 // method in `json` to escape per-IP load charging.
 type MethodDispatcher interface {
 	ExecuteMethod(ctx *RpcContext, method string, params []byte) (any, *RpcError)
+}
+
+// Shutdowner requests an orderly node shutdown. The capability is wired before
+// RPC transports are constructed and remains stable for every request.
+type Shutdowner interface {
+	RequestShutdown()
+}
+
+// ShutdownFunc adapts a function to Shutdowner for construction and test
+// fixtures. Production wiring should use a controller that owns the channel.
+type ShutdownFunc func()
+
+func (f ShutdownFunc) RequestShutdown() {
+	if f != nil {
+		f()
+	}
 }
 
 // ValidatorListPublisherInfo is the per-publisher snapshot the
@@ -202,11 +220,9 @@ type ServiceContainer struct {
 	// LedgerService provides ledger operations
 	Ledger LedgerService
 
-	// Dispatcher forwards RPC calls (used by 'json' method)
-	Dispatcher MethodDispatcher
-
-	// ShutdownFunc gracefully stops the server (used by 'stop' method)
-	ShutdownFunc func()
+	// Shutdown requests an orderly node shutdown. It is supplied to the
+	// construction-only builder and copied into the immutable graph.
+	Shutdown Shutdowner
 
 	// NodePublicKey is the base58-encoded node identity public key (e.g. "n9...")
 	NodePublicKey string
@@ -460,14 +476,6 @@ type ServiceContainer struct {
 	// wired — the handler then returns notEnabled, matching rippled's
 	// advisoryDelete() gate.
 	AdvisoryDeleteState AdvisoryDeleteStore
-
-	// URLSubscriptions backs rippled's url-based (RPCSub) admin
-	// subscriptions: subscribe/unsubscribe requests carrying a url are
-	// routed here instead of to a per-connection subscription. Populated by
-	// the WebSocket server, which owns the registry so url subscribers share
-	// the broadcast fan-out with WebSocket connections. Nil when no
-	// WebSocket server is wired — the handlers then report notSupported.
-	URLSubscriptions URLSubscriptionService
 
 	// AccountHistorySubscriptions is the optional provider for rippled's
 	// experimental account_history_tx_stream. Nil means the node cannot perform
@@ -1641,11 +1649,454 @@ type NFTOffersResult struct {
 	Marker      string         `json:"marker,omitempty"` // Only present when more results available
 }
 
-// NewServiceContainer constructs a ServiceContainer wired to the given
-// ledger service. Callers attach the runtime services as components come
-// online.
+type serviceGraphProfile struct {
+	RequireLedger             bool
+	RequireShutdown           bool
+	RequireClientLoad         bool
+	RequireDiagnostics        bool
+	RequireConfig             bool
+	RequireSubscriptionMetric bool
+}
+
+// ServiceGraphBuilder is mutable construction state. It is never passed to a
+// request context or transport; Build returns the only published graph.
+type ServiceGraphBuilder struct {
+	ServiceContainer
+}
+
+// NewServiceContainer constructs the legacy mutable wiring state. New node
+// code should use NewServiceGraphBuilder; this function remains for small
+// fixture setup before NewTestServiceGraph is called.
 func NewServiceContainer(ledger LedgerService) *ServiceContainer {
-	return &ServiceContainer{
-		Ledger: ledger,
+	return &ServiceContainer{Ledger: ledger}
+}
+
+// NewServiceGraphBuilder starts construction with the mandatory ledger
+// dependency. Additional capabilities are attached while startup stages run.
+func NewServiceGraphBuilder(ledger LedgerService) *ServiceGraphBuilder {
+	return &ServiceGraphBuilder{ServiceContainer: ServiceContainer{Ledger: ledger}}
+}
+
+// Build validates the strict production dependency profile and publishes an
+// immutable graph.
+func (b *ServiceGraphBuilder) Build() (*ServiceGraph, error) {
+	return b.buildProfile(serviceGraphProfile{
+		RequireLedger:             true,
+		RequireShutdown:           true,
+		RequireClientLoad:         true,
+		RequireDiagnostics:        true,
+		RequireConfig:             true,
+		RequireSubscriptionMetric: true,
+	})
+}
+
+func (b *ServiceGraphBuilder) buildProfile(profile serviceGraphProfile) (*ServiceGraph, error) {
+	if b == nil {
+		return nil, fmt.Errorf("service graph builder is nil")
 	}
+	if profile.RequireLedger && serviceCapabilityNil(b.Ledger) {
+		return nil, fmt.Errorf("service graph requires a ledger service")
+	}
+	if profile.RequireShutdown && serviceCapabilityNil(b.Shutdown) {
+		return nil, fmt.Errorf("service graph requires a shutdown capability")
+	}
+	if profile.RequireClientLoad && b.ClientLoad == nil {
+		return nil, fmt.Errorf("service graph requires a client-load shedder")
+	}
+	if profile.RequireDiagnostics && serviceCapabilityNil(b.RPCDiagnostics) {
+		return nil, fmt.Errorf("service graph requires RPC diagnostics")
+	}
+	if profile.RequireConfig && b.ServerInfoConfig.Ports == nil {
+		return nil, fmt.Errorf("service graph requires a server configuration snapshot")
+	}
+	if profile.RequireSubscriptionMetric && b.SubscriptionMetrics == nil {
+		return nil, fmt.Errorf("service graph requires subscription metrics")
+	}
+
+	snapshot := cloneServiceContainer(b.ServiceContainer)
+	// These dependencies belong to the transport/request layer, not the
+	// application graph. They are deliberately absent from ServiceContainer.
+	return &ServiceGraph{snapshot: snapshot}, nil
+}
+
+func serviceCapabilityNil(capability any) bool {
+	if capability == nil {
+		return true
+	}
+	value := reflect.ValueOf(capability)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+// NewTestServiceGraph publishes a sparse graph for handler and transport
+// fixtures. Production validation is exercised through ServiceGraphBuilder.Build.
+func NewTestServiceGraph(services *ServiceContainer) *ServiceGraph {
+	if services == nil {
+		services = &ServiceContainer{}
+	}
+	builder := &ServiceGraphBuilder{ServiceContainer: *services}
+	graph, err := builder.buildProfile(serviceGraphProfile{})
+	if err != nil {
+		panic(err)
+	}
+	return graph
+}
+
+// ServiceGraph is the immutable application capability graph published to
+// RPC contexts and transports. Its state is private; live capabilities may
+// expose their own synchronized operations, but the graph topology cannot be
+// changed after Build returns.
+type ServiceGraph struct {
+	snapshot ServiceContainer
+}
+
+func (g *ServiceGraph) services() *ServiceContainer {
+	if g == nil {
+		return nil
+	}
+	return &g.snapshot
+}
+
+func (g *ServiceGraph) Ledger() LedgerService {
+	if s := g.services(); s != nil {
+		return s.Ledger
+	}
+	return nil
+}
+
+func (g *ServiceGraph) Shutdowner() Shutdowner {
+	if s := g.services(); s != nil {
+		return s.Shutdown
+	}
+	return nil
+}
+
+func (g *ServiceGraph) NodePublicKey() string {
+	if s := g.services(); s != nil {
+		return s.NodePublicKey
+	}
+	return ""
+}
+
+func (g *ServiceGraph) SystemTime() func() time.Time {
+	if s := g.services(); s != nil {
+		return s.SystemTime
+	}
+	return nil
+}
+
+func (g *ServiceGraph) ServerInfoConfig() ServerInfoConfigSnapshot {
+	if s := g.services(); s != nil {
+		return cloneServerInfoConfig(s.ServerInfoConfig)
+	}
+	return ServerInfoConfigSnapshot{}
+}
+
+func (g *ServiceGraph) Capabilities() RPCCapabilities {
+	if s := g.services(); s != nil {
+		return s.Capabilities
+	}
+	return RPCCapabilities{}
+}
+
+func (g *ServiceGraph) LastCloseInfo() func() (int, int) {
+	if s := g.services(); s != nil {
+		return s.LastCloseInfo
+	}
+	return nil
+}
+
+func (g *ServiceGraph) ConsensusInfo() func(bool) map[string]any {
+	if s := g.services(); s != nil {
+		return s.ConsensusInfo
+	}
+	return nil
+}
+
+func (g *ServiceGraph) Manifests() ManifestLookup {
+	if s := g.services(); s != nil {
+		return s.Manifests
+	}
+	return nil
+}
+
+func (g *ServiceGraph) ValidatorPublicKey() []byte {
+	if s := g.services(); s != nil {
+		return append([]byte(nil), s.ValidatorPublicKey...)
+	}
+	return nil
+}
+
+func (g *ServiceGraph) ValidationQuorum() func() int {
+	if s := g.services(); s != nil {
+		return s.ValidationQuorum
+	}
+	return nil
+}
+
+func (g *ServiceGraph) ValidatorList() ValidatorListReader {
+	if s := g.services(); s != nil {
+		return s.ValidatorList
+	}
+	return nil
+}
+
+func (g *ServiceGraph) LocalStaticTrustedKeysBase58() func() []string {
+	if s := g.services(); s != nil {
+		return s.LocalStaticTrustedKeysBase58
+	}
+	return nil
+}
+
+func (g *ServiceGraph) TrustedValidatorKeysBase58() func() []string {
+	if s := g.services(); s != nil {
+		return s.TrustedValidatorKeysBase58
+	}
+	return nil
+}
+
+func (g *ServiceGraph) SigningKeysBase58() func() map[string]string {
+	if s := g.services(); s != nil {
+		return s.SigningKeysBase58
+	}
+	return nil
+}
+
+func (g *ServiceGraph) NegativeUNLBase58() func() []string {
+	if s := g.services(); s != nil {
+		return s.NegativeUNLBase58
+	}
+	return nil
+}
+
+func (g *ServiceGraph) BetaRPCAPI() bool {
+	if s := g.services(); s != nil {
+		return s.BetaRPCAPI
+	}
+	return false
+}
+
+func (g *ServiceGraph) TxQMetrics() func() TxQServerMetrics {
+	if s := g.services(); s != nil {
+		return s.TxQMetrics
+	}
+	return nil
+}
+
+func (g *ServiceGraph) TxQFeeMetrics() func() TxQFeeMetrics {
+	if s := g.services(); s != nil {
+		return s.TxQFeeMetrics
+	}
+	return nil
+}
+
+func (g *ServiceGraph) JqTransOverflow() func() uint64 {
+	if s := g.services(); s != nil {
+		return s.JqTransOverflow
+	}
+	return nil
+}
+
+func (g *ServiceGraph) PeerDisconnects() func() (uint64, uint64) {
+	if s := g.services(); s != nil {
+		return s.PeerDisconnects
+	}
+	return nil
+}
+
+func (g *ServiceGraph) PeerReservationAdd() func(string, string) (string, bool, error) {
+	if s := g.services(); s != nil {
+		return s.PeerReservationAdd
+	}
+	return nil
+}
+
+func (g *ServiceGraph) PeerReservationDel() func(string) (string, bool, error) {
+	if s := g.services(); s != nil {
+		return s.PeerReservationDel
+	}
+	return nil
+}
+
+func (g *ServiceGraph) PeerReservationList() func() []PeerReservationEntry {
+	if s := g.services(); s != nil {
+		return s.PeerReservationList
+	}
+	return nil
+}
+
+func (g *ServiceGraph) PeerConnect() func(string) error {
+	if s := g.services(); s != nil {
+		return s.PeerConnect
+	}
+	return nil
+}
+
+func (g *ServiceGraph) ResourceBlacklist() func(*int) map[string]any {
+	if s := g.services(); s != nil {
+		return s.ResourceBlacklist
+	}
+	return nil
+}
+
+func (g *ServiceGraph) StateAccounting() func() StateAccountingSnapshot {
+	if s := g.services(); s != nil {
+		return s.StateAccounting
+	}
+	return nil
+}
+
+func (g *ServiceGraph) CloseTimeOffset() func() time.Duration {
+	if s := g.services(); s != nil {
+		return s.CloseTimeOffset
+	}
+	return nil
+}
+
+func (g *ServiceGraph) FetchPackCacheSize() func() uint32 {
+	if s := g.services(); s != nil {
+		return s.FetchPackCacheSize
+	}
+	return nil
+}
+
+func (g *ServiceGraph) LoadFactorFees() func() LoadFactorFees {
+	if s := g.services(); s != nil {
+		return s.LoadFactorFees
+	}
+	return nil
+}
+
+func (g *ServiceGraph) IsLoadedCluster() func() bool {
+	if s := g.services(); s != nil {
+		return s.IsLoadedCluster
+	}
+	return nil
+}
+
+func (g *ServiceGraph) IsLoadedLocal() func() bool {
+	if s := g.services(); s != nil {
+		return s.IsLoadedLocal
+	}
+	return nil
+}
+
+func (g *ServiceGraph) ClientLoad() *ClientLoadShedder {
+	if s := g.services(); s != nil {
+		return s.ClientLoad
+	}
+	return nil
+}
+
+func (g *ServiceGraph) RPCDiagnostics() RPCDiagnostics {
+	if s := g.services(); s != nil {
+		return s.RPCDiagnostics
+	}
+	return nil
+}
+
+func (g *ServiceGraph) SubscriptionMetrics() func() SubscriptionMetrics {
+	if s := g.services(); s != nil {
+		return s.SubscriptionMetrics
+	}
+	return nil
+}
+
+func (g *ServiceGraph) GetCounts() func() CountsResult {
+	if s := g.services(); s != nil {
+		return s.GetCounts
+	}
+	return nil
+}
+
+func (g *ServiceGraph) TxReduceRelayMetrics() func() TxReduceRelayMetrics {
+	if s := g.services(); s != nil {
+		return s.TxReduceRelayMetrics
+	}
+	return nil
+}
+
+func (g *ServiceGraph) FetchInfo() func() map[string]any {
+	if s := g.services(); s != nil {
+		return s.FetchInfo
+	}
+	return nil
+}
+
+func (g *ServiceGraph) FetchInfoClear() func() {
+	if s := g.services(); s != nil {
+		return s.FetchInfoClear
+	}
+	return nil
+}
+
+func (g *ServiceGraph) RequestLedger() func([32]byte, uint32) (map[string]any, bool, bool) {
+	if s := g.services(); s != nil {
+		return s.RequestLedger
+	}
+	return nil
+}
+
+func (g *ServiceGraph) LedgerCleanerConfigure() func(LedgerCleanerParams) LedgerCleanerStatus {
+	if s := g.services(); s != nil {
+		return s.LedgerCleanerConfigure
+	}
+	return nil
+}
+
+func (g *ServiceGraph) LedgerCleanerStatusFn() func() LedgerCleanerStatus {
+	if s := g.services(); s != nil {
+		return s.LedgerCleanerStatusFn
+	}
+	return nil
+}
+
+func (g *ServiceGraph) UNLBlocked() func() bool {
+	if s := g.services(); s != nil {
+		return s.UNLBlocked
+	}
+	return nil
+}
+
+func (g *ServiceGraph) AdvisoryDeleteState() AdvisoryDeleteStore {
+	if s := g.services(); s != nil {
+		return s.AdvisoryDeleteState
+	}
+	return nil
+}
+
+func (g *ServiceGraph) AccountHistorySubscriptions() AccountHistorySubscriptionService {
+	if s := g.services(); s != nil {
+		return s.AccountHistorySubscriptions
+	}
+	return nil
+}
+
+func (g *ServiceGraph) QueueAccountTxs() func([20]byte) []QueuedTxInfo {
+	if s := g.services(); s != nil {
+		return s.QueueAccountTxs
+	}
+	return nil
+}
+
+func (g *ServiceGraph) QueueAllTxs() func() []QueuedTxInfo {
+	if s := g.services(); s != nil {
+		return s.QueueAllTxs
+	}
+	return nil
+}
+
+func cloneServiceContainer(input ServiceContainer) ServiceContainer {
+	input.ValidatorPublicKey = append([]byte(nil), input.ValidatorPublicKey...)
+	input.ServerInfoConfig = cloneServerInfoConfig(input.ServerInfoConfig)
+	return input
+}
+
+func cloneServerInfoConfig(input ServerInfoConfigSnapshot) ServerInfoConfigSnapshot {
+	input.Ports = append([]ServerInfoPortSnapshot(nil), input.Ports...)
+	return input
 }

--- a/internal/rpc/types/services_test.go
+++ b/internal/rpc/types/services_test.go
@@ -2,9 +2,91 @@ package types
 
 import (
 	"context"
+	"reflect"
 	"sync"
 	"testing"
 )
+
+type serviceGraphLedger struct{ LedgerService }
+
+type serviceGraphDiagnostics struct{}
+
+func (serviceGraphDiagnostics) Start(string) func(bool) { return func(bool) {} }
+func (serviceGraphDiagnostics) Snapshot() RPCDiagnosticsSnapshot {
+	return RPCDiagnosticsSnapshot{}
+}
+
+func completeServiceGraphBuilder() *ServiceGraphBuilder {
+	return &ServiceGraphBuilder{ServiceContainer: ServiceContainer{
+		Ledger:              &serviceGraphLedger{},
+		Shutdown:            ShutdownFunc(func() {}),
+		ClientLoad:          NewClientLoadShedder(),
+		RPCDiagnostics:      serviceGraphDiagnostics{},
+		ServerInfoConfig:    ServerInfoConfigSnapshot{Ports: []ServerInfoPortSnapshot{}},
+		SubscriptionMetrics: func() SubscriptionMetrics { return SubscriptionMetrics{} },
+	}}
+}
+
+func TestServiceGraphBuildValidatesProductionDependencies(t *testing.T) {
+	if _, err := completeServiceGraphBuilder().Build(); err != nil {
+		t.Fatalf("complete graph build: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		remove func(*ServiceGraphBuilder)
+	}{
+		{name: "ledger", remove: func(b *ServiceGraphBuilder) { b.Ledger = nil }},
+		{name: "typed nil ledger", remove: func(b *ServiceGraphBuilder) { b.Ledger = (*serviceGraphLedger)(nil) }},
+		{name: "shutdown", remove: func(b *ServiceGraphBuilder) { b.Shutdown = nil }},
+		{name: "typed nil shutdown", remove: func(b *ServiceGraphBuilder) { b.Shutdown = ShutdownFunc(nil) }},
+		{name: "client load", remove: func(b *ServiceGraphBuilder) { b.ClientLoad = nil }},
+		{name: "diagnostics", remove: func(b *ServiceGraphBuilder) { b.RPCDiagnostics = nil }},
+		{name: "typed nil diagnostics", remove: func(b *ServiceGraphBuilder) { b.RPCDiagnostics = (*serviceGraphDiagnostics)(nil) }},
+		{name: "configuration", remove: func(b *ServiceGraphBuilder) { b.ServerInfoConfig.Ports = nil }},
+		{name: "subscription metrics", remove: func(b *ServiceGraphBuilder) { b.SubscriptionMetrics = nil }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			builder := completeServiceGraphBuilder()
+			test.remove(builder)
+			if _, err := builder.Build(); err == nil {
+				t.Fatal("incomplete production graph unexpectedly built")
+			}
+		})
+	}
+}
+
+func TestServiceGraphBuildCopiesTopologyAndSnapshots(t *testing.T) {
+	firstLedger := &serviceGraphLedger{}
+	secondLedger := &serviceGraphLedger{}
+	builder := completeServiceGraphBuilder()
+	builder.Ledger = firstLedger
+	builder.ValidatorPublicKey = []byte{1, 2, 3}
+	builder.ServerInfoConfig.Ports = []ServerInfoPortSnapshot{{Port: 5005, Protocol: "http"}}
+
+	graph, err := builder.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	builder.Ledger = secondLedger
+	builder.ValidatorPublicKey[0] = 9
+	builder.ServerInfoConfig.Ports[0].Port = 6006
+
+	if graph.Ledger() != firstLedger {
+		t.Fatal("builder mutation changed the published ledger capability")
+	}
+	key := graph.ValidatorPublicKey()
+	config := graph.ServerInfoConfig()
+	if !reflect.DeepEqual(key, []byte{1, 2, 3}) || config.Ports[0].Port != 5005 {
+		t.Fatalf("published snapshots changed: key=%v config=%+v", key, config)
+	}
+	key[0] = 8
+	config.Ports[0].Port = 7007
+	if graph.ValidatorPublicKey()[0] != 1 || graph.ServerInfoConfig().Ports[0].Port != 5005 {
+		t.Fatal("accessors exposed mutable snapshot storage")
+	}
+}
 
 func TestClientLoadShedderReleaseOwnership(t *testing.T) {
 	var shedder ClientLoadShedder

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -96,13 +96,15 @@ type RpcContext struct {
 	ClientIP   string
 	ResourceIP string
 	PeerSource PeerSource
-	// Services is the per-request service container handlers read to
-	// reach the ledger service, dispatcher, manifest cache, etc. The
-	// HTTP/WebSocket dispatchers populate this from the server's wired
-	// container; tests construct RpcContext directly with whatever
-	// fixtures they need. Replaces the former package-level
-	// types.Services global.
-	Services *ServiceContainer
+	// Services is the immutable application graph shared by all requests.
+	// Transport-owned dependencies are carried separately below.
+	Services *ServiceGraph
+	// Dispatcher forwards the json proxy through the current transport's
+	// method registry without putting a transport back into the application
+	// graph.
+	Dispatcher MethodDispatcher
+	// URLSubscriptions is the transport-owned RPCSub registry, when enabled.
+	URLSubscriptions URLSubscriptionService
 	// LoadCost is the resource charge selected while handling the request.
 	// Dispatch initializes it to the reference cost; handlers raise it only
 	// after reaching the equivalent rippled work boundary.

--- a/internal/rpc/validators_test.go
+++ b/internal/rpc/validators_test.go
@@ -25,7 +25,7 @@ import (
 // trusted_validator_keys, publisher_lists, validation_quorum are present.
 func TestValidatorsResponseStructure(t *testing.T) {
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.ValidatorsMethod{}
 	ctx := &types.RpcContext{
@@ -62,7 +62,7 @@ func TestValidatorsResponseStructure(t *testing.T) {
 // trusted_validator_keys.size() == 0 and publisher_lists.size() == 0.
 func TestValidatorsEmptyList(t *testing.T) {
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.ValidatorsMethod{}
 	ctx := &types.RpcContext{
@@ -96,10 +96,10 @@ func TestValidatorsEmptyList(t *testing.T) {
 }
 
 func TestValidatorsDisabledQuorumUsesRippledWireValue(t *testing.T) {
-	services := &types.ServiceContainer{
+	services := types.NewTestServiceGraph(&types.ServiceContainer{
 		Ledger:           newMockLedgerService(),
 		ValidationQuorum: func() int { return math.MaxInt },
-	}
+	})
 	method := &handlers.ValidatorsMethod{}
 	ctx := &types.RpcContext{
 		Context: context.Background(), Role: types.RoleAdmin,
@@ -117,7 +117,7 @@ func TestValidatorsDisabledQuorumUsesRippledWireValue(t *testing.T) {
 
 func TestValidatorsUsesEffectiveTrustedKeys(t *testing.T) {
 	const localKey = "nLocalValidator"
-	services := &types.ServiceContainer{
+	services := types.NewTestServiceGraph(&types.ServiceContainer{
 		Ledger: newMockLedgerService(),
 		LocalStaticTrustedKeysBase58: func() []string {
 			return nil
@@ -125,7 +125,7 @@ func TestValidatorsUsesEffectiveTrustedKeys(t *testing.T) {
 		TrustedValidatorKeysBase58: func() []string {
 			return []string{localKey}
 		},
-	}
+	})
 
 	result, rpcErr := (&handlers.ValidatorsMethod{}).Handle(&types.RpcContext{
 		Context:    context.Background(),
@@ -171,7 +171,7 @@ func TestValidatorsMethodMetadata(t *testing.T) {
 // The validators method accepts no parameters but should not fail if extras are sent.
 func TestValidatorsWithParams(t *testing.T) {
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.ValidatorsMethod{}
 	ctx := &types.RpcContext{
@@ -200,7 +200,7 @@ func TestValidatorsWithParams(t *testing.T) {
 // status == "success" and the result to contain validation key fields.
 func TestValidationCreateReturnsKeyPair(t *testing.T) {
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.ValidationCreateMethod{}
 	ctx := &types.RpcContext{
@@ -242,7 +242,7 @@ func TestValidationCreateReturnsKeyPair(t *testing.T) {
 // "BAWL MAN JADE MOON DOVE GEM SON NOW HAD ADEN GLOW TIRE" and expects success.
 func TestValidationCreateWithSecret(t *testing.T) {
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.ValidationCreateMethod{}
 	ctx := &types.RpcContext{
@@ -396,7 +396,7 @@ func TestValidationCreateMethodMetadata(t *testing.T) {
 // is the correct response.
 func TestConsensusInfoResponseStructure(t *testing.T) {
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.ConsensusInfoMethod{}
 	ctx := &types.RpcContext{
@@ -455,7 +455,7 @@ func TestConsensusInfoMethodMetadata(t *testing.T) {
 // The consensus_info method accepts no parameters but should not fail if extras are sent.
 func TestConsensusInfoWithParams(t *testing.T) {
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock})
 
 	method := &handlers.ConsensusInfoMethod{}
 	ctx := &types.RpcContext{
@@ -482,13 +482,14 @@ func TestConsensusInfoWithParams(t *testing.T) {
 // Reference: rippled Stop.cpp — returns message "ripple server stopping".
 func TestStopReturnsStoppingMessage(t *testing.T) {
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	container := types.NewServiceContainer(mock)
 
 	// Set up a shutdown function that records it was called
 	shutdownCalled := false
-	services.ShutdownFunc = func() {
+	container.Shutdown = types.ShutdownFunc(func() {
 		shutdownCalled = true
-	}
+	})
+	services := types.NewTestServiceGraph(container)
 
 	method := &handlers.StopMethod{}
 	ctx := &types.RpcContext{
@@ -566,10 +567,7 @@ func TestStopServiceUnavailable(t *testing.T) {
 // When the shutdown function is not set, stop should return an internal error.
 func TestStopShutdownFuncNil(t *testing.T) {
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
-
-	// ShutdownFunc is nil by default
-	services.ShutdownFunc = nil
+	services := types.NewTestServiceGraph(types.NewServiceContainer(mock))
 
 	method := &handlers.StopMethod{}
 	ctx := &types.RpcContext{
@@ -592,12 +590,13 @@ func TestStopShutdownFuncNil(t *testing.T) {
 // TestStopWithParams tests that providing params does not affect stop behavior.
 func TestStopWithParams(t *testing.T) {
 	mock := newMockLedgerService()
-	services := &types.ServiceContainer{Ledger: mock}
+	container := types.NewServiceContainer(mock)
 
 	shutdownCalled := false
-	services.ShutdownFunc = func() {
+	container.Shutdown = types.ShutdownFunc(func() {
 		shutdownCalled = true
-	}
+	})
+	services := types.NewTestServiceGraph(container)
 
 	method := &handlers.StopMethod{}
 	ctx := &types.RpcContext{

--- a/internal/rpc/vault_info_conformance_test.go
+++ b/internal/rpc/vault_info_conformance_test.go
@@ -50,7 +50,7 @@ func vaultInfoTestContext(mock *vaultInfoMockLedgerService) (*handlers.VaultInfo
 		Context:    context.Background(),
 		Role:       types.RoleGuest,
 		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: mock},
+		Services:   types.NewTestServiceGraph(&types.ServiceContainer{Ledger: mock}),
 	}
 }
 

--- a/internal/rpc/version_test.go
+++ b/internal/rpc/version_test.go
@@ -77,7 +77,7 @@ func TestVersionV2ShapeNumericNoGood(t *testing.T) {
 				Context:    context.Background(),
 				Role:       types.RoleGuest,
 				ApiVersion: tc.version,
-				Services:   &types.ServiceContainer{BetaRPCAPI: tc.beta},
+				Services:   types.NewTestServiceGraph(&types.ServiceContainer{BetaRPCAPI: tc.beta}),
 			}
 
 			result, rpcErr := method.Handle(ctx, nil)
@@ -122,7 +122,7 @@ func TestVersionLastTracksBetaFlag(t *testing.T) {
 				Context:    context.Background(),
 				Role:       types.RoleGuest,
 				ApiVersion: types.ApiVersion2,
-				Services:   &types.ServiceContainer{BetaRPCAPI: tc.beta},
+				Services:   types.NewTestServiceGraph(&types.ServiceContainer{BetaRPCAPI: tc.beta}),
 			}
 
 			result, rpcErr := method.Handle(ctx, nil)

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -253,8 +253,6 @@ func (ws *WebSocketServer) SubscriptionManager() *subscription.Manager {
 	return ws.subscriptionManager
 }
 
-// URLSubscriptionService returns the transport-owned URL subscription
-// registry.
 func (ws *WebSocketServer) URLSubscriptionService() types.URLSubscriptionService {
 	return ws.urlSubscriptions
 }

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -51,7 +51,8 @@ type WebSocketServer struct {
 	closing             bool
 	timeout             time.Duration
 	ledgerInfoProvider  types.LedgerInfoProvider
-	services            *types.ServiceContainer
+	services            *types.ServiceGraph
+	urlSubscriptions    types.URLSubscriptionService
 	urlSubs             *urlSubscriptionRegistry
 	peerSourceHolder
 	resourceManager   *resource.Manager
@@ -72,13 +73,14 @@ type WebSocketServer struct {
 // A nil subscription manager selects a new manager for the standalone server.
 type WebSocketServerOptions struct {
 	Timeout             time.Duration
-	Services            *types.ServiceContainer
+	Services            *types.ServiceGraph
 	ResourceManager     *resource.Manager
 	PeerSource          types.PeerSource
 	Registry            *types.MethodRegistry
 	PingInterval        time.Duration
 	LedgerInfoProvider  types.LedgerInfoProvider
 	SubscriptionManager *subscription.Manager
+	URLSubscriptions    types.URLSubscriptionService
 }
 
 // websocketConnection owns the transport-specific state for one logical
@@ -144,13 +146,15 @@ func NewWebSocketServer(options WebSocketServerOptions) *WebSocketServer {
 		ws.methodRegistry = defaultMethodRegistry()
 	}
 	ws.pathFindRefresh = newPathFindRefreshManager(ws)
-	if ws.services != nil {
-		ws.services.SubscriptionMetrics = manager.Metrics
+	if registry, ok := options.URLSubscriptions.(*urlSubscriptionRegistry); ok {
+		ws.urlSubs = registry
+		ws.urlSubscriptions = registry
+	} else if options.URLSubscriptions != nil {
+		ws.urlSubscriptions = options.URLSubscriptions
+	} else {
+		ws.urlSubs = newURLSubscriptionRegistry(manager, options.Services, options.LedgerInfoProvider)
+		ws.urlSubscriptions = ws.urlSubs
 	}
-	// The URL (RPCSub) registry lives on the WebSocket server because URL
-	// subscribers share its subscription manager's broadcast fan-out. Node
-	// composition installs the returned service on the shared container.
-	ws.urlSubs = newURLSubscriptionRegistry(ws)
 	ws.setPeerSource(options.PeerSource)
 	return ws
 }
@@ -249,8 +253,8 @@ func (ws *WebSocketServer) SubscriptionManager() *subscription.Manager {
 	return ws.subscriptionManager
 }
 
-// URLSubscriptionService returns the URL subscription registry that node
-// composition installs on the shared service container after construction.
+// URLSubscriptionService returns the transport-owned URL subscription
+// registry.
 func (ws *WebSocketServer) URLSubscriptionService() types.URLSubscriptionService {
-	return ws.urlSubs
+	return ws.urlSubscriptions
 }

--- a/internal/rpc/websocket_dispatch.go
+++ b/internal/rpc/websocket_dispatch.go
@@ -50,7 +50,7 @@ func (ws *WebSocketServer) handleMessage(wsConn *websocketConnection, message []
 	peerIP := getWebSocketClientIP(wsConn.conn)
 	clientIP := resolveWSClientIP(peerIP, wsConn.forwardedFor, wsConn.portCtx)
 	role := roleForRequest(peerIP, wsConn.user, cmdMap, wsConn.portCtx)
-	loadCtx := newRpcContext(wsConn.Context(), role, types.DefaultApiVersion, clientIP, ws.loadPeerSource(), ws.services)
+	loadCtx := newRpcContext(wsConn.Context(), role, types.DefaultApiVersion, clientIP, ws.loadPeerSource(), ws.services, nil, ws.urlSubscriptions)
 	loadCtx.ResourceConsumer = wsConn.resourceConsumer
 	if rpcErr := gateLoad(ws.resourceManager, loadCtx, "", wsLog()); rpcErr != nil {
 		wsConn.closeWithPolicyViolation("threshold exceeded")
@@ -161,8 +161,8 @@ func (ws *WebSocketServer) handleSpecialCommand(wsConn *websocketConnection, ctx
 	}
 
 	result, rpcErr, recovered := func() (any, *types.RpcError, bool) {
-		if ws.services != nil && ws.services.ClientLoad != nil {
-			release := ws.services.ClientLoad.Begin()
+		if ws.services != nil && ws.services.ClientLoad() != nil {
+			release := ws.services.ClientLoad().Begin()
 			defer release()
 		}
 		finishDiagnostics := startRPCDiagnostics(ws.services, cmd.Command)

--- a/internal/rpc/websocket_lifecycle.go
+++ b/internal/rpc/websocket_lifecycle.go
@@ -162,5 +162,7 @@ func (ws *WebSocketServer) shutdown(ctx context.Context) {
 
 	closeFrames.Wait()
 	ws.wg.Wait()
-	ws.urlSubs.Close()
+	if ws.urlSubs != nil {
+		ws.urlSubs.Close()
+	}
 }

--- a/internal/rpc/websocket_pathfind.go
+++ b/internal/rpc/websocket_pathfind.go
@@ -56,12 +56,12 @@ func (ws *WebSocketServer) executePathFindCreate(wsConn *websocketConnection, ct
 		return nil, rpcErr
 	}
 
-	if ctx.Services == nil || ctx.Services.Ledger == nil {
+	if ctx.Services == nil || ctx.Services.Ledger() == nil {
 		return nil, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent",
 			"No closed ledger available")
 	}
-	session.setSearchLevelMax(ctx.Services.Capabilities.PathSearchMax)
-	view, err := ctx.Services.Ledger.GetClosedLedgerView()
+	session.setSearchLevelMax(ctx.Services.Capabilities().PathSearchMax)
+	view, err := ctx.Services.Ledger().GetClosedLedgerView()
 	if err != nil {
 		return nil, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent",
 			"No closed ledger available")
@@ -70,7 +70,7 @@ func (ws *WebSocketServer) executePathFindCreate(wsConn *websocketConnection, ct
 	event := session.Execute(view, false)
 
 	wsConn.installPathFindSession(session)
-	ws.queuePathFindSessions(currentPathFindView(ctx.Services.Ledger), wsConn)
+	ws.queuePathFindSessions(currentPathFindView(ctx.Services.Ledger()), wsConn)
 
 	return event, nil
 }

--- a/internal/rpc/websocket_peers_test.go
+++ b/internal/rpc/websocket_peers_test.go
@@ -22,7 +22,7 @@ func TestWebSocket_PeersRPC_UsesPeerSource(t *testing.T) {
 	}
 
 	ledger := &mockLedgerService{}
-	services := &types.ServiceContainer{Ledger: ledger}
+	services := types.NewTestServiceGraph(&types.ServiceContainer{Ledger: ledger})
 
 	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second, Services: services, PeerSource: src})
 

--- a/internal/rpc/websocket_special_dispatch_test.go
+++ b/internal/rpc/websocket_special_dispatch_test.go
@@ -16,11 +16,11 @@ import (
 
 func newSpecialDispatchHarness(t *testing.T) (*WebSocketServer, *websocketConnection, *types.RpcContext) {
 	t.Helper()
-	services := &types.ServiceContainer{
+	services := types.NewTestServiceGraph(&types.ServiceContainer{
 		ClientLoad:     types.NewClientLoadShedder(),
 		RPCDiagnostics: NewRPCDiagnostics(),
 		Capabilities:   types.RPCCapabilities{PathSearchMax: 3},
-	}
+	})
 	manager := resource.NewManager(nil, nil)
 	ws := NewWebSocketServer(WebSocketServerOptions{
 		Timeout:         time.Second,
@@ -39,7 +39,7 @@ func newSpecialDispatchHarness(t *testing.T) (*WebSocketServer, *websocketConnec
 	require.True(t, attached)
 	conn.registration = registration
 	t.Cleanup(func() { ws.subscriptionManager.Detach(registration) })
-	ctx := newRpcContext(context.Background(), types.RoleGuest, types.DefaultApiVersion, "192.0.2.1", nil, services)
+	ctx := newRpcContext(context.Background(), types.RoleGuest, types.DefaultApiVersion, "192.0.2.1", nil, services, nil, nil)
 	consumer := manager.NewInboundEndpoint(ctx.ClientIP)
 	require.NotNil(t, consumer)
 	t.Cleanup(consumer.Release)
@@ -48,6 +48,19 @@ func newSpecialDispatchHarness(t *testing.T) (*WebSocketServer, *websocketConnec
 	ctx.ResourceAdmission, _ = consumer.Admit(resource.FeeReferenceRPC())
 	require.NotNil(t, ctx.ResourceAdmission)
 	return ws, conn, ctx
+}
+
+func setSpecialServices(ctx *types.RpcContext, mutate func(*types.ServiceContainer)) {
+	previous := ctx.Services
+	services := &types.ServiceContainer{}
+	if previous != nil {
+		services.ClientLoad = previous.ClientLoad()
+		services.RPCDiagnostics = previous.RPCDiagnostics()
+		services.Capabilities = previous.Capabilities()
+		services.IsLoadedLocal = previous.IsLoadedLocal()
+	}
+	mutate(services)
+	ctx.Services = types.NewTestServiceGraph(services)
 }
 
 func specialDispatchResponse(t *testing.T, conn *websocketConnection) map[string]any {
@@ -86,7 +99,7 @@ func TestWebSocketSpecialDispatchBusyBoundary(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ws, conn, ctx := newSpecialDispatchHarness(t)
 			for range test.inFlight {
-				ws.services.ClientLoad.Begin()
+				ws.services.ClientLoad().Begin()
 			}
 			if !test.wantCalled {
 				require.NoError(t, ws.resourceManager.ImportConsumers("peer", resource.Gossip{Items: []resource.GossipItem{{
@@ -97,7 +110,7 @@ func TestWebSocketSpecialDispatchBusyBoundary(t *testing.T) {
 			called := false
 			ws.handleSpecialCommand(conn, ctx, specialDispatchCommand("subscribe"), func(_ *websocketConnection, _ *types.RpcContext, _ types.WebSocketCommand) (any, *types.RpcError) {
 				called = true
-				if got := ws.services.ClientLoad.InFlight(); got != int64(test.inFlight+1) {
+				if got := ws.services.ClientLoad().InFlight(); got != int64(test.inFlight+1) {
 					t.Fatalf("in-flight inside handler = %d, want %d", got, test.inFlight+1)
 				}
 				return map[string]any{}, nil
@@ -113,7 +126,7 @@ func TestWebSocketSpecialDispatchBusyBoundary(t *testing.T) {
 			if !test.wantCalled && (!ctx.LoadWarning || response["warning"] != nil) {
 				t.Fatalf("busy admission must consume but hide its load warning: %v", response)
 			}
-			if got := ws.services.ClientLoad.InFlight(); got != int64(test.inFlight) {
+			if got := ws.services.ClientLoad().InFlight(); got != int64(test.inFlight) {
 				t.Fatalf("in-flight after dispatch = %d, want %d", got, test.inFlight)
 			}
 		})
@@ -188,10 +201,10 @@ func TestWebSocketSpecialDispatchRecoversPanic(t *testing.T) {
 	if got, want := resourceLocalBalance(t, ws.resourceManager, ctx.ClientIP), uint32(resource.FeeExceptionRPC().Cost()/resource.DecayWindowSeconds); got != want {
 		t.Fatalf("panic charge = %v, want %v", got, want)
 	}
-	if got := ws.services.ClientLoad.InFlight(); got != 0 {
+	if got := ws.services.ClientLoad().InFlight(); got != 0 {
 		t.Fatalf("in-flight leaked after panic: %d", got)
 	}
-	if stats := ws.services.RPCDiagnostics.Snapshot().Methods["subscribe"]; stats.Started != 1 || stats.Finished != 0 || stats.Errored != 1 {
+	if stats := ws.services.RPCDiagnostics().Snapshot().Methods["subscribe"]; stats.Started != 1 || stats.Finished != 0 || stats.Errored != 1 {
 		t.Fatalf("diagnostics = %#v", stats)
 	}
 }
@@ -220,7 +233,9 @@ func TestWebSocketPathFindDynamicLoadCost(t *testing.T) {
 
 func TestWebSocketPathFindCapabilityPrecedesSubcommandValidation(t *testing.T) {
 	ws, conn, ctx := newSpecialDispatchHarness(t)
-	ctx.Services.Capabilities.PathSearchMax = 0
+	setSpecialServices(ctx, func(services *types.ServiceContainer) {
+		services.Capabilities.PathSearchMax = 0
+	})
 	_, rpcErr := ws.executePathFind(conn, ctx, types.WebSocketCommand{Params: json.RawMessage(`{not json`)})
 	if rpcErr == nil || rpcErr.ErrorString != "notSupported" {
 		t.Fatalf("disabled path_find error = %v, want notSupported", rpcErr)
@@ -229,7 +244,9 @@ func TestWebSocketPathFindCapabilityPrecedesSubcommandValidation(t *testing.T) {
 
 func TestWebSocketPathFindCreateDoesNotUseLegacyBusyGate(t *testing.T) {
 	ws, conn, ctx := newSpecialDispatchHarness(t)
-	ctx.Services.IsLoadedLocal = func() bool { return true }
+	setSpecialServices(ctx, func(services *types.ServiceContainer) {
+		services.IsLoadedLocal = func() bool { return true }
+	})
 	_, rpcErr := ws.executePathFind(conn, ctx, types.WebSocketCommand{
 		Params: json.RawMessage(`{"subcommand":"create"}`),
 	})

--- a/internal/rpc/websocket_subscribe.go
+++ b/internal/rpc/websocket_subscribe.go
@@ -28,7 +28,7 @@ func (ws *WebSocketServer) executeSubscribe(wsConn *websocketConnection, ctx *ty
 		if !ctx.Role.IsAdmin() {
 			return nil, types.RpcErrorNoPermission("subscribe")
 		}
-		result, rpcErr := ws.urlSubs.Subscribe(ctx, request)
+		result, rpcErr := ws.urlSubscriptions.Subscribe(ctx, request)
 		if rpcErr != nil {
 			return nil, rpcErr
 		}
@@ -183,7 +183,7 @@ func (ws *WebSocketServer) executeUnsubscribe(wsConn *websocketConnection, ctx *
 		if !ctx.Role.IsAdmin() {
 			return nil, types.RpcErrorNoPermission("unsubscribe")
 		}
-		result, rpcErr := ws.urlSubs.Unsubscribe(ctx, request)
+		result, rpcErr := ws.urlSubscriptions.Unsubscribe(ctx, request)
 		if rpcErr != nil {
 			return nil, rpcErr
 		}
@@ -223,14 +223,18 @@ func (ws *WebSocketServer) buildSubscribeAck(ctx *types.RpcContext, request type
 }
 
 func (ws *WebSocketServer) buildSubscribeAckSampled(ctx *types.RpcContext, request types.SubscriptionRequest, serverState map[string]any) map[string]any {
+	return buildSubscribeAckSampled(ws.ledgerInfoProvider, ctx, request, serverState)
+}
+
+func buildSubscribeAckSampled(ledgerInfoProvider types.LedgerInfoProvider, ctx *types.RpcContext, request types.SubscriptionRequest, serverState map[string]any) map[string]any {
 	result := make(map[string]any)
 	for key, value := range serverState {
 		result[key] = value
 	}
 
 	if slices.Contains(request.Streams, types.SubLedger) {
-		if ws.ledgerInfoProvider != nil {
-			info := ws.ledgerInfoProvider.GetCurrentLedgerInfo()
+		if ledgerInfoProvider != nil {
+			info := ledgerInfoProvider.GetCurrentLedgerInfo()
 			if info != nil {
 				if info.LedgerAvailable {
 					result["ledger_index"] = info.LedgerIndex
@@ -254,7 +258,7 @@ func (ws *WebSocketServer) buildSubscribeAckSampled(ctx *types.RpcContext, reque
 	}
 
 	for _, book := range request.Books {
-		if (!book.Snapshot && !book.StateNow) || ctx.Services == nil || ctx.Services.Ledger == nil {
+		if (!book.Snapshot && !book.StateNow) || ctx.Services == nil || ctx.Services.Ledger() == nil {
 			continue
 		}
 		pays, gets, domain, rpcErr := subscription.SnapshotBook(book)
@@ -262,8 +266,8 @@ func (ws *WebSocketServer) buildSubscribeAckSampled(ctx *types.RpcContext, reque
 			continue
 		}
 		if book.Both || book.BothSides {
-			bids, _ := ws.snapshotBook(ctx, gets, pays, book.Taker, domain)
-			asks, _ := ws.snapshotBook(ctx, pays, gets, book.Taker, domain)
+			bids, _ := snapshotBook(ctx, gets, pays, book.Taker, domain)
+			asks, _ := snapshotBook(ctx, pays, gets, book.Taker, domain)
 			if bids != nil {
 				result["bids"] = appendOffers(result["bids"], bids)
 			}
@@ -272,7 +276,7 @@ func (ws *WebSocketServer) buildSubscribeAckSampled(ctx *types.RpcContext, reque
 			}
 			continue
 		}
-		offers, _ := ws.snapshotBook(ctx, gets, pays, book.Taker, domain)
+		offers, _ := snapshotBook(ctx, gets, pays, book.Taker, domain)
 		if offers != nil {
 			result["offers"] = appendOffers(result["offers"], offers)
 		}
@@ -287,10 +291,14 @@ func (ws *WebSocketServer) buildSubscribeAckSampled(ctx *types.RpcContext, reque
 // reject the entire subscribe (rippled Subscribe.cpp:339-394 ignores
 // the snapshot block on lookup failure too).
 func (ws *WebSocketServer) snapshotBook(ctx *types.RpcContext, takerGets, takerPays types.Amount, taker, domain string) ([]types.BookOffer, error) {
-	if ctx == nil || ctx.Services == nil || ctx.Services.Ledger == nil {
+	return snapshotBook(ctx, takerGets, takerPays, taker, domain)
+}
+
+func snapshotBook(ctx *types.RpcContext, takerGets, takerPays types.Amount, taker, domain string) ([]types.BookOffer, error) {
+	if ctx == nil || ctx.Services == nil || ctx.Services.Ledger() == nil {
 		return nil, nil
 	}
-	res, err := ctx.Services.Ledger.GetBookOffers(ctx.Context, takerGets, takerPays, taker, domain, "validated", defaultBookSnapshotLimit, "", false)
+	res, err := ctx.Services.Ledger().GetBookOffers(ctx.Context, takerGets, takerPays, taker, domain, "validated", defaultBookSnapshotLimit, "", false)
 	if err != nil || res == nil {
 		return nil, err
 	}

--- a/internal/rpc/websocket_test.go
+++ b/internal/rpc/websocket_test.go
@@ -924,7 +924,7 @@ func TestWebSocketSpecialCommandDecodeErrorsAreFixed(t *testing.T) {
 
 			test.invoke(ws, wsConn, &types.RpcContext{
 				ApiVersion: types.DefaultApiVersion,
-				Services:   &types.ServiceContainer{Capabilities: types.RPCCapabilities{PathSearchMax: 3}},
+				Services:   types.NewTestServiceGraph(&types.ServiceContainer{Capabilities: types.RPCCapabilities{PathSearchMax: 3}}),
 			}, cmd)
 			body := <-wsConn.Outbound()
 			if got := string(body); got != test.want {

--- a/internal/testing/rpcenv/rpcenv.go
+++ b/internal/testing/rpcenv/rpcenv.go
@@ -128,7 +128,7 @@ func (e *Env) RPCAs(method string, params any, role types.Role, apiVersion int) 
 		Context:    context.Background(),
 		Role:       role,
 		ApiVersion: apiVersion,
-		Services:   e.services,
+		Services:   types.NewTestServiceGraph(e.services),
 	}
 	return handler.Handle(ctx, raw)
 }

--- a/internal/testing/rpcenv/subscription_test.go
+++ b/internal/testing/rpcenv/subscription_test.go
@@ -24,7 +24,7 @@ func openSubscriptionWebSocket(t *testing.T) (*rpc.WebSocketServer, *websocket.C
 	env := rpcenv.New(t)
 	ws := rpc.NewWebSocketServer(rpc.WebSocketServerOptions{
 		Timeout:  time.Second,
-		Services: env.Services(),
+		Services: types.NewTestServiceGraph(env.Services()),
 	})
 	httpServer := httptest.NewServer(http.HandlerFunc(ws.ServeHTTP))
 	client, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(httpServer.URL, "http"), nil)


### PR DESCRIPTION
## Summary

- construct and validate the complete RPC dependency graph before listener startup
- publish only immutable graph accessors and keep shutdown stable from construction onward
- inject dispatcher and URL-subscription dependencies explicitly at transport boundaries

This is layer 5 of 7 and depends on #1605.

Part of #1490.

## Test plan

- `go test -count=1 ./internal/rpc/... ./internal/node ./internal/testing/rpcenv`
- `go test -race -count=1 ./internal/rpc/handlers ./internal/rpc ./internal/node`
- `go vet ./internal/rpc/... ./internal/node ./internal/testing/rpcenv`
- `golangci-lint run`
- `just build-all`