### PR TITLE
Close referenced issues after merges

### DIFF
--- a/.github/workflows/close-issues-on-merge.yml
+++ b/.github/workflows/close-issues-on-merge.yml
@@ -1,0 +1,32 @@
+name: Close issues on merge
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close referenced issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+        run: |
+          issue_numbers="$(
+            printf '%s\n' "$PR_BODY" |
+              grep -Eio '(^|[^[:alnum:]_])(fix(e[sd])?|close[sd]?|resolve[sd]?)[[:space:]]+#[0-9]+' |
+              grep -Eo '#[0-9]+' |
+              tr -d '#' |
+              sort -un ||
+              true
+          )"
+
+          while IFS= read -r issue_number; do
+            [ -n "$issue_number" ] || continue
+            gh issue close "$issue_number" --repo "$GITHUB_REPOSITORY" --reason completed
+          done <<< "$issue_numbers"


### PR DESCRIPTION
## Summary

- close issues referenced by standard `fix`, `close`, or `resolve` keywords when a pull request is merged into any branch
- deduplicate issue numbers before closing them with the built-in `GITHUB_TOKEN`
- avoid checking out or executing pull request code

## Why

GitHub only applies closing keywords automatically when a pull request is merged into the default branch. Feature pull requests in this repository often target version branches, leaving their referenced issues open after merge.

## Security

The workflow uses `pull_request_target` only for the trusted workflow definition, grants only `issues: write`, treats the pull request body as data, and never checks out or executes code from the pull request.

## Validation

- parsed the workflow YAML and verified its event, merged guard, permissions, and absence of actions/checkouts
- exercised all nine supported keyword variants, case-insensitive matching, deduplication, false-positive boundaries, and the empty/no-match path
- ran `git diff --check`
