### PR TITLE
feat(consensus): align manifest relay and snapshots (#1595)

### DIFF
--- a/internal/consensus/adaptor/manifest_emit.go
+++ b/internal/consensus/adaptor/manifest_emit.go
@@ -3,8 +3,11 @@ package adaptor
 import (
 	"errors"
 	"fmt"
+	"math/rand/v2"
 
+	"github.com/LeJamon/go-xrpl/crypto/sha512half"
 	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
+	"github.com/LeJamon/go-xrpl/internal/manifest"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"google.golang.org/protobuf/encoding/protowire"
@@ -88,13 +91,13 @@ func encodeManifestFrames(serialized ...[]byte) ([][]byte, error) {
 	return frames, nil
 }
 
-// SendLocalManifestTo sends the aggregated TMManifests frames (every
-// cached validator manifest) to a single peer. Returns nil and emits
-// nothing when the cache is empty or no sender is wired (test-only
+// SendLocalManifestTo sends the selected, aggregated TMManifests frames
+// (all listed manifests plus the bounded unlisted subset) to a single peer.
+// It emits nothing when the cache is empty or no sender is wired (test-only
 // construction). Any encode error is logged and swallowed: emission is
 // best-effort, the next reconnect will retry on its own.
 func (r *Router) SendLocalManifestTo(peerID peermanagement.PeerID) {
-	frames := r.cachedManifestFrames()
+	frames, hashes := r.cachedManifestSnapshot()
 	if len(frames) == 0 {
 		return
 	}
@@ -108,7 +111,9 @@ func (r *Router) SendLocalManifestTo(peerID peermanagement.PeerID) {
 		// surface at debug to aid diagnosis without spamming logs on a
 		// flapping peer.
 		r.logger.Debug("send local manifest to peer failed", "error", err, "peer", peerID)
+		return
 	}
+	r.recordManifestSuppression(peerID, hashes)
 }
 
 // BroadcastLocalManifest gossips the aggregated TMManifests frames to
@@ -116,7 +121,7 @@ func (r *Router) SendLocalManifestTo(peerID peermanagement.PeerID) {
 // were queued for (0 when there's nothing to broadcast or no peers are
 // connected) so callers can decide whether to log the emission.
 func (r *Router) BroadcastLocalManifest() int {
-	frames := r.cachedManifestFrames()
+	frames, hashes := r.cachedManifestSnapshot()
 	if len(frames) == 0 {
 		return 0
 	}
@@ -135,6 +140,9 @@ func (r *Router) BroadcastLocalManifest() int {
 			return fanoutErr.Attempted - fanoutErr.Failed
 		}
 		return 0
+	}
+	for _, peer := range peers {
+		r.recordManifestSuppression(peer.ID, hashes)
 	}
 	return len(peers)
 }
@@ -215,41 +223,121 @@ func (r *Router) addPeerToActiveAcquisitions(peerID uint64) {
 // Encode failures are NOT cached so a transient error doesn't pin a
 // stale frame; the next caller re-attempts.
 func (r *Router) cachedManifestFrames() [][]byte {
+	frames, _ := r.cachedManifestSnapshot()
+	return frames
+}
+
+func (r *Router) cachedManifestSnapshot() ([][]byte, [][32]byte) {
 	if r.manifests == nil {
-		return nil
+		return nil, nil
 	}
 
-	// Read sequence outside the frame lock so we never nest the cache's
-	// RLock under our own mutex. A racing increment between this read
-	// and the lock acquisition just causes the next caller to rebuild —
-	// not a correctness issue.
+	// Snapshot and trust classification happen before taking the frame lock.
+	// This keeps cache/list locks out of the frame-cache critical section and
+	// avoids the lock ordering inversion between validator-list trust and the
+	// manifest cache.
 	seq := r.manifests.Sequence()
+	wires, hashes, trustHash := r.selectManifestSnapshot()
+	if current := r.manifests.Sequence(); current != seq {
+		seq = current
+		wires, hashes, trustHash = r.selectManifestSnapshot()
+	}
 
 	r.manifestFrameMu.Lock()
 	defer r.manifestFrameMu.Unlock()
 
-	if r.manifestFrameBuilt && r.manifestFrameSeq == seq {
-		return r.manifestFrames
+	if r.manifestFrameBuilt && r.manifestFrameSeq == seq &&
+		r.manifestFrameTrust == trustHash &&
+		r.manifestFrameLimit == r.manifestUntrustedLimit {
+		return r.manifestFrames, append([][32]byte(nil), r.manifestFrameHashes...)
 	}
 
-	wires := r.manifests.SerializedAll()
 	if len(wires) == 0 {
 		// Empty cache — cache that fact too so the next call doesn't
 		// re-walk byMaster only to find it still empty.
 		r.manifestFrames = nil
+		r.manifestFrameHashes = nil
 		r.manifestFrameSeq = seq
+		r.manifestFrameTrust = trustHash
+		r.manifestFrameLimit = r.manifestUntrustedLimit
 		r.manifestFrameBuilt = true
-		return nil
+		return nil, nil
 	}
 
 	frames, err := encodeManifestFrames(wires...)
 	if err != nil {
 		r.logger.Warn("failed to encode local manifest frame", "error", err)
-		return nil
+		return nil, nil
 	}
 
 	r.manifestFrames = frames
+	r.manifestFrameHashes = hashes
 	r.manifestFrameSeq = seq
+	r.manifestFrameTrust = trustHash
+	r.manifestFrameLimit = r.manifestUntrustedLimit
 	r.manifestFrameBuilt = true
-	return frames
+	return frames, append([][32]byte(nil), hashes...)
+}
+
+// selectManifestSnapshot returns all currently listed/trusted manifests and
+// only the configured number of unlisted entries. Selection precedes the
+// shuffle so listed entries cannot be displaced by random ordering.
+func (r *Router) selectManifestSnapshot() ([][]byte, [][32]byte, [32]byte) {
+	entries := r.manifests.Snapshot()
+	if len(entries) == 0 {
+		return nil, nil, [32]byte{}
+	}
+
+	trustInput := make([]byte, 0, len(entries)*34)
+	selected := make([]*manifest.Manifest, 0, len(entries))
+	untrusted := make([]*manifest.Manifest, 0, len(entries))
+	for _, entry := range entries {
+		policy := manifest.Uncapped
+		if r.manifestClassify != nil {
+			policy = r.manifestClassify(entry.MasterKey())
+		}
+		master := entry.MasterKey()
+		trustInput = append(trustInput, master[:]...)
+		trustInput = append(trustInput, byte(policy))
+		if policy == manifest.Uncapped {
+			selected = append(selected, entry)
+		} else {
+			untrusted = append(untrusted, entry)
+		}
+	}
+	limit := r.manifestUntrustedLimit
+	if limit < 0 {
+		limit = 0
+	}
+	if limit > len(untrusted) {
+		limit = len(untrusted)
+	}
+	selected = append(selected, untrusted[:limit]...)
+
+	wires := make([][]byte, len(selected))
+	hashesByWire := make(map[string][32]byte, len(selected))
+	for i, entry := range selected {
+		wire := entry.Serialized()
+		wires[i] = wire
+		hashesByWire[string(wire)] = entry.Hash()
+	}
+	if r.manifestShuffle != nil {
+		r.manifestShuffle(wires)
+	} else {
+		rand.Shuffle(len(wires), func(i, j int) { wires[i], wires[j] = wires[j], wires[i] })
+	}
+	hashes := make([][32]byte, len(wires))
+	for i, wire := range wires {
+		hashes[i] = hashesByWire[string(wire)]
+	}
+	return wires, hashes, sha512half.Sum(trustInput)
+}
+
+func (r *Router) recordManifestSuppression(peerID peermanagement.PeerID, hashes [][32]byte) {
+	if r.messageSeen == nil {
+		return
+	}
+	for _, hash := range hashes {
+		r.messageSeen.recordPeer(hash, uint64(peerID))
+	}
 }

--- a/internal/consensus/adaptor/manifest_relay_issue1595_test.go
+++ b/internal/consensus/adaptor/manifest_relay_issue1595_test.go
@@ -219,7 +219,7 @@ func TestRouter_ManifestSnapshotUsesMultipleBoundedFrames(t *testing.T) {
 
 	frames := router.cachedManifestFrames()
 	require.Len(t, frames, 2)
-	var emitted [][]byte
+	emitted := make([][]byte, 0, len(wires))
 	for _, frame := range frames {
 		emitted = append(emitted, frameToManifestBytes(t, frame)...)
 	}

--- a/internal/consensus/adaptor/manifest_relay_issue1595_test.go
+++ b/internal/consensus/adaptor/manifest_relay_issue1595_test.go
@@ -1,0 +1,263 @@
+package adaptor
+
+import (
+	"bytes"
+	"sort"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/manifest"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/require"
+)
+
+func applyManifestWires(t *testing.T, cache *manifest.Cache, wires ...[]byte) [][33]byte {
+	t.Helper()
+	masters := make([][33]byte, 0, len(wires))
+	for _, wire := range wires {
+		parsed, err := manifest.Deserialize(wire)
+		require.NoError(t, err)
+		require.Equal(t, manifest.Accepted, cache.ApplyManifest(parsed, manifest.Capped))
+		masters = append(masters, parsed.MasterKey())
+	}
+	return masters
+}
+
+func manifestMessage(t *testing.T, peer peermanagement.PeerID, wires ...[]byte) *peermanagement.InboundMessage {
+	t.Helper()
+	list := make([]message.Manifest, len(wires))
+	for i, wire := range wires {
+		list[i] = message.Manifest{STObject: wire}
+	}
+	return &peermanagement.InboundMessage{
+		PeerID:  peer,
+		Type:    message.TypeManifests,
+		Payload: encodePayload(t, &message.Manifests{List: list}),
+	}
+}
+
+func TestRouter_ManifestAdmissionClassifiesListedAndBoundsUnlisted(t *testing.T) {
+	sender := &fakeManifestSender{}
+	router, cache, _ := routerWithCache(t, sender, 0, 0)
+	badData := &badDataRecordingSender{}
+	router.gossip = badData
+	router.SetManifestCache(cache, nil)
+	router.SetManifestUntrustedLimit(1)
+
+	unlistedFirst := buildWireManifest(t, 1, 0x01, 0x11)
+	listed := buildWireManifest(t, 1, 0x02, 0x12)
+	unlistedAfter := buildWireManifest(t, 1, 0x03, 0x13)
+	parsedListed, err := manifest.Deserialize(listed)
+	require.NoError(t, err)
+	router.SetManifestClassifier(func(master [33]byte) manifest.ManifestRateLimitCapPolicy {
+		if master == parsedListed.MasterKey() {
+			return manifest.Uncapped
+		}
+		return manifest.Capped
+	})
+
+	router.handleManifests(manifestMessage(t, 7, unlistedFirst, listed, unlistedAfter))
+	for _, wire := range [][]byte{unlistedFirst, listed} {
+		parsed, parseErr := manifest.Deserialize(wire)
+		require.NoError(t, parseErr)
+		_, ok := cache.GetManifest(parsed.MasterKey())
+		require.True(t, ok)
+	}
+	parsedAfter, err := manifest.Deserialize(unlistedAfter)
+	require.NoError(t, err)
+	_, ok := cache.GetManifest(parsedAfter.MasterKey())
+	require.False(t, ok, "entry after the untrusted budget must be skipped")
+	require.Equal(t, 1, cache.UntrustedCount())
+
+	sender.mu.Lock()
+	require.Len(t, sender.bcasts, 1)
+	require.Empty(t, sender.bcastsExcept)
+	relayed := frameToManifestBytes(t, sender.bcasts[0])
+	sender.mu.Unlock()
+	require.Equal(t, [][]byte{unlistedFirst, listed}, relayed)
+	require.Equal(t,
+		[]badDataCall{{peerID: 7, reason: "manifests-untrusted-limit"}},
+		badData.getBadDataCalls())
+}
+
+func TestRouter_ManifestMalformedDoesNotConsumeUntrustedBudget(t *testing.T) {
+	router, cache, _ := routerWithCache(t, nil, 0, 0)
+	badData := &badDataRecordingSender{}
+	router.gossip = badData
+	router.SetManifestCache(cache, nil)
+	router.SetManifestUntrustedLimit(2)
+	router.SetManifestClassifier(func([33]byte) manifest.ManifestRateLimitCapPolicy {
+		return manifest.Capped
+	})
+
+	first := buildWireManifest(t, 1, 0x21, 0x31)
+	second := buildWireManifest(t, 1, 0x22, 0x32)
+	third := buildWireManifest(t, 1, 0x23, 0x33)
+	router.handleManifests(manifestMessage(t, 8, []byte{0x01}, first, second, third))
+
+	for _, wire := range [][]byte{first, second} {
+		parsed, err := manifest.Deserialize(wire)
+		require.NoError(t, err)
+		_, ok := cache.GetManifest(parsed.MasterKey())
+		require.True(t, ok)
+	}
+	parsedThird, err := manifest.Deserialize(third)
+	require.NoError(t, err)
+	_, ok := cache.GetManifest(parsedThird.MasterKey())
+	require.False(t, ok, "the third valid unlisted entry must be beyond the budget")
+	require.ElementsMatch(t,
+		[]badDataCall{{peerID: 8, reason: "manifest-invalid"}, {peerID: 8, reason: "manifests-untrusted-limit"}},
+		badData.getBadDataCalls())
+}
+
+func TestRouter_ManifestStaleAndInvalidConsumeUntrustedBudget(t *testing.T) {
+	router, cache, _ := routerWithCache(t, nil, 0, 0)
+	sender := &badDataRecordingSender{}
+	router.gossip = sender
+	router.SetManifestCache(cache, nil)
+	router.SetManifestUntrustedLimit(2)
+	router.SetManifestClassifier(func([33]byte) manifest.ManifestRateLimitCapPolicy {
+		return manifest.Capped
+	})
+
+	stale := buildWireManifest(t, 1, 0x41, 0x51)
+	parsedStale, err := manifest.Deserialize(stale)
+	require.NoError(t, err)
+	require.Equal(t, manifest.Accepted, cache.ApplyManifest(parsedStale, manifest.Capped))
+	invalid := buildWireManifest(t, 2, 0x42, 0x52)
+	invalid[len(invalid)-1] ^= 1
+	newer := buildWireManifest(t, 1, 0x43, 0x53)
+
+	router.handleManifests(manifestMessage(t, 9, stale, invalid, newer))
+	parsedNewer, err := manifest.Deserialize(newer)
+	require.NoError(t, err)
+	_, ok := cache.GetManifest(parsedNewer.MasterKey())
+	require.False(t, ok, "stale and invalid entries must consume both untrusted slots")
+	require.Equal(t, 1, cache.UntrustedCount())
+	calls := sender.getBadDataCalls()
+	require.Len(t, calls, 2)
+	require.ElementsMatch(t,
+		[]badDataCall{{peerID: 9, reason: "manifests-untrusted-limit"}, {peerID: 9, reason: "manifest-invalid"}},
+		calls)
+}
+
+func TestRouter_ManifestCapacityRejectionIsNonMalformed(t *testing.T) {
+	router, _, _ := routerWithCache(t, nil, 0, 0)
+	cache := manifest.NewCache(1)
+	router.SetManifestCache(cache, nil)
+	sender := &badDataRecordingSender{}
+	router.gossip = sender
+	router.SetManifestUntrustedLimit(2)
+	router.SetManifestClassifier(func([33]byte) manifest.ManifestRateLimitCapPolicy {
+		return manifest.Capped
+	})
+
+	prefill := buildWireManifest(t, 1, 0x61, 0x71)
+	require.Len(t, applyManifestWires(t, cache, prefill), 1)
+	candidateOne := buildWireManifest(t, 1, 0x62, 0x72)
+	candidateTwo := buildWireManifest(t, 1, 0x63, 0x73)
+	router.handleManifests(manifestMessage(t, 10, candidateOne, candidateTwo))
+
+	for _, wire := range [][]byte{candidateOne, candidateTwo} {
+		parsed, err := manifest.Deserialize(wire)
+		require.NoError(t, err)
+		_, ok := cache.GetManifest(parsed.MasterKey())
+		require.False(t, ok)
+	}
+	require.Equal(t, 1, cache.UntrustedCount())
+	require.Empty(t, sender.getBadDataCalls(), "capacity rejection is not malformed")
+}
+
+func TestRouter_ManifestSnapshotSelectsBeforeShuffleAndInvalidatesOnTrustChange(t *testing.T) {
+	router, cache, _ := routerWithCache(t, nil, 0, 0)
+	router.SetManifestCache(cache, nil)
+	router.SetManifestUntrustedLimit(1)
+	wires := [][]byte{
+		buildWireManifest(t, 1, 0x81, 0x91),
+		buildWireManifest(t, 1, 0x82, 0x92),
+		buildWireManifest(t, 1, 0x83, 0x93),
+	}
+	masters := applyManifestWires(t, cache, wires...)
+	listed := map[[33]byte]struct{}{masters[0]: {}, masters[1]: {}}
+	router.SetManifestClassifier(func(master [33]byte) manifest.ManifestRateLimitCapPolicy {
+		if _, ok := listed[master]; ok {
+			return manifest.Uncapped
+		}
+		return manifest.Capped
+	})
+	router.SetManifestShuffle(func(selected [][]byte) {
+		sort.Slice(selected, func(i, j int) bool { return bytes.Compare(selected[i], selected[j]) > 0 })
+	})
+
+	first := router.cachedManifestFrames()
+	require.Len(t, first, 1)
+	selected := frameToManifestBytes(t, first[0])
+	require.Len(t, selected, 3)
+	require.ElementsMatch(t, wires, selected)
+
+	listed = map[[33]byte]struct{}{masters[0]: {}}
+	second := router.cachedManifestFrames()
+	require.Len(t, second, 1)
+	secondSelected := frameToManifestBytes(t, second[0])
+	require.Len(t, secondSelected, 2, "trust-only changes must rebuild the snapshot")
+	require.Contains(t, secondSelected, wires[0])
+}
+
+func TestRouter_ManifestSnapshotUsesMultipleBoundedFrames(t *testing.T) {
+	router, cache, _ := routerWithCache(t, nil, 0, 0)
+	router.SetManifestCache(cache, nil)
+	router.SetManifestUntrustedLimit(101)
+	wires := make([][]byte, 101)
+	for i := range wires {
+		wires[i] = buildWireManifest(t, 1, byte(i), byte(i+101))
+	}
+	applyManifestWires(t, cache, wires...)
+	router.SetManifestClassifier(func([33]byte) manifest.ManifestRateLimitCapPolicy {
+		return manifest.Capped
+	})
+	router.SetManifestShuffle(func([][]byte) {})
+
+	frames := router.cachedManifestFrames()
+	require.Len(t, frames, 2)
+	var emitted [][]byte
+	for _, frame := range frames {
+		emitted = append(emitted, frameToManifestBytes(t, frame)...)
+	}
+	require.Len(t, emitted, len(wires))
+	require.ElementsMatch(t, wires, emitted)
+}
+
+func TestRouter_ManifestSuppressionRecordsOnlyEmittedSelection(t *testing.T) {
+	sender := &fakeManifestSender{}
+	router, cache, _ := routerWithCache(t, sender, 0, 0)
+	router.SetManifestCache(cache, nil)
+	router.SetManifestUntrustedLimit(0)
+	wires := [][]byte{
+		buildWireManifest(t, 1, 0xA1, 0xB1),
+		buildWireManifest(t, 1, 0xA2, 0xB2),
+	}
+	masters := applyManifestWires(t, cache, wires...)
+	router.SetManifestClassifier(func(master [33]byte) manifest.ManifestRateLimitCapPolicy {
+		if master == masters[0] {
+			return manifest.Uncapped
+		}
+		return manifest.Capped
+	})
+	router.SetManifestShuffle(func(selected [][]byte) {
+		sort.Slice(selected, func(i, j int) bool { return bytes.Compare(selected[i], selected[j]) < 0 })
+	})
+	first, err := manifest.Deserialize(wires[0])
+	require.NoError(t, err)
+	second, err := manifest.Deserialize(wires[1])
+	require.NoError(t, err)
+	require.False(t, router.messageSeen.seenRecently(first.Hash()))
+	require.False(t, router.messageSeen.seenRecently(second.Hash()))
+	frames := router.cachedManifestFrames()
+	require.Equal(t, 0, router.manifestUntrustedLimit)
+	require.Len(t, frames, 1)
+	require.Len(t, frameToManifestBytes(t, frames[0]), 1)
+
+	router.SendLocalManifestTo(17)
+	require.True(t, router.messageSeen.seenRecently(first.Hash()))
+	require.False(t, router.messageSeen.seenRecently(second.Hash()))
+}

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -155,8 +155,6 @@ type Router struct {
 	manifestClassify       func([33]byte) manifest.ManifestRateLimitCapPolicy
 	manifestUntrustedLimit int
 	manifestLimitSet       bool
-	// manifestShuffle is injectable so snapshot tests can assert selection
-	// deterministically. A nil function uses the production random shuffle.
 	manifestShuffle      func([][]byte)
 	manifestWorkerCancel context.CancelFunc
 	manifestWorkerDone   chan struct{}
@@ -591,8 +589,6 @@ func (r *Router) SetManifestUntrustedLimit(limit int) {
 	r.manifestLimitSet = true
 }
 
-// SetManifestShuffle overrides snapshot shuffling. Passing nil restores the
-// production random shuffle.
 func (r *Router) SetManifestShuffle(shuffle func([][]byte)) {
 	r.manifestShuffle = shuffle
 }

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -148,8 +148,16 @@ type Router struct {
 	// Components bootstrap so the router can apply inbound TMManifests
 	// frames and — on Accepted — relay them to other peers.
 	// May be nil in tests that don't exercise the manifest path.
-	manifests            *manifest.Cache
-	manifestAdmission    func([33]byte) bool
+	manifests *manifest.Cache
+	// manifestClassify resolves a parsed master key to the cache admission
+	// policy. Production classifies listed/trusted keys as Uncapped and all
+	// others as Capped before applying a manifest.
+	manifestClassify       func([33]byte) manifest.ManifestRateLimitCapPolicy
+	manifestUntrustedLimit int
+	manifestLimitSet       bool
+	// manifestShuffle is injectable so snapshot tests can assert selection
+	// deterministically. A nil function uses the production random shuffle.
+	manifestShuffle      func([][]byte)
 	manifestWorkerCancel context.CancelFunc
 	manifestWorkerDone   chan struct{}
 
@@ -179,10 +187,13 @@ type Router struct {
 	// manifestFrameSeq is a valid cursor (a fresh cache starts at 0),
 	// so we need an explicit "have we ever built?" flag rather than
 	// using the zero value as the sentinel.
-	manifestFrameMu    sync.Mutex
-	manifestFrames     [][]byte
-	manifestFrameSeq   uint64
-	manifestFrameBuilt bool
+	manifestFrameMu     sync.Mutex
+	manifestFrames      [][]byte
+	manifestFrameHashes [][32]byte
+	manifestFrameSeq    uint64
+	manifestFrameTrust  [32]byte
+	manifestFrameLimit  int
+	manifestFrameBuilt  bool
 
 	// In-flight tx-set acquisition state keyed by tx-set ID.
 	// Each entry's SHAMap accumulates across multiple TMLedgerData
@@ -389,25 +400,26 @@ func newRouter(engine consensus.RouterEngine, adaptor *Adaptor, inbox <-chan *pe
 		network.serve = noop
 	}
 	r := &Router{
-		engine:             engine,
-		adaptor:            adaptor,
-		gossip:             network.gossip,
-		txSetNet:           network.txSet,
-		acquisition:        network.acquisition,
-		serve:              network.serve,
-		inbox:              inbox,
-		logger:             logger,
-		peerStates:         make(map[peermanagement.PeerID]*peerLedgerState),
-		peerDisconnectWake: make(chan struct{}, 1),
-		peerConnectWake:    make(chan struct{}, 1),
-		replayer:           inbound.NewReplayer(logger, inbound.SystemClock, inbound.DefaultMaxInFlightReplays),
-		fetchTracker:       inbound.NewTracker(),
-		fetchPacks:         newFetchPackCache(),
-		messageSeen:        newMessageSuppression(messageDedupTTL, messageDedupMaxEntries),
-		txSetAcquire:       make(map[consensus.TxSetID]*txSetAcquireState),
-		txSetRetryKnobs:    defaultTxSetRetryKnobs(),
-		seqHash:            make(map[uint32]ledgerHashEntry),
-		lifecycleCtx:       context.Background(),
+		engine:                 engine,
+		adaptor:                adaptor,
+		gossip:                 network.gossip,
+		txSetNet:               network.txSet,
+		acquisition:            network.acquisition,
+		serve:                  network.serve,
+		inbox:                  inbox,
+		logger:                 logger,
+		peerStates:             make(map[peermanagement.PeerID]*peerLedgerState),
+		peerDisconnectWake:     make(chan struct{}, 1),
+		peerConnectWake:        make(chan struct{}, 1),
+		replayer:               inbound.NewReplayer(logger, inbound.SystemClock, inbound.DefaultMaxInFlightReplays),
+		fetchTracker:           inbound.NewTracker(),
+		fetchPacks:             newFetchPackCache(),
+		messageSeen:            newMessageSuppression(messageDedupTTL, messageDedupMaxEntries),
+		manifestUntrustedLimit: manifest.DefaultMaxUntrustedCount,
+		txSetAcquire:           make(map[consensus.TxSetID]*txSetAcquireState),
+		txSetRetryKnobs:        defaultTxSetRetryKnobs(),
+		seqHash:                make(map[uint32]ledgerHashEntry),
+		lifecycleCtx:           context.Background(),
 	}
 	// Wire the stash → acquisition hook so quorum decisions on unknown
 	// ledgers don't sit silently in pendingLedgerValidations.
@@ -556,10 +568,33 @@ func (r *Router) belowFloor(seq uint32) bool {
 func (r *Router) SetManifestCache(cache *manifest.Cache, overlay *peermanagement.Overlay) {
 	r.manifests = cache
 	r.overlay = overlay
+	if cache != nil && !r.manifestLimitSet {
+		r.manifestUntrustedLimit = cache.MaxUntrustedCount()
+	}
 }
 
-func (r *Router) SetManifestAdmission(admit func([33]byte) bool) {
-	r.manifestAdmission = admit
+// SetManifestClassifier installs the listed/trusted resolver used for
+// inbound admission and outbound snapshot selection. A nil classifier keeps
+// the standalone/test default of treating every manifest as uncapped.
+func (r *Router) SetManifestClassifier(classify func([33]byte) manifest.ManifestRateLimitCapPolicy) {
+	r.manifestClassify = classify
+}
+
+// SetManifestUntrustedLimit sets the per-message unlisted-manifest budget and
+// the outbound snapshot's unlisted selection limit. It is independent of the
+// wire frame's entry-count/byte batching limits.
+func (r *Router) SetManifestUntrustedLimit(limit int) {
+	if limit < 0 {
+		limit = 0
+	}
+	r.manifestUntrustedLimit = limit
+	r.manifestLimitSet = true
+}
+
+// SetManifestShuffle overrides snapshot shuffling. Passing nil restores the
+// production random shuffle.
+func (r *Router) SetManifestShuffle(shuffle func([][]byte)) {
+	r.manifestShuffle = shuffle
 }
 
 func (r *Router) setPeerSessionView(view peerSessionView) {

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -155,9 +155,9 @@ type Router struct {
 	manifestClassify       func([33]byte) manifest.ManifestRateLimitCapPolicy
 	manifestUntrustedLimit int
 	manifestLimitSet       bool
-	manifestShuffle      func([][]byte)
-	manifestWorkerCancel context.CancelFunc
-	manifestWorkerDone   chan struct{}
+	manifestShuffle        func([][]byte)
+	manifestWorkerCancel   context.CancelFunc
+	manifestWorkerDone     chan struct{}
 
 	// overlay is held so the router can relay accepted manifests and emit
 	// the local cache to peers. Nil in tests without manifest support.

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/LeJamon/go-xrpl/crypto/sha512half"
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/consensus/rcl"
 	"github.com/LeJamon/go-xrpl/internal/ledger/openledger"
@@ -106,42 +105,7 @@ func (r *Router) handleManifests(msg *peermanagement.InboundMessage) bool {
 		return false
 	}
 
-	accepted := make([][]byte, 0, manifestFrameMaxEntries)
-	valid := false
-	badManifest := false
-	count, err := message.WalkManifests(msg.Payload, func(wire []byte) {
-		hash := sha512half.Sum(wire)
-		if r.messageSeen != nil && r.messageSeen.seenRecently(hash) {
-			valid = true
-			return
-		}
-		parsed, err := manifest.Deserialize(wire)
-		if err != nil {
-			r.logger.Debug("manifest parse failed",
-				"error", err, "peer", msg.PeerID)
-			badManifest = true
-			return
-		}
-		if r.manifestAdmission != nil && !r.manifestAdmission(parsed.MasterKey()) {
-			valid = true
-			return
-		}
-		switch d := r.manifests.ApplyManifest(parsed, manifest.Uncapped); d {
-		case manifest.Accepted:
-			valid = true
-			accepted = append(accepted, wire)
-			if r.messageSeen != nil {
-				r.messageSeen.observe(hash)
-			}
-		case manifest.Invalid, manifest.BadMasterKey, manifest.BadEphemeralKey:
-			badManifest = true
-		case manifest.Stale:
-			valid = true
-			if r.messageSeen != nil {
-				r.messageSeen.observe(hash)
-			}
-		}
-	})
+	count, err := message.WalkManifests(msg.Payload, nil)
 	if err != nil {
 		r.logger.Warn("failed to decode manifests frame", "error", err, "peer", msg.PeerID)
 		reason := "manifests-decode"
@@ -160,14 +124,63 @@ func (r *Router) handleManifests(msg *peermanagement.InboundMessage) bool {
 	if count > manifestFrameMaxEntries && !msg.SelectPeerCharge(resource.FeeModerateBurdenPeer(), "manifests-oversize") {
 		r.gossip.IncPeerBadData(uint64(msg.PeerID), "manifests-oversize")
 	}
+
+	accepted := make([][]byte, 0, min(count, manifestFrameMaxEntries))
+	valid := false
+	badManifest := false
+	untrusted := 0
+	skippedUntrusted := false
+	_, _ = message.WalkManifests(msg.Payload, func(wire []byte) {
+		parsed, err := manifest.Deserialize(wire)
+		if err != nil {
+			r.logger.Debug("manifest parse failed",
+				"error", err, "peer", msg.PeerID)
+			badManifest = true
+			return
+		}
+		hash := parsed.Hash()
+		policy := manifest.Uncapped
+		if r.manifestClassify != nil {
+			policy = r.manifestClassify(parsed.MasterKey())
+		}
+		if policy != manifest.Uncapped {
+			if untrusted >= r.manifestUntrustedLimit {
+				skippedUntrusted = true
+				valid = true
+				return
+			}
+			untrusted++
+			policy = manifest.Capped
+		}
+		switch d := r.manifests.ApplyManifest(parsed, policy); d {
+		case manifest.Accepted:
+			valid = true
+			accepted = append(accepted, wire)
+			if r.messageSeen != nil {
+				r.messageSeen.observe(hash)
+			}
+		case manifest.Invalid, manifest.BadMasterKey, manifest.BadEphemeralKey:
+			badManifest = true
+		case manifest.Stale:
+			valid = true
+			if r.messageSeen != nil {
+				r.messageSeen.observe(hash)
+			}
+		case manifest.UntrustedCapacity:
+			valid = true
+		}
+	})
+	if skippedUntrusted && !msg.SelectPeerCharge(resource.FeeMalformedRequest(), "manifests-untrusted-limit") {
+		r.gossip.IncPeerBadData(uint64(msg.PeerID), "manifests-untrusted-limit")
+	}
 	if badManifest {
 		r.gossip.IncPeerBadData(uint64(msg.PeerID), "manifest-invalid")
 	}
-	r.relayManifests(msg.PeerID, accepted)
+	r.relayManifests(accepted)
 	return valid
 }
 
-func (r *Router) relayManifests(source peermanagement.PeerID, serialized [][]byte) {
+func (r *Router) relayManifests(serialized [][]byte) {
 	if len(serialized) == 0 {
 		return
 	}
@@ -180,7 +193,7 @@ func (r *Router) relayManifests(source peermanagement.PeerID, serialized [][]byt
 	if sender == nil {
 		return
 	}
-	if err := sender.BroadcastManifestFramesExcept(source, frames); err != nil {
+	if err := sender.BroadcastManifestFrames(frames); err != nil {
 		r.logger.Warn("failed to broadcast manifest relay frame", "error", err)
 	}
 }

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -93,12 +93,6 @@ func (r *Router) handleInboundMessage(msg *peermanagement.InboundMessage) {
 	}
 }
 
-// handleManifests ingests a TMManifests frame, applies admitted entries, and
-// relays the accepted subset as aggregate frames to peers other than the source.
-//
-// Decode failures attribute "manifest-decode" badData to the sender. A
-// mix of valid and invalid entries in the same frame results in the
-// valid ones being applied; the frame isn't rejected wholesale.
 func (r *Router) handleManifests(msg *peermanagement.InboundMessage) bool {
 	if r.manifests == nil {
 		// Cache not wired (tests or minimal configs) — silently drop.

--- a/internal/consensus/adaptor/router_manifests_test.go
+++ b/internal/consensus/adaptor/router_manifests_test.go
@@ -417,7 +417,7 @@ func TestRouter_HandleManifests_RelaysAcceptedEntriesToAllPeers(t *testing.T) {
 	require.Len(t, broadcasts, 2, "collections above the internal frame cap must relay as one bounded sequence")
 	require.Empty(t, broadcastsExcept)
 
-	var got [][]byte
+	got := make([][]byte, 0, acceptedCount)
 	for _, frame := range broadcasts {
 		got = append(got, frameToManifestBytes(t, frame)...)
 	}

--- a/internal/consensus/adaptor/router_manifests_test.go
+++ b/internal/consensus/adaptor/router_manifests_test.go
@@ -284,34 +284,6 @@ func TestRouter_HandleManifests_InvalidDoesNotStore(t *testing.T) {
 	}
 }
 
-func TestRouter_HandleManifests_AdmissionBoundsDurableCache(t *testing.T) {
-	sender := &fakeManifestSender{}
-	router, cache, _ := routerWithCache(t, sender, 0, 0)
-	wire := buildWireManifest(t, 1, 0x41, 0x42)
-	parsed, err := manifest.Deserialize(wire)
-	require.NoError(t, err)
-	msg := &peermanagement.InboundMessage{
-		PeerID: 7,
-		Type:   message.TypeManifests,
-		Payload: encodePayload(t, &message.Manifests{List: []message.Manifest{{
-			STObject: wire,
-		}}}),
-	}
-
-	router.SetManifestAdmission(func([33]byte) bool { return false })
-	require.True(t, router.handleManifests(msg))
-	_, stored := cache.GetManifest(parsed.MasterKey())
-	require.False(t, stored)
-	require.Empty(t, sender.bcastsExcept)
-
-	router.SetManifestAdmission(func(master [33]byte) bool { return master == parsed.MasterKey() })
-	require.True(t, router.handleManifests(msg))
-	storedWire, stored := cache.GetManifest(parsed.MasterKey())
-	require.True(t, stored)
-	require.Equal(t, wire, storedWire)
-	require.Len(t, sender.bcastsExcept, 1)
-}
-
 func TestRouter_HandleManifests_ChargesInvalidEntriesOncePerFrame(t *testing.T) {
 	router, sender := makeRouterWithBadDataRecorder(t)
 	router.SetManifestCache(manifest.NewCache(), nil)
@@ -411,6 +383,49 @@ func TestRouter_ManifestAcceptedAfterPeerRemovalCompletesBootstrap(t *testing.T)
 	case <-time.After(5 * time.Second):
 		t.Fatal("bootstrap did not continue after disconnected manifest was accepted")
 	}
+}
+
+func TestRouter_HandleManifests_RelaysAcceptedEntriesToAllPeers(t *testing.T) {
+	sender := &fakeManifestSender{}
+	router, _, _ := routerWithCache(t, sender, 0, 0)
+	badData := &badDataRecordingSender{}
+	router.gossip = badData
+
+	const acceptedCount = 101
+	wires := make([][]byte, 0, acceptedCount)
+	list := make([]message.Manifest, 0, acceptedCount+2)
+	for i := range acceptedCount {
+		wire := buildWireManifest(t, 1, byte(i), byte(i+acceptedCount))
+		wires = append(wires, wire)
+		list = append(list, message.Manifest{STObject: wire})
+	}
+	list = append(list,
+		message.Manifest{STObject: wires[0]},
+		message.Manifest{STObject: []byte{0x01}},
+	)
+
+	router.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  7,
+		Type:    message.TypeManifests,
+		Payload: encodePayload(t, &message.Manifests{List: list}),
+	})
+
+	sender.mu.Lock()
+	broadcasts := append([][]byte(nil), sender.bcasts...)
+	broadcastsExcept := append([]broadcastExceptCall(nil), sender.bcastsExcept...)
+	sender.mu.Unlock()
+	require.Len(t, broadcasts, 2, "collections above the internal frame cap must relay as one bounded sequence")
+	require.Empty(t, broadcastsExcept)
+
+	var got [][]byte
+	for _, frame := range broadcasts {
+		got = append(got, frameToManifestBytes(t, frame)...)
+	}
+	require.Len(t, got, acceptedCount)
+	for i := range wires {
+		require.Equal(t, wires[i], got[i], "accepted manifests must retain input order and bytes")
+	}
+	require.Equal(t, []badDataCall{{peerID: 7, reason: "manifest-invalid"}}, badData.getBadDataCalls())
 }
 
 func TestRouter_ManifestWorkerDoesNotBlockDispatch(t *testing.T) {
@@ -562,7 +577,7 @@ func TestRouter_ManifestWorkerJoinsOnShutdown(t *testing.T) {
 	_, ok := cache.GetSigningKey(queuedManifest.MasterKey())
 	require.True(t, ok, "shutdown must drain queued manifest jobs")
 	sender.mu.Lock()
-	broadcasts := len(sender.bcastsExcept)
+	broadcasts := len(sender.bcasts)
 	sender.mu.Unlock()
 	require.Equal(t, 2, broadcasts, "shutdown must relay active and queued accepted manifests")
 }

--- a/internal/consensus/adaptor/router_manifests_test.go
+++ b/internal/consensus/adaptor/router_manifests_test.go
@@ -425,7 +425,10 @@ func TestRouter_HandleManifests_RelaysAcceptedEntriesToAllPeers(t *testing.T) {
 	for i := range wires {
 		require.Equal(t, wires[i], got[i], "accepted manifests must retain input order and bytes")
 	}
-	require.Equal(t, []badDataCall{{peerID: 7, reason: "manifest-invalid"}}, badData.getBadDataCalls())
+	require.Equal(t, []badDataCall{
+		{peerID: 7, reason: "manifests-oversize"},
+		{peerID: 7, reason: "manifest-invalid"},
+	}, badData.getBadDataCalls())
 }
 
 func TestRouter_ManifestWorkerDoesNotBlockDispatch(t *testing.T) {

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -525,9 +525,13 @@ func NewFromConfig(
 	router.SetAcqInbox(overlay.LedgerDataMessages())
 	router.SetManifestInbox(overlay.ManifestMessages())
 	router.SetManifestCache(validatorManifests, overlay)
-	router.SetManifestAdmission(func(master [33]byte) bool {
+	router.SetManifestUntrustedLimit(appCfg.Overlay.EffectiveMaxUntrustedCount())
+	router.SetManifestClassifier(func(master [33]byte) manifest.ManifestRateLimitCapPolicy {
 		nodeID := consensus.CalcNodeID(master)
-		return adaptor.IsTrusted(nodeID) || adaptor.IsListed(nodeID)
+		if adaptor.IsTrusted(nodeID) || adaptor.IsListed(nodeID) {
+			return manifest.Uncapped
+		}
+		return manifest.Capped
 	})
 	router.setPeerSessionView(overlay)
 	router.SetMinimumOnlineFloor(floor)

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -38,6 +38,7 @@ import (
 	"github.com/LeJamon/go-xrpl/crypto"
 	"github.com/LeJamon/go-xrpl/crypto/ed25519"
 	"github.com/LeJamon/go-xrpl/crypto/secp256k1"
+	"github.com/LeJamon/go-xrpl/crypto/sha512half"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
 
@@ -60,6 +61,7 @@ type Manifest struct {
 	sequence        uint32
 	domain          string
 	serialized      []byte
+	hash            [32]byte
 	masterSignature string
 	signature       string
 	signingPreimage []byte
@@ -102,6 +104,16 @@ func (m *Manifest) Serialized() []byte {
 		return nil
 	}
 	return append([]byte(nil), m.serialized...)
+}
+
+// Hash returns the Manifest::hash suppression identity for this manifest.
+// Rippled hashes the canonical STObject under the MAN\0 domain, rather than
+// hashing the raw serialized bytes without a domain prefix.
+func (m *Manifest) Hash() [32]byte {
+	if m == nil {
+		return [32]byte{}
+	}
+	return m.hash
 }
 
 // Revoked reports whether the manifest revokes its master key.
@@ -194,6 +206,11 @@ func Deserialize(data []byte) (*Manifest, error) {
 		serialized:      append([]byte(nil), data...),
 		masterSignature: masterSignature,
 	}
+	canonical, err := binarycodec.EncodeBytes(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("manifest: canonical encoding: %w", err)
+	}
+	m.hash = sha512half.Sum(protocol.HashPrefixManifest().Bytes(), canonical)
 
 	if dom, ok := decoded["Domain"]; ok {
 		s, ok := dom.(string)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	rootcrypto "github.com/LeJamon/go-xrpl/crypto"
 	"github.com/LeJamon/go-xrpl/crypto/secp256k1"
+	"github.com/LeJamon/go-xrpl/crypto/sha512half"
 	"github.com/LeJamon/go-xrpl/internal/manifest"
 	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/stretchr/testify/require"
@@ -144,6 +145,16 @@ func TestManifest_RejectsFieldsOutsideManifestFormat(t *testing.T) {
 			require.ErrorContains(t, err, "unexpected field "+field)
 		})
 	}
+}
+
+func TestManifest_HashUsesManifestDomain(t *testing.T) {
+	wire, _, _ := buildManifest(t, 1, false, 0x15, 0x16)
+	parsed, err := manifest.Deserialize(wire)
+	require.NoError(t, err)
+
+	want := sha512half.Sum(protocol.HashPrefixManifest().Bytes(), wire)
+	require.Equal(t, want, parsed.Hash())
+	require.NotEqual(t, sha512half.Sum(wire), parsed.Hash())
 }
 
 func TestManifest_RejectsOversizedPayloadBeforeDecode(t *testing.T) {

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -762,9 +762,6 @@ func (a *Aggregator) Tick() {
 		if sequence := a.promoteRemainingLocked(s, now); sequence != 0 {
 			promoted = append(promoted, promotion{publisher: pubKey, sequence: sequence})
 		}
-		if s.Status == StatusExpired {
-			s.Validators = nil
-		}
 	}
 	a.recomputeAndEmitLocked()
 	a.mu.Unlock()
@@ -844,6 +841,11 @@ func (a *Aggregator) computeValidatorCountsLocked(now time.Time) map[[33]byte]in
 	}
 	a.listed.Store(&listed)
 	a.listedMasters.Store(&listedMasters)
+	if a.validatorManifests != nil {
+		for master := range listedMasters {
+			a.validatorManifests.PromoteToTrusted(master)
+		}
+	}
 	return counts
 }
 

--- a/internal/validator/list/aggregator_test.go
+++ b/internal/validator/list/aggregator_test.go
@@ -867,7 +867,7 @@ func TestAggregator_ApplyList_EffectiveSet_Sentinel(t *testing.T) {
 
 // Direct expired-list ingest populates the publisher list and preserves it
 // for the RPC projection even though it does not contribute to trust.
-func TestAggregator_ApplyList_Expired_PreservesValidatorsUntilTick(t *testing.T) {
+func TestAggregator_ApplyList_Expired_PreservesValidatorsAcrossTick(t *testing.T) {
 	pub := newPublisher(t, 0x01, 0x02)
 	v1 := derivedValidatorKey(0x10)
 
@@ -892,12 +892,70 @@ func TestAggregator_ApplyList_Expired_PreservesValidatorsUntilTick(t *testing.T)
 		t.Fatalf("expired publisher list was not retained: %+v", snap[0].Validators)
 	}
 	if !agg.IsMasterListed(v1) {
-		t.Fatal("directly ingested expired validator must remain listed until Tick")
+		t.Fatal("directly ingested expired validator must remain listed")
 	}
 	agg.Tick()
-	if agg.IsMasterListed(v1) {
-		t.Fatal("expired validator remained listed after Tick")
+	if !agg.IsMasterListed(v1) {
+		t.Fatal("directly ingested expired validator must remain listed after Tick")
 	}
+}
+
+func TestAggregator_ApplyList_EmbeddedManifestUsesExpiredListingAfterTick(t *testing.T) {
+	expiredPublisher := newPublisher(t, 0x01, 0x02)
+	currentPublisher := newPublisher(t, 0x03, 0x04)
+	valMaster32, valMasterPriv := deterministicKey(0x20)
+	valEph32, valEphPriv := deterministicKey(0x21)
+	var valMaster, valEph [33]byte
+	copy(valMaster[:], append([]byte{0xED}, valMaster32...))
+	copy(valEph[:], append([]byte{0xED}, valEph32...))
+	valManifestRaw := buildManifest(t, valMaster, valMasterPriv, valEph, valEphPriv, 1)
+
+	validatorCache := manifest.NewCache()
+	agg, err := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{
+			list.PublisherKey(expiredPublisher.masterPub),
+			list.PublisherKey(currentPublisher.masterPub),
+		},
+		Threshold:          2,
+		ValidatorManifests: validatorCache,
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
+	})
+	require.NoError(t, err)
+
+	now := fixedClock()()
+	expiredBlob, expiredSig := expiredPublisher.signList(t, 1, 0, now.Add(-time.Hour).Unix(), [][33]byte{valMaster})
+	disposition, _, _ := agg.ApplyList(expiredPublisher.manifestB64, expiredBlob, expiredSig, 1, "expired://")
+	require.Equal(t, list.Expired, disposition)
+	agg.Tick()
+	require.True(t, agg.IsMasterListed(valMaster))
+
+	type entry struct {
+		ValidationPublicKey string `json:"validation_public_key"`
+		Manifest            string `json:"manifest,omitempty"`
+	}
+	otherValidator := derivedValidatorKey(0x30)
+	body := struct {
+		Sequence   uint32  `json:"sequence"`
+		Expiration uint32  `json:"expiration"`
+		Validators []entry `json:"validators"`
+	}{
+		Sequence:   1,
+		Expiration: uint32(now.Add(time.Hour).Unix() - protocol.RippleEpochUnix),
+		Validators: []entry{{
+			ValidationPublicKey: hex.EncodeToString(otherValidator[:]),
+			Manifest:            base64.StdEncoding.EncodeToString(valManifestRaw),
+		}},
+	}
+	jsonBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+	blob := []byte(base64.StdEncoding.EncodeToString(jsonBytes))
+	sig := []byte(hex.EncodeToString(ed25519.Sign(currentPublisher.ephPriv, jsonBytes)))
+
+	disposition, _, _ = agg.ApplyList(currentPublisher.manifestB64, blob, sig, 1, "current://")
+	require.Equal(t, list.Accepted, disposition)
+	_, ok := validatorCache.GetSigningKey(valMaster)
+	require.True(t, ok)
 }
 
 // TestAggregator_ApplyList_Expired_SeedsEmbeddedManifests pins the
@@ -1064,11 +1122,15 @@ func TestAggregator_PendingPromotionAppliesEmbeddedManifest(t *testing.T) {
 	var valMaster, valEph [33]byte
 	copy(valMaster[:], append([]byte{0xED}, valMaster32...))
 	copy(valEph[:], append([]byte{0xED}, valEph32...))
-	valManifest := base64.StdEncoding.EncodeToString(buildManifest(t, valMaster, valMasterPriv, valEph, valEphPriv, 1))
+	valManifestRaw := buildManifest(t, valMaster, valMasterPriv, valEph, valEphPriv, 1)
+	valManifest := base64.StdEncoding.EncodeToString(valManifestRaw)
 
 	now := fixedClock()()
 	mutableNow := now
-	validatorCache := manifest.NewCache()
+	validatorCache := manifest.NewCache(1)
+	parsedManifest, err := manifest.Deserialize(valManifestRaw)
+	require.NoError(t, err)
+	require.Equal(t, manifest.Accepted, validatorCache.ApplyManifest(parsedManifest, manifest.Capped))
 	agg, err := list.New(list.Config{
 		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
 		Threshold:          1,
@@ -1101,15 +1163,16 @@ func TestAggregator_PendingPromotionAppliesEmbeddedManifest(t *testing.T) {
 	blob := []byte(base64.StdEncoding.EncodeToString(jsonBytes))
 	signature := []byte(hex.EncodeToString(ed25519.Sign(pub.ephPriv, jsonBytes)))
 	require.Equal(t, list.Pending, mustApply(t, agg, pub.manifestB64, blob, signature))
-	if _, ok := validatorCache.GetSigningKey(valMaster); ok {
-		t.Fatal("pending embedded manifest applied before promotion")
-	}
+	require.True(t, validatorCache.IsUntrusted(valMaster))
 
 	mutableNow = now.Add(3 * time.Hour)
 	agg.Tick()
 	if _, ok := validatorCache.GetSigningKey(valMaster); !ok {
 		t.Fatal("pending embedded manifest was not applied at promotion")
 	}
+	require.True(t, agg.IsMasterListed(valMaster))
+	require.False(t, validatorCache.IsUntrusted(valMaster))
+	require.Zero(t, validatorCache.UntrustedCount())
 }
 
 func TestAggregatorExpiredPendingPromotionDoesNotApplyEmbeddedManifest(t *testing.T) {
@@ -1119,11 +1182,15 @@ func TestAggregatorExpiredPendingPromotionDoesNotApplyEmbeddedManifest(t *testin
 	var valMaster, valEph [33]byte
 	copy(valMaster[:], append([]byte{0xED}, valMaster32...))
 	copy(valEph[:], append([]byte{0xED}, valEph32...))
-	valManifest := base64.StdEncoding.EncodeToString(buildManifest(t, valMaster, valMasterPriv, valEph, valEphPriv, 1))
+	valManifestRaw := buildManifest(t, valMaster, valMasterPriv, valEph, valEphPriv, 1)
+	valManifest := base64.StdEncoding.EncodeToString(valManifestRaw)
 
 	now := fixedClock()()
 	mutableNow := now
-	validatorCache := manifest.NewCache()
+	validatorCache := manifest.NewCache(1)
+	parsedManifest, err := manifest.Deserialize(valManifestRaw)
+	require.NoError(t, err)
+	require.Equal(t, manifest.Accepted, validatorCache.ApplyManifest(parsedManifest, manifest.Capped))
 	agg, err := list.New(list.Config{
 		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
 		Threshold:          1,
@@ -1158,9 +1225,9 @@ func TestAggregatorExpiredPendingPromotionDoesNotApplyEmbeddedManifest(t *testin
 
 	mutableNow = now.Add(2 * time.Hour)
 	agg.Tick()
-	if _, ok := validatorCache.GetSigningKey(valMaster); ok {
-		t.Fatal("expired pending list applied its embedded validator manifest")
-	}
+	require.False(t, agg.IsMasterListed(valMaster))
+	require.True(t, validatorCache.IsUntrusted(valMaster))
+	require.Equal(t, 1, validatorCache.UntrustedCount())
 }
 
 func TestAggregatorOnChangeCallbackBoundaries(t *testing.T) {

--- a/internal/validator/list/aggregator_test.go
+++ b/internal/validator/list/aggregator_test.go
@@ -173,6 +173,75 @@ func TestAggregator_ApplyList_Accepted_SinglePublisher_SingleValidator(t *testin
 	changeMu.Unlock()
 }
 
+func TestAggregator_PromotesListedValidatorManifest(t *testing.T) {
+	pub := newPublisher(t, 0x06, 0x07)
+	otherPublisher := newPublisher(t, 0x08, 0x09)
+	validatorMaster := derivedValidatorKey(0x18)
+	_, validatorMasterPriv := deterministicKey(0x18)
+	validatorEphemeral32, validatorEphemeralPriv := deterministicKey(0x19)
+	var validatorEphemeral [33]byte
+	copy(validatorEphemeral[:], append([]byte{0xed}, validatorEphemeral32...))
+
+	validatorManifests := manifest.NewCache(1)
+	validatorRaw := buildManifest(t, validatorMaster, validatorMasterPriv, validatorEphemeral, validatorEphemeralPriv, 1)
+	validator, err := manifest.Deserialize(validatorRaw)
+	require.NoError(t, err)
+	require.Equal(t, manifest.Accepted, validatorManifests.ApplyManifest(validator, manifest.Capped))
+	require.Equal(t, 1, validatorManifests.UntrustedCount())
+
+	agg, err := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{
+			list.PublisherKey(pub.masterPub),
+			list.PublisherKey(otherPublisher.masterPub),
+		},
+		Threshold:          2,
+		ValidatorManifests: validatorManifests,
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
+	})
+	require.NoError(t, err)
+
+	now := fixedClock()()
+	blob, sig := pub.signList(t, 1, 0, now.Add(24*time.Hour).Unix(), [][33]byte{validatorMaster})
+	disposition, _, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
+	require.Equal(t, list.Accepted, disposition)
+	require.True(t, agg.IsMasterListed(validatorMaster))
+	require.False(t, validatorManifests.IsUntrusted(validatorMaster))
+	require.Equal(t, 0, validatorManifests.UntrustedCount())
+}
+
+func TestAggregator_ExpiredListPromotesValidatorManifest(t *testing.T) {
+	pub := newPublisher(t, 0x06, 0x07)
+	validatorMaster := derivedValidatorKey(0x18)
+	_, validatorMasterPriv := deterministicKey(0x18)
+	validatorEphemeral32, validatorEphemeralPriv := deterministicKey(0x19)
+	var validatorEphemeral [33]byte
+	copy(validatorEphemeral[:], append([]byte{0xed}, validatorEphemeral32...))
+
+	validatorManifests := manifest.NewCache(1)
+	validatorRaw := buildManifest(t, validatorMaster, validatorMasterPriv, validatorEphemeral, validatorEphemeralPriv, 1)
+	validator, err := manifest.Deserialize(validatorRaw)
+	require.NoError(t, err)
+	require.Equal(t, manifest.Accepted, validatorManifests.ApplyManifest(validator, manifest.Capped))
+	require.Equal(t, 1, validatorManifests.UntrustedCount())
+
+	agg, err := list.New(list.Config{
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: validatorManifests,
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
+	})
+	require.NoError(t, err)
+
+	now := fixedClock()()
+	blob, sig := pub.signList(t, 1, 0, now.Add(-time.Hour).Unix(), [][33]byte{validatorMaster})
+	disposition, _, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
+	require.Equal(t, list.Expired, disposition)
+	require.False(t, validatorManifests.IsUntrusted(validatorMaster))
+	require.Equal(t, 0, validatorManifests.UntrustedCount())
+}
+
 func TestAggregator_ApplyList_Threshold_TwoOfThree(t *testing.T) {
 	pub1 := newPublisher(t, 0x01, 0x02)
 	pub2 := newPublisher(t, 0x03, 0x04)

--- a/internal/validator/list/aggregator_test.go
+++ b/internal/validator/list/aggregator_test.go
@@ -1230,6 +1230,68 @@ func TestAggregatorExpiredPendingPromotionDoesNotApplyEmbeddedManifest(t *testin
 	require.Equal(t, 1, validatorCache.UntrustedCount())
 }
 
+func TestAggregatorExpiredPendingPromotionAppliesManifestListedByAnotherPublisher(t *testing.T) {
+	expiredPub := newPublisher(t, 0x80, 0x81)
+	activePub := newPublisher(t, 0x82, 0x83)
+	valMaster32, valMasterPriv := deterministicKey(0x84)
+	valEph32, valEphPriv := deterministicKey(0x85)
+	var valMaster, valEph [33]byte
+	copy(valMaster[:], append([]byte{0xED}, valMaster32...))
+	copy(valEph[:], append([]byte{0xED}, valEph32...))
+	valManifestRaw := buildManifest(t, valMaster, valMasterPriv, valEph, valEphPriv, 1)
+	valManifest := base64.StdEncoding.EncodeToString(valManifestRaw)
+
+	now := fixedClock()()
+	mutableNow := now
+	validatorCache := manifest.NewCache(1)
+	agg, err := list.New(list.Config{
+		PublisherKeys: []list.PublisherKey{
+			list.PublisherKey(expiredPub.masterPub),
+			list.PublisherKey(activePub.masterPub),
+		},
+		Threshold:          1,
+		ValidatorManifests: validatorCache,
+		PublisherManifests: manifest.NewCache(),
+		Clock:              func() time.Time { return mutableNow },
+	})
+	require.NoError(t, err)
+	activeBlob, activeSignature := activePub.signList(t, 1, 0, now.Add(24*time.Hour).Unix(), [][33]byte{valMaster})
+	require.Equal(t, list.Accepted, mustApply(t, agg, activePub.manifestB64, activeBlob, activeSignature))
+	parsedManifest, err := manifest.Deserialize(valManifestRaw)
+	require.NoError(t, err)
+	require.Equal(t, manifest.Accepted, validatorCache.ApplyManifest(parsedManifest, manifest.Capped))
+
+	type entry struct {
+		ValidationPublicKey string `json:"validation_public_key"`
+		Manifest            string `json:"manifest,omitempty"`
+	}
+	body := struct {
+		Sequence   uint32  `json:"sequence"`
+		Expiration uint32  `json:"expiration"`
+		Effective  uint32  `json:"effective"`
+		Validators []entry `json:"validators"`
+	}{
+		Sequence:   4,
+		Expiration: uint32(now.Add(90*time.Minute).Unix() - protocol.RippleEpochUnix),
+		Effective:  uint32(now.Add(time.Hour).Unix() - protocol.RippleEpochUnix),
+		Validators: []entry{{
+			ValidationPublicKey: hex.EncodeToString(valMaster[:]),
+			Manifest:            valManifest,
+		}},
+	}
+	jsonBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+	blob := []byte(base64.StdEncoding.EncodeToString(jsonBytes))
+	signature := []byte(hex.EncodeToString(ed25519.Sign(expiredPub.ephPriv, jsonBytes)))
+	require.Equal(t, list.Pending, mustApply(t, agg, expiredPub.manifestB64, blob, signature))
+
+	mutableNow = now.Add(2 * time.Hour)
+	agg.Tick()
+	require.True(t, agg.IsMasterListed(valMaster))
+	require.False(t, validatorCache.IsUntrusted(valMaster))
+	require.Zero(t, validatorCache.UntrustedCount())
+}
+
 func TestAggregatorOnChangeCallbackBoundaries(t *testing.T) {
 	newCase := func(t *testing.T, seed byte) (*list.Aggregator, *publisherFixture, []byte, []byte, [33]byte) {
 		t.Helper()

--- a/internal/validator/list/publisher_state.go
+++ b/internal/validator/list/publisher_state.go
@@ -546,8 +546,8 @@ func (a *Aggregator) promotePendingSequenceLocked(s *publisherState, sequence ui
 				a.validatorManifests.PromoteToTrusted(key)
 			}
 		}
-		a.applyEmbeddedPendingManifestsLocked(s, chosen.EmbeddedManifests)
 	}
+	a.applyEmbeddedPendingManifestsLocked(s, chosen.EmbeddedManifests)
 	delete(s.Remaining, sequence)
 	a.recordMaxSequenceLocked(s, sequence)
 	a.normalizeRemainingLocked(s)

--- a/internal/validator/list/publisher_state.go
+++ b/internal/validator/list/publisher_state.go
@@ -318,6 +318,11 @@ func (a *Aggregator) applyAcceptedLocked(s *publisherState, blob *blobJSON, sign
 
 	keys := a.extractValidatorKeys(blob, "validator list: skipping invalid validator entry")
 	s.Validators = keys
+	if a.validatorManifests != nil {
+		for _, key := range keys {
+			a.validatorManifests.PromoteToTrusted(key)
+		}
+	}
 	a.applyEmbeddedManifestsLocked(s, blob.Validators)
 }
 
@@ -536,6 +541,11 @@ func (a *Aggregator) promotePendingSequenceLocked(s *publisherState, sequence ui
 		s.Status = StatusExpired
 		s.Validators = nil
 	} else {
+		if a.validatorManifests != nil {
+			for _, key := range s.Validators {
+				a.validatorManifests.PromoteToTrusted(key)
+			}
+		}
 		a.applyEmbeddedPendingManifestsLocked(s, chosen.EmbeddedManifests)
 	}
 	delete(s.Remaining, sequence)


### PR DESCRIPTION
## Summary\n\n- classify listed manifests as uncapped and bound per-message unlisted processing\n- relay accepted aggregate bytes to all peers using manifest-domain suppression hashes\n- emit all listed manifests plus a bounded shuffled unlisted snapshot\n- preserve expired-list admission semantics and promote listed validator identities\n\n## Verification\n\n- go test ./internal/manifest ./internal/validator/list ./internal/consensus/adaptor ./internal/peermanagement -count=1\n- repeated focused race tests\n- just lint\n\nRefs #1595\n\n<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>