### PR TITLE
BatchV1_1: implement replay-resistant signing and authorization

### DIFF
--- a/amendment/amendment_test.go
+++ b/amendment/amendment_test.go
@@ -516,7 +516,7 @@ func TestAllExpectedFeaturesExist(t *testing.T) {
 		"DeepFreeze",
 		"DynamicNFT",
 		"PermissionedDomains",
-		"Batch",
+		"BatchV1_1",
 		"PermissionedDEX",
 		"TokenEscrow",
 		"fixTokenEscrowV1",

--- a/amendment/registry.go
+++ b/amendment/registry.go
@@ -29,10 +29,10 @@ var (
 // observing FeatureXxx never see a zero ID.
 var (
 	FeatureSponsor                       = registerFeature("Sponsor", SupportedYes, VoteDefaultNo)
+	FeatureBatchV1_1                     = registerFeature("BatchV1_1", SupportedYes, VoteDefaultNo)
 	FeatureFixCleanup3_2_0               = registerFix("fixCleanup3_2_0", SupportedYes, VoteDefaultNo)
 	FeatureFixCleanup3_1_3               = registerFix("fixCleanup3_1_3", SupportedYes, VoteDefaultYes)
 	FeatureMPTokensV2                    = registerFeature("MPTokensV2", SupportedNo, VoteDefaultNo)
-	FeatureFixBatchInnerSigs             = registerFix("fixBatchInnerSigs", SupportedNo, VoteDefaultNo)
 	FeatureConfidentialTransfer          = registerFeature("ConfidentialTransfer", confidentialTransferSupport(), VoteDefaultNo)
 	FeatureFixDirectoryLimit             = registerFix("fixDirectoryLimit", SupportedYes, VoteDefaultNo)
 	FeatureFixIncludeKeyletFields        = registerFix("fixIncludeKeyletFields", SupportedYes, VoteDefaultNo)
@@ -45,7 +45,6 @@ var (
 	FeatureFixEnforceNFTokenTrustlineV2  = registerFix("fixEnforceNFTokenTrustlineV2", SupportedYes, VoteDefaultNo)
 	FeatureFixAMMv1_3                    = registerFix("fixAMMv1_3", SupportedYes, VoteDefaultNo)
 	FeaturePermissionedDEX               = registerFeature("PermissionedDEX", SupportedYes, VoteDefaultNo)
-	FeatureBatch                         = registerFeature("Batch", SupportedNo, VoteDefaultNo)
 	FeatureLendingProtocol               = registerFeature("LendingProtocol", SupportedYes, VoteDefaultNo)
 	FeatureSingleAssetVault              = registerFeature("SingleAssetVault", SupportedYes, VoteDefaultNo)
 	FeaturePermissionDelegationV1_1      = registerFeature("PermissionDelegationV1_1", SupportedNo, VoteDefaultNo)

--- a/codec/binarycodec/codec.go
+++ b/codec/binarycodec/codec.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"strconv"
 
+	"github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/codec/binarycodec/definitions"
 	"github.com/LeJamon/go-xrpl/codec/binarycodec/serdes"
 	"github.com/LeJamon/go-xrpl/codec/binarycodec/types"
@@ -16,7 +17,11 @@ var (
 	// ErrSigningClaimFieldNotFound is returned when the channel and amount fields are not both present.
 	ErrSigningClaimFieldNotFound = errors.New("channel and amount fields are required")
 	// ErrBatchFlagsFieldNotFound is returned when the flags field is missing.
-	ErrBatchFlagsFieldNotFound = errors.New("missing flags field")
+	ErrBatchFlagsFieldNotFound    = errors.New("missing flags field")
+	ErrBatchAccountFieldNotFound  = errors.New("missing account field")
+	ErrBatchSequenceFieldNotFound = errors.New("missing sequence field")
+	ErrBatchAccountNotString      = errors.New("account field must be a string")
+	ErrBatchSequenceNotUInt32     = errors.New("sequence field must be a uint32")
 	// ErrBatchTxIDsFieldNotFound is returned when the txIDs field is missing.
 	ErrBatchTxIDsFieldNotFound = errors.New("missing txIDs field")
 	// ErrBatchTxIDsNotArray is returned when the txIDs field is not an array.
@@ -27,6 +32,7 @@ var (
 	ErrBatchFlagsNotUInt32 = errors.New("flags field must be a uint32")
 	// ErrBatchTxIDsLengthTooLong is returned when the txIDs field is too long.
 	ErrBatchTxIDsLengthTooLong = errors.New("txIDs length exceeds maximum uint32 value")
+	ErrBatchTooManyTxIDs       = errors.New("txIDs length exceeds maximum batch size")
 	// ErrUnknownField is returned when Encode receives a JSON key with no
 	// matching field definition. Silently dropping unknown keys masks typos
 	// (e.g. "Acount" vs "Account") that produce different binary transactions.
@@ -198,6 +204,12 @@ func EncodeForSigningClaim(json map[string]any) (string, error) {
 
 // EncodeForSigningBatch encodes a batch transaction into binary format in preparation for signing.
 func EncodeForSigningBatch(json map[string]any) (string, error) {
+	if json["account"] == nil {
+		return "", ErrBatchAccountFieldNotFound
+	}
+	if json["sequence"] == nil {
+		return "", ErrBatchSequenceFieldNotFound
+	}
 	if json["flags"] == nil {
 		return "", ErrBatchFlagsFieldNotFound
 	}
@@ -208,6 +220,23 @@ func EncodeForSigningBatch(json map[string]any) (string, error) {
 	txIDsInterface, ok := json["txIDs"].([]string)
 	if !ok {
 		return "", ErrBatchTxIDsNotArray
+	}
+	if len(txIDsInterface) > 8 {
+		return "", ErrBatchTooManyTxIDs
+	}
+
+	account, ok := json["account"].(string)
+	if !ok {
+		return "", ErrBatchAccountNotString
+	}
+	_, accountID, err := addresscodec.DecodeClassicAddressToAccountID(account)
+	if err != nil {
+		return "", err
+	}
+
+	sequence, ok := json["sequence"].(uint32)
+	if !ok {
+		return "", ErrBatchSequenceNotUInt32
 	}
 
 	_, ok = json["flags"].(uint32)
@@ -231,9 +260,16 @@ func EncodeForSigningBatch(json map[string]any) (string, error) {
 		return "", err
 	}
 
-	totalSize := len(batchPrefix) + 2*len(flagsBytes) + 2*len(txIDsLengthBytes) + txIDsLength*2*types.HashLengthBytes
+	totalSize := len(batchPrefix) + 2*len(accountID) + 8 + 2*len(flagsBytes) + 2*len(txIDsLengthBytes) + txIDsLength*2*types.HashLengthBytes
 	buf := make([]byte, 0, totalSize)
 	buf = append(buf, batchPrefix...)
+	buf = appendHexUpper(buf, accountID)
+	sequenceBytes := make([]byte, 4)
+	sequenceBytes[0] = byte(sequence >> 24)
+	sequenceBytes[1] = byte(sequence >> 16)
+	sequenceBytes[2] = byte(sequence >> 8)
+	sequenceBytes[3] = byte(sequence)
+	buf = appendHexUpper(buf, sequenceBytes)
 	buf = appendHexUpper(buf, flagsBytes)
 	buf = appendHexUpper(buf, txIDsLengthBytes)
 

--- a/codec/binarycodec/codec.go
+++ b/codec/binarycodec/codec.go
@@ -17,11 +17,15 @@ var (
 	// ErrSigningClaimFieldNotFound is returned when the channel and amount fields are not both present.
 	ErrSigningClaimFieldNotFound = errors.New("channel and amount fields are required")
 	// ErrBatchFlagsFieldNotFound is returned when the flags field is missing.
-	ErrBatchFlagsFieldNotFound    = errors.New("missing flags field")
-	ErrBatchAccountFieldNotFound  = errors.New("missing account field")
+	ErrBatchFlagsFieldNotFound = errors.New("missing flags field")
+	// ErrBatchAccountFieldNotFound is returned when the batch account field is missing.
+	ErrBatchAccountFieldNotFound = errors.New("missing account field")
+	// ErrBatchSequenceFieldNotFound is returned when the batch sequence field is missing.
 	ErrBatchSequenceFieldNotFound = errors.New("missing sequence field")
-	ErrBatchAccountNotString      = errors.New("account field must be a string")
-	ErrBatchSequenceNotUInt32     = errors.New("sequence field must be a uint32")
+	// ErrBatchAccountNotString is returned when the batch account field is not a string.
+	ErrBatchAccountNotString = errors.New("account field must be a string")
+	// ErrBatchSequenceNotUInt32 is returned when the batch sequence is not a uint32.
+	ErrBatchSequenceNotUInt32 = errors.New("sequence field must be a uint32")
 	// ErrBatchTxIDsFieldNotFound is returned when the txIDs field is missing.
 	ErrBatchTxIDsFieldNotFound = errors.New("missing txIDs field")
 	// ErrBatchTxIDsNotArray is returned when the txIDs field is not an array.
@@ -32,7 +36,8 @@ var (
 	ErrBatchFlagsNotUInt32 = errors.New("flags field must be a uint32")
 	// ErrBatchTxIDsLengthTooLong is returned when the txIDs field is too long.
 	ErrBatchTxIDsLengthTooLong = errors.New("txIDs length exceeds maximum uint32 value")
-	ErrBatchTooManyTxIDs       = errors.New("txIDs length exceeds maximum batch size")
+	// ErrBatchTooManyTxIDs is returned when the batch contains too many txIDs.
+	ErrBatchTooManyTxIDs = errors.New("txIDs length exceeds maximum batch size")
 	// ErrUnknownField is returned when Encode receives a JSON key with no
 	// matching field definition. Silently dropping unknown keys masks typos
 	// (e.g. "Acount" vs "Account") that produce different binary transactions.

--- a/codec/binarycodec/codec_test.go
+++ b/codec/binarycodec/codec_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/codec/binarycodec/types"
 	"github.com/stretchr/testify/require"
 )
@@ -875,7 +876,7 @@ func TestEncodeForSigningBatch(t *testing.T) {
 					"795AAC88B59E95C3497609749127E69F12958BC016C600C770AEEB1474C840B4",
 				},
 			},
-			output:      "424348000000000100000002ABE4871E9083DF66727045D49DEEDD3A6F166EB7F8D1E92FE868F02E76B2C5CA795AAC88B59E95C3497609749127E69F12958BC016C600C770AEEB1474C840B4",
+			output:      "424348000000000000000000000000000000000000000000000000070000000100000002ABE4871E9083DF66727045D49DEEDD3A6F166EB7F8D1E92FE868F02E76B2C5CA795AAC88B59E95C3497609749127E69F12958BC016C600C770AEEB1474C840B4",
 			expectedErr: nil,
 		},
 		{
@@ -886,8 +887,72 @@ func TestEncodeForSigningBatch(t *testing.T) {
 					"1111111111111111111111111111111111111111111111111111111111111111",
 				},
 			},
-			output:      "4243480000000000000000011111111111111111111111111111111111111111111111111111111111111111",
+			output:      "4243480000000000000000000000000000000000000000000000000700000000000000011111111111111111111111111111111111111111111111111111111111111111",
 			expectedErr: nil,
+		},
+		{
+			description: "fail - batch missing account field",
+			input: map[string]any{
+				"sequence": uint32(7),
+				"flags":    uint32(1),
+				"txIDs":    []string{},
+			},
+			expectedErr: ErrBatchAccountFieldNotFound,
+		},
+		{
+			description: "fail - batch account has wrong type",
+			input: map[string]any{
+				"account":  7,
+				"sequence": uint32(7),
+				"flags":    uint32(1),
+				"txIDs":    []string{},
+			},
+			expectedErr: ErrBatchAccountNotString,
+		},
+		{
+			description: "fail - batch account is not a classic address",
+			input: map[string]any{
+				"account":  "not-a-classic-address",
+				"sequence": uint32(7),
+				"flags":    uint32(1),
+				"txIDs":    []string{},
+			},
+			expectedErr: addresscodec.ErrInvalidClassicAddress,
+		},
+		{
+			description: "fail - batch missing sequence field",
+			input: map[string]any{
+				"account": "rrrrrrrrrrrrrrrrrrrrrhoLvTp",
+				"flags":   uint32(1),
+				"txIDs":   []string{},
+			},
+			expectedErr: ErrBatchSequenceFieldNotFound,
+		},
+		{
+			description: "fail - batch sequence has wrong type",
+			input: map[string]any{
+				"account":  "rrrrrrrrrrrrrrrrrrrrrhoLvTp",
+				"sequence": 7,
+				"flags":    uint32(1),
+				"txIDs":    []string{},
+			},
+			expectedErr: ErrBatchSequenceNotUInt32,
+		},
+		{
+			description: "fail - batch exceeds maximum txIDs",
+			input: map[string]any{
+				"flags": uint32(1),
+				"txIDs": make([]string, 9),
+			},
+			expectedErr: ErrBatchTooManyTxIDs,
+		},
+		{
+			description: "fail - batch has malformed txID",
+			input: map[string]any{
+				"flags": uint32(1),
+				"txIDs": []string{"00"},
+			},
+			expectedErr: &types.InvalidHashLengthError{Expected: 32},
 		},
 		{
 			description: "fail - batch missing flags field",
@@ -954,6 +1019,12 @@ func TestEncodeForSigningBatch(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.description, func(t *testing.T) {
 			t.Parallel()
+			if _, present := tc.input["account"]; !present && tc.expectedErr != ErrBatchAccountFieldNotFound {
+				tc.input["account"] = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
+			}
+			if _, present := tc.input["sequence"]; !present && tc.expectedErr != ErrBatchSequenceFieldNotFound {
+				tc.input["sequence"] = uint32(7)
+			}
 			got, err := EncodeForSigningBatch(tc.input)
 
 			if tc.expectedErr != nil {

--- a/codec/binarycodec/rippled_hash_prefix_test.go
+++ b/codec/binarycodec/rippled_hash_prefix_test.go
@@ -238,7 +238,9 @@ func TestEncodeForSigningClaim_HashPrefix(t *testing.T) {
 // TestEncodeForSigningBatch_HashPrefix verifies batch signing prefix.
 func TestEncodeForSigningBatch_HashPrefix(t *testing.T) {
 	input := map[string]any{
-		"flags": uint32(1),
+		"account":  "rrrrrrrrrrrrrrrrrrrrrhoLvTp",
+		"sequence": uint32(1),
+		"flags":    uint32(1),
 		"txIDs": []string{
 			"ABE4871E9083DF66727045D49DEEDD3A6F166EB7F8D1E92FE868F02E76B2C5CA",
 		},

--- a/docs/amendments.md
+++ b/docs/amendments.md
@@ -7,13 +7,13 @@ XRPL amendments known to this node, generated from the amendment registry
 amendment's behavior; **Default vote** is whether the node votes for it by
 default (operators override via the `[amendments]` config section).
 
-Total: 109 amendments.
+Total: 108 amendments.
 
 | Amendment | Supported | Default vote |
 |-----------|-----------|--------------|
 | `AMM` | yes | no |
 | `AMMClawback` | yes | no |
-| `Batch` | no | no |
+| `BatchV1_1` | yes | no |
 | `CheckCashMakesTrustLine` | yes | no |
 | `Checks` | yes | no |
 | `Clawback` | yes | no |
@@ -82,7 +82,6 @@ Total: 109 amendments.
 | `fixAMMv1_2` | yes | no |
 | `fixAMMv1_3` | yes | no |
 | `fixAmendmentMajorityCalc` | yes | no |
-| `fixBatchInnerSigs` | no | no |
 | `fixCheckThreading` | yes | no |
 | `fixCleanup3_1_3` | yes | yes |
 | `fixCleanup3_2_0` | yes | no |

--- a/internal/ledger/inbound/replay_delta_apply_test.go
+++ b/internal/ledger/inbound/replay_delta_apply_test.go
@@ -238,7 +238,7 @@ func TestReplayDelta_Apply_RequiresExpectedBatchInnerLeaves(t *testing.T) {
 
 	rules := amendment.NewRulesBuilder().
 		FromPreset(amendment.PresetAllSupported).
-		Enable(amendment.FeatureBatch).
+		Enable(amendment.FeatureBatchV1_1).
 		Build()
 	_, err = rd.Apply(tx.EngineConfig{
 		BaseFee:                   10,

--- a/internal/ledger/service/tx_query_submit_test.go
+++ b/internal/ledger/service/tx_query_submit_test.go
@@ -209,7 +209,7 @@ func TestService_SubmitTransaction_BatchSignerFailureRemainsQueryable(t *testing
 	cfg := defaultServiceConfig()
 	cfg.Standalone = false
 	cfg.Startup.Mode = service.StartupFresh
-	cfg.GenesisConfig.Amendments = append(cfg.GenesisConfig.Amendments, amendment.FeatureBatch)
+	cfg.GenesisConfig.Amendments = append(cfg.GenesisConfig.Amendments, amendment.FeatureBatchV1_1)
 	svc, err := service.New(cfg)
 	if err != nil {
 		t.Fatalf("service.New: %v", err)
@@ -218,12 +218,12 @@ func TestService_SubmitTransaction_BatchSignerFailureRemainsQueryable(t *testing
 		t.Fatalf("service.Start: %v", err)
 	}
 	t.Cleanup(svc.Stop)
-	if !svc.TransactionRules().Enabled(amendment.FeatureBatch) {
+	if !svc.TransactionRules().Enabled(amendment.FeatureBatchV1_1) {
 		t.Fatal("Batch amendment not enabled in service rules")
 	}
 
 	env := jtx.NewTestEnv(t)
-	env.EnableFeatureNow("Batch")
+	env.EnableFeatureNow("BatchV1_1")
 	env.SetVerifySignatures(true)
 	outer := jtx.MasterAccount()
 	innerSigner := jtx.NewAccount("batch-signer")
@@ -264,8 +264,8 @@ func TestService_SubmitTransaction_BatchSignerFailureRemainsQueryable(t *testing
 	if err != nil {
 		t.Fatalf("SubmitTransaction: %v", err)
 	}
-	if result.Result != ter.TemBAD_SIGNATURE {
-		t.Fatalf("Result = %s, want temBAD_SIGNATURE", result.Result)
+	if result.Result != ter.TemINVALID {
+		t.Fatalf("Result = %s, want temINVALID", result.Result)
 	}
 	if result.Applied {
 		t.Fatal("invalid BatchSigner signature must not apply")

--- a/internal/testing/batch/batch_test.go
+++ b/internal/testing/batch/batch_test.go
@@ -21,14 +21,11 @@ import (
 )
 
 // newBatchEnv builds a test environment with the Batch amendment active.
-// Batch is Supported::no upstream (rippled 3.1.1 withdrew support pending
-// fixBatchInnerSigs), so the all-supported preset no longer activates it and
-// every Batch test must opt in. EnableFeatureNow enables it from genesis,
-// matching the behaviour these tests relied on when the preset carried Batch.
+// BatchV1_1 defaults to no, so every Batch behavior test opts in explicitly.
 func newBatchEnv(t *testing.T) *jtx.TestEnv {
 	t.Helper()
 	env := jtx.NewTestEnv(t)
-	env.EnableFeatureNow("Batch")
+	env.EnableFeatureNow("BatchV1_1")
 	return env
 }
 
@@ -89,6 +86,7 @@ func TestEnabled(t *testing.T) {
 
 	t.Run("batch disabled", func(t *testing.T) {
 		env := jtx.NewTestEnv(t)
+		env.DisableFeature("BatchV1_1")
 
 		alice := jtx.NewAccount("alice")
 		bob := jtx.NewAccount("bob")
@@ -115,40 +113,19 @@ func TestEnabled(t *testing.T) {
 		env.Fund(alice, bob)
 		env.Close()
 
-		// A directly-submitted inner-flagged transaction (no signature) reaches
-		// the engine and fails with temINVALID_FLAG. Reference: rippled
-		// checkValidity short-circuits it to Valid before fixBatchInnerSigs, so
-		// it reaches the engine (Batch_test.cpp doTestInnerSubmitRPC).
+		// The flag is valid only while applying an inner transaction with a
+		// parent Batch ID.
 		p := MakeInnerPayment(alice, bob, jtx.XRP(1), env.Seq(alice))
 		p.Fee = fmt.Sprintf("%d", env.BaseFee())
 		p.SigningPubKey = "" // inner batch format, but submitted directly
 
 		result := env.SubmitWithOptions(p, jtx.SubmitOptions{SkipSignature: true})
-		jtx.RequireTxFail(t, result, "temINVALID_FLAG")
-	})
-
-	t.Run("tfInnerBatchTxn on non-batch tx - fixBatchInnerSigs enabled", func(t *testing.T) {
-		env := newBatchEnv(t)
-		env.EnableFeatureNow("fixBatchInnerSigs")
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		// With fixBatchInnerSigs an inner-flagged transaction never has a valid
-		// signature, so it is rejected as invalid rather than reaching the
-		// engine. Reference: rippled apply.cpp checkValidity (PR #6069).
-		p := MakeInnerPayment(alice, bob, jtx.XRP(1), env.Seq(alice))
-		p.Fee = fmt.Sprintf("%d", env.BaseFee())
-		p.SigningPubKey = ""
-
-		result := env.SubmitWithOptions(p, jtx.SubmitOptions{SkipSignature: true})
-		jtx.RequireTxFail(t, result, "temINVALID")
+		jtx.RequireTxFail(t, result, "temINVALID_INNER_BATCH")
 	})
 
 	t.Run("tfInnerBatchTxn on non-batch tx - feature disabled", func(t *testing.T) {
 		env := jtx.NewTestEnv(t)
+		env.DisableFeature("BatchV1_1")
 
 		alice := jtx.NewAccount("alice")
 		bob := jtx.NewAccount("bob")
@@ -284,7 +261,7 @@ func TestPreflight(t *testing.T) {
 		require.False(t, result.Success)
 	})
 
-	t.Run("temREDUNDANT - duplicate batch signer", func(t *testing.T) {
+	t.Run("temBAD_SIGNER - duplicate batch signer", func(t *testing.T) {
 		env := newBatchEnv(t)
 		alice := jtx.NewAccount("alice")
 		bob := jtx.NewAccount("bob")
@@ -302,6 +279,32 @@ func TestPreflight(t *testing.T) {
 
 		result := env.Submit(batch)
 		require.False(t, result.Success)
+	})
+
+	t.Run("temBAD_SIGNER - unsorted batch signers", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		carol := jtx.NewAccount("carol")
+		env.Fund(alice, bob, carol)
+		env.Close()
+
+		batch := NewBatchBuilder(
+			alice,
+			env.Seq(alice),
+			CalcBatchFeeFromEnv(env, 2, 2),
+			batchtx.BatchFlagAllOrNothing,
+		).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 1, env.Seq(bob))).
+			AddInnerTx(MakeInnerPaymentXRP(carol, alice, 1, env.Seq(carol))).
+			AddSigner(bob, "DEADBEEF").
+			AddSigner(carol, "DEADBEEF").
+			Build()
+		require.Len(t, batch.BatchSigners, 2)
+		batch.BatchSigners[0], batch.BatchSigners[1] = batch.BatchSigners[1], batch.BatchSigners[0]
+
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "temBAD_SIGNER")
 	})
 
 	t.Run("temBAD_SIGNER - signer is outer account", func(t *testing.T) {
@@ -330,11 +333,11 @@ func TestPreflight(t *testing.T) {
 		env.Close()
 
 		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 9, 2)
+		batchFee := CalcBatchFeeFromEnv(env, batchtx.MaxBatchSigners+1, 2)
 		builder := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeFakeInnerTx()).
 			AddInnerTx(MakeFakeInnerTx())
-		for i := range 9 {
+		for i := range batchtx.MaxBatchSigners + 1 {
 			signer := jtx.NewAccount(fmt.Sprintf("signer%d", i))
 			builder.AddSigner(signer, "DEADBEEF")
 		}
@@ -1729,7 +1732,7 @@ func TestBatchTxQueue(t *testing.T) {
 	t.Run("batch cannot queue", func(t *testing.T) {
 		cfg := makeSmallQueueConfig(2)
 		env := jtx.NewTestEnvWithTxQ(t, cfg)
-		env.EnableFeatureNow("Batch")
+		env.EnableFeatureNow("BatchV1_1")
 
 		alice := jtx.NewAccount("alice")
 		bob := jtx.NewAccount("bob")
@@ -1800,7 +1803,7 @@ func TestBatchTxQueue(t *testing.T) {
 		// "inner batch transactions are counter towards the ledger tx count"
 		cfg := makeSmallQueueConfig(2)
 		env := jtx.NewTestEnvWithTxQ(t, cfg)
-		env.EnableFeatureNow("Batch")
+		env.EnableFeatureNow("BatchV1_1")
 
 		alice := jtx.NewAccount("alice")
 		bob := jtx.NewAccount("bob")
@@ -3172,11 +3175,11 @@ func TestBatchCalculateBaseFee(t *testing.T) {
 
 		bob := jtx.NewAccount("bob")
 		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 9, 2)
+		batchFee := CalcBatchFeeFromEnv(env, batchtx.MaxBatchSigners+1, 2)
 		builder := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2))
-		for i := range 9 {
+		for i := range batchtx.MaxBatchSigners + 1 {
 			signer := jtx.NewAccount(fmt.Sprintf("signer%d", i))
 			builder.AddSigner(signer, "DEADBEEF")
 		}
@@ -3184,7 +3187,7 @@ func TestBatchCalculateBaseFee(t *testing.T) {
 
 		err := batch.Validate()
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "exceeds 8")
+		require.Contains(t, err.Error(), "exceeds 24")
 	})
 
 	t.Run("valid batch fee calculation", func(t *testing.T) {
@@ -3303,14 +3306,14 @@ func TestBatchSigningVectors(t *testing.T) {
 		jtx.RequireTxFail(t, result, "temBAD_SIGNER")
 	})
 
-	// temBAD_SIGNATURE: signer Account is bob (required) and the signature is made
+	// temINVALID: signer Account is bob (required) and the signature is made
 	// with bob's key, but the presented SigningPubKey is alice's, so the signature
 	// fails to verify against it (Batch_test.cpp:555-579).
 	// The cryptographic BatchSigner check runs in the engine's signature stage, so
 	// it is exercised with VerifySignatures enabled (the outer batch is signed by
 	// alice). This mirrors rippled, where checkBatchSign rejects in preflight before
 	// the preclaim authorization check is reached.
-	t.Run("temBAD_SIGNATURE - signature key mismatched to signing pubkey", func(t *testing.T) {
+	t.Run("temINVALID - signature key mismatched to signing pubkey", func(t *testing.T) {
 		env := newBatchEnv(t)
 		env.VerifySignatures = true
 		alice := jtx.NewAccount("alice")
@@ -3327,12 +3330,12 @@ func TestBatchSigningVectors(t *testing.T) {
 			Build()
 
 		result := env.SubmitSigned(batch)
-		jtx.RequireTxFail(t, result, "temBAD_SIGNATURE")
+		jtx.RequireTxFail(t, result, "temINVALID")
 	})
 
-	// temBAD_SIGNATURE: bob is the required signer with his own public key but a
+	// temINVALID: bob is the required signer with his own public key but a
 	// corrupted signature that does not verify over the batch digest.
-	t.Run("temBAD_SIGNATURE - garbage signature", func(t *testing.T) {
+	t.Run("temINVALID - garbage signature", func(t *testing.T) {
 		env := newBatchEnv(t)
 		env.VerifySignatures = true
 		alice := jtx.NewAccount("alice")
@@ -3349,7 +3352,7 @@ func TestBatchSigningVectors(t *testing.T) {
 			Build()
 
 		result := env.SubmitSigned(batch)
-		jtx.RequireTxFail(t, result, "temBAD_SIGNATURE")
+		jtx.RequireTxFail(t, result, "temINVALID")
 	})
 
 	// tesSUCCESS: a single required signer (bob) signs the batch digest with his
@@ -3483,9 +3486,8 @@ func TestBatchSigningVectors(t *testing.T) {
 
 // TestBatchSignerArrayBound exercises the rules-gated upper bound on a
 // multi-signed BatchSigner's nested Signers array. rippled enforces it in
-// multiSignHelper (called from Batch::preflight with ctx.rules): 32 with
-// featureExpandedSignerList, 8 without. An over-bound array there surfaces as
-// temBAD_SIGNATURE at the checkBatchSign call site (Batch.cpp:439-444).
+// multiSignHelper (called from Batch::preflight with ctx.rules). An over-bound
+// array is a bad-signature validity result and surfaces as temINVALID.
 // Reference: rippled STTx::maxMultiSigners + Batch_test.cpp multi-sign vectors.
 func TestBatchSignerArrayBound(t *testing.T) {
 	// makeNestedSigners builds n distinct, funded signer accounts.
@@ -3526,6 +3528,6 @@ func TestBatchSignerArrayBound(t *testing.T) {
 		env.Close()
 
 		result := env.Submit(batch)
-		require.Equal(t, "temBAD_SIGNATURE", result.Code)
+		require.Equal(t, "temINVALID", result.Code)
 	})
 }

--- a/internal/testing/batch/builder.go
+++ b/internal/testing/batch/builder.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/crypto/ed25519"
 	"github.com/LeJamon/go-xrpl/crypto/secp256k1"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/account"
@@ -55,6 +56,7 @@ type BatchBuilder struct {
 type signSpec struct {
 	index          int
 	multi          bool
+	batchSigner    *jtx.Account
 	signerAccounts []*jtx.Account
 	signingKeys    []*jtx.Account
 }
@@ -90,6 +92,7 @@ func (b *BatchBuilder) AddInnerTx(txn tx.Transaction) *BatchBuilder {
 func (b *BatchBuilder) AddSigner(account *jtx.Account, signature string) *BatchBuilder {
 	b.signSpecs = append(b.signSpecs, signSpec{
 		index:       len(b.signers),
+		batchSigner: account,
 		signingKeys: []*jtx.Account{account},
 	})
 	b.signers = append(b.signers, batchtx.BatchSigner{
@@ -109,6 +112,7 @@ func (b *BatchBuilder) AddSigner(account *jtx.Account, signature string) *BatchB
 func (b *BatchBuilder) AddSignerWithRegKey(account, regKey *jtx.Account, signature string) *BatchBuilder {
 	b.signSpecs = append(b.signSpecs, signSpec{
 		index:       len(b.signers),
+		batchSigner: account,
 		signingKeys: []*jtx.Account{regKey},
 	})
 	b.signers = append(b.signers, batchtx.BatchSigner{
@@ -129,6 +133,7 @@ func (b *BatchBuilder) AddSignerWithRegKey(account, regKey *jtx.Account, signatu
 func (b *BatchBuilder) AddMismatchedSigner(account, pubKey, signingKey *jtx.Account) *BatchBuilder {
 	b.signSpecs = append(b.signSpecs, signSpec{
 		index:       len(b.signers),
+		batchSigner: account,
 		signingKeys: []*jtx.Account{signingKey},
 	})
 	b.signers = append(b.signers, batchtx.BatchSigner{
@@ -182,6 +187,7 @@ func (b *BatchBuilder) AddMultiSignBatchSigner(masterAccount *jtx.Account, signe
 	b.signSpecs = append(b.signSpecs, signSpec{
 		index:          len(b.signers),
 		multi:          true,
+		batchSigner:    masterAccount,
 		signerAccounts: sorted,
 		signingKeys:    sorted,
 	})
@@ -224,6 +230,7 @@ func (b *BatchBuilder) AddMultiSignBatchSignerWithRegKeys(masterAccount *jtx.Acc
 	b.signSpecs = append(b.signSpecs, signSpec{
 		index:          len(b.signers),
 		multi:          true,
+		batchSigner:    masterAccount,
 		signerAccounts: signerAccounts,
 		signingKeys:    signingKeys,
 	})
@@ -260,6 +267,14 @@ func (b *BatchBuilder) Build() *batchtx.Batch {
 	if len(b.signers) > 0 {
 		batch.BatchSigners = b.signers
 		b.signBatchSigners(batch)
+		sort.SliceStable(batch.BatchSigners, func(i, j int) bool {
+			left, leftErr := state.DecodeAccountID(batch.BatchSigners[i].BatchSigner.Account)
+			right, rightErr := state.DecodeAccountID(batch.BatchSigners[j].BatchSigner.Account)
+			if leftErr != nil || rightErr != nil {
+				return batch.BatchSigners[i].BatchSigner.Account < batch.BatchSigners[j].BatchSigner.Account
+			}
+			return bytes.Compare(left[:], right[:]) < 0
+		})
 	}
 	return batch
 }
@@ -275,15 +290,18 @@ func (b *BatchBuilder) signBatchSigners(batch *batchtx.Batch) {
 	}
 	for _, spec := range b.signSpecs {
 		signer := &batch.BatchSigners[spec.index].BatchSigner
+		dataStart := make([]byte, 0, len(digest)+20)
+		dataStart = append(dataStart, digest...)
+		dataStart = append(dataStart, spec.batchSigner.ID[:]...)
 		if spec.multi {
 			for j, key := range spec.signingKeys {
 				nestedID := spec.signerAccounts[j].ID
-				msg := append(append([]byte{}, digest...), nestedID[:]...)
+				msg := append(append([]byte{}, dataStart...), nestedID[:]...)
 				signer.Signers[j].Signer.TxnSignature = signBatchMessage(key, msg)
 			}
 			continue
 		}
-		signer.BatchTxnSignature = signBatchMessage(spec.signingKeys[0], digest)
+		signer.BatchTxnSignature = signBatchMessage(spec.signingKeys[0], dataStart)
 	}
 }
 

--- a/internal/testing/mpt/confidential_batch_native_test.go
+++ b/internal/testing/mpt/confidential_batch_native_test.go
@@ -75,7 +75,7 @@ func confidentialBatchHex(value []byte) string { return hex.EncodeToString(value
 
 func TestConfidentialMPTBatchAllOrNothingRollsBackStaleProof(t *testing.T) {
 	env := jtx.NewTestEnv(t)
-	env.EnableFeatureNow("Batch")
+	env.EnableFeatureNow("BatchV1_1")
 	env.EnableFeatureNow("ConfidentialTransfer")
 	holder := jtx.NewAccount("confidential-holder")
 	issuer := jtx.NewAccount("confidential-issuer")
@@ -172,7 +172,7 @@ func newConfidentialBatchFixture(t *testing.T) *confidentialBatchFixture {
 	t.Helper()
 	env := jtx.NewTestEnv(t)
 	env.EnableFeatureNow("ConfidentialTransfer")
-	env.EnableFeatureNow("Batch")
+	env.EnableFeatureNow("BatchV1_1")
 	issuer := jtx.NewAccount("confidential-batch-issuer")
 	sender := jtx.NewAccount("confidential-batch-sender")
 	destination := jtx.NewAccount("confidential-batch-destination")

--- a/internal/testing/testing_test.go
+++ b/internal/testing/testing_test.go
@@ -179,18 +179,18 @@ func TestRegisterAccountRejectsIdentityCollisions(t *testing.T) {
 
 func TestSetAmendmentsClonesAndCanClear(t *testing.T) {
 	env := NewTestEnv(t)
-	names := []string{"Batch"}
+	names := []string{"BatchV1_1"}
 	env.SetAmendments(names)
 	names[0] = "XRPFees"
-	require.True(t, env.FeatureEnabled("Batch"))
+	require.True(t, env.FeatureEnabled("BatchV1_1"))
 	require.False(t, env.FeatureEnabled("XRPFees"))
 	env.Close()
-	require.True(t, env.FeatureEnabled("Batch"))
+	require.True(t, env.FeatureEnabled("BatchV1_1"))
 
 	env.SetAmendments(nil)
-	require.False(t, env.FeatureEnabled("Batch"))
+	require.False(t, env.FeatureEnabled("BatchV1_1"))
 	env.Close()
-	require.False(t, env.FeatureEnabled("Batch"))
+	require.False(t, env.FeatureEnabled("BatchV1_1"))
 }
 
 func TestMultiSignFee(t *testing.T) {

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -101,8 +101,10 @@ const (
 	// outer (nested batches are not supported), matching rippled TxFlags.h.
 	tfBatchMask uint32 = ^(tx.TfUniversal | BatchFlagAllOrNothing | BatchFlagOnlyOne | BatchFlagUntilFailure | BatchFlagIndependent) | tx.TfInnerBatchTxn
 
-	// MaxBatchTransactions is the maximum number of inner transactions
-	MaxBatchTransactions = 8
+	// MaxBatchTransactions is the maximum number of inner transactions.
+	MaxBatchTransactions = tx.MaxBatchTransactions
+	// MaxBatchSigners is the maximum number of accounts that may authorize a Batch.
+	MaxBatchSigners = tx.MaxBatchSigners
 )
 
 // Batch errors. Inner-tx errors mirror the per-inner rejections in rippled
@@ -111,8 +113,9 @@ var (
 	ErrBatchTooFewTxns            = ter.Errorf(ter.TemARRAY_EMPTY, "batch must have at least 2 transactions")
 	ErrBatchTooManyTxns           = ter.Errorf(ter.TemARRAY_TOO_LARGE, "batch exceeds 8 transactions")
 	ErrBatchMustHaveOneFlag       = ter.Errorf(ter.TemINVALID_FLAG, "exactly one batch mode flag required")
-	ErrBatchTooManySigners        = ter.Errorf(ter.TemARRAY_TOO_LARGE, "batch signers exceeds 8 entries")
-	ErrBatchDuplicateSigner       = ter.Errorf(ter.TemREDUNDANT, "duplicate batch signer")
+	ErrBatchTooManySigners        = ter.Errorf(ter.TemARRAY_TOO_LARGE, "batch signers exceeds 24 entries")
+	ErrBatchDuplicateSigner       = ter.Errorf(ter.TemBAD_SIGNER, "duplicate batch signer")
+	ErrBatchUnsortedSigner        = ter.Errorf(ter.TemBAD_SIGNER, "batch signers must be strictly ordered")
 	ErrBatchSignerIsOuter         = ter.Errorf(ter.TemBAD_SIGNER, "batch signer cannot be outer account")
 	ErrBatchSignerNotRequired     = ter.Errorf(ter.TemBAD_SIGNER, "no account signature for inner txn")
 	ErrBatchMissingSigner         = ter.Errorf(ter.TemBAD_SIGNER, "missing batch signer for inner txn account")
@@ -210,59 +213,55 @@ func checkInnerSignatureFields(signingPubKey, txnSignature string, hasSigners bo
 	return nil
 }
 
-// validateInnerTransactions runs the per-inner checks and, as a side effect,
-// builds the set of inner-tx accounts other than the outer account — the
-// accounts that must each be covered by a BatchSigner.
+// validateInnerTransactions runs the per-inner checks.
 // Reference: rippled Batch.cpp:249-380 (per-inner checks in Batch::preflight).
-func (b *Batch) validateInnerTransactions() (map[string]struct{}, error) {
+func (b *Batch) validateInnerTransactions() error {
 	flags := b.GetFlags()
 	enforceUnique := flags&(BatchFlagAllOrNothing|BatchFlagUntilFailure) != 0
 
 	uniqueHashes := make(map[[32]byte]struct{}, len(b.RawTransactions))
 	accountSeqTicket := make(map[string]map[uint32]struct{})
-	requiredSigners := make(map[string]struct{})
-
 	for _, rt := range b.RawTransactions {
 		inner := rt.RawTransaction.InnerTx
 		if inner == nil {
-			return nil, ErrBatchNilInnerTx
+			return ErrBatchNilInnerTx
 		}
 		if inner.TxType() == tx.TypeClawback {
 			if err := tx.ValidateTransactionTemplateAllowlist(inner); err != nil {
-				return nil, ErrBatchInvalidInnerTx
+				return ErrBatchInvalidInnerTx
 			}
 		}
 
 		hash, err := tx.ComputeTransactionHash(inner)
 		if err != nil {
-			return nil, ErrBatchInnerHashUncomputable
+			return ErrBatchInnerHashUncomputable
 		}
 		if _, dup := uniqueHashes[hash]; dup {
-			return nil, ErrBatchDuplicateInnerTx
+			return ErrBatchDuplicateInnerTx
 		}
 		uniqueHashes[hash] = struct{}{}
 
 		if inner.TxType() == tx.TypeBatch {
-			return nil, ErrBatchInnerIsBatch
+			return ErrBatchInnerIsBatch
 		}
 
 		if _, disabled := disabledInnerTxTypes[inner.TxType()]; disabled {
-			return nil, ErrBatchInnerDisabledType
+			return ErrBatchInnerDisabledType
 		}
 
 		innerCommon := inner.GetCommon()
 
 		if innerCommon.GetFlags()&tx.TfInnerBatchTxn == 0 {
-			return nil, ErrBatchInnerMissingFlag
+			return ErrBatchInnerMissingFlag
 		}
 		if err := checkInnerSignatureFields(innerCommon.SigningPubKey, innerCommon.TxnSignature, len(innerCommon.Signers) > 0); err != nil {
-			return nil, err
+			return err
 		}
 		// A CounterpartySignature is optional on an inner transaction and should
 		// not be present, but if it is it must not carry any signature material.
 		if cp := innerCommon.CounterpartySignature; cp != nil {
 			if err := checkInnerSignatureFields(cp.SigningPubKey, cp.TxnSignature, len(cp.Signers) > 0); err != nil {
-				return nil, err
+				return err
 			}
 		}
 		if sponsor := innerCommon.SponsorSignature; sponsor != nil {
@@ -271,18 +270,18 @@ func (b *Batch) validateInnerTransactions() (map[string]struct{}, error) {
 				sponsor.TxnSignature,
 				len(sponsor.Signers) > 0,
 			); err != nil {
-				return nil, err
+				return err
 			}
 		}
 		if err := validateInnerFee(innerCommon.Fee); err != nil {
-			return nil, err
+			return err
 		}
 		// Inner transactions have Fee=0, so fee sponsorship is nonsensical and
 		// explicitly rejected by rippled. Reserve sponsorship remains allowed
 		// for the transaction types on the common allow-list.
 		if innerCommon.Sponsor != "" && innerCommon.SponsorFlags != nil &&
 			*innerCommon.SponsorFlags&tx.SpfSponsorFee != 0 {
-			return nil, ErrBatchInnerFeeSponsored
+			return ErrBatchInnerFeeSponsored
 		}
 
 		// The inner's own preflight1 rejects a ticket combined with AccountTxnID
@@ -293,7 +292,7 @@ func (b *Batch) validateInnerTransactions() (map[string]struct{}, error) {
 		// otherwise. Reference: rippled Batch.cpp inner preflight -> Transactor.cpp preflight1.
 		usesTicket := innerCommon.TicketSequence != nil && (innerCommon.Sequence == nil || *innerCommon.Sequence == 0)
 		if usesTicket && innerCommon.AccountTxnID != "" {
-			return nil, ErrBatchInnerTicketAndTxnID
+			return ErrBatchInnerTicketAndTxnID
 		}
 
 		// rippled treats sfSequence absent and sfSequence==0 identically via
@@ -304,10 +303,10 @@ func (b *Batch) validateInnerTransactions() (map[string]struct{}, error) {
 		}
 		hasTicket := innerCommon.TicketSequence != nil
 		if hasTicket && seqVal != 0 {
-			return nil, ErrBatchInnerSeqAndTicket
+			return ErrBatchInnerSeqAndTicket
 		}
 		if !hasTicket && seqVal == 0 {
-			return nil, ErrBatchInnerSeqAndTicket
+			return ErrBatchInnerSeqAndTicket
 		}
 
 		if enforceUnique {
@@ -319,33 +318,47 @@ func (b *Batch) validateInnerTransactions() (map[string]struct{}, error) {
 			}
 			if seqVal != 0 {
 				if _, dup := seen[seqVal]; dup {
-					return nil, ErrBatchInnerDupSeqOrTicket
+					return ErrBatchInnerDupSeqOrTicket
 				}
 				seen[seqVal] = struct{}{}
 			}
 			if hasTicket {
 				ticket := *innerCommon.TicketSequence
 				if _, dup := seen[ticket]; dup {
-					return nil, ErrBatchInnerDupSeqOrTicket
+					return ErrBatchInnerDupSeqOrTicket
 				}
 				seen[ticket] = struct{}{}
 			}
 		}
+	}
+	return nil
+}
 
-		authorizer := innerCommon.Account
-		if innerCommon.Delegate != "" {
-			authorizer = innerCommon.Delegate
+func (b *Batch) requiredBatchSigners() map[string]struct{} {
+	required := make(map[string]struct{})
+	for _, rt := range b.RawTransactions {
+		inner := rt.RawTransaction.InnerTx
+		if inner == nil {
+			continue
+		}
+		common := inner.GetCommon()
+		authorizer := common.Account
+		if common.Delegate != "" {
+			authorizer = common.Delegate
 		}
 		if authorizer != b.Account {
-			requiredSigners[authorizer] = struct{}{}
+			required[authorizer] = struct{}{}
 		}
-		if innerCommon.SponsorSignature != nil &&
-			innerCommon.Sponsor != "" &&
-			innerCommon.Sponsor != b.Account {
-			requiredSigners[innerCommon.Sponsor] = struct{}{}
+		if cp, ok := inner.(tx.CounterpartyProvider); ok {
+			if counterparty := cp.GetCounterparty(); counterparty != "" && counterparty != b.Account {
+				required[counterparty] = struct{}{}
+			}
+		}
+		if common.SponsorSignature != nil && common.Sponsor != "" && common.Sponsor != b.Account {
+			required[common.Sponsor] = struct{}{}
 		}
 	}
-	return requiredSigners, nil
+	return required
 }
 
 // Reference: rippled Batch.cpp:314-322 — inner fee must be present and 0.
@@ -356,6 +369,20 @@ func validateInnerFee(fee string) error {
 	feeInt, err := strconv.ParseInt(fee, 10, 64)
 	if err != nil || feeInt != 0 {
 		return ErrBatchInnerBadFee
+	}
+	return nil
+}
+
+func (b *Batch) validateBatchSignerBounds() error {
+	if len(b.BatchSigners) > MaxBatchSigners {
+		return ErrBatchTooManySigners
+	}
+	for _, wrapper := range b.BatchSigners {
+		signer := wrapper.BatchSigner
+		n := len(signer.Signers)
+		if n > sign.MaxMultiSigners || (signer.SigningPubKey == "" && n < sign.MinMultiSigners) {
+			return ErrBatchInvalidSignature
+		}
 	}
 	return nil
 }
@@ -391,20 +418,23 @@ func (b *Batch) Validate() error {
 	if len(b.RawTransactions) > MaxBatchTransactions {
 		return ErrBatchTooManyTxns
 	}
+	if len(b.BatchSigners) > MaxBatchSigners {
+		return ErrBatchTooManySigners
+	}
 
 	// Runs before the engine's BatchOuter loop so malformed inners surface
 	// with their specific TER instead of generic temINVALID_INNER_BATCH.
-	// Also collects the inner-tx accounts that each require a BatchSigner.
 	// Reference: rippled Batch.cpp:249-380.
-	requiredSigners, err := b.validateInnerTransactions()
-	if err != nil {
+	if err := b.validateInnerTransactions(); err != nil {
 		return err
 	}
+	return nil
+}
 
-	// Validate the BatchSigners array: uniqueness, outer-account exclusion,
-	// and requiredSigners coverage.
-	// Reference: rippled Batch.cpp:387-453.
-	return b.validateBatchSigners(requiredSigners)
+// PreflightSigValidated checks exact signer coverage only after all cryptographic
+// signatures have passed, matching Batch::preflightSigValidated.
+func (b *Batch) PreflightSigValidated() error {
+	return b.validateBatchSigners(b.requiredBatchSigners())
 }
 
 // Inner transactions are flattened to STObject maps via their own Flatten() methods.
@@ -538,7 +568,7 @@ func (b *Batch) AddInnerTransaction(innerTx tx.Transaction) {
 }
 
 func (b *Batch) RequiredAmendments() [][32]byte {
-	return [][32]byte{amendment.FeatureBatch}
+	return [][32]byte{amendment.FeatureBatchV1_1}
 }
 
 // GetBatchSigners returns the batch signers as BatchSignerInfo for authorization checking.

--- a/internal/tx/batch/batch_test.go
+++ b/internal/tx/batch/batch_test.go
@@ -394,15 +394,15 @@ func TestBatchValidation(t *testing.T) {
 			name: "invalid - too many batch signers",
 			tx: func() *Batch {
 				b := makeValidBatch()
-				for i := range 9 {
+				for range MaxBatchSigners + 1 {
 					b.BatchSigners = append(b.BatchSigners, BatchSigner{
-						BatchSigner: BatchSignerData{Account: "rSigner" + string(rune('0'+i))},
+						BatchSigner: BatchSignerData{Account: testSigner1, SigningPubKey: "ABC"},
 					})
 				}
 				return b
 			}(),
 			wantErr: true,
-			errMsg:  "exceeds 8",
+			errMsg:  "exceeds 24",
 		},
 		{
 			// rSigner1's inner makes it a required signer, so the first signer entry
@@ -415,8 +415,8 @@ func TestBatchValidation(t *testing.T) {
 				flags := BatchFlagAllOrNothing
 				b.Common.Flags = &flags
 				b.BatchSigners = []BatchSigner{
-					{BatchSigner: BatchSignerData{Account: testSigner1}},
-					{BatchSigner: BatchSignerData{Account: testSigner1}}, // duplicate
+					{BatchSigner: BatchSignerData{Account: testSigner1, SigningPubKey: "ABC"}},
+					{BatchSigner: BatchSignerData{Account: testSigner1, SigningPubKey: "ABC"}}, // duplicate
 				}
 				return b
 			}(),
@@ -428,7 +428,7 @@ func TestBatchValidation(t *testing.T) {
 			tx: func() *Batch {
 				b := makeValidBatch()
 				b.BatchSigners = []BatchSigner{
-					{BatchSigner: BatchSignerData{Account: testOuter}}, // same as outer
+					{BatchSigner: BatchSignerData{Account: testOuter, SigningPubKey: "ABC"}}, // same as outer
 				}
 				return b
 			}(),
@@ -444,6 +444,9 @@ func TestBatchValidation(t *testing.T) {
 			tt.tx.Common.Sequence = &seq
 
 			err := tt.tx.Validate()
+			if err == nil {
+				err = tt.tx.PreflightSigValidated()
+			}
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.errMsg != "" {
@@ -543,7 +546,7 @@ func TestBatchAddInnerTransaction(t *testing.T) {
 func TestBatchRequiredAmendments(t *testing.T) {
 	b := NewBatch(testOuter)
 	amendments := b.RequiredAmendments()
-	assert.Contains(t, amendments, amendment.FeatureBatch)
+	assert.Contains(t, amendments, amendment.FeatureBatchV1_1)
 }
 
 // Constants Tests
@@ -648,7 +651,8 @@ func TestBatchRequiredSignersUseInnerAuthorizers(t *testing.T) {
 		b.AddInnerTransaction(makeTestPayment())
 		b.SetFlags(BatchFlagAllOrNothing)
 
-		require.ErrorIs(t, b.Validate(), ErrBatchMissingSigner)
+		require.NoError(t, b.Validate())
+		require.ErrorIs(t, b.PreflightSigValidated(), ErrBatchMissingSigner)
 
 		b.BatchSigners = []BatchSigner{{BatchSigner: BatchSignerData{
 			Account:           testSigner2,
@@ -656,7 +660,22 @@ func TestBatchRequiredSignersUseInnerAuthorizers(t *testing.T) {
 			BatchTxnSignature: "AA",
 		}}}
 		require.NoError(t, b.Validate())
+		require.NoError(t, b.PreflightSigValidated())
 	})
+}
+
+func TestBatchSignersMustBeStrictlyOrdered(t *testing.T) {
+	b := NewBatch(testOuter)
+	b.AddInnerTransaction(makeTestPaymentFrom(testSigner1))
+	b.AddInnerTransaction(makeTestPaymentFrom(testSigner2))
+	b.SetFlags(BatchFlagAllOrNothing)
+	b.BatchSigners = []BatchSigner{
+		{BatchSigner: BatchSignerData{Account: testSigner2, SigningPubKey: "01"}},
+		{BatchSigner: BatchSignerData{Account: testSigner1, SigningPubKey: "02"}},
+	}
+
+	require.NoError(t, b.Validate())
+	require.ErrorIs(t, b.PreflightSigValidated(), ErrBatchUnsortedSigner)
 }
 
 // TestCalculateMinimumFee_MultiSignedInner pins

--- a/internal/tx/batch/sign.go
+++ b/internal/tx/batch/sign.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"sort"
 
 	"github.com/LeJamon/go-xrpl/crypto/ed25519"
 	"github.com/LeJamon/go-xrpl/crypto/secp256k1"
@@ -12,15 +13,18 @@ import (
 	"github.com/LeJamon/go-xrpl/protocol"
 )
 
-// serializeBatch builds the digest signed by each BatchSigner:
+// serializeBatch builds the common portion of the data signed by each BatchSigner:
 //
-//	HashPrefix::batch || outer flags || txid count || inner txids
+//	HashPrefix::batch || outer account || sequence-or-ticket || outer flags ||
+//	inner count || ordered inner txids
 //
 // The result is the raw message slice; the signature scheme hashes it
 // internally (SHA512-Half). Reference: rippled Batch.h serializeBatch.
-func serializeBatch(flags uint32, txids [][32]byte) []byte {
-	msg := make([]byte, 0, 4+4+4+len(txids)*32)
+func serializeBatch(outerAccount [20]byte, seqValue, flags uint32, txids [][32]byte) []byte {
+	msg := make([]byte, 0, 4+20+4+4+4+len(txids)*32)
 	msg = append(msg, protocol.HashPrefixBatch().Bytes()...)
+	msg = append(msg, outerAccount[:]...)
+	msg = binary.BigEndian.AppendUint32(msg, seqValue)
 	msg = binary.BigEndian.AppendUint32(msg, flags)
 	msg = binary.BigEndian.AppendUint32(msg, uint32(len(txids)))
 	for _, txid := range txids {
@@ -29,15 +33,32 @@ func serializeBatch(flags uint32, txids [][32]byte) []byte {
 	return msg
 }
 
-// BatchSigningMessage returns the serializeBatch digest that each BatchSigner
-// signs over: HashPrefix::batch || outer flags || txid count || inner txids.
-// The returned bytes are the raw message; the signing scheme hashes them.
+// BatchSigningMessage returns the common Batch signing preimage. A single-signed
+// BatchSigner appends its AccountID. A multi-signed BatchSigner appends the
+// BatchSigner AccountID followed by the nested signer AccountID.
 func (b *Batch) BatchSigningMessage() ([]byte, error) {
+	if len(b.RawTransactions) > MaxBatchTransactions {
+		return nil, ErrBatchTooManyTxns
+	}
+	outerAccount, err := state.DecodeAccountID(b.Account)
+	if err != nil {
+		return nil, ErrBatchInvalidSignature
+	}
 	txids, err := b.batchTransactionIDs()
 	if err != nil {
 		return nil, err
 	}
-	return serializeBatch(b.GetFlags(), txids), nil
+	return serializeBatch(outerAccount, b.outerSeqValue(), b.GetFlags(), txids), nil
+}
+
+func (b *Batch) outerSeqValue() uint32 {
+	if b.Sequence != nil && *b.Sequence != 0 {
+		return *b.Sequence
+	}
+	if b.TicketSequence != nil {
+		return *b.TicketSequence
+	}
+	return 0
 }
 
 // batchTransactionIDs returns the transaction IDs of the inner transactions in
@@ -63,12 +84,15 @@ func (b *Batch) batchTransactionIDs() ([][32]byte, error) {
 // over the serializeBatch digest. Each signer is single-signed (direct
 // SigningPubKey + BatchTxnSignature) or multi-signed (nested Signers array,
 // each over the digest suffixed with the signer's account ID). Any failure
-// yields temBAD_SIGNATURE. The engine calls this from its signature-verification
-// stage so it is skipped under SkipSignatureVerification; the structural and
-// coverage checks on BatchSigners run unconditionally in Validate.
+// yields an invalid-signature error. The engine calls this from its signature-
+// verification stage so it is skipped under SkipSignatureVerification; exact
+// signer coverage is checked afterward in PreflightSigValidated.
 // Reference: rippled STTx::checkBatchSign, checkBatchSingleSign, checkBatchMultiSign.
 func (b *Batch) VerifyBatchSignatures() error {
-	digest, err := b.BatchSigningMessage()
+	if err := b.validateBatchSignerBounds(); err != nil {
+		return err
+	}
+	message, err := b.BatchSigningMessage()
 	if err != nil {
 		return err
 	}
@@ -76,12 +100,12 @@ func (b *Batch) VerifyBatchSignatures() error {
 	for i := range b.BatchSigners {
 		signer := b.BatchSigners[i].BatchSigner
 		if signer.SigningPubKey == "" {
-			if err := verifyBatchMultiSign(digest, signer); err != nil {
+			if err := verifyBatchMultiSign(message, signer); err != nil {
 				return err
 			}
 			continue
 		}
-		if err := verifyBatchSingleSign(digest, signer); err != nil {
+		if err := verifyBatchSingleSign(message, signer); err != nil {
 			return err
 		}
 	}
@@ -92,11 +116,18 @@ func (b *Batch) VerifyBatchSignatures() error {
 // validate against SigningPubKey and BatchTxnSignature. A signer that also
 // carries nested Signers is signed two ways and rejected.
 // Reference: rippled singleSignHelper.
-func verifyBatchSingleSign(digest []byte, signer BatchSignerData) error {
+func verifyBatchSingleSign(message []byte, signer BatchSignerData) error {
 	if len(signer.Signers) > 0 {
 		return ErrBatchInvalidSignature
 	}
-	if !verifyBatchSig(digest, signer.SigningPubKey, signer.BatchTxnSignature) {
+	signerID, err := state.DecodeAccountID(signer.Account)
+	if err != nil {
+		return ErrBatchInvalidSignature
+	}
+	signingData := make([]byte, 0, len(message)+len(signerID))
+	signingData = append(signingData, message...)
+	signingData = append(signingData, signerID[:]...)
+	if !verifyBatchSig(signingData, signer.SigningPubKey, signer.BatchTxnSignature) {
 		return ErrBatchInvalidSignature
 	}
 	return nil
@@ -106,7 +137,7 @@ func verifyBatchSingleSign(digest []byte, signer BatchSignerData) error {
 // signs the digest suffixed with its own account ID. Signers must be ordered by
 // account ID, contain no duplicates, and none may be the batch-signer account.
 // Reference: rippled multiSignHelper.
-func verifyBatchMultiSign(digest []byte, signer BatchSignerData) error {
+func verifyBatchMultiSign(message []byte, signer BatchSignerData) error {
 	if len(signer.Signers) == 0 {
 		return ErrBatchInvalidSignature
 	}
@@ -121,6 +152,10 @@ func verifyBatchMultiSign(digest []byte, signer BatchSignerData) error {
 	if err != nil {
 		return ErrBatchInvalidSignature
 	}
+
+	dataStart := make([]byte, 0, len(message)+20)
+	dataStart = append(dataStart, message...)
+	dataStart = append(dataStart, batchSignerID[:]...)
 
 	var lastID [20]byte
 	first := true
@@ -141,8 +176,8 @@ func verifyBatchMultiSign(digest []byte, signer BatchSignerData) error {
 		lastID = nestedID
 		first = false
 
-		msg := make([]byte, 0, len(digest)+20)
-		msg = append(msg, digest...)
+		msg := make([]byte, 0, len(dataStart)+20)
+		msg = append(msg, dataStart...)
 		msg = append(msg, nestedID[:]...)
 		if !verifyBatchSig(msg, nested.SigningPubKey, nested.TxnSignature) {
 			return ErrBatchInvalidSignature
@@ -170,34 +205,60 @@ func verifyBatchSig(msg []byte, pubKeyHex, sigHex string) bool {
 	}
 }
 
-// validateBatchSigners mirrors the structural BatchSigners checks of rippled
-// Batch::preflight (Batch.cpp:387-453): every BatchSigner account must be unique,
+// validateBatchSigners mirrors the BatchSigners checks of rippled
+// Batch::preflightSigValidated: every BatchSigner account must be unique,
 // not the outer account, and required by an inner transaction; after all signers
 // are consumed the required set must be empty. requiredSigners is the set of
 // inner-tx accounts other than the outer account. The cryptographic verification
-// of each signature lives in VerifyBatchSignatures, which the engine runs from its
-// signature stage so it honours SkipSignatureVerification.
+// of each signature lives in VerifyBatchSignatures, which the engine runs first.
 func (b *Batch) validateBatchSigners(requiredSigners map[string]struct{}) error {
-	if len(b.BatchSigners) > MaxBatchTransactions {
+	if len(b.BatchSigners) > MaxBatchSigners {
 		return ErrBatchTooManySigners
 	}
 
 	if len(b.BatchSigners) > 0 {
-		seen := make(map[string]struct{}, len(b.BatchSigners))
+		outerID, err := state.DecodeAccountID(b.Account)
+		if err != nil {
+			return ErrBatchSignerIsOuter
+		}
+		requiredIDs := make([][20]byte, 0, len(requiredSigners))
+		for account := range requiredSigners {
+			id, err := state.DecodeAccountID(account)
+			if err != nil {
+				return ErrBatchMissingSigner
+			}
+			requiredIDs = append(requiredIDs, id)
+		}
+		sort.Slice(requiredIDs, func(i, j int) bool {
+			return bytes.Compare(requiredIDs[i][:], requiredIDs[j][:]) < 0
+		})
+
+		signerIDs := make([][20]byte, len(b.BatchSigners))
+		var lastID [20]byte
 		for i := range b.BatchSigners {
 			acct := b.BatchSigners[i].BatchSigner.Account
-			if acct == b.Account {
-				return ErrBatchSignerIsOuter
-			}
-			if _, dup := seen[acct]; dup {
-				return ErrBatchDuplicateSigner
-			}
-			seen[acct] = struct{}{}
-
-			if _, required := requiredSigners[acct]; !required {
+			accountID, err := state.DecodeAccountID(acct)
+			if err != nil {
 				return ErrBatchSignerNotRequired
 			}
-			delete(requiredSigners, acct)
+			if accountID == outerID {
+				return ErrBatchSignerIsOuter
+			}
+			if i > 0 {
+				switch bytes.Compare(lastID[:], accountID[:]) {
+				case 0:
+					return ErrBatchDuplicateSigner
+				case 1:
+					return ErrBatchUnsortedSigner
+				}
+			}
+			lastID = accountID
+			signerIDs[i] = accountID
+		}
+		for i, accountID := range signerIDs {
+			if i >= len(requiredIDs) || accountID != requiredIDs[i] {
+				return ErrBatchSignerNotRequired
+			}
 		}
 
 		// Structural "signed two ways" check, mirroring checkBatchSign's presence
@@ -219,7 +280,7 @@ func (b *Batch) validateBatchSigners(requiredSigners map[string]struct{}) error 
 		}
 	}
 
-	if len(requiredSigners) != 0 {
+	if len(b.BatchSigners) != len(requiredSigners) {
 		return ErrBatchMissingSigner
 	}
 	return nil

--- a/internal/tx/batch/sign_test.go
+++ b/internal/tx/batch/sign_test.go
@@ -2,31 +2,45 @@ package batch
 
 import (
 	"encoding/binary"
+	"encoding/hex"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/crypto/ed25519"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
 
-// TestSerializeBatchDigest pins the digest layout to rippled serializeBatch:
-// HashPrefix::batch || flags || txid count || inner txids.
+// TestSerializeBatchDigest pins the digest layout to rippled serializeBatch.
 func TestSerializeBatchDigest(t *testing.T) {
+	outer := [20]byte{0xAA, 0xBB}
 	txids := [][32]byte{
 		{0x01},
 		{0x02, 0x03},
 	}
 	flags := BatchFlagAllOrNothing
+	sequence := uint32(0x10203040)
 
-	got := serializeBatch(flags, txids)
+	got := serializeBatch(outer, sequence, flags, txids)
 
-	require.Len(t, got, 4+4+4+len(txids)*32)
+	require.Len(t, got, 4+20+4+4+4+len(txids)*32)
 	require.Equal(t, protocol.HashPrefixBatch().Bytes(), got[0:4])
-	require.Equal(t, flags, binary.BigEndian.Uint32(got[4:8]))
-	require.Equal(t, uint32(len(txids)), binary.BigEndian.Uint32(got[8:12]))
-	require.Equal(t, txids[0][:], got[12:44])
-	require.Equal(t, txids[1][:], got[44:76])
+	require.Equal(t, outer[:], got[4:24])
+	require.Equal(t, sequence, binary.BigEndian.Uint32(got[24:28]))
+	require.Equal(t, flags, binary.BigEndian.Uint32(got[28:32]))
+	require.Equal(t, uint32(len(txids)), binary.BigEndian.Uint32(got[32:36]))
+	require.Equal(t, txids[0][:], got[36:68])
+	require.Equal(t, txids[1][:], got[68:100])
+	require.Equal(t,
+		"42434800AABB000000000000000000000000000000000000102030400001000000000002"+
+			"0100000000000000000000000000000000000000000000000000000000000000"+
+			"0203000000000000000000000000000000000000000000000000000000000000",
+		stringsUpperHex(got),
+	)
 }
 
 // TestBatchSigningMessageMatchesTxids confirms the batch digest is built from the
@@ -36,6 +50,7 @@ func TestBatchSigningMessageMatchesTxids(t *testing.T) {
 	b.AddInnerTransaction(makeTestPayment())
 	b.AddInnerTransaction(makeTestPayment())
 	b.SetFlags(BatchFlagAllOrNothing)
+	b.SetSequence(7)
 
 	ids := make([][32]byte, len(b.RawTransactions))
 	for i, rt := range b.RawTransactions {
@@ -46,13 +61,172 @@ func TestBatchSigningMessageMatchesTxids(t *testing.T) {
 
 	msg, err := b.BatchSigningMessage()
 	require.NoError(t, err)
-	require.Equal(t, serializeBatch(BatchFlagAllOrNothing, ids), msg)
+	outerID, err := state.DecodeAccountID(testOuter)
+	require.NoError(t, err)
+	require.Equal(t, serializeBatch(outerID, 7, BatchFlagAllOrNothing, ids), msg)
 
 	// Flipping the outer flag changes the digest.
 	b.SetFlags(BatchFlagOnlyOne)
 	msg2, err := b.BatchSigningMessage()
 	require.NoError(t, err)
 	require.NotEqual(t, msg, msg2)
+}
+
+func TestBatchSignerSigningDataBindings(t *testing.T) {
+	privateKey, publicKey, err := ed25519.Algorithm{}.DeriveKeypair([]byte("batch-v1.1-signer"), false)
+	require.NoError(t, err)
+	signerAccount, err := addresscodec.EncodeClassicAddressFromPublicKeyHex(publicKey)
+	require.NoError(t, err)
+
+	b := NewBatch(testOuter)
+	b.SetSequence(7)
+	b.SetFlags(BatchFlagAllOrNothing)
+	b.AddInnerTransaction(makeTestPaymentFrom(signerAccount))
+	b.AddInnerTransaction(makeTestPayment())
+
+	message, err := b.BatchSigningMessage()
+	require.NoError(t, err)
+	signerID, err := state.DecodeAccountID(signerAccount)
+	require.NoError(t, err)
+	signingData := append(append([]byte{}, message...), signerID[:]...)
+	signature, err := ed25519.Algorithm{}.Sign(string(signingData), privateKey)
+	require.NoError(t, err)
+	b.BatchSigners = []BatchSigner{{BatchSigner: BatchSignerData{
+		Account:           signerAccount,
+		SigningPubKey:     publicKey,
+		BatchTxnSignature: signature,
+	}}}
+
+	require.NoError(t, b.Validate())
+	require.NoError(t, b.VerifyBatchSignatures())
+
+	t.Run("outer account", func(t *testing.T) {
+		original := b.Account
+		b.Account = testSigner2
+		require.Error(t, b.VerifyBatchSignatures())
+		b.Account = original
+	})
+	t.Run("sequence", func(t *testing.T) {
+		original := *b.Sequence
+		b.SetSequence(original + 1)
+		require.Error(t, b.VerifyBatchSignatures())
+		b.SetSequence(original)
+	})
+	t.Run("ticket proxy", func(t *testing.T) {
+		original := b.Sequence
+		zero := uint32(0)
+		ticket := uint32(9)
+		b.Sequence = &zero
+		b.TicketSequence = &ticket
+		require.Error(t, b.VerifyBatchSignatures())
+		b.Sequence = original
+		b.TicketSequence = nil
+	})
+	t.Run("flags", func(t *testing.T) {
+		b.SetFlags(BatchFlagOnlyOne)
+		require.Error(t, b.VerifyBatchSignatures())
+		b.SetFlags(BatchFlagAllOrNothing)
+	})
+	t.Run("inner order", func(t *testing.T) {
+		b.RawTransactions[0], b.RawTransactions[1] = b.RawTransactions[1], b.RawTransactions[0]
+		require.Error(t, b.VerifyBatchSignatures())
+		b.RawTransactions[0], b.RawTransactions[1] = b.RawTransactions[1], b.RawTransactions[0]
+	})
+	t.Run("inner count", func(t *testing.T) {
+		originalCount := len(b.RawTransactions)
+		b.AddInnerTransaction(makeTestPayment())
+		require.Error(t, b.VerifyBatchSignatures())
+		b.RawTransactions = b.RawTransactions[:originalCount]
+	})
+	t.Run("inner transaction ID", func(t *testing.T) {
+		common := b.RawTransactions[0].RawTransaction.InnerTx.GetCommon()
+		original := *common.Sequence
+		common.SetSequence(original + 1)
+		require.Error(t, b.VerifyBatchSignatures())
+		common.SetSequence(original)
+	})
+	t.Run("batch signer account", func(t *testing.T) {
+		b.BatchSigners[0].BatchSigner.Account = testSigner1
+		require.Error(t, b.VerifyBatchSignatures())
+		b.BatchSigners[0].BatchSigner.Account = signerAccount
+	})
+}
+
+func TestTicketedBatchSignerSigningData(t *testing.T) {
+	privateKey, publicKey, err := ed25519.Algorithm{}.DeriveKeypair([]byte("batch-v1.1-ticket-signer"), false)
+	require.NoError(t, err)
+	signerAccount, err := addresscodec.EncodeClassicAddressFromPublicKeyHex(publicKey)
+	require.NoError(t, err)
+
+	b := NewBatch(testOuter)
+	zero := uint32(0)
+	ticket := uint32(19)
+	b.Sequence = &zero
+	b.TicketSequence = &ticket
+	b.SetFlags(BatchFlagAllOrNothing)
+	b.AddInnerTransaction(makeTestPaymentFrom(signerAccount))
+	b.AddInnerTransaction(makeTestPayment())
+
+	message, err := b.BatchSigningMessage()
+	require.NoError(t, err)
+	outerID, err := state.DecodeAccountID(testOuter)
+	require.NoError(t, err)
+	txids, err := b.batchTransactionIDs()
+	require.NoError(t, err)
+	require.Equal(t, serializeBatch(outerID, ticket, BatchFlagAllOrNothing, txids), message)
+
+	signerID, err := state.DecodeAccountID(signerAccount)
+	require.NoError(t, err)
+	signingData := append(append([]byte{}, message...), signerID[:]...)
+	signature, err := ed25519.Algorithm{}.Sign(string(signingData), privateKey)
+	require.NoError(t, err)
+	b.BatchSigners = []BatchSigner{{BatchSigner: BatchSignerData{
+		Account:           signerAccount,
+		SigningPubKey:     publicKey,
+		BatchTxnSignature: signature,
+	}}}
+
+	require.NoError(t, b.Validate())
+	require.NoError(t, b.VerifyBatchSignatures())
+}
+
+func TestMultiSignedBatchSignerBindsMasterAccount(t *testing.T) {
+	privateKey, publicKey, err := ed25519.Algorithm{}.DeriveKeypair([]byte("batch-v1.1-nested-signer"), false)
+	require.NoError(t, err)
+	nestedAccount, err := addresscodec.EncodeClassicAddressFromPublicKeyHex(publicKey)
+	require.NoError(t, err)
+
+	b := NewBatch(testOuter)
+	b.SetSequence(7)
+	b.SetFlags(BatchFlagAllOrNothing)
+	b.AddInnerTransaction(makeTestPaymentFrom(testSigner1))
+	b.AddInnerTransaction(makeTestPayment())
+	message, err := b.BatchSigningMessage()
+	require.NoError(t, err)
+	masterID, err := state.DecodeAccountID(testSigner1)
+	require.NoError(t, err)
+	nestedID, err := state.DecodeAccountID(nestedAccount)
+	require.NoError(t, err)
+	signingData := append(append(append([]byte{}, message...), masterID[:]...), nestedID[:]...)
+	signature, err := ed25519.Algorithm{}.Sign(string(signingData), privateKey)
+	require.NoError(t, err)
+	b.BatchSigners = []BatchSigner{{BatchSigner: BatchSignerData{
+		Account: testSigner1,
+		Signers: []tx.SignerWrapper{{Signer: tx.Signer{
+			Account:       nestedAccount,
+			SigningPubKey: publicKey,
+			TxnSignature:  signature,
+		}}},
+	}}}
+
+	require.NoError(t, b.Validate())
+	require.NoError(t, b.VerifyBatchSignatures())
+	b.BatchSigners[0].BatchSigner.Account = testSigner2
+	require.Error(t, b.VerifyBatchSignatures())
+}
+
+func stringsUpperHex(value []byte) string {
+	return strings.ToUpper(hex.EncodeToString(value))
 }
 
 // TestVerifyBatchSignaturesRejectsBadSignatures confirms the cryptographic check

--- a/internal/tx/batch/sponsor_test.go
+++ b/internal/tx/batch/sponsor_test.go
@@ -78,8 +78,11 @@ func TestBatchInnerSponsorRules(t *testing.T) {
 			tx.SpfSponsorReserve,
 			false,
 		)
-		if err := batch.Validate(); !errors.Is(err, ErrBatchMissingSigner) {
-			t.Fatalf("Validate() error = %v, want %v", err, ErrBatchMissingSigner)
+		if err := batch.Validate(); err != nil {
+			t.Fatalf("Validate() error = %v", err)
+		}
+		if err := batch.PreflightSigValidated(); !errors.Is(err, ErrBatchMissingSigner) {
+			t.Fatalf("PreflightSigValidated() error = %v, want %v", err, ErrBatchMissingSigner)
 		}
 
 		batch.BatchSigners = []BatchSigner{{
@@ -90,6 +93,9 @@ func TestBatchInnerSponsorRules(t *testing.T) {
 			},
 		}}
 		if err := batch.Validate(); err != nil {
+			t.Fatalf("empty inner SponsorSignature with BatchSigner rejected: %v", err)
+		}
+		if err := batch.PreflightSigValidated(); err != nil {
 			t.Fatalf("empty inner SponsorSignature with BatchSigner rejected: %v", err)
 		}
 	})

--- a/internal/tx/batch_limits.go
+++ b/internal/tx/batch_limits.go
@@ -1,0 +1,6 @@
+package tx
+
+const (
+	MaxBatchTransactions = 8
+	MaxBatchSigners      = MaxBatchTransactions * 3
+)

--- a/internal/tx/engine/confidential_preflight_test.go
+++ b/internal/tx/engine/confidential_preflight_test.go
@@ -15,7 +15,7 @@ import (
 func confidentialPreflightRules(enabled bool) *amendment.Rules {
 	builder := amendment.NewRulesBuilder().
 		FromPreset(amendment.PresetAllSupported).
-		Enable(amendment.FeatureBatch).
+		Enable(amendment.FeatureBatchV1_1).
 		Enable(amendment.FeaturePermissionDelegationV1_1)
 	if enabled {
 		builder.Enable(amendment.FeatureConfidentialTransfer)

--- a/internal/tx/engine/preclaim.go
+++ b/internal/tx/engine/preclaim.go
@@ -450,7 +450,7 @@ func (e *Engine) checkPseudoAccountSign(common *txcore.Common) ter.Result {
 
 func (e *Engine) checkPseudoAccount(idAccount string) ter.Result {
 	if !e.rules().Enabled(amendment.FeatureLendingProtocol) &&
-		!e.rules().Enabled(amendment.FeatureBatch) {
+		!e.rules().Enabled(amendment.FeatureBatchV1_1) {
 		return ter.TesSUCCESS
 	}
 	return e.rejectPseudoAccount(idAccount)

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -70,18 +70,6 @@ func (e *Engine) preflight(tx txcore.Transaction) (result ter.Result) {
 		}
 	}
 
-	// Reference: rippled Batch.cpp:303-312.
-	if outer, ok := tx.(BatchOuter); ok {
-		for _, inner := range outer.InnerTransactions() {
-			if inner == nil {
-				return ter.TemINVALID_INNER_BATCH
-			}
-			if r := e.preflightInner(inner); r != ter.TesSUCCESS {
-				return ter.TemINVALID_INNER_BATCH
-			}
-		}
-	}
-
 	return ter.TesSUCCESS
 }
 
@@ -131,6 +119,19 @@ func (e *Engine) preflightStructure(tx txcore.Transaction, common *txcore.Common
 	// T::preflight — the tx-type-specific body.
 	if result := runTypePreflight(tx, rules); result != ter.TesSUCCESS {
 		return result
+	}
+	// Batch runs each inner transaction's full structural preflight before
+	// preflight2 verifies any signature.
+	// Reference: rippled Batch.cpp:303-312.
+	if outer, ok := tx.(BatchOuter); ok {
+		for _, inner := range outer.InnerTransactions() {
+			if inner == nil {
+				return ter.TemINVALID_INNER_BATCH
+			}
+			if r := e.preflightInner(inner); r != ter.TesSUCCESS {
+				return ter.TemINVALID_INNER_BATCH
+			}
+		}
 	}
 
 	// preflight2 structural stage — the multi-sign structural rules run after
@@ -316,26 +317,17 @@ func (e *Engine) preflightInner(innerTx txcore.Transaction) ter.Result {
 // follows fee and sequence validation, so a transaction that is both
 // inner-flagged and malformed there surfaces the earlier code.
 //
-// The rejection code mirrors rippled across the two amendment gates:
-//   - Batch disabled: the flag itself is undefined → temINVALID_FLAG
-//     (rippled Transactor::preflight1, unchanged by fixBatchInnerSigs).
-//   - Batch enabled: such a transaction still has no valid signature (its
-//     SigningPubKey is empty). With fixBatchInnerSigs it is rejected as a bad
-//     signature before reaching the engine (rippled apply.cpp checkValidity
-//     falls through to checkSign → SigBad → temINVALID). Before the fix it
-//     reached the transaction engine and failed with temINVALID_FLAG. Either
-//     way it can never apply.
+// Without BatchV1_1 the flag is undefined. With BatchV1_1 it is valid only on
+// an inner transaction carrying a parent batch ID, so the standalone path is
+// rejected as temINVALID_INNER_BATCH.
 func preflightInnerBatchFlag(common *txcore.Common, rules *amendment.Rules) ter.Result {
 	if common.Flags == nil || *common.Flags&txcore.TfInnerBatchTxn == 0 {
 		return ter.TesSUCCESS
 	}
-	if !rules.Enabled(amendment.FeatureBatch) {
+	if !rules.Enabled(amendment.FeatureBatchV1_1) {
 		return ter.TemINVALID_FLAG
 	}
-	if rules.Enabled(amendment.FeatureFixBatchInnerSigs) {
-		return ter.TemINVALID
-	}
-	return ter.TemINVALID_FLAG
+	return ter.TemINVALID_INNER_BATCH
 }
 
 // checkDelegate validates the sfDelegate field.
@@ -566,7 +558,7 @@ func (e *Engine) preflightSponsorSignStructure(common *txcore.Common) ter.Result
 // preflightBatchSignerStructure enforces the rules-gated upper bound on each
 // multi-signed BatchSigner's nested Signers array. rippled checks this inside
 // multiSignHelper (called from Batch::preflight with ctx.rules); an out-of-range
-// array there surfaces as temBAD_SIGNATURE at the checkBatchSign call site. The
+// array there is a bad-signature validity result and surfaces as temINVALID. The
 // crypto verification of those signers lives in Batch.Validate(), which has no
 // rules access, so the rules-dependent size bound is enforced here in preflight.
 func (e *Engine) preflightBatchSignerStructure(tx txcore.Transaction) ter.Result {
@@ -582,7 +574,7 @@ func (e *Engine) preflightBatchSignerStructure(tx txcore.Transaction) ter.Result
 			continue
 		}
 		if n := len(signer.Signers); n < sign.MinMultiSigners || n > maxSigners {
-			return ter.TemBAD_SIGNATURE
+			return ter.TemINVALID
 		}
 	}
 	return ter.TesSUCCESS
@@ -619,12 +611,12 @@ func (e *Engine) verifySignatures(tx txcore.Transaction) ter.Result {
 	}
 	// Batch-signer signatures are verified over the batch signing digest, the same
 	// stage rippled runs STTx::checkBatchSign (always RequireFullyCanonicalSig::yes).
-	// The structural/coverage checks on BatchSigners run unconditionally in Validate;
-	// only the cryptographic verification is gated here so it honours
+	// Structural bounds run before hashing; coverage/order runs in
+	// PreflightSigValidated. Only cryptographic verification is gated here so it honours
 	// SkipSignatureVerification like every other signature.
 	if bsv, ok := tx.(txcore.BatchSignatureVerifier); ok {
 		if err := bsv.VerifyBatchSignatures(); err != nil {
-			return ter.TemBAD_SIGNATURE
+			return ter.TemINVALID
 		}
 	}
 	return ter.TesSUCCESS

--- a/internal/tx/engine/preflight_inner_batch_test.go
+++ b/internal/tx/engine/preflight_inner_batch_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
-// batchRules builds a rules set containing exactly the named amendments.
 func batchRules(names ...string) *amendment.Rules {
 	b := amendment.NewRulesBuilder()
 	for _, n := range names {

--- a/internal/tx/engine/preflight_inner_batch_test.go
+++ b/internal/tx/engine/preflight_inner_batch_test.go
@@ -8,11 +8,9 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
-// batchRules builds a rules set from the all-supported preset with the named
-// amendments additionally enabled. Batch and fixBatchInnerSigs are Supported::no
-// upstream, so they are absent from the preset and must be enabled explicitly.
+// batchRules builds a rules set containing exactly the named amendments.
 func batchRules(names ...string) *amendment.Rules {
-	b := amendment.NewRulesBuilder().FromPreset(amendment.PresetAllSupported)
+	b := amendment.NewRulesBuilder()
 	for _, n := range names {
 		b.EnableByName(n)
 	}
@@ -27,9 +25,7 @@ func innerFlaggedTx() *txcore.Common {
 }
 
 // TestPreflightInnerBatchFlag exercises the tfInnerBatchTxn rejection on a
-// directly-submitted transaction across the Batch and fixBatchInnerSigs gates,
-// mirroring rippled's Transactor::preflight1 (temINVALID_FLAG when Batch is
-// disabled) and apply.cpp checkValidity (fixBatchInnerSigs, PR #6069).
+// directly-submitted transaction across the BatchV1_1 gate.
 func TestPreflightInnerBatchFlag(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -45,16 +41,9 @@ func TestPreflightInnerBatchFlag(t *testing.T) {
 		{
 			// Pre-fix: the transaction reached the engine and failed with
 			// temINVALID_FLAG (checkValidity short-circuited it to Valid).
-			name:  "batch enabled, fix disabled",
-			rules: batchRules("Batch"),
-			want:  ter.TemINVALID_FLAG,
-		},
-		{
-			// Post-fix: an inner-flagged transaction never has a valid
-			// signature, so it is rejected as invalid before applying.
-			name:  "batch enabled, fix enabled",
-			rules: batchRules("Batch", "fixBatchInnerSigs"),
-			want:  ter.TemINVALID,
+			name:  "batch enabled",
+			rules: batchRules("BatchV1_1"),
+			want:  ter.TemINVALID_INNER_BATCH,
 		},
 	}
 	for _, tt := range tests {
@@ -70,7 +59,7 @@ func TestPreflightInnerBatchFlag(t *testing.T) {
 // tfInnerBatchTxn) is unaffected by the gate regardless of the amendments.
 func TestPreflightInnerBatchFlag_AbsentFlag(t *testing.T) {
 	tx := txcore.NewBaseTx(txcore.TypePayment, precedenceSourceAddr)
-	rules := batchRules("Batch", "fixBatchInnerSigs")
+	rules := batchRules("BatchV1_1")
 	if got := preflightInnerBatchFlag(tx.GetCommon(), rules); got != ter.TesSUCCESS {
 		t.Fatalf("preflightInnerBatchFlag(no flag) = %v, want TesSUCCESS", got)
 	}

--- a/internal/tx/engine/preflight_precedence_test.go
+++ b/internal/tx/engine/preflight_precedence_test.go
@@ -330,10 +330,13 @@ func TestPreflightPrecedence_InnerBatchFlagLast(t *testing.T) {
 // transactions.macro amendment gate (RequiredAmendments) is the first
 // invokePreflight check, ahead of preflight0's NetworkID checks.
 func TestPreflightPrecedence_MacroGateBeforeNetworkID(t *testing.T) {
-	e := preflightEngine(allRules()) // Batch disabled
+	rules := amendment.NewRulesBuilder().FromPreset(amendment.PresetAllSupported).
+		Disable(amendment.FeatureBatchV1_1).
+		Build()
+	e := preflightEngine(rules)
 	tx := &reqAmendmentTx{
 		BaseTx:     newAccountSet(precedenceSourceAddr),
-		amendments: [][32]byte{amendment.FeatureBatch},
+		amendments: [][32]byte{amendment.FeatureBatchV1_1},
 	}
 	tx.NetworkID = u32(99) // legacy node forbids the field → tel* if reached
 	if got := e.preflight(tx); got != ter.TemDISABLED {

--- a/internal/tx/lending/lending.go
+++ b/internal/tx/lending/lending.go
@@ -306,6 +306,8 @@ func NewLoanSet(account, loanBrokerID, principalRequested string) *LoanSet {
 
 func (l *LoanSet) TxType() tx.Type { return tx.TypeLoanSet }
 
+func (l *LoanSet) GetCounterparty() string { return l.Counterparty }
+
 // GetFlagsMask adopts the engine FlagsMasker seam with the LoanSet invalid-flags
 // mask (rippled LoanSet::getFlagsMask = tfLoanSetMask), checked at preflight0.
 func (l *LoanSet) GetFlagsMask(rules *amendment.Rules) uint32 {

--- a/internal/tx/local_checks.go
+++ b/internal/tx/local_checks.go
@@ -57,12 +57,12 @@ func TransactionLocalChecksFailureReason(transaction Transaction) string {
 		return reason
 	}
 	if transaction.TxType() == TypeBatch {
-		if signers, ok := transaction.(BatchSignerProvider); ok && len(signers.GetBatchSigners()) > 8 {
+		if signers, ok := transaction.(BatchSignerProvider); ok && len(signers.GetBatchSigners()) > MaxBatchSigners {
 			return "Batch Signers array exceeds max entries."
 		}
 		if outer, ok := transaction.(interface{ InnerTransactions() []Transaction }); ok {
 			inners := outer.InnerTransactions()
-			if len(inners) > 8 {
+			if len(inners) > MaxBatchTransactions {
 				return "Raw Transactions array exceeds max entries."
 			}
 			for _, inner := range inners {
@@ -88,14 +88,14 @@ func TransactionMapLocalChecksFailureReason(txType Type, fields map[string]any) 
 		return reason
 	}
 	if txType == TypeBatch {
-		if batchSigners, ok := fields["BatchSigners"].([]any); ok && len(batchSigners) > 8 {
+		if batchSigners, ok := fields["BatchSigners"].([]any); ok && len(batchSigners) > MaxBatchSigners {
 			return "Batch Signers array exceeds max entries."
 		}
 		rawTransactions, ok := fields["RawTransactions"].([]any)
 		if !ok {
 			return ""
 		}
-		if len(rawTransactions) > 8 {
+		if len(rawTransactions) > MaxBatchTransactions {
 			return "Raw Transactions array exceeds max entries."
 		}
 		for _, raw := range rawTransactions {

--- a/internal/tx/local_checks_test.go
+++ b/internal/tx/local_checks_test.go
@@ -241,18 +241,32 @@ func TestTransactionLocalChecksBatchLimits(t *testing.T) {
 		want  string
 	}{
 		{
+			name: "batch signers at limit",
+			batch: &localChecksBatch{
+				localChecksTransaction: newLocalChecksTransaction(TypeBatch, map[string]any{}),
+				signers:                make([]BatchSignerInfo, MaxBatchSigners),
+			},
+		},
+		{
 			name: "batch signers limit",
 			batch: &localChecksBatch{
 				localChecksTransaction: newLocalChecksTransaction(TypeBatch, map[string]any{}),
-				signers:                make([]BatchSignerInfo, 9),
+				signers:                make([]BatchSignerInfo, MaxBatchSigners+1),
 			},
 			want: "Batch Signers array exceeds max entries.",
+		},
+		{
+			name: "raw transactions at limit",
+			batch: &localChecksBatch{
+				localChecksTransaction: newLocalChecksTransaction(TypeBatch, map[string]any{}),
+				inners:                 make([]Transaction, MaxBatchTransactions),
+			},
 		},
 		{
 			name: "raw transactions limit",
 			batch: &localChecksBatch{
 				localChecksTransaction: newLocalChecksTransaction(TypeBatch, map[string]any{}),
-				inners:                 make([]Transaction, 9),
+				inners:                 make([]Transaction, MaxBatchTransactions+1),
 			},
 			want: "Raw Transactions array exceeds max entries.",
 		},
@@ -270,6 +284,41 @@ func TestTransactionLocalChecksBatchLimits(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if got := TransactionLocalChecksFailureReason(test.batch); got != test.want {
 				t.Fatalf("TransactionLocalChecksFailureReason = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestTransactionMapLocalChecksBatchLimits(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields map[string]any
+		want   string
+	}{
+		{
+			name:   "batch signers at limit",
+			fields: map[string]any{"BatchSigners": make([]any, MaxBatchSigners)},
+		},
+		{
+			name:   "batch signers over limit",
+			fields: map[string]any{"BatchSigners": make([]any, MaxBatchSigners+1)},
+			want:   "Batch Signers array exceeds max entries.",
+		},
+		{
+			name:   "raw transactions at limit",
+			fields: map[string]any{"RawTransactions": make([]any, MaxBatchTransactions)},
+		},
+		{
+			name:   "raw transactions over limit",
+			fields: map[string]any{"RawTransactions": make([]any, MaxBatchTransactions+1)},
+			want:   "Raw Transactions array exceeds max entries.",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := TransactionMapLocalChecksFailureReason(TypeBatch, test.fields); got != test.want {
+				t.Fatalf("TransactionMapLocalChecksFailureReason = %q, want %q", got, test.want)
 			}
 		})
 	}

--- a/internal/tx/sign/signature.go
+++ b/internal/tx/sign/signature.go
@@ -99,14 +99,6 @@ func IsMultiSigned(tx txcore.Transaction) bool {
 // optional counterparty signatures are valid.
 func CheckSTTxSignature(transaction txcore.Transaction, rules *amendment.Rules, checkSigs bool) string {
 	common := transaction.GetCommon()
-	if common.GetFlags()&txcore.TfInnerBatchTxn != 0 && rules != nil && rules.Enabled(amendment.FeatureBatch) {
-		if common.HasField("TxnSignature") || common.SigningPubKey != "" || common.HasField("Signers") {
-			return "Malformed: Invalid inner batch transaction."
-		}
-		if !rules.Enabled(amendment.FeatureFixBatchInnerSigs) {
-			return ""
-		}
-	}
 	if !checkSigs {
 		return ""
 	}

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -187,6 +187,12 @@ type BatchSignatureVerifier interface {
 	VerifyBatchSignatures() error
 }
 
+// CounterpartyProvider is implemented by transactions that name an account
+// whose consent is required in addition to the initiator's authorization.
+type CounterpartyProvider interface {
+	GetCounterparty() string
+}
+
 // Amount is an alias for state.Amount — represents either XRP (as drops int64) or an issued currency amount
 type Amount = state.Amount
 


### PR DESCRIPTION
## Summary

- migrate transaction type 71 to the final `BatchV1_1` amendment gate
- bind Batch authorization to the outer account, sequence or ticket, flags, and ordered inner transaction IDs
- enforce exact Batch signer coverage, ordering, uniqueness, and pre-verification bounds
- reject ordinary signatures on inner transactions and standalone inner submission

## Verification

- golden signing/hash and mutation cases against rippled v3.3.0
- focused Batch, codec, engine, ledger-service, and integration suites
- `just build`, `just vet`, and `just lint`

Stack 1/2. Base: `v3.3.0`. Next: #1623.

Fixes #1369
