### PR TITLE
feat(manifest): bound cache admission and configuration (#1595)

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -817,6 +818,26 @@ func TestLoadConfig_ManifestCountTypedAndBoundaryValues(t *testing.T) {
 			path := writeConfig(t, t.TempDir(), "xrpld.toml", minimalTestConfig()+"\n[overlay]\nmax_untrusted_count = "+value+"\n")
 			_, err := LoadConfig(Paths{Main: path})
 			require.Error(t, err)
+		})
+	}
+}
+
+func TestValidateManifestCountsRejectsOutOfRangeIntegers(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{name: "signed", value: int64(1<<32 + MinManifestCount)},
+		{name: "unsigned", value: uint64(1<<32 + MinManifestCount)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			v := viper.New()
+			v.Set("overlay.max_untrusted_count", test.value)
+			err := validateManifestCounts(v)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "max_untrusted_count")
 		})
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -744,6 +744,83 @@ func TestOverlayConfig_ResourceLimitsValidation(t *testing.T) {
 	}
 }
 
+func TestOverlayConfig_ManifestCountDefaultsAndBounds(t *testing.T) {
+	intValue := func(value int) *int { return &value }
+	tests := []struct {
+		name          string
+		untrusted     *int
+		trusted       *int
+		wantUntrusted int
+		wantTrusted   int
+		wantErr       bool
+	}{
+		{name: "absent", wantUntrusted: DefaultMaxUntrustedCount, wantTrusted: DefaultMaxTrustedCount},
+		{name: "untrusted_only", untrusted: intValue(50), wantUntrusted: 50, wantTrusted: DefaultMaxTrustedCount},
+		{name: "trusted_only", trusted: intValue(1000), wantUntrusted: DefaultMaxUntrustedCount, wantTrusted: 1000},
+		{name: "both", untrusted: intValue(1000), trusted: intValue(50), wantUntrusted: 1000, wantTrusted: 50},
+		{name: "untrusted_below_minimum", untrusted: intValue(49), wantErr: true},
+		{name: "untrusted_above_maximum", untrusted: intValue(1001), wantErr: true},
+		{name: "untrusted_zero", untrusted: intValue(0), wantErr: true},
+		{name: "untrusted_negative", untrusted: intValue(-1), wantErr: true},
+		{name: "trusted_below_minimum", trusted: intValue(49), wantErr: true},
+		{name: "trusted_above_maximum", trusted: intValue(1001), wantErr: true},
+		{name: "trusted_zero", trusted: intValue(0), wantErr: true},
+		{name: "trusted_negative", trusted: intValue(-1), wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			overlay := OverlayConfig{MaxUntrustedCount: test.untrusted, MaxTrustedCount: test.trusted}
+			err := overlay.Validate()
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.wantUntrusted, overlay.EffectiveMaxUntrustedCount())
+			require.Equal(t, test.wantTrusted, overlay.EffectiveMaxTrustedCount())
+		})
+	}
+}
+
+func TestLoadConfig_ManifestCountTypedAndBoundaryValues(t *testing.T) {
+	validValues := []string{
+		"max_untrusted_count = 50\nmax_trusted_count = 1000",
+		"max_untrusted_count = 1000\nmax_trusted_count = 50",
+	}
+	for _, overlay := range validValues {
+		t.Run(strings.ReplaceAll(overlay, "\n", ";"), func(t *testing.T) {
+			path := writeConfig(t, t.TempDir(), "xrpld.toml", minimalTestConfig()+"\n[overlay]\n"+overlay+"\n")
+			cfg, err := LoadConfig(Paths{Main: path})
+			require.NoError(t, err)
+			require.NotNil(t, cfg.Overlay.MaxUntrustedCount)
+			require.NotNil(t, cfg.Overlay.MaxTrustedCount)
+		})
+	}
+
+	for _, value := range []string{"49", "1001", "0", "-1"} {
+		t.Run("untrusted_"+value, func(t *testing.T) {
+			path := writeConfig(t, t.TempDir(), "xrpld.toml", minimalTestConfig()+"\n[overlay]\nmax_untrusted_count = "+value+"\n")
+			_, err := LoadConfig(Paths{Main: path})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "max_untrusted_count")
+		})
+		t.Run("trusted_"+value, func(t *testing.T) {
+			path := writeConfig(t, t.TempDir(), "xrpld.toml", minimalTestConfig()+"\n[overlay]\nmax_trusted_count = "+value+"\n")
+			_, err := LoadConfig(Paths{Main: path})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "max_trusted_count")
+		})
+	}
+
+	for _, value := range []string{"\"50\"", "50.5", "true", "[50]"} {
+		t.Run("malformed_untrusted_"+value, func(t *testing.T) {
+			path := writeConfig(t, t.TempDir(), "xrpld.toml", minimalTestConfig()+"\n[overlay]\nmax_untrusted_count = "+value+"\n")
+			_, err := LoadConfig(Paths{Main: path})
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestConfigValidation_CompleteConfig(t *testing.T) {
 	assert.NoError(t, ValidateConfig(validCompleteConfig()))
 }

--- a/config/examples/xrpld.toml
+++ b/config/examples/xrpld.toml
@@ -175,6 +175,8 @@ journal_size_limit = 1582080
 [overlay]
 max_unknown_time = 600   # seconds (300-1800)
 max_diverged_time = 300  # seconds (60-900)
+# max_untrusted_count = 300  # cached unlisted manifests (50-1000)
+# max_trusted_count = 300    # trusted manifests allowed per message (50-1000)
 # public_ip = "203.0.113.7"
 # verify_endpoints = 1   # 0|1 (default 1); 0 accepts non-public gossip
                          # addresses for local dev — a security risk on

--- a/config/loader.go
+++ b/config/loader.go
@@ -2,9 +2,9 @@ package config
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/go-viper/mapstructure/v2"
@@ -21,7 +21,7 @@ func LoadConfig(paths Paths) (*Config, error) {
 	if err := loadMainConfig(v, paths.Main); err != nil {
 		return nil, fmt.Errorf("failed to load main config: %w", err)
 	}
-	if err := validateManifestCountTypes(v); err != nil {
+	if err := validateManifestCounts(v); err != nil {
 		return nil, fmt.Errorf("failed to load main config: %w", err)
 	}
 
@@ -63,29 +63,29 @@ func LoadConfig(paths Paths) (*Config, error) {
 	return &config, nil
 }
 
-// validateManifestCountTypes rejects weakly-typed TOML values before
+// validateManifestCounts rejects weakly-typed TOML values before
 // mapstructure can coerce them into *int fields. Manifest counts are integer
 // settings; accepting strings or floating-point values here would make a
 // malformed configuration appear valid after decoding.
-func validateManifestCountTypes(v *viper.Viper) error {
+func validateManifestCounts(v *viper.Viper) error {
 	for _, key := range []string{"overlay.max_untrusted_count", "overlay.max_trusted_count"} {
 		if !v.IsSet(key) {
 			continue
 		}
-		raw := v.Get(key)
-		switch value := raw.(type) {
-		case int:
-		case int8:
-		case int16:
-		case int32:
-		case int64:
-		case uint:
-		case uint8:
-		case uint16:
-		case uint32:
-		case uint64:
-			if value > uint64(math.MaxInt) {
-				return fmt.Errorf("%s must be an integer count", key)
+
+		value := reflect.ValueOf(v.Get(key))
+		switch value.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			count := value.Int()
+			if count < MinManifestCount || count > MaxManifestCount {
+				return fmt.Errorf("%s must be between %d and %d, got %d",
+					key, MinManifestCount, MaxManifestCount, count)
+			}
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			count := value.Uint()
+			if count < MinManifestCount || count > MaxManifestCount {
+				return fmt.Errorf("%s must be between %d and %d, got %d",
+					key, MinManifestCount, MaxManifestCount, count)
 			}
 		default:
 			return fmt.Errorf("%s must be an integer count", key)

--- a/config/loader.go
+++ b/config/loader.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,6 +19,9 @@ func LoadConfig(paths Paths) (*Config, error) {
 
 	// Load main configuration file (required)
 	if err := loadMainConfig(v, paths.Main); err != nil {
+		return nil, fmt.Errorf("failed to load main config: %w", err)
+	}
+	if err := validateManifestCountTypes(v); err != nil {
 		return nil, fmt.Errorf("failed to load main config: %w", err)
 	}
 
@@ -57,6 +61,37 @@ func LoadConfig(paths Paths) (*Config, error) {
 	}
 
 	return &config, nil
+}
+
+// validateManifestCountTypes rejects weakly-typed TOML values before
+// mapstructure can coerce them into *int fields. Manifest counts are integer
+// settings; accepting strings or floating-point values here would make a
+// malformed configuration appear valid after decoding.
+func validateManifestCountTypes(v *viper.Viper) error {
+	for _, key := range []string{"overlay.max_untrusted_count", "overlay.max_trusted_count"} {
+		if !v.IsSet(key) {
+			continue
+		}
+		raw := v.Get(key)
+		switch value := raw.(type) {
+		case int:
+		case int8:
+		case int16:
+		case int32:
+		case int64:
+		case uint:
+		case uint8:
+		case uint16:
+		case uint32:
+		case uint64:
+			if value > uint64(math.MaxInt) {
+				return fmt.Errorf("%s must be an integer count", key)
+			}
+		default:
+			return fmt.Errorf("%s must be an integer count", key)
+		}
+	}
+	return nil
 }
 
 // loadMainConfig loads the main configuration file

--- a/config/peer.go
+++ b/config/peer.go
@@ -17,15 +17,27 @@ import (
 //     gossip; nil (absent) means the built-in default (1 = verify on),
 //     0 skips validation for local dev networks — a security risk on a
 //     public network
+//   - max_untrusted_count / max_trusted_count are optional manifest limits;
+//     absence defaults independently to 300 and configured values must be in
+//     the inclusive range 50..1000
 type OverlayConfig struct {
 	PublicIP             string               `toml:"public_ip" mapstructure:"public_ip"`
 	IPLimit              int                  `toml:"ip_limit" mapstructure:"ip_limit"`
 	MaxUnknownTime       int                  `toml:"max_unknown_time" mapstructure:"max_unknown_time"`
 	MaxDivergedTime      int                  `toml:"max_diverged_time" mapstructure:"max_diverged_time"`
 	VerifyEndpoints      *int                 `toml:"verify_endpoints" mapstructure:"verify_endpoints"`
+	MaxUntrustedCount    *int                 `toml:"max_untrusted_count" mapstructure:"max_untrusted_count"`
+	MaxTrustedCount      *int                 `toml:"max_trusted_count" mapstructure:"max_trusted_count"`
 	InboundRetainedBytes int64                `toml:"inbound_retained_bytes" mapstructure:"inbound_retained_bytes"`
 	ResourceLimits       ResourceLimitsConfig `toml:"resource_limits" mapstructure:"resource_limits"`
 }
+
+const (
+	DefaultMaxUntrustedCount = 300
+	DefaultMaxTrustedCount   = 300
+	MinManifestCount         = 50
+	MaxManifestCount         = 1000
+)
 
 // ResourceLimitsConfig bounds peer reputation and cluster-gossip state.
 // Zero values retain the built-in limits.
@@ -109,8 +121,37 @@ func (o *OverlayConfig) Validate() error {
 	if limits.MaxImportItems > 1024 {
 		return fmt.Errorf("resource_limits.max_import_items must not exceed 1024, got %d", limits.MaxImportItems)
 	}
+	for _, count := range []struct {
+		name  string
+		value *int
+	}{
+		{name: "max_untrusted_count", value: o.MaxUntrustedCount},
+		{name: "max_trusted_count", value: o.MaxTrustedCount},
+	} {
+		if count.value == nil {
+			continue
+		}
+		if *count.value < MinManifestCount || *count.value > MaxManifestCount {
+			return fmt.Errorf("%s must be between %d and %d, got %d",
+				count.name, MinManifestCount, MaxManifestCount, *count.value)
+		}
+	}
 
 	return nil
+}
+
+func (o *OverlayConfig) EffectiveMaxUntrustedCount() int {
+	if o == nil || o.MaxUntrustedCount == nil {
+		return DefaultMaxUntrustedCount
+	}
+	return *o.MaxUntrustedCount
+}
+
+func (o *OverlayConfig) EffectiveMaxTrustedCount() int {
+	if o == nil || o.MaxTrustedCount == nil {
+		return DefaultMaxTrustedCount
+	}
+	return *o.MaxTrustedCount
 }
 
 // Validate performs validation on the transaction queue configuration.

--- a/config/peer.go
+++ b/config/peer.go
@@ -32,6 +32,7 @@ type OverlayConfig struct {
 	ResourceLimits       ResourceLimitsConfig `toml:"resource_limits" mapstructure:"resource_limits"`
 }
 
+// Manifest count defaults and bounds apply to overlay admission and wire limits.
 const (
 	DefaultMaxUntrustedCount = 300
 	DefaultMaxTrustedCount   = 300
@@ -140,6 +141,7 @@ func (o *OverlayConfig) Validate() error {
 	return nil
 }
 
+// EffectiveMaxUntrustedCount returns the configured limit or its default.
 func (o *OverlayConfig) EffectiveMaxUntrustedCount() int {
 	if o == nil || o.MaxUntrustedCount == nil {
 		return DefaultMaxUntrustedCount
@@ -147,6 +149,7 @@ func (o *OverlayConfig) EffectiveMaxUntrustedCount() int {
 	return *o.MaxUntrustedCount
 }
 
+// EffectiveMaxTrustedCount returns the configured limit or its default.
 func (o *OverlayConfig) EffectiveMaxTrustedCount() int {
 	if o == nil || o.MaxTrustedCount == nil {
 		return DefaultMaxTrustedCount

--- a/config/peer.go
+++ b/config/peer.go
@@ -32,7 +32,6 @@ type OverlayConfig struct {
 	ResourceLimits       ResourceLimitsConfig `toml:"resource_limits" mapstructure:"resource_limits"`
 }
 
-// Manifest count defaults and bounds apply to overlay admission and wire limits.
 const (
 	DefaultMaxUntrustedCount = 300
 	DefaultMaxTrustedCount   = 300
@@ -141,7 +140,6 @@ func (o *OverlayConfig) Validate() error {
 	return nil
 }
 
-// EffectiveMaxUntrustedCount returns the configured limit or its default.
 func (o *OverlayConfig) EffectiveMaxUntrustedCount() int {
 	if o == nil || o.MaxUntrustedCount == nil {
 		return DefaultMaxUntrustedCount
@@ -149,7 +147,6 @@ func (o *OverlayConfig) EffectiveMaxUntrustedCount() int {
 	return *o.MaxUntrustedCount
 }
 
-// EffectiveMaxTrustedCount returns the configured limit or its default.
 func (o *OverlayConfig) EffectiveMaxTrustedCount() int {
 	if o == nil || o.MaxTrustedCount == nil {
 		return DefaultMaxTrustedCount

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -288,6 +288,11 @@ browser origin must also configure Basic Auth.
 |-----|---------|---------|
 | `max_unknown_time` | `600` | Seconds a peer may stay in the "unknown" sanity state (300–1800). |
 | `max_diverged_time` | `300` | Seconds a peer may stay "diverged" before being dropped (60–900). |
+| `max_untrusted_count` | `300` | Maximum cached manifests for unlisted validator masters (50–1000). |
+| `max_trusted_count` | `300` | Trusted-manifest allowance used when sizing manifest messages (50–1000). |
+
+Both manifest-count keys are optional and default independently to `300`; an
+explicit value must be between `50` and `1000`, inclusive.
 
 ### `[transaction_queue]`
 

--- a/internal/consensus/adaptor/manifest_persistence_test.go
+++ b/internal/consensus/adaptor/manifest_persistence_test.go
@@ -150,6 +150,17 @@ func TestNewFromConfigFailsWhenManifestStoreCannotLoad(t *testing.T) {
 	require.ErrorContains(t, err, "RawData")
 }
 
+func TestNewFromConfigRejectsInvalidManifestCacheLimit(t *testing.T) {
+	value := 49
+	components, err := NewFromConfig(context.Background(), &config.Config{
+		DatabasePath: t.TempDir(),
+		Overlay:      config.OverlayConfig{MaxUntrustedCount: &value},
+	}, nil, nil, nil)
+	require.Nil(t, components)
+	require.ErrorContains(t, err, "validate overlay config")
+	require.ErrorContains(t, err, "max_untrusted_count")
+}
+
 func applyTokenManifest(t *testing.T, cache *manifest.Cache, masterSeed, signingSeed byte, sequence uint32) [33]byte {
 	t.Helper()
 	fixture := newTokenFixtureWithSeeds(t, masterSeed, signingSeed, sequence)

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -126,7 +126,7 @@ func (r *Router) handleManifests(msg *peermanagement.InboundMessage) bool {
 			valid = true
 			return
 		}
-		switch d := r.manifests.ApplyManifest(parsed); d {
+		switch d := r.manifests.ApplyManifest(parsed, manifest.Uncapped); d {
 		case manifest.Accepted:
 			valid = true
 			accepted = append(accepted, wire)

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -380,6 +380,13 @@ func persistedManifests(cache *manifest.Cache, keep func([33]byte) bool) [][]byt
 	return out
 }
 
+func manifestCountSource(configured bool) string {
+	if configured {
+		return "configured"
+	}
+	return "default"
+}
+
 // NewFromConfig creates and wires all consensus/networking components from the app config.
 //
 // validationRepo is optional — pass nil to disable the on-disk validation
@@ -395,6 +402,10 @@ func NewFromConfig(
 	validationRepo relationaldb.ValidationRepository,
 	floor MinimumOnlineFloor,
 ) (_ *Components, err error) {
+	if err := appCfg.Overlay.Validate(); err != nil {
+		return nil, fmt.Errorf("validate overlay config: %w", err)
+	}
+
 	// Create validator identity first (nil if not a validator) so we can
 	// pass its pubkey into the overlay for the self-target TMSquelch
 	// filter: without this a peer could silence our own validator's
@@ -408,8 +419,16 @@ func NewFromConfig(
 		return nil, fmt.Errorf("parse validator_list_keys: %w", err)
 	}
 
-	validatorManifests := manifest.NewCache()
-	publisherManifests := manifest.NewCache()
+	maxUntrustedCount := appCfg.Overlay.EffectiveMaxUntrustedCount()
+	maxTrustedCount := appCfg.Overlay.EffectiveMaxTrustedCount()
+	slog.Info("manifest cache limits",
+		"t", "adaptor.NewFromConfig",
+		"max_untrusted_count", maxUntrustedCount,
+		"max_untrusted_count_source", manifestCountSource(appCfg.Overlay.MaxUntrustedCount != nil),
+		"max_trusted_count", maxTrustedCount,
+		"max_trusted_count_source", manifestCountSource(appCfg.Overlay.MaxTrustedCount != nil))
+	validatorManifests := manifest.NewCache(maxUntrustedCount)
+	publisherManifests := manifest.NewCache(maxUntrustedCount)
 	manifestStore, err := manifest.OpenSQLiteStore(ctx, appCfg.LocalStateDir())
 	if err != nil {
 		return nil, fmt.Errorf("open manifest store: %w", err)
@@ -645,7 +664,7 @@ func NewFromConfig(
 }
 
 func seedLocalManifest(cache *manifest.Cache, local *manifest.Manifest) error {
-	disposition := cache.ApplyManifest(local)
+	disposition := cache.ApplyManifest(local, manifest.Uncapped)
 	if disposition == manifest.Invalid {
 		return fmt.Errorf("seed local manifest into cache: disposition=%s", disposition)
 	}
@@ -659,7 +678,7 @@ func restoreManifests(role string, cache *manifest.Cache, rows [][]byte) {
 			slog.Warn("stored manifest rejected", "role", role, "row", i, "error", err)
 			continue
 		}
-		switch disposition := cache.ApplyManifest(parsed); disposition {
+		switch disposition := cache.ApplyManifest(parsed, manifest.Uncapped); disposition {
 		case manifest.Accepted, manifest.Stale:
 		default:
 			slog.Warn("stored manifest rejected", "role", role, "row", i, "disposition", disposition.String())

--- a/internal/manifest/cache.go
+++ b/internal/manifest/cache.go
@@ -57,9 +57,6 @@ const (
 	Uncapped
 )
 
-// ApplyPolicy is a concise alias for ManifestRateLimitCapPolicy.
-type ApplyPolicy = ManifestRateLimitCapPolicy
-
 // String returns a debug-friendly label for the disposition.
 func (d Disposition) String() string {
 	switch d {
@@ -166,7 +163,7 @@ func (c *Cache) ApplyManifest(m *Manifest, policies ...ManifestRateLimitCapPolic
 	if len(policies) > 0 {
 		policy = policies[0]
 	}
-	capped := policy == Capped
+	capped := policy != Uncapped
 
 	c.applyMu.Lock()
 

--- a/internal/manifest/cache.go
+++ b/internal/manifest/cache.go
@@ -31,7 +31,34 @@ const (
 	// BadEphemeralKey: the incoming manifest's ephemeral key is already
 	// known as either an ephemeral or master key in this cache.
 	BadEphemeralKey
+
+	// UntrustedCapacity: the incoming manifest belongs to a brand-new
+	// untrusted master and the cache's untrusted capacity is full.
+	UntrustedCapacity
 )
+
+const (
+	// DefaultMaxUntrustedCount is the built-in limit for capped manifest
+	// applications.
+	DefaultMaxUntrustedCount = 300
+
+	// DefaultMaxTrustedCount is the built-in trusted-manifest message limit.
+	// The cache itself only enforces the untrusted limit.
+	DefaultMaxTrustedCount = 300
+)
+
+// ManifestRateLimitCapPolicy controls whether ApplyManifest enforces the
+// untrusted-master capacity. Capped is intended for untrusted peer gossip;
+// configured, persisted, and already-listed manifests use Uncapped.
+type ManifestRateLimitCapPolicy uint8
+
+const (
+	Capped ManifestRateLimitCapPolicy = iota
+	Uncapped
+)
+
+// ApplyPolicy is a concise alias for ManifestRateLimitCapPolicy.
+type ApplyPolicy = ManifestRateLimitCapPolicy
 
 // String returns a debug-friendly label for the disposition.
 func (d Disposition) String() string {
@@ -46,6 +73,8 @@ func (d Disposition) String() string {
 		return "bad_master_key"
 	case BadEphemeralKey:
 		return "bad_ephemeral_key"
+	case UntrustedCapacity:
+		return "untrusted_capacity"
 	default:
 		return "unknown"
 	}
@@ -73,6 +102,14 @@ type Cache struct {
 	// trusted.
 	byMaster map[[33]byte]Manifest
 
+	// untrustedMasters contains masters first accepted through a Capped
+	// application. Membership is independent of byMaster: promotion and
+	// uncapped updates free a slot without evicting the cached manifest.
+	untrustedMasters map[[33]byte]struct{}
+
+	// maxUntrustedCount is immutable for the lifetime of the cache.
+	maxUntrustedCount int
+
 	// signingToMaster maps ephemeral signing key → master key. Cleared
 	// when the master rotates (old ephemeral removed) or revokes
 	// (entry removed so lookups no longer resolve).
@@ -95,29 +132,61 @@ type acceptedEvent struct {
 	subscribers []uint64
 }
 
-// NewCache returns an empty Cache.
-func NewCache() *Cache {
+// NewCache returns an empty Cache. The optional argument is retained for
+// compatibility with callers that use the persistence-foundation constructor;
+// omission selects DefaultMaxUntrustedCount.
+func NewCache(maxUntrusted ...int) *Cache {
+	capacity := DefaultMaxUntrustedCount
+	if len(maxUntrusted) > 0 {
+		capacity = maxUntrusted[0]
+		if capacity < 0 {
+			capacity = 0
+		}
+	}
 	return &Cache{
-		byMaster:        make(map[[33]byte]Manifest),
-		signingToMaster: make(map[[33]byte][33]byte),
-		subscribers:     make(map[uint64]func(*Manifest)),
+		byMaster:          make(map[[33]byte]Manifest),
+		untrustedMasters:  make(map[[33]byte]struct{}),
+		maxUntrustedCount: capacity,
+		signingToMaster:   make(map[[33]byte][33]byte),
+		subscribers:       make(map[uint64]func(*Manifest)),
 	}
 }
 
 // ApplyManifest ingests a parsed manifest, verifies it, and — if the
 // checks pass — stores it atomically. Returns the disposition so the
 // caller can decide whether to relay (Accepted) or charge the sender
-// (Invalid / BadMasterKey / BadEphemeralKey). Stale is a no-op.
-func (c *Cache) ApplyManifest(m *Manifest) Disposition {
+// (Invalid / BadMasterKey / BadEphemeralKey). Stale and UntrustedCapacity are
+// no-ops. A call without a policy defaults to Capped for compatibility; all
+// production callers pass Capped or Uncapped explicitly.
+func (c *Cache) ApplyManifest(m *Manifest, policies ...ManifestRateLimitCapPolicy) Disposition {
 	if m == nil {
 		return Invalid
 	}
-	owned, err := Deserialize(m.serialized)
-	if err != nil {
-		return Invalid
+	policy := Capped
+	if len(policies) > 0 {
+		policy = policies[0]
 	}
+	capped := policy == Capped
 
 	c.applyMu.Lock()
+
+	// Check capacity using the parsed master key before deserializing or
+	// verifying a brand-new capped manifest. The write-locked path repeats this
+	// check because another writer may have filled the final slot in between.
+	c.mu.RLock()
+	_, existing := c.byMaster[m.masterKey]
+	if capped && !existing && len(c.untrustedMasters) >= c.maxUntrustedCount {
+		c.mu.RUnlock()
+		c.applyMu.Unlock()
+		return UntrustedCapacity
+	}
+	c.mu.RUnlock()
+
+	owned, err := Deserialize(m.serialized)
+	if err != nil {
+		c.applyMu.Unlock()
+		return Invalid
+	}
 
 	c.mu.RLock()
 	if existing, ok := c.byMaster[owned.masterKey]; ok && owned.sequence <= existing.sequence {
@@ -135,7 +204,7 @@ func (c *Cache) ApplyManifest(m *Manifest) Disposition {
 		return Invalid
 	}
 
-	disp := c.applyLocked(owned)
+	disp := c.applyLocked(owned, capped)
 	drain := false
 	if disp == Accepted {
 		drain = c.enqueueAccepted(owned)
@@ -147,9 +216,15 @@ func (c *Cache) ApplyManifest(m *Manifest) Disposition {
 	return disp
 }
 
-func (c *Cache) applyLocked(m *Manifest) Disposition {
+func (c *Cache) applyLocked(m *Manifest, capped bool) Disposition {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	if capped {
+		if _, ok := c.byMaster[m.masterKey]; !ok && len(c.untrustedMasters) >= c.maxUntrustedCount {
+			return UntrustedCapacity
+		}
+	}
 
 	// Re-check Stale under the write lock against any direct map
 	// writer that bypassed applyMu.
@@ -182,12 +257,58 @@ func (c *Cache) applyLocked(m *Manifest) Disposition {
 	}
 
 	c.byMaster[m.masterKey] = *cloneManifest(m)
+	if !isUpdate && capped {
+		c.untrustedMasters[m.masterKey] = struct{}{}
+	} else if isUpdate && !capped {
+		delete(c.untrustedMasters, m.masterKey)
+	}
 	if !m.Revoked() {
 		c.signingToMaster[m.signingKey] = m.masterKey
 	}
 	// Advance on insert, rotation, and revocation so emitters re-encode.
 	c.seq++
 	return Accepted
+}
+
+// PromoteToTrusted removes masterKey from the untrusted capacity accounting.
+// It does not alter or evict the cached manifest and is idempotent; a later
+// de-listing never re-adds the key automatically.
+func (c *Cache) PromoteToTrusted(masterKey [33]byte) {
+	c.mu.Lock()
+	delete(c.untrustedMasters, masterKey)
+	c.mu.Unlock()
+}
+
+// MaxUntrustedCount returns the immutable untrusted capacity configured for
+// this cache.
+func (c *Cache) MaxUntrustedCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.maxUntrustedCount
+}
+
+// UntrustedCount returns the number of cached masters currently consuming an
+// untrusted capacity slot.
+func (c *Cache) UntrustedCount() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.untrustedMasters)
+}
+
+// IsUntrusted reports whether masterKey currently consumes an untrusted
+// capacity slot.
+func (c *Cache) IsUntrusted(masterKey [33]byte) bool {
+	if c == nil {
+		return false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	_, ok := c.untrustedMasters[masterKey]
+	return ok
 }
 
 // SubscribeAccepted registers a subscriber for newly accepted manifests and

--- a/internal/manifest/cache.go
+++ b/internal/manifest/cache.go
@@ -38,12 +38,8 @@ const (
 )
 
 const (
-	// DefaultMaxUntrustedCount is the built-in limit for capped manifest
-	// applications.
 	DefaultMaxUntrustedCount = 300
 
-	// DefaultMaxTrustedCount is the built-in trusted-manifest message limit.
-	// The cache itself only enforces the untrusted limit.
 	DefaultMaxTrustedCount = 300
 )
 
@@ -276,8 +272,6 @@ func (c *Cache) PromoteToTrusted(masterKey [33]byte) {
 	c.mu.Unlock()
 }
 
-// MaxUntrustedCount returns the immutable untrusted capacity configured for
-// this cache.
 func (c *Cache) MaxUntrustedCount() int {
 	if c == nil {
 		return 0
@@ -285,8 +279,6 @@ func (c *Cache) MaxUntrustedCount() int {
 	return c.maxUntrustedCount
 }
 
-// UntrustedCount returns the number of cached masters currently consuming an
-// untrusted capacity slot.
 func (c *Cache) UntrustedCount() int {
 	if c == nil {
 		return 0
@@ -296,8 +288,6 @@ func (c *Cache) UntrustedCount() int {
 	return len(c.untrustedMasters)
 }
 
-// IsUntrusted reports whether masterKey currently consumes an untrusted
-// capacity slot.
 func (c *Cache) IsUntrusted(masterKey [33]byte) bool {
 	if c == nil {
 		return false

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -44,7 +44,12 @@ import (
 // RevokedSequence marks a manifest as a master-key revocation.
 const RevokedSequence uint32 = math.MaxUint32
 
-const maxSerializedSize = 1024
+// MaxSerializedSize is the largest serialized manifest accepted by the
+// protocol. The bound is checked before STObject decoding so oversized input
+// cannot trigger parser allocations.
+const MaxSerializedSize = 358
+
+const maxSerializedSize = MaxSerializedSize
 
 // Manifest is a parsed, syntactically-valid validator manifest.
 // Signature verification is separate — callers invoke Verify before

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"math/big"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -146,8 +147,136 @@ func TestManifest_RejectsFieldsOutsideManifestFormat(t *testing.T) {
 }
 
 func TestManifest_RejectsOversizedPayloadBeforeDecode(t *testing.T) {
-	_, err := manifest.Deserialize(make([]byte, 1025))
-	require.ErrorContains(t, err, "payload exceeds 1024 bytes")
+	_, err := manifest.Deserialize(make([]byte, manifest.MaxSerializedSize+1))
+	require.ErrorContains(t, err, "payload exceeds 358 bytes")
+}
+
+func TestManifest_MaximumSerializedPayloadReachesDecoder(t *testing.T) {
+	_, err := manifest.Deserialize(make([]byte, manifest.MaxSerializedSize))
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "payload exceeds")
+}
+
+func TestManifest_CappedCapacityUpdatesAndPromotion(t *testing.T) {
+	firstWire, firstMaster, _ := buildManifest(t, 1, false, 0x41, 0x42)
+	first, err := manifest.Deserialize(firstWire)
+	require.NoError(t, err)
+	secondWire, secondMaster, _ := buildManifest(t, 1, false, 0x43, 0x44)
+	second, err := manifest.Deserialize(secondWire)
+	require.NoError(t, err)
+
+	cache := manifest.NewCache(1)
+	require.Equal(t, manifest.Accepted, cache.ApplyManifest(first, manifest.Capped))
+	require.True(t, cache.IsUntrusted(firstMaster))
+	require.Equal(t, 1, cache.UntrustedCount())
+
+	// A full capped cache rejects a new master before signature/key checks and
+	// retains every accepted entry without eviction.
+	badSecondWire := append([]byte(nil), secondWire...)
+	badSecondWire[len(badSecondWire)-1] ^= 0x01
+	badSecond, err := manifest.Deserialize(badSecondWire)
+	require.NoError(t, err)
+	require.Equal(t, manifest.UntrustedCapacity, cache.ApplyManifest(badSecond, manifest.Capped))
+	require.Equal(t, 1, cache.UntrustedCount())
+	_, ok := cache.GetManifest(secondMaster)
+	require.False(t, ok)
+	_, ok = cache.GetManifest(firstMaster)
+	require.True(t, ok)
+
+	// Rotations and revocations of an already-cached master bypass capacity.
+	rotationWire, _, _ := buildManifest(t, 2, false, 0x41, 0x45)
+	rotation, err := manifest.Deserialize(rotationWire)
+	require.NoError(t, err)
+	require.Equal(t, manifest.Accepted, cache.ApplyManifest(rotation, manifest.Capped))
+	require.Equal(t, 1, cache.UntrustedCount())
+	revocationWire, _, _ := buildManifest(t, manifest.RevokedSequence, true, 0x41, 0)
+	revocation, err := manifest.Deserialize(revocationWire)
+	require.NoError(t, err)
+	require.Equal(t, manifest.Accepted, cache.ApplyManifest(revocation, manifest.Capped))
+	require.Equal(t, 1, cache.UntrustedCount())
+
+	// Promotion frees the slot but keeps the cached revocation; a subsequent
+	// capped insertion may consume that slot.
+	cache.PromoteToTrusted(firstMaster)
+	cache.PromoteToTrusted(firstMaster)
+	require.Equal(t, 0, cache.UntrustedCount())
+	require.True(t, cache.Revoked(firstMaster))
+	require.Equal(t, manifest.Accepted, cache.ApplyManifest(second, manifest.Capped))
+	require.Equal(t, 1, cache.UntrustedCount())
+
+	// An uncapped update of a counted master frees its slot and de-listing does
+	// not add it back.
+	secondRotationWire, _, _ := buildManifest(t, 2, false, 0x43, 0x46)
+	secondRotation, err := manifest.Deserialize(secondRotationWire)
+	require.NoError(t, err)
+	require.Equal(t, manifest.Accepted, cache.ApplyManifest(secondRotation, manifest.Uncapped))
+	require.Equal(t, 0, cache.UntrustedCount())
+	require.Equal(t, manifest.Stale, cache.ApplyManifest(secondRotation, manifest.Capped))
+	require.Equal(t, 0, cache.UntrustedCount())
+}
+
+func TestManifest_UncappedBypassesCapacityAndRolesAreIsolated(t *testing.T) {
+	firstWire, firstMaster, _ := buildManifest(t, 1, false, 0x51, 0x52)
+	first, err := manifest.Deserialize(firstWire)
+	require.NoError(t, err)
+	secondWire, secondMaster, _ := buildManifest(t, 1, false, 0x53, 0x54)
+	second, err := manifest.Deserialize(secondWire)
+	require.NoError(t, err)
+
+	validators := manifest.NewCache(1)
+	publishers := manifest.NewCache(1)
+	require.Equal(t, manifest.Accepted, validators.ApplyManifest(first, manifest.Capped))
+	require.Equal(t, manifest.Accepted, publishers.ApplyManifest(first, manifest.Capped))
+	require.Equal(t, manifest.UntrustedCapacity, validators.ApplyManifest(second, manifest.Capped))
+	require.Equal(t, manifest.UntrustedCapacity, publishers.ApplyManifest(second, manifest.Capped))
+
+	// Configured/listed/DB paths remain uncapped and are isolated per role.
+	require.Equal(t, manifest.Accepted, validators.ApplyManifest(second, manifest.Uncapped))
+	require.False(t, validators.IsUntrusted(secondMaster))
+	require.Equal(t, 1, validators.UntrustedCount())
+	require.True(t, validators.IsUntrusted(firstMaster))
+	require.False(t, publishers.IsUntrusted(secondMaster))
+	require.Equal(t, 1, publishers.UntrustedCount())
+}
+
+func TestManifest_CappedCapacityConcurrentFirstInsert(t *testing.T) {
+	cache := manifest.NewCache(1)
+	const count = 12
+	manifests := make([]*manifest.Manifest, 0, count)
+	for i := 0; i < count; i++ {
+		wire, _, _ := buildManifest(t, 1, false, byte(0x61+i), byte(0x71+i))
+		parsed, err := manifest.Deserialize(wire)
+		require.NoError(t, err)
+		manifests = append(manifests, parsed)
+	}
+
+	results := make(chan manifest.Disposition, count)
+	var wg sync.WaitGroup
+	for _, parsed := range manifests {
+		wg.Add(1)
+		go func(m *manifest.Manifest) {
+			defer wg.Done()
+			results <- cache.ApplyManifest(m, manifest.Capped)
+		}(parsed)
+	}
+	wg.Wait()
+	close(results)
+
+	accepted := 0
+	capacity := 0
+	for disposition := range results {
+		switch disposition {
+		case manifest.Accepted:
+			accepted++
+		case manifest.UntrustedCapacity:
+			capacity++
+		default:
+			t.Fatalf("unexpected disposition %s", disposition)
+		}
+	}
+	require.Equal(t, 1, accepted)
+	require.Equal(t, count-1, capacity)
+	require.Equal(t, 1, cache.UntrustedCount())
 }
 
 func TestDispositionString(t *testing.T) {
@@ -160,6 +289,7 @@ func TestDispositionString(t *testing.T) {
 		{manifest.Invalid, "invalid"},
 		{manifest.BadMasterKey, "bad_master_key"},
 		{manifest.BadEphemeralKey, "bad_ephemeral_key"},
+		{manifest.UntrustedCapacity, "untrusted_capacity"},
 		{manifest.Disposition(99), "unknown"},
 	}
 	for _, test := range tests {

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -170,8 +170,6 @@ func TestManifest_CappedCapacityUpdatesAndPromotion(t *testing.T) {
 	require.True(t, cache.IsUntrusted(firstMaster))
 	require.Equal(t, 1, cache.UntrustedCount())
 
-	// A full capped cache rejects a new master before signature/key checks and
-	// retains every accepted entry without eviction.
 	badSecondWire := append([]byte(nil), secondWire...)
 	badSecondWire[len(badSecondWire)-1] ^= 0x01
 	badSecond, err := manifest.Deserialize(badSecondWire)
@@ -184,7 +182,6 @@ func TestManifest_CappedCapacityUpdatesAndPromotion(t *testing.T) {
 	_, ok = cache.GetManifest(firstMaster)
 	require.True(t, ok)
 
-	// Rotations and revocations of an already-cached master bypass capacity.
 	rotationWire, _, _ := buildManifest(t, 2, false, 0x41, 0x45)
 	rotation, err := manifest.Deserialize(rotationWire)
 	require.NoError(t, err)
@@ -196,8 +193,6 @@ func TestManifest_CappedCapacityUpdatesAndPromotion(t *testing.T) {
 	require.Equal(t, manifest.Accepted, cache.ApplyManifest(revocation, manifest.Capped))
 	require.Equal(t, 1, cache.UntrustedCount())
 
-	// Promotion frees the slot but keeps the cached revocation; a subsequent
-	// capped insertion may consume that slot.
 	cache.PromoteToTrusted(firstMaster)
 	cache.PromoteToTrusted(firstMaster)
 	require.Equal(t, 0, cache.UntrustedCount())
@@ -205,8 +200,6 @@ func TestManifest_CappedCapacityUpdatesAndPromotion(t *testing.T) {
 	require.Equal(t, manifest.Accepted, cache.ApplyManifest(second, manifest.Capped))
 	require.Equal(t, 1, cache.UntrustedCount())
 
-	// An uncapped update of a counted master frees its slot and de-listing does
-	// not add it back.
 	secondRotationWire, _, _ := buildManifest(t, 2, false, 0x43, 0x46)
 	secondRotation, err := manifest.Deserialize(secondRotationWire)
 	require.NoError(t, err)
@@ -231,7 +224,6 @@ func TestManifest_UncappedBypassesCapacityAndRolesAreIsolated(t *testing.T) {
 	require.Equal(t, manifest.UntrustedCapacity, validators.ApplyManifest(second, manifest.Capped))
 	require.Equal(t, manifest.UntrustedCapacity, publishers.ApplyManifest(second, manifest.Capped))
 
-	// Configured/listed/DB paths remain uncapped and are isolated per role.
 	require.Equal(t, manifest.Accepted, validators.ApplyManifest(second, manifest.Uncapped))
 	require.False(t, validators.IsUntrusted(secondMaster))
 	require.Equal(t, 1, validators.UntrustedCount())

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -176,6 +176,7 @@ func TestManifest_CappedCapacityUpdatesAndPromotion(t *testing.T) {
 	badSecondWire[len(badSecondWire)-1] ^= 0x01
 	badSecond, err := manifest.Deserialize(badSecondWire)
 	require.NoError(t, err)
+	require.Equal(t, manifest.UntrustedCapacity, cache.ApplyManifest(badSecond, manifest.ManifestRateLimitCapPolicy(255)))
 	require.Equal(t, manifest.UntrustedCapacity, cache.ApplyManifest(badSecond, manifest.Capped))
 	require.Equal(t, 1, cache.UntrustedCount())
 	_, ok := cache.GetManifest(secondMaster)

--- a/internal/manifest/token.go
+++ b/internal/manifest/token.go
@@ -9,6 +9,11 @@ import (
 	"strings"
 )
 
+// MaxManifestBase64 is the largest base64 representation of a serialized
+// manifest accepted by token/config paths. It is the encoded size of
+// MaxSerializedSize bytes.
+const MaxManifestBase64 = ((MaxSerializedSize + 2) / 3) * 4
+
 // ValidatorToken is the parsed payload of a rippled-format
 // `[validator_token]` config block, as produced by `validator-keys-tool`.
 //
@@ -66,6 +71,9 @@ func LoadValidatorToken(block string) (*ValidatorToken, error) {
 	if raw.Manifest == "" {
 		return nil, errors.New("validator_token: missing manifest")
 	}
+	if len(raw.Manifest) > MaxManifestBase64 {
+		return nil, fmt.Errorf("validator_token: manifest exceeds %d base64 characters", MaxManifestBase64)
+	}
 	if raw.ValidationSecretKey == "" {
 		return nil, errors.New("validator_token: missing validation_secret_key")
 	}
@@ -89,6 +97,9 @@ func LoadValidatorToken(block string) (*ValidatorToken, error) {
 func (t *ValidatorToken) DecodeManifest() ([]byte, error) {
 	if t == nil || t.ManifestB64 == "" {
 		return nil, errors.New("validator_token: nil or empty manifest")
+	}
+	if len(t.ManifestB64) > MaxManifestBase64 {
+		return nil, fmt.Errorf("validator_token: manifest exceeds %d base64 characters", MaxManifestBase64)
 	}
 	b, err := base64.StdEncoding.DecodeString(t.ManifestB64)
 	if err != nil {

--- a/internal/manifest/token_test.go
+++ b/internal/manifest/token_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -61,6 +62,23 @@ func TestLoadValidatorToken_DecodeManifest(t *testing.T) {
 	}
 	if m.Sequence() == 0 {
 		t.Errorf("expected non-zero manifest sequence, got 0")
+	}
+}
+
+func TestValidatorToken_ManifestBase64Boundary(t *testing.T) {
+	for _, size := range []int{MaxManifestBase64, MaxManifestBase64 + 1} {
+		t.Run(strconv.Itoa(size), func(t *testing.T) {
+			_, err := (&ValidatorToken{ManifestB64: strings.Repeat("A", size)}).DecodeManifest()
+			if size == MaxManifestBase64 {
+				if err != nil && strings.Contains(err.Error(), "exceeds") {
+					t.Fatalf("maximum-length input was rejected before base64 decoding: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), "exceeds 480") {
+				t.Fatalf("oversized input error = %v, want 480-character limit", err)
+			}
+		})
 	}
 }
 

--- a/internal/validator/list/aggregator_test.go
+++ b/internal/validator/list/aggregator_test.go
@@ -377,6 +377,18 @@ func TestAggregator_ApplyList_BadManifest(t *testing.T) {
 	}
 }
 
+func TestAggregator_ApplyList_OversizedManifest(t *testing.T) {
+	agg, _ := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{{0xED, 1, 2, 3}},
+		Threshold:     1,
+		Clock:         fixedClock(),
+	})
+	d, _, _ := agg.ApplyList(bytes.Repeat([]byte{'A'}, manifest.MaxManifestBase64+1), []byte("blob"), []byte("00"), 1, "test://")
+	if d != list.Invalid {
+		t.Fatalf("disposition: got %s want Invalid", d)
+	}
+}
+
 // TestAggregator_ApplyList_MissingRequiredField pins the rippled-faithful
 // blob-validation requirement that `sequence`, `expiration`, and
 // `validators` are JSON-present (rippled ValidatorList.cpp:1394-1397

--- a/internal/validator/list/publisher_state.go
+++ b/internal/validator/list/publisher_state.go
@@ -35,6 +35,10 @@ func (a *Aggregator) applyListInternal(globalManifest, localManifest []byte, loc
 		manifestBytes = localManifest
 	}
 
+	if len(manifestBytes) > manifest.MaxManifestBase64 {
+		a.logger.Debug("validator list: manifest exceeds maximum base64 size", "site", siteURI)
+		return Untrusted, PublisherKey{}, 0
+	}
 	manifestRaw, err := decodeBase64Tolerant(manifestBytes)
 	if err != nil {
 		a.logger.Debug("validator list: manifest base64 decode failed", "error", err, "site", siteURI)
@@ -69,7 +73,7 @@ func (a *Aggregator) applyListInternal(globalManifest, localManifest []byte, loc
 	var manifestSequence uint32
 	manifestSequenceSet := false
 	if a.publisherManifests != nil {
-		switch d := a.publisherManifests.ApplyManifest(parsed); d {
+		switch d := a.publisherManifests.ApplyManifest(parsed, manifest.Uncapped); d {
 		case manifest.Accepted:
 			manifestAccepted = true
 		case manifest.Stale:
@@ -340,6 +344,9 @@ func (a *Aggregator) applyEmbeddedManifestsLocked(s *publisherState, entries []b
 		if v.Manifest == "" {
 			continue
 		}
+		if len(v.Manifest) > manifest.MaxManifestBase64 {
+			continue
+		}
 		raw, err := decodeBase64Tolerant([]byte(v.Manifest))
 		if err != nil {
 			continue
@@ -359,7 +366,7 @@ func (a *Aggregator) applyEmbeddedManifestRawLocked(listed map[[33]byte]struct{}
 			"master", hex.EncodeToString(masterKey[:]))
 		return
 	}
-	_ = a.validatorManifests.ApplyManifest(parsed)
+	_ = a.validatorManifests.ApplyManifest(parsed, manifest.Uncapped)
 }
 
 func (a *Aggregator) applyEmbeddedPendingManifestsLocked(s *publisherState, entries []pendingEmbeddedManifest) {
@@ -444,6 +451,9 @@ func (a *Aggregator) pendingEmbeddedManifests(blob *blobJSON) []pendingEmbeddedM
 	var out []pendingEmbeddedManifest
 	for _, entry := range blob.Validators {
 		if entry.Manifest == "" {
+			continue
+		}
+		if len(entry.Manifest) > manifest.MaxManifestBase64 {
 			continue
 		}
 		raw, err := decodeBase64Tolerant([]byte(entry.Manifest))

--- a/internal/validator/list/publisher_state.go
+++ b/internal/validator/list/publisher_state.go
@@ -442,6 +442,9 @@ func (a *Aggregator) applyPendingLocked(s *publisherState, blob *blobJSON, signi
 	if version > s.Version {
 		s.Version = version
 	}
+	if s.Version < 2 {
+		s.Version = 2
+	}
 	s.RawManifest = append([]byte(nil), rawManifest...)
 	a.recordMaxSequenceLocked(s, blob.Sequence)
 	return Pending

--- a/internal/validator/list/publisher_state.go
+++ b/internal/validator/list/publisher_state.go
@@ -37,7 +37,7 @@ func (a *Aggregator) applyListInternal(globalManifest, localManifest []byte, loc
 
 	if len(manifestBytes) > manifest.MaxManifestBase64 {
 		a.logger.Debug("validator list: manifest exceeds maximum base64 size", "site", siteURI)
-		return Untrusted, PublisherKey{}, 0
+		return Invalid, PublisherKey{}, 0
 	}
 	manifestRaw, err := decodeBase64Tolerant(manifestBytes)
 	if err != nil {


### PR DESCRIPTION
## Summary\n\n- add capped and uncapped validator-manifest admission with bounded untrusted identities\n- add trust promotion, v3.3 manifest size validation, and role-isolated cache wiring\n- parse max_untrusted_count and max_trusted_count with rippled-compatible defaults and bounds\n\n## Verification\n\n- go test ./config ./internal/manifest ./internal/validator/list ./internal/consensus/adaptor -count=1\n- just lint\n\nRefs #1595\n\n<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>