### PR TITLE
refactor: split RPC ledger capabilities (#1490)

### DIFF
--- a/internal/node/lifecycle_test.go
+++ b/internal/node/lifecycle_test.go
@@ -28,7 +28,7 @@ import (
 func TestBindRPCWiresExplicitSharedServices(t *testing.T) {
 	runtime := &nodeRuntime{
 		appConfig:  &config.Config{},
-		services:   newRPCServiceContainer(rpcadapter.NewLedgerServiceAdapter(nil), &config.Config{}),
+		services:   newRPCServiceGraphBuilder(rpcadapter.NewLedgerServiceAdapter(nil), &config.Config{}),
 		serverLog:  xrpllog.Discard(),
 		shutdownCh: make(chan struct{}, 1),
 		shutdowner: types.ShutdownFunc(func() {}),

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -97,7 +97,7 @@ func rpcCapabilities(cfg *config.Config) types.RPCCapabilities {
 	}
 }
 
-func newRPCServiceContainer(ledger types.LedgerService, cfg *config.Config) *types.ServiceGraphBuilder {
+func newRPCServiceGraphBuilder(ledger types.LedgerService, cfg *config.Config) *types.ServiceGraphBuilder {
 	services := types.NewServiceGraphBuilder(ledger)
 	services.ClientLoad = types.NewClientLoadShedder()
 	services.RPCDiagnostics = rpc.NewRPCDiagnostics()

--- a/internal/node/rpc_capabilities_test.go
+++ b/internal/node/rpc_capabilities_test.go
@@ -15,7 +15,7 @@ func TestNewRPCServiceContainerFreezesCapabilities(t *testing.T) {
 		BetaRPCAPI:     1,
 	}
 
-	services := newRPCServiceContainer(nil, cfg)
+	services := newRPCServiceGraphBuilder(nil, cfg)
 	require.True(t, services.Capabilities.SigningEnabled)
 	require.Zero(t, services.Capabilities.PathSearchMax)
 	require.True(t, services.BetaRPCAPI)
@@ -29,7 +29,7 @@ func TestNewRPCServiceContainerFreezesCapabilities(t *testing.T) {
 }
 
 func TestRPCCapabilitiesDefaults(t *testing.T) {
-	services := newRPCServiceContainer(nil, &config.Config{})
+	services := newRPCServiceGraphBuilder(nil, &config.Config{})
 	require.False(t, services.Capabilities.SigningEnabled)
 	require.Equal(t, 3, services.Capabilities.PathSearchMax)
 }

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -276,7 +276,7 @@ func (r *nodeRuntime) configureMaintenance() error {
 	r.stopSampler = sampler.Stop
 
 	r.ledgerAdapter = rpcadapter.NewLedgerServiceAdapter(r.ledger)
-	r.services = newRPCServiceContainer(r.ledgerAdapter, r.appConfig)
+	r.services = newRPCServiceGraphBuilder(r.ledgerAdapter, r.appConfig)
 	if err := r.configureStandaloneNodeIdentity(); err != nil {
 		return err
 	}
@@ -1043,7 +1043,7 @@ func (r *nodeRuntime) bindStreams() error {
 		serverStatus.publish(nil)
 
 		r.wsServer.UpdatePathFindSessions(func() (types.LedgerStateView, error) {
-			return r.serviceGraph.Ledger().GetClosedLedgerView()
+			return r.serviceGraph.LedgerViews().GetClosedLedgerView()
 		})
 
 		r.serverLog.Debug("Broadcasted ledger",

--- a/internal/rpc/adapter/core.go
+++ b/internal/rpc/adapter/core.go
@@ -14,6 +14,8 @@ type LedgerServiceAdapter struct {
 }
 
 var _ types.LedgerService = (*LedgerServiceAdapter)(nil)
+var _ types.LedgerReadService = (*LedgerServiceAdapter)(nil)
+var _ types.LedgerMutationService = (*LedgerServiceAdapter)(nil)
 var _ types.LedgerNavigator = (*LedgerServiceAdapter)(nil)
 var _ types.LedgerAccessor = (*LedgerServiceAdapter)(nil)
 var _ types.TransactionSubmitter = (*LedgerServiceAdapter)(nil)

--- a/internal/rpc/handlers/feature.go
+++ b/internal/rpc/handlers/feature.go
@@ -123,7 +123,7 @@ func (m *FeatureMethod) getAmendmentState(services *types.ServiceGraph) (enabled
 		return nil, nil
 	}
 
-	view, err := services.Ledger().GetClosedLedgerView()
+	view, err := services.ClosedLedgerState()
 	if err != nil || view == nil {
 		return nil, nil
 	}

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -640,10 +640,8 @@ func lookupLedger(ctx *types.RpcContext, input any) (types.LedgerReader, bool, *
 	return resolved.Value, resolved.Validated, nil
 }
 
-func getLedgerByHashContext(ctx context.Context, svc types.LedgerService, hash [32]byte) (types.LedgerReader, error) {
-	if contextual, ok := svc.(interface {
-		GetLedgerByHashContext(context.Context, [32]byte) (types.LedgerReader, error)
-	}); ok {
+func getLedgerByHashContext(ctx context.Context, svc types.LedgerReadService, hash [32]byte) (types.LedgerReader, error) {
+	if contextual, ok := svc.(types.ContextLedgerHashReader); ok {
 		return contextual.GetLedgerByHashContext(ctx, hash)
 	}
 	return svc.GetLedgerByHash(hash)

--- a/internal/rpc/handlers/json.go
+++ b/internal/rpc/handlers/json.go
@@ -23,6 +23,16 @@ func (m *jsonMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any,
 			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
 		}
 	}
+	if request.Method == "" && len(request.Params) > 0 {
+		var nested struct {
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params,omitempty"`
+		}
+		if json.Unmarshal(request.Params, &nested) == nil && nested.Method != "" {
+			request.Method = nested.Method
+			request.Params = nested.Params
+		}
+	}
 
 	if request.Method == "" {
 		return nil, types.RpcErrorInvalidParams("Missing required parameter: method")

--- a/internal/rpc/handlers/ledger_accept.go
+++ b/internal/rpc/handlers/ledger_accept.go
@@ -20,7 +20,7 @@ func (m *LedgerAcceptMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		return nil, types.RpcErrorNotStandalone("ledger_accept is only available in standalone mode")
 	}
 
-	closedSeq, err := ctx.Services.Ledger().AcceptLedger(ctx.Context)
+	closedSeq, err := ctx.Services.LedgerMutation().AcceptLedger(ctx.Context)
 	if err != nil {
 		return nil, rpcInternalError("ledger_accept: accepting ledger failed", err)
 	}

--- a/internal/rpc/handlers/ripple_path_find.go
+++ b/internal/rpc/handlers/ripple_path_find.go
@@ -432,7 +432,7 @@ func resolvePathFindLedger(
 	hasSelector bool,
 ) (types.LedgerStateView, *pathFindLedgerMeta, *types.RpcError) {
 	if !hasSelector {
-		view, err := ctx.Services.Ledger().GetClosedLedgerView()
+		view, err := ctx.Services.LedgerViews().GetClosedLedgerView()
 		if err != nil {
 			return nil, nil, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent", "Current ledger is unavailable.")
 		}

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -395,7 +395,7 @@ func rpcErrorAlreadySingleSigned() *types.RpcError {
 		types.RpcALREADY_SINGLE_SIG, "alreadySingleSig", "alreadySingleSig", "Already single-signed.")
 }
 
-func submitWithFailHard(ledger types.LedgerService, txJSON []byte, txBlob string, failHard bool) (*types.SubmitResult, error) {
+func submitWithFailHard(ledger types.TransactionSubmission, txJSON []byte, txBlob string, failHard bool) (*types.SubmitResult, error) {
 	if failHard {
 		if submitter, ok := ledger.(types.FailHardSubmitter); ok {
 			return submitter.SubmitTransactionFailHard(txJSON, txBlob)
@@ -508,7 +508,7 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 		// TicketSequence supplies the sequence instead (Sequence = 0).
 		if _, ok := txMap["Sequence"]; !ok {
 			_, hasTicket := txMap["TicketSequence"]
-			seq, err := services.Ledger().GetAutofillSequence(srcAddress, hasTicket)
+			seq, err := services.LedgerMutation().GetAutofillSequence(srcAddress, hasTicket)
 			if err != nil {
 				if errors.Is(err, svcerr.ErrAccountNotFound) {
 					return nil, types.RpcErrorSrcActNotFound("Source account not found.")
@@ -548,7 +548,7 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 			if mErr != nil {
 				return nil, rpcInternalError("sign: fee probe marshaling failed", mErr)
 			}
-			fee, feeErr := services.Ledger().GetAutofillFee(probe, rpcCtx.Role.IsUnlimited(), feeOpts.Mult, feeOpts.Div)
+			fee, feeErr := services.LedgerMutation().GetAutofillFee(probe, rpcCtx.Role.IsUnlimited(), feeOpts.Mult, feeOpts.Div)
 			if feeErr != nil {
 				var hfe *svcerr.HighFeeError
 				if errors.As(feeErr, &hfe) {

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -123,7 +123,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		// rippled's simulate autofill uses the default fee_mult_max /
 		// fee_div_max (getCurrentNetworkFee default arguments).
 		feeOpts := defaultFeeOptions()
-		fee, feeErr := ctx.Services.Ledger().GetAutofillFee(probe, ctx.Role.IsUnlimited(), feeOpts.Mult, feeOpts.Div)
+		fee, feeErr := ctx.Services.LedgerMutation().GetAutofillFee(probe, ctx.Role.IsUnlimited(), feeOpts.Mult, feeOpts.Div)
 		if feeErr != nil {
 			var hfe *svcerr.HighFeeError
 			if errors.As(feeErr, &hfe) {
@@ -166,7 +166,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 			return nil, types.RpcErrorInvalidField("tx.Account")
 		}
 		_, hasTicket := txJsonMap["TicketSequence"]
-		seq, seqErr := ctx.Services.Ledger().GetAutofillSequence(accountStr, hasTicket)
+		seq, seqErr := ctx.Services.LedgerMutation().GetAutofillSequence(accountStr, hasTicket)
 		if seqErr != nil {
 			switch {
 			case errors.Is(seqErr, svcerr.ErrAccountMalformed):
@@ -231,7 +231,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		return nil, rpcInternalError("simulate: transaction marshaling failed", err)
 	}
 
-	result, err := ctx.Services.Ledger().SimulateTransaction(txJSON)
+	result, err := ctx.Services.LedgerMutation().SimulateTransaction(txJSON)
 	if err != nil {
 		return nil, rpcInternalError("simulate: transaction simulation failed", err)
 	}

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -144,7 +144,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (re
 	// When the client passed fail_hard:true and the ledger service
 	// implements the FailHardSubmitter surface, route through it so
 	// non-applying submissions are not held or relayed.
-	submitResult, submitErr := submitWithFailHard(ctx.Services.Ledger(), txJSON, txBlobHex, failHard)
+	submitResult, submitErr := submitWithFailHard(ctx.Services.LedgerMutation(), txJSON, txBlobHex, failHard)
 	if submitErr != nil {
 		return nil, rpcTransactionSubmissionError("submit: transaction submission failed", submitErr)
 	}

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -167,7 +167,7 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 	// Route fail_hard submissions through the optional surface so they
 	// are not held or relayed on non-apply. Mirrors rippled
 	// NetworkOPs.cpp:1685-1689 (`!enforceFailHard`).
-	result, submitErr := submitWithFailHard(ctx.Services.Ledger(), txJSON, txBlob, request.FailHard)
+	result, submitErr := submitWithFailHard(ctx.Services.LedgerMutation(), txJSON, txBlob, request.FailHard)
 	if submitErr != nil {
 		return nil, rpcTransactionSubmissionError("submit_multisigned: transaction submission failed", submitErr)
 	}

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -81,6 +81,9 @@ func NewServer(options ServerOptions) *Server {
 	if manager == nil {
 		manager = resource.NewManager(nil, nil)
 	}
+	if isNilURLSubscriptionService(options.URLSubscriptions) {
+		options.URLSubscriptions = nil
+	}
 	server := &Server{
 		registry:         options.Registry,
 		timeout:          options.Timeout,

--- a/internal/rpc/sign_test.go
+++ b/internal/rpc/sign_test.go
@@ -14,15 +14,8 @@ import (
 
 func signingEnabledContext(ctx *types.RpcContext) *types.RpcContext {
 	clone := *ctx
-	var ledger types.LedgerService
-	if ctx.Services != nil {
-		ledger = ctx.Services.Ledger()
-	}
-	clone.Services = types.NewTestServiceGraph(&types.ServiceContainer{
-		Ledger: ledger,
-		Capabilities: types.RPCCapabilities{
-			SigningEnabled: true,
-		},
+	clone.Services = types.NewTestServiceGraphFrom(ctx.Services, func(services *types.ServiceContainer) {
+		services.Capabilities.SigningEnabled = true
 	})
 	return &clone
 }

--- a/internal/rpc/transport_regression_test.go
+++ b/internal/rpc/transport_regression_test.go
@@ -143,6 +143,12 @@ func TestRPCConstructorsUseExplicitDependencies(t *testing.T) {
 		"wrapped":  nilWrapped,
 	} {
 		t.Run("typed nil "+name, func(t *testing.T) {
+			typedNilHTTP := NewServer(ServerOptions{
+				Services:         services,
+				URLSubscriptions: service,
+			})
+			require.Nil(t, typedNilHTTP.urlSubscriptions)
+
 			typedNilWS := NewWebSocketServer(WebSocketServerOptions{
 				Services:            services,
 				SubscriptionManager: manager,

--- a/internal/rpc/transport_regression_test.go
+++ b/internal/rpc/transport_regression_test.go
@@ -135,6 +135,23 @@ func TestRPCConstructorsUseExplicitDependencies(t *testing.T) {
 	})
 	require.Same(t, customManager, customWS.SubscriptionManager())
 	require.Same(t, custom, customWS.URLSubscriptionService())
+
+	var nilRegistry *urlSubscriptionRegistry
+	var nilWrapped *wrappedURLSubscriptionService
+	for name, service := range map[string]types.URLSubscriptionService{
+		"registry": nilRegistry,
+		"wrapped":  nilWrapped,
+	} {
+		t.Run("typed nil "+name, func(t *testing.T) {
+			typedNilWS := NewWebSocketServer(WebSocketServerOptions{
+				Services:            services,
+				SubscriptionManager: manager,
+				URLSubscriptions:    service,
+			})
+			require.Same(t, manager, typedNilWS.SubscriptionManager())
+			require.NotNil(t, typedNilWS.URLSubscriptionService())
+		})
+	}
 }
 
 func seedTransportRegressionLoad(manager *resource.Manager, balance int) {

--- a/internal/rpc/transport_regression_test.go
+++ b/internal/rpc/transport_regression_test.go
@@ -18,6 +18,10 @@ import (
 
 const transportRegressionClientIP = "203.0.113.5"
 
+type wrappedURLSubscriptionService struct {
+	types.URLSubscriptionService
+}
+
 func postTransportRegressionRequest(t *testing.T, server *Server, body string) *httptest.ResponseRecorder {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
@@ -111,6 +115,26 @@ func TestRPCConstructorsUseExplicitDependencies(t *testing.T) {
 	if _, ok := wsServer.methodRegistry.Get("ping"); !ok {
 		t.Fatal("WebSocket method registry was not ready at construction return")
 	}
+
+	registryManager := subscription.NewManager()
+	urlSubscriptions := NewURLSubscriptionService(registryManager, services, provider)
+	sharedWS := NewWebSocketServer(WebSocketServerOptions{
+		Services:            services,
+		SubscriptionManager: subscription.NewManager(),
+		URLSubscriptions:    urlSubscriptions,
+	})
+	require.Same(t, registryManager, sharedWS.SubscriptionManager())
+	require.Same(t, urlSubscriptions, sharedWS.URLSubscriptionService())
+
+	custom := &wrappedURLSubscriptionService{URLSubscriptionService: urlSubscriptions}
+	customManager := subscription.NewManager()
+	customWS := NewWebSocketServer(WebSocketServerOptions{
+		Services:            services,
+		SubscriptionManager: customManager,
+		URLSubscriptions:    custom,
+	})
+	require.Same(t, customManager, customWS.SubscriptionManager())
+	require.Same(t, custom, customWS.URLSubscriptionService())
 }
 
 func seedTransportRegressionLoad(manager *resource.Manager, balance int) {

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -859,17 +859,26 @@ func (s *ClientLoadShedder) PathfindActive() int64 {
 	return s.pathfindActive.Load()
 }
 
-// LedgerNavigator provides ledger index navigation and mode queries.
-type LedgerNavigator interface {
+// LedgerSelectionReader provides read-only ledger index and mode queries.
+type LedgerSelectionReader interface {
 	GetCurrentLedgerIndex() uint32
 	GetClosedLedgerIndex() uint32
 	GetValidatedLedgerIndex() uint32
-	AcceptLedger(ctx context.Context) (uint32, error)
 	IsStandalone() bool
 }
 
-// LedgerAccessor provides ledger retrieval and server metadata.
-type LedgerAccessor interface {
+type LedgerAcceptor interface {
+	AcceptLedger(ctx context.Context) (uint32, error)
+}
+
+// LedgerNavigator is the construction compatibility aggregate.
+type LedgerNavigator interface {
+	LedgerSelectionReader
+	LedgerAcceptor
+}
+
+// LedgerDataReader provides ledger retrieval and server metadata.
+type LedgerDataReader interface {
 	GetLedgerBySequence(seq uint32) (LedgerReader, error)
 	GetLedgerByHash(hash [32]byte) (LedgerReader, error)
 	GetServerInfo() LedgerServerInfo
@@ -878,8 +887,17 @@ type LedgerAccessor interface {
 	GetLedgerRange(ctx context.Context, minSeq, maxSeq uint32) (*LedgerRangeResult, error)
 	GetLedgerEntry(ctx context.Context, entryKey [32]byte, ledgerIndex string) (*LedgerEntryResult, error)
 	GetLedgerData(ctx context.Context, ledgerIndex string, limit uint32, marker string) (*LedgerDataResult, error)
-	GetClosedLedgerView() (LedgerStateView, error)
 	IsAmendmentBlocked() bool
+}
+
+type ClosedLedgerViewSource interface {
+	GetClosedLedgerView() (LedgerStateView, error)
+}
+
+// LedgerAccessor is the construction compatibility aggregate.
+type LedgerAccessor interface {
+	LedgerDataReader
+	ClosedLedgerViewSource
 }
 
 // TxTablesProvider reports whether the node maintains the transaction
@@ -922,13 +940,16 @@ type FailHardSubmitter interface {
 	SubmitTransactionFailHard(txJSON []byte, txBlobHex string) (*SubmitResult, error)
 }
 
-type TransactionSubmitter interface {
+type TransactionQuerier interface {
+	GetTransaction(txHash [32]byte) (*TransactionInfo, error)
+	GetTransactionHistory(ctx context.Context, startIndex uint32) (*TxHistoryResult, error)
+}
+
+type TransactionSubmission interface {
 	// txBlobHex is the signed transaction blob, or an empty string when the
 	// caller has only transaction JSON.
 	SubmitTransaction(txJSON []byte, txBlobHex string) (*SubmitResult, error)
 	SimulateTransaction(txJSON []byte) (*SubmitResult, error)
-	GetTransaction(txHash [32]byte) (*TransactionInfo, error)
-	GetTransactionHistory(ctx context.Context, startIndex uint32) (*TxHistoryResult, error)
 
 	// GetAutofillFee returns the Fee a transaction should carry to enter
 	// the open ledger. Mirrors rippled getCurrentNetworkFee
@@ -955,6 +976,12 @@ type TransactionSubmitter interface {
 	GetAutofillSequence(account string, hasTicketSequence bool) (sequence uint32, err error)
 }
 
+// TransactionSubmitter is the construction compatibility aggregate.
+type TransactionSubmitter interface {
+	TransactionQuerier
+	TransactionSubmission
+}
+
 // LedgerContext contains the durable ledger fields needed to decorate
 // historical transaction rows.
 type LedgerContext struct {
@@ -966,6 +993,10 @@ type LedgerContext struct {
 // ledger to remain in the in-memory history window.
 type LedgerContextReader interface {
 	GetLedgerContext(ctx context.Context, sequence uint32) (*LedgerContext, error)
+}
+
+type ContextLedgerHashReader interface {
+	GetLedgerByHashContext(ctx context.Context, hash [32]byte) (LedgerReader, error)
 }
 
 // TransactionRulesSource provides the amendment rules used to admit a
@@ -987,25 +1018,46 @@ type AccountQuerier interface {
 	GetAccountNFTs(ctx context.Context, account string, ledgerIndex string, limit uint32, marker string) (*AccountNFTsResult, error)
 }
 
-// LedgerService is the full interface for ledger operations.
-// It composes the sub-interfaces and includes remaining methods.
-type LedgerService interface {
-	LedgerNavigator
-	LedgerAccessor
-	TransactionSubmitter
-	AccountQuerier
-
-	// Book and market data
+type BookReader interface {
 	GetBookOffers(ctx context.Context, takerGets, takerPays Amount, taker, domain string, ledgerIndex string, limit uint32, marker string, withProofs bool) (*BookOffersResult, error)
+}
 
-	// Gateway operations
+type GatewayReader interface {
 	GetGatewayBalances(ctx context.Context, account string, hotWallets []string, ledgerIndex string) (*GatewayBalancesResult, error)
 	GetNoRippleCheck(ctx context.Context, account string, role string, ledgerIndex string, limit uint32, transactions bool) (*NoRippleCheckResult, error)
 	GetDepositAuthorized(ctx context.Context, sourceAccount string, destinationAccount string, ledgerIndex string, credentials []string) (*DepositAuthorizedResult, error)
+}
 
-	// NFT operations
+type NFTReader interface {
 	GetNFTBuyOffers(ctx context.Context, nftID [32]byte, ledgerIndex string, limit uint32, marker string) (*NFTOffersResult, error)
 	GetNFTSellOffers(ctx context.Context, nftID [32]byte, ledgerIndex string, limit uint32, marker string) (*NFTOffersResult, error)
+}
+
+// LedgerReadService is the read-only ledger capability published to ordinary
+// RPC consumers.
+type LedgerReadService interface {
+	LedgerSelectionReader
+	LedgerDataReader
+	TransactionQuerier
+	AccountQuerier
+	BookReader
+	GatewayReader
+	NFTReader
+}
+
+// LedgerMutationService is reserved for RPCs that close ledgers or submit and
+// simulate transactions.
+type LedgerMutationService interface {
+	LedgerAcceptor
+	TransactionSubmission
+}
+
+// LedgerService is the construction-time aggregate implemented by the ledger
+// adapter. ServiceGraph publishes its read and mutation facets separately.
+type LedgerService interface {
+	LedgerReadService
+	LedgerMutationService
+	ClosedLedgerViewSource
 }
 
 // LedgerViewSource is an optional LedgerService facet for handlers that need
@@ -1026,21 +1078,28 @@ type OpenLedgerViewSource interface {
 	GetOpenLedgerView() (LedgerStateView, error)
 }
 
-// LedgerStateView provides low-level read access to ledger state.
-// This interface matches tx.LedgerView for pathfinding and other operations
-// that need direct state access. Any *ledger.Ledger satisfies this.
-type LedgerStateView interface {
+// LedgerStateReader provides low-level read access to ledger state.
+type LedgerStateReader interface {
 	Read(k keylet.Keylet) ([]byte, error)
 	Exists(k keylet.Keylet) (bool, error)
-	Insert(k keylet.Keylet, data []byte) error
-	Update(k keylet.Keylet, data []byte) error
-	Erase(k keylet.Keylet) error
 	ForEach(fn func(key [32]byte, data []byte) bool) error
 	Succ(key [32]byte) ([32]byte, []byte, bool, error)
-	AdjustDropsDestroyed(d drops.XRPAmount) error
 	TxExists(txID [32]byte) (bool, error)
 	Rules() *amendment.Rules
 	LedgerSeq() uint32
+}
+
+type LedgerStateWriter interface {
+	Insert(k keylet.Keylet, data []byte) error
+	Update(k keylet.Keylet, data []byte) error
+	Erase(k keylet.Keylet) error
+	AdjustDropsDestroyed(d drops.XRPAmount) error
+}
+
+// LedgerStateView is the full engine-facing state interface.
+type LedgerStateView interface {
+	LedgerStateReader
+	LedgerStateWriter
 }
 
 // DepositAuthorizedResult contains the result of deposit_authorized RPC
@@ -1746,6 +1805,19 @@ func NewTestServiceGraph(services *ServiceContainer) *ServiceGraph {
 	return graph
 }
 
+// NewTestServiceGraphFrom copies a published graph and applies fixture-only
+// overrides before publishing a new snapshot.
+func NewTestServiceGraphFrom(graph *ServiceGraph, configure func(*ServiceContainer)) *ServiceGraph {
+	services := ServiceContainer{}
+	if graph != nil && graph.services() != nil {
+		services = cloneServiceContainer(*graph.services())
+	}
+	if configure != nil {
+		configure(&services)
+	}
+	return NewTestServiceGraph(&services)
+}
+
 // ServiceGraph is the immutable application capability graph published to
 // RPC contexts and transports. Its state is private; live capabilities may
 // expose their own synchronized operations, but the graph topology cannot be
@@ -1761,11 +1833,33 @@ func (g *ServiceGraph) services() *ServiceContainer {
 	return &g.snapshot
 }
 
-func (g *ServiceGraph) Ledger() LedgerService {
+func (g *ServiceGraph) Ledger() LedgerReadService {
 	if s := g.services(); s != nil {
 		return s.Ledger
 	}
 	return nil
+}
+
+func (g *ServiceGraph) LedgerMutation() LedgerMutationService {
+	if s := g.services(); s != nil {
+		return s.Ledger
+	}
+	return nil
+}
+
+func (g *ServiceGraph) LedgerViews() ClosedLedgerViewSource {
+	if s := g.services(); s != nil {
+		return s.Ledger
+	}
+	return nil
+}
+
+func (g *ServiceGraph) ClosedLedgerState() (LedgerStateReader, error) {
+	views := g.LedgerViews()
+	if views == nil {
+		return nil, fmt.Errorf("closed ledger view is unavailable")
+	}
+	return views.GetClosedLedgerView()
 }
 
 func (g *ServiceGraph) Shutdowner() Shutdowner {
@@ -2091,6 +2185,18 @@ func (g *ServiceGraph) QueueAllTxs() func() []QueuedTxInfo {
 }
 
 func cloneServiceContainer(input ServiceContainer) ServiceContainer {
+	if serviceCapabilityNil(input.Manifests) {
+		input.Manifests = nil
+	}
+	if serviceCapabilityNil(input.ValidatorList) {
+		input.ValidatorList = nil
+	}
+	if serviceCapabilityNil(input.AdvisoryDeleteState) {
+		input.AdvisoryDeleteState = nil
+	}
+	if serviceCapabilityNil(input.AccountHistorySubscriptions) {
+		input.AccountHistorySubscriptions = nil
+	}
 	input.ValidatorPublicKey = append([]byte(nil), input.ValidatorPublicKey...)
 	input.ServerInfoConfig = cloneServerInfoConfig(input.ServerInfoConfig)
 	return input

--- a/internal/rpc/types/services_test.go
+++ b/internal/rpc/types/services_test.go
@@ -11,6 +11,34 @@ type serviceGraphLedger struct{ LedgerService }
 
 type serviceGraphDiagnostics struct{}
 
+type serviceGraphOptionalCapabilities struct {
+	ManifestLookup
+	ValidatorListReader
+	AdvisoryDeleteStore
+	AccountHistorySubscriptionService
+}
+
+type readOnlyLedgerCapability struct {
+	LedgerSelectionReader
+	LedgerDataReader
+	TransactionQuerier
+	AccountQuerier
+	BookReader
+	GatewayReader
+	NFTReader
+}
+
+type ledgerMutationCapability struct {
+	LedgerAcceptor
+	TransactionSubmission
+}
+
+type readOnlyLedgerState struct{ LedgerStateReader }
+
+var _ LedgerReadService = (*readOnlyLedgerCapability)(nil)
+var _ LedgerMutationService = (*ledgerMutationCapability)(nil)
+var _ LedgerStateReader = (*readOnlyLedgerState)(nil)
+
 func (serviceGraphDiagnostics) Start(string) func(bool) { return func(bool) {} }
 func (serviceGraphDiagnostics) Snapshot() RPCDiagnosticsSnapshot {
 	return RPCDiagnosticsSnapshot{}
@@ -85,6 +113,41 @@ func TestServiceGraphBuildCopiesTopologyAndSnapshots(t *testing.T) {
 	config.Ports[0].Port = 7007
 	if graph.ValidatorPublicKey()[0] != 1 || graph.ServerInfoConfig().Ports[0].Port != 5005 {
 		t.Fatal("accessors exposed mutable snapshot storage")
+	}
+}
+
+func TestServiceGraphBuildNormalizesTypedNilOptionalCapabilities(t *testing.T) {
+	builder := completeServiceGraphBuilder()
+	var optional *serviceGraphOptionalCapabilities
+	builder.Manifests = optional
+	builder.ValidatorList = optional
+	builder.AdvisoryDeleteState = optional
+	builder.AccountHistorySubscriptions = optional
+
+	graph, err := builder.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if graph.Manifests() != nil || graph.ValidatorList() != nil || graph.AdvisoryDeleteState() != nil || graph.AccountHistorySubscriptions() != nil {
+		t.Fatal("typed-nil optional capability escaped the graph build")
+	}
+}
+
+func TestServiceGraphPublishesSeparateLedgerCapabilities(t *testing.T) {
+	graphType := reflect.TypeOf((*ServiceGraph)(nil))
+	readMethod, ok := graphType.MethodByName("Ledger")
+	if !ok {
+		t.Fatal("ServiceGraph.Ledger is missing")
+	}
+	if readMethod.Type.Out(0) != reflect.TypeOf((*LedgerReadService)(nil)).Elem() {
+		t.Fatalf("Ledger return type = %v", readMethod.Type.Out(0))
+	}
+	mutationMethod, ok := graphType.MethodByName("LedgerMutation")
+	if !ok {
+		t.Fatal("ServiceGraph.LedgerMutation is missing")
+	}
+	if mutationMethod.Type.Out(0) != reflect.TypeOf((*LedgerMutationService)(nil)).Elem() {
+		t.Fatalf("LedgerMutation return type = %v", mutationMethod.Type.Out(0))
 	}
 }
 

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"fmt"
 	"net/http"
+	"reflect"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -121,6 +122,9 @@ func NewWebSocketServer(options WebSocketServerOptions) *WebSocketServer {
 	if resourceManager == nil {
 		resourceManager = resource.NewManager(nil, nil)
 	}
+	if isNilURLSubscriptionService(options.URLSubscriptions) {
+		options.URLSubscriptions = nil
+	}
 	manager := options.SubscriptionManager
 	if registry, ok := options.URLSubscriptions.(*urlSubscriptionRegistry); ok && registry.manager != nil {
 		manager = registry.manager
@@ -165,6 +169,19 @@ func NewWebSocketServer(options WebSocketServerOptions) *WebSocketServer {
 	}
 	ws.setPeerSource(options.PeerSource)
 	return ws
+}
+
+func isNilURLSubscriptionService(service types.URLSubscriptionService) bool {
+	if service == nil {
+		return true
+	}
+	value := reflect.ValueOf(service)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
 func (ws *WebSocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -69,6 +69,8 @@ type WebSocketServer struct {
 	forceDone chan struct{}
 }
 
+var _ types.MethodDispatcher = (*WebSocketServer)(nil)
+
 // WebSocketServerOptions controls construction of a WebSocket RPC server.
 // A nil subscription manager selects a new manager for the standalone server.
 type WebSocketServerOptions struct {
@@ -80,7 +82,10 @@ type WebSocketServerOptions struct {
 	PingInterval        time.Duration
 	LedgerInfoProvider  types.LedgerInfoProvider
 	SubscriptionManager *subscription.Manager
-	URLSubscriptions    types.URLSubscriptionService
+	// URLSubscriptions shares URL subscribers with other RPC transports. A
+	// registry returned by NewURLSubscriptionService transfers ownership to
+	// the server and is closed with it; other implementations remain caller-owned.
+	URLSubscriptions types.URLSubscriptionService
 }
 
 // websocketConnection owns the transport-specific state for one logical
@@ -117,6 +122,9 @@ func NewWebSocketServer(options WebSocketServerOptions) *WebSocketServer {
 		resourceManager = resource.NewManager(nil, nil)
 	}
 	manager := options.SubscriptionManager
+	if registry, ok := options.URLSubscriptions.(*urlSubscriptionRegistry); ok && registry.manager != nil {
+		manager = registry.manager
+	}
 	if manager == nil {
 		manager = subscription.NewManager()
 	}
@@ -255,4 +263,10 @@ func (ws *WebSocketServer) SubscriptionManager() *subscription.Manager {
 
 func (ws *WebSocketServer) URLSubscriptionService() types.URLSubscriptionService {
 	return ws.urlSubscriptions
+}
+
+// ExecuteMethod lets the json RPC forward through the same immutable registry
+// and request context as a direct WebSocket command.
+func (ws *WebSocketServer) ExecuteMethod(ctx *types.RpcContext, method string, params []byte) (any, *types.RpcError) {
+	return dispatchNestedMethod(ws.methodRegistry, ctx, method, params, wsLog())
 }

--- a/internal/rpc/websocket_dispatch.go
+++ b/internal/rpc/websocket_dispatch.go
@@ -50,7 +50,7 @@ func (ws *WebSocketServer) handleMessage(wsConn *websocketConnection, message []
 	peerIP := getWebSocketClientIP(wsConn.conn)
 	clientIP := resolveWSClientIP(peerIP, wsConn.forwardedFor, wsConn.portCtx)
 	role := roleForRequest(peerIP, wsConn.user, cmdMap, wsConn.portCtx)
-	loadCtx := newRpcContext(wsConn.Context(), role, types.DefaultApiVersion, clientIP, ws.loadPeerSource(), ws.services, nil, ws.urlSubscriptions)
+	loadCtx := newRpcContext(wsConn.Context(), role, types.DefaultApiVersion, clientIP, ws.loadPeerSource(), ws.services, ws, ws.urlSubscriptions)
 	loadCtx.ResourceConsumer = wsConn.resourceConsumer
 	if rpcErr := gateLoad(ws.resourceManager, loadCtx, "", wsLog()); rpcErr != nil {
 		wsConn.closeWithPolicyViolation("threshold exceeded")

--- a/internal/rpc/websocket_pathfind.go
+++ b/internal/rpc/websocket_pathfind.go
@@ -61,7 +61,7 @@ func (ws *WebSocketServer) executePathFindCreate(wsConn *websocketConnection, ct
 			"No closed ledger available")
 	}
 	session.setSearchLevelMax(ctx.Services.Capabilities().PathSearchMax)
-	view, err := ctx.Services.Ledger().GetClosedLedgerView()
+	view, err := ctx.Services.LedgerViews().GetClosedLedgerView()
 	if err != nil {
 		return nil, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent",
 			"No closed ledger available")
@@ -70,7 +70,7 @@ func (ws *WebSocketServer) executePathFindCreate(wsConn *websocketConnection, ct
 	event := session.Execute(view, false)
 
 	wsConn.installPathFindSession(session)
-	ws.queuePathFindSessions(currentPathFindView(ctx.Services.Ledger()), wsConn)
+	ws.queuePathFindSessions(currentPathFindView(ctx.Services), wsConn)
 
 	return event, nil
 }
@@ -129,13 +129,14 @@ func (ws *WebSocketServer) queuePathFindSessions(getView func() (types.LedgerSta
 	manager.enqueue(getView, targets)
 }
 
-func currentPathFindView(ledger types.LedgerService) func() (types.LedgerStateView, error) {
+func currentPathFindView(services *types.ServiceGraph) func() (types.LedgerStateView, error) {
 	return func() (types.LedgerStateView, error) {
+		ledger := services.Ledger()
 		if source, ok := ledger.(types.LedgerViewSource); ok {
 			view, _, err := source.GetLedgerViewBySeq(ledger.GetCurrentLedgerIndex())
 			return view, err
 		}
-		return ledger.GetClosedLedgerView()
+		return services.LedgerViews().GetClosedLedgerView()
 	}
 }
 func (c *websocketConnection) clearPathFindSession() *PathFindSession {

--- a/internal/rpc/websocket_test.go
+++ b/internal/rpc/websocket_test.go
@@ -949,6 +949,19 @@ func TestWebSocketRejectsTrailingJSON(t *testing.T) {
 	}
 }
 
+func TestWebSocketJSONDispatchUsesServerRegistry(t *testing.T) {
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
+	body := wsRawRoundTrip(t, ws, `{"command":"json","params":{"method":"ping"},"id":7}`)
+
+	var response map[string]any
+	if err := json.Unmarshal(body, &response); err != nil {
+		t.Fatalf("decode response %s: %v", body, err)
+	}
+	if response["status"] != "success" || response["error"] != nil {
+		t.Fatalf("json dispatch response = %v", response)
+	}
+}
+
 func TestWebSocketJSONInvalidWireEnvelope(t *testing.T) {
 	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
 	tests := []struct {

--- a/internal/testing/rpcenv/adapter.go
+++ b/internal/testing/rpcenv/adapter.go
@@ -33,6 +33,8 @@ type ledgerAdapter struct {
 }
 
 var _ types.LedgerService = (*ledgerAdapter)(nil)
+var _ types.LedgerReadService = (*ledgerAdapter)(nil)
+var _ types.LedgerMutationService = (*ledgerAdapter)(nil)
 
 func newLedgerAdapter(env *jtx.TestEnv) *ledgerAdapter {
 	a := &ledgerAdapter{env: env, closedLedgers: make(map[uint32]*ledger.Ledger)}


### PR DESCRIPTION
## Summary

- separate ledger reads, ledger mutations, engine views, and closed-ledger state into narrow capabilities
- normalize optional typed-nil services before graph publication
- preserve nested JSON dispatch on WebSocket and make URL service ownership explicit

This is layer 6 of 7 and depends on #1606.

Part of #1490.

## Test plan

- `go test -count=1 ./internal/rpc/... ./internal/node ./internal/testing/rpcenv`
- `go test -race -count=1 ./internal/rpc/types ./internal/rpc/handlers ./internal/rpc ./internal/node`
- `go vet ./internal/rpc/... ./internal/node ./internal/testing/rpcenv`
- `golangci-lint run`
- `just build-all`