### PR TITLE
BatchV1_1: complete engine, TxQ, relay, and replay integration

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -901,13 +901,11 @@ func (a *Adaptor) AddPendingTx(blob []byte, local bool) {
 	_, _ = a.SubmitPendingTx(blob, local)
 }
 
-// SubmitPendingTx is AddPendingTx with the classification result surfaced, so
-// the peer-relay path can gate re-broadcast on a non-Failure result.
-func (a *Adaptor) SubmitPendingTx(blob []byte, local bool) (openledger.Result, error) {
+func (a *Adaptor) SubmitPendingTx(blob []byte, local bool) (openledger.SubmitOutcome, error) {
 	if a.ledgerService == nil {
-		return openledger.ResultFailure, errors.New("ledger service unavailable")
+		return openledger.SubmitOutcome{Class: openledger.ResultFailure}, errors.New("ledger service unavailable")
 	}
-	res, err := a.ledgerService.SubmitOpenLedgerTx(blob, local)
+	res, err := a.ledgerService.SubmitOpenLedgerTxDetailed(blob, local)
 	if err != nil {
 		a.logger.Warn("openLedger submit failed",
 			"err", err,

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -137,6 +137,7 @@ type Router struct {
 	// messages would accelerate selection and produce earlier squelches for
 	// the same traffic pattern.
 	messageSeen *messageSuppression
+	txSeen      *transactionSuppression
 	// validationWork verifies signatures outside the router goroutine. Trusted
 	// and untrusted work use separate bounded queues so untrusted traffic cannot
 	// occupy the trusted capacity.
@@ -414,6 +415,7 @@ func newRouter(engine consensus.RouterEngine, adaptor *Adaptor, inbox <-chan *pe
 		fetchPacks:             newFetchPackCache(),
 		messageSeen:            newMessageSuppression(messageDedupTTL, messageDedupMaxEntries),
 		manifestUntrustedLimit: manifest.DefaultMaxUntrustedCount,
+		txSeen:                 newTransactionSuppression(5*time.Minute, 1<<17),
 		txSetAcquire:           make(map[consensus.TxSetID]*txSetAcquireState),
 		txSetRetryKnobs:        defaultTxSetRetryKnobs(),
 		seqHash:                make(map[uint32]ledgerHashEntry),

--- a/internal/consensus/adaptor/router_dedup.go
+++ b/internal/consensus/adaptor/router_dedup.go
@@ -108,6 +108,90 @@ type messageSuppression struct {
 	now     func() time.Time
 }
 
+const transactionProcessInterval = 10 * time.Second
+
+type transactionSuppression struct {
+	mu      sync.Mutex
+	entries map[[32]byte]*transactionSuppressionEntry
+	order   list.List
+	ttl     time.Duration
+	maxSize int
+	now     func() time.Time
+}
+
+type transactionSuppressionEntry struct {
+	processedAt time.Time
+	touchedAt   time.Time
+	bad         bool
+	order       *list.Element
+}
+
+func newTransactionSuppression(ttl time.Duration, maxSize int) *transactionSuppression {
+	if maxSize < 1 {
+		maxSize = 1
+	}
+	return &transactionSuppression{
+		entries: make(map[[32]byte]*transactionSuppressionEntry),
+		ttl:     ttl,
+		maxSize: maxSize,
+		now:     time.Now,
+	}
+}
+
+// claim atomically reserves the expensive ingress processing for one worker.
+// Duplicates refresh cache retention but do not extend the process interval.
+func (s *transactionSuppression) claim(hash [32]byte) (shouldProcess, bad bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+	s.evictExpiredLocked(now)
+	if entry, ok := s.entries[hash]; ok {
+		entry.touchedAt = now
+		s.order.MoveToBack(entry.order)
+		if now.Sub(entry.processedAt) < transactionProcessInterval {
+			return false, entry.bad
+		}
+		entry.processedAt = now
+		return true, entry.bad
+	}
+	entry := &transactionSuppressionEntry{processedAt: now, touchedAt: now}
+	entry.order = s.order.PushBack(hash)
+	s.entries[hash] = entry
+	for len(s.entries) > s.maxSize {
+		s.removeOldestLocked()
+	}
+	return true, false
+}
+
+func (s *transactionSuppression) markBad(hash [32]byte) {
+	s.mu.Lock()
+	if entry := s.entries[hash]; entry != nil {
+		entry.bad = true
+	}
+	s.mu.Unlock()
+}
+
+func (s *transactionSuppression) evictExpiredLocked(now time.Time) {
+	for oldest := s.order.Front(); oldest != nil; oldest = s.order.Front() {
+		hash := oldest.Value.([32]byte)
+		entry := s.entries[hash]
+		if entry != nil && now.Sub(entry.touchedAt) < s.ttl {
+			return
+		}
+		s.removeOldestLocked()
+	}
+}
+
+func (s *transactionSuppression) removeOldestLocked() {
+	oldest := s.order.Front()
+	if oldest == nil {
+		return
+	}
+	hash := oldest.Value.([32]byte)
+	delete(s.entries, hash)
+	s.order.Remove(oldest)
+}
+
 type suppressionEntry struct {
 	seenAt time.Time
 	peers  map[uint64]struct{}

--- a/internal/consensus/adaptor/router_dedup.go
+++ b/internal/consensus/adaptor/router_dedup.go
@@ -123,6 +123,7 @@ type transactionSuppressionEntry struct {
 	processedAt time.Time
 	touchedAt   time.Time
 	bad         bool
+	peers       map[uint64]struct{}
 	order       *list.Element
 }
 
@@ -140,12 +141,13 @@ func newTransactionSuppression(ttl time.Duration, maxSize int) *transactionSuppr
 
 // claim atomically reserves the expensive ingress processing for one worker.
 // Duplicates refresh cache retention but do not extend the process interval.
-func (s *transactionSuppression) claim(hash [32]byte) (shouldProcess, bad bool) {
+func (s *transactionSuppression) claim(hash [32]byte, peerID uint64) (shouldProcess, bad bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	now := s.now()
 	s.evictExpiredLocked(now)
 	if entry, ok := s.entries[hash]; ok {
+		addTransactionPeer(entry, peerID)
 		entry.touchedAt = now
 		s.order.MoveToBack(entry.order)
 		if now.Sub(entry.processedAt) < transactionProcessInterval {
@@ -155,12 +157,35 @@ func (s *transactionSuppression) claim(hash [32]byte) (shouldProcess, bad bool) 
 		return true, entry.bad
 	}
 	entry := &transactionSuppressionEntry{processedAt: now, touchedAt: now}
+	addTransactionPeer(entry, peerID)
 	entry.order = s.order.PushBack(hash)
 	s.entries[hash] = entry
 	for len(s.entries) > s.maxSize {
 		s.removeOldestLocked()
 	}
 	return true, false
+}
+
+func addTransactionPeer(entry *transactionSuppressionEntry, peerID uint64) {
+	if peerID == 0 {
+		return
+	}
+	if entry.peers == nil {
+		entry.peers = make(map[uint64]struct{})
+	}
+	entry.peers[peerID] = struct{}{}
+}
+
+func (s *transactionSuppression) releasePeers(hash [32]byte) map[uint64]struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry := s.entries[hash]
+	if entry == nil {
+		return nil
+	}
+	peers := entry.peers
+	entry.peers = nil
+	return peers
 }
 
 func (s *transactionSuppression) markBad(hash [32]byte) {

--- a/internal/consensus/adaptor/router_dedup_test.go
+++ b/internal/consensus/adaptor/router_dedup_test.go
@@ -2,6 +2,8 @@ package adaptor
 
 import (
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -216,4 +218,90 @@ func TestProposalSuppression_AdmitsOnlyAfterEngineAcceptance(t *testing.T) {
 
 	router.handleProposal(inbound)
 	assert.Equal(t, 2, engine.calls, "accepted duplicate must bypass the engine")
+}
+
+func TestTransactionSuppressionClaimIsAtomic(t *testing.T) {
+	cache := newTransactionSuppression(5*time.Minute, 64)
+	var hash [32]byte
+	hash[0] = 1
+
+	var processed atomic.Int32
+	var workers sync.WaitGroup
+	start := make(chan struct{})
+	for range 64 {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+			if shouldProcess, _ := cache.claim(hash); shouldProcess {
+				processed.Add(1)
+			}
+		}()
+	}
+	close(start)
+	workers.Wait()
+	require.Equal(t, int32(1), processed.Load())
+}
+
+func TestTransactionSuppressionVerdictAndIntervals(t *testing.T) {
+	now := time.Unix(1_000, 0)
+	cache := newTransactionSuppression(5*time.Minute, 64)
+	cache.now = func() time.Time { return now }
+	var hash [32]byte
+	hash[0] = 1
+
+	shouldProcess, bad := cache.claim(hash)
+	require.True(t, shouldProcess)
+	require.False(t, bad)
+	cache.markBad(hash)
+
+	shouldProcess, bad = cache.claim(hash)
+	require.False(t, shouldProcess)
+	require.True(t, bad)
+
+	now = now.Add(transactionProcessInterval)
+	shouldProcess, bad = cache.claim(hash)
+	require.True(t, shouldProcess)
+	require.True(t, bad)
+
+	now = now.Add(5 * time.Minute)
+	shouldProcess, bad = cache.claim(hash)
+	require.True(t, shouldProcess)
+	require.False(t, bad)
+}
+
+func TestTransactionSuppressionValidDuplicateIsSilent(t *testing.T) {
+	cache := newTransactionSuppression(5*time.Minute, 64)
+	var hash [32]byte
+	hash[0] = 1
+
+	shouldProcess, bad := cache.claim(hash)
+	require.True(t, shouldProcess)
+	require.False(t, bad)
+
+	shouldProcess, bad = cache.claim(hash)
+	require.False(t, shouldProcess)
+	require.False(t, bad)
+}
+
+func TestTransactionSuppressionDuplicateRefreshesRetention(t *testing.T) {
+	now := time.Unix(1_000, 0)
+	cache := newTransactionSuppression(5*time.Minute, 64)
+	cache.now = func() time.Time { return now }
+	var hash [32]byte
+	hash[0] = 1
+
+	shouldProcess, _ := cache.claim(hash)
+	require.True(t, shouldProcess)
+	cache.markBad(hash)
+
+	now = now.Add(9 * time.Second)
+	shouldProcess, bad := cache.claim(hash)
+	require.False(t, shouldProcess)
+	require.True(t, bad)
+
+	now = now.Add(5*time.Minute - 5*time.Second)
+	shouldProcess, bad = cache.claim(hash)
+	require.True(t, shouldProcess)
+	require.True(t, bad)
 }

--- a/internal/consensus/adaptor/router_dedup_test.go
+++ b/internal/consensus/adaptor/router_dedup_test.go
@@ -228,12 +228,12 @@ func TestTransactionSuppressionClaimIsAtomic(t *testing.T) {
 	var processed atomic.Int32
 	var workers sync.WaitGroup
 	start := make(chan struct{})
-	for range 64 {
+	for peerID := uint64(1); peerID <= 64; peerID++ {
 		workers.Add(1)
 		go func() {
 			defer workers.Done()
 			<-start
-			if shouldProcess, _ := cache.claim(hash); shouldProcess {
+			if shouldProcess, _ := cache.claim(hash, peerID); shouldProcess {
 				processed.Add(1)
 			}
 		}()
@@ -241,6 +241,45 @@ func TestTransactionSuppressionClaimIsAtomic(t *testing.T) {
 	close(start)
 	workers.Wait()
 	require.Equal(t, int32(1), processed.Load())
+	require.Len(t, cache.releasePeers(hash), 64)
+}
+
+func TestTransactionSuppressionReleasePeersMovesSet(t *testing.T) {
+	cache := newTransactionSuppression(5*time.Minute, 64)
+	var hash [32]byte
+	hash[0] = 1
+
+	cache.claim(hash, 11)
+	cache.claim(hash, 12)
+	first := cache.releasePeers(hash)
+	require.Equal(t, map[uint64]struct{}{11: {}, 12: {}}, first)
+	require.Empty(t, cache.releasePeers(hash))
+
+	cache.claim(hash, 13)
+	second := cache.releasePeers(hash)
+	require.Equal(t, map[uint64]struct{}{13: {}}, second)
+	require.Equal(t, map[uint64]struct{}{11: {}, 12: {}}, first)
+}
+
+func TestTransactionRelaySkipIncludesDuplicateSources(t *testing.T) {
+	cache := newTransactionSuppression(5*time.Minute, 64)
+	router := &Router{txSeen: cache}
+	var hash [32]byte
+	hash[0] = 1
+
+	cache.claim(hash, 3)
+	cache.claim(hash, 4)
+	require.Equal(t,
+		map[peermanagement.PeerID]struct{}{3: {}, 4: {}},
+		router.transactionRelaySkip(hash, 3),
+	)
+
+	var missing [32]byte
+	missing[0] = 2
+	require.Equal(t,
+		map[peermanagement.PeerID]struct{}{3: {}},
+		router.transactionRelaySkip(missing, 3),
+	)
 }
 
 func TestTransactionSuppressionVerdictAndIntervals(t *testing.T) {
@@ -250,22 +289,22 @@ func TestTransactionSuppressionVerdictAndIntervals(t *testing.T) {
 	var hash [32]byte
 	hash[0] = 1
 
-	shouldProcess, bad := cache.claim(hash)
+	shouldProcess, bad := cache.claim(hash, 0)
 	require.True(t, shouldProcess)
 	require.False(t, bad)
 	cache.markBad(hash)
 
-	shouldProcess, bad = cache.claim(hash)
+	shouldProcess, bad = cache.claim(hash, 0)
 	require.False(t, shouldProcess)
 	require.True(t, bad)
 
 	now = now.Add(transactionProcessInterval)
-	shouldProcess, bad = cache.claim(hash)
+	shouldProcess, bad = cache.claim(hash, 0)
 	require.True(t, shouldProcess)
 	require.True(t, bad)
 
 	now = now.Add(5 * time.Minute)
-	shouldProcess, bad = cache.claim(hash)
+	shouldProcess, bad = cache.claim(hash, 0)
 	require.True(t, shouldProcess)
 	require.False(t, bad)
 }
@@ -275,11 +314,11 @@ func TestTransactionSuppressionValidDuplicateIsSilent(t *testing.T) {
 	var hash [32]byte
 	hash[0] = 1
 
-	shouldProcess, bad := cache.claim(hash)
+	shouldProcess, bad := cache.claim(hash, 0)
 	require.True(t, shouldProcess)
 	require.False(t, bad)
 
-	shouldProcess, bad = cache.claim(hash)
+	shouldProcess, bad = cache.claim(hash, 0)
 	require.False(t, shouldProcess)
 	require.False(t, bad)
 }
@@ -291,17 +330,17 @@ func TestTransactionSuppressionDuplicateRefreshesRetention(t *testing.T) {
 	var hash [32]byte
 	hash[0] = 1
 
-	shouldProcess, _ := cache.claim(hash)
+	shouldProcess, _ := cache.claim(hash, 0)
 	require.True(t, shouldProcess)
 	cache.markBad(hash)
 
 	now = now.Add(9 * time.Second)
-	shouldProcess, bad := cache.claim(hash)
+	shouldProcess, bad := cache.claim(hash, 0)
 	require.False(t, shouldProcess)
 	require.True(t, bad)
 
 	now = now.Add(5*time.Minute - 5*time.Second)
-	shouldProcess, bad = cache.claim(hash)
+	shouldProcess, bad = cache.claim(hash, 0)
 	require.True(t, shouldProcess)
 	require.True(t, bad)
 }

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -658,7 +658,7 @@ func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) (dispatch
 	}
 	admittedBad := false
 	if pendingErr == nil && r.txSeen != nil {
-		shouldProcess, bad := r.txSeen.claim(pending.Hash)
+		shouldProcess, bad := r.txSeen.claim(pending.Hash, uint64(msg.PeerID))
 		if !shouldProcess {
 			if bad {
 				dispatch.charge = resource.FeeUselessData()
@@ -726,7 +726,7 @@ func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) (dispatch
 			"blob_size", len(canonicalBlob),
 			"status", txMsg.Status,
 		)
-		r.relayTransaction(msg.PeerID, canonicalBlob, outcome.Queued)
+		r.relayTransaction(r.transactionRelaySkip(pending.Hash, msg.PeerID), canonicalBlob, outcome.Queued)
 		dispatch.relayed = true
 	} else {
 		r.logger.Debug("inbound tx rejected by pending pool",
@@ -743,7 +743,7 @@ func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) (dispatch
 }
 
 // relayTransaction rebroadcasts an accepted peer-originated TMTransaction,
-// excluding the originating peer.
+// excluding peers known to already hold it.
 //
 // The outbound wire shape: status normalized to tsCURRENT (the inbound
 // peer's claimed status is informational only) and receivetimestamp
@@ -751,14 +751,22 @@ func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) (dispatch
 //
 // Overlay.RelayTransaction applies reduce-relay peer selection: the full
 // frame goes to a subset of peers and the rest learn of the tx via the
-// TMHaveTransactions announce. We don't consult a separate suppression
-// set for the multi-hop case because de-dup happens implicitly via
-// openledger.Submit's view.TxExists pre-filter: a duplicate arrival from
-// another peer classifies as ResultFailure and the relay gate above never
-// fires. Excluding the origin is the minimum correctness boundary —
-// without it the originator would receive its own packet back and either
-// re-charge us bandwidth or, in a 2-peer cycle, oscillate indefinitely.
-func (r *Router) relayTransaction(except peermanagement.PeerID, blob []byte, deferred bool) {
+// TMHaveTransactions announce.
+func (r *Router) transactionRelaySkip(
+	hash [32]byte,
+	origin peermanagement.PeerID,
+) map[peermanagement.PeerID]struct{} {
+	toSkip := map[peermanagement.PeerID]struct{}{origin: {}}
+	if r.txSeen == nil {
+		return toSkip
+	}
+	for peerID := range r.txSeen.releasePeers(hash) {
+		toSkip[peermanagement.PeerID(peerID)] = struct{}{}
+	}
+	return toSkip
+}
+
+func (r *Router) relayTransaction(toSkip map[peermanagement.PeerID]struct{}, blob []byte, deferred bool) {
 	if r.overlay == nil {
 		return
 	}
@@ -771,7 +779,7 @@ func (r *Router) relayTransaction(except peermanagement.PeerID, blob []byte, def
 	// Reduce-relay peer selection derives the transaction ID from the wire
 	// frame itself. If the frame cannot be decoded, the overlay falls back to
 	// full relay rather than announcing an unfulfillable hash.
-	r.overlay.RelayTransaction(except, frame)
+	r.overlay.RelayTransactionSkipping(toSkip, frame)
 }
 
 func relayTransactionMessage(blob []byte, deferred bool) *message.Transaction {

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -742,16 +742,6 @@ func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) (dispatch
 	return dispatch
 }
 
-// relayTransaction rebroadcasts an accepted peer-originated TMTransaction,
-// excluding peers known to already hold it.
-//
-// The outbound wire shape: status normalized to tsCURRENT (the inbound
-// peer's claimed status is informational only) and receivetimestamp
-// freshly stamped from the local Ripple clock.
-//
-// Overlay.RelayTransaction applies reduce-relay peer selection: the full
-// frame goes to a subset of peers and the rest learn of the tx via the
-// TMHaveTransactions announce.
 func (r *Router) transactionRelaySkip(
 	hash [32]byte,
 	origin peermanagement.PeerID,
@@ -766,6 +756,16 @@ func (r *Router) transactionRelaySkip(
 	return toSkip
 }
 
+// relayTransaction rebroadcasts an accepted peer-originated TMTransaction,
+// excluding peers known to already hold it.
+//
+// The outbound wire shape: status normalized to tsCURRENT (the inbound
+// peer's claimed status is informational only) and receivetimestamp
+// freshly stamped from the local Ripple clock.
+//
+// Overlay.RelayTransactionSkipping applies reduce-relay peer selection: the
+// full frame goes to a subset of peers and the rest learn of the tx via the
+// TMHaveTransactions announce.
 func (r *Router) relayTransaction(toSkip map[peermanagement.PeerID]struct{}, blob []byte, deferred bool) {
 	if r.overlay == nil {
 		return

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -612,6 +612,7 @@ type transactionDispatchResult struct {
 	chargeContext string
 	submitResult  openledger.Result
 	submitError   error
+	deferred      bool
 	relayed       bool
 }
 
@@ -688,9 +689,10 @@ func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) (dispatch
 
 	// Peer-relay path — the originating peer manages its own resends,
 	// so we don't pin the blob in our LocalTxs held pool.
-	res, err := r.adaptor.SubmitPendingTx(canonicalBlob, false)
-	dispatch.submitResult = res
+	outcome, err := r.adaptor.SubmitPendingTx(canonicalBlob, false)
+	dispatch.submitResult = outcome.Class
 	dispatch.submitError = err
+	dispatch.deferred = outcome.Queued
 	if errors.Is(err, txengine.ErrInvalidSignature) {
 		if pendingErr == nil && r.txSeen != nil {
 			r.txSeen.markBad(pending.Hash)
@@ -714,7 +716,7 @@ func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) (dispatch
 	// folds both terQUEUED and tec into ResultSuccess, so ResultSuccess is
 	// the exact superset that should relay. ResultRetry (non-queued ter*)
 	// and ResultFailure (tef/tem/tel) do NOT relay.
-	if err == nil && res == openledger.ResultSuccess {
+	if err == nil && outcome.Class == openledger.ResultSuccess {
 		// Debug, not Info: at thousands of tx/s an unconditional Info write here
 		// is a per-transaction blocking syscall on the submit hot path.
 		r.logger.Debug("inbound tx accepted into pending pool",
@@ -724,7 +726,7 @@ func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) (dispatch
 			"blob_size", len(canonicalBlob),
 			"status", txMsg.Status,
 		)
-		r.relayTransaction(msg.PeerID, canonicalBlob)
+		r.relayTransaction(msg.PeerID, canonicalBlob, outcome.Queued)
 		dispatch.relayed = true
 	} else {
 		r.logger.Debug("inbound tx rejected by pending pool",
@@ -733,7 +735,7 @@ func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) (dispatch
 			"peer", msg.PeerID,
 			"blob_size", len(canonicalBlob),
 			"status", txMsg.Status,
-			"result", res,
+			"result", outcome.Class,
 			"error", err,
 		)
 	}
@@ -756,15 +758,11 @@ func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) (dispatch
 // fires. Excluding the origin is the minimum correctness boundary —
 // without it the originator would receive its own packet back and either
 // re-charge us bandwidth or, in a 2-peer cycle, oscillate indefinitely.
-func (r *Router) relayTransaction(except peermanagement.PeerID, blob []byte) {
+func (r *Router) relayTransaction(except peermanagement.PeerID, blob []byte, deferred bool) {
 	if r.overlay == nil {
 		return
 	}
-	out := &message.Transaction{
-		RawTransaction:   blob,
-		Status:           message.TxStatusCurrent,
-		ReceiveTimestamp: uint64(protocol.RippleSeconds(time.Now())),
-	}
+	out := relayTransactionMessage(blob, deferred)
 	frame, err := message.EncodeFrame(out)
 	if err != nil {
 		r.logger.Warn("relay transaction encode failed", "error", err)
@@ -774,6 +772,15 @@ func (r *Router) relayTransaction(except peermanagement.PeerID, blob []byte) {
 	// frame itself. If the frame cannot be decoded, the overlay falls back to
 	// full relay rather than announcing an unfulfillable hash.
 	r.overlay.RelayTransaction(except, frame)
+}
+
+func relayTransactionMessage(blob []byte, deferred bool) *message.Transaction {
+	return &message.Transaction{
+		RawTransaction:   blob,
+		Status:           message.TxStatusCurrent,
+		ReceiveTimestamp: uint64(protocol.RippleSeconds(time.Now())),
+		Deferred:         deferred,
+	}
 }
 
 func (r *Router) handleHaveSet(msg *peermanagement.InboundMessage) {

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -10,10 +10,13 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/consensus/rcl"
 	"github.com/LeJamon/go-xrpl/internal/ledger/openledger"
+	ledgerservice "github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/manifest"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
 
@@ -604,7 +607,15 @@ func validateValidationBounds(v *consensus.Validation) (string, bool) {
 	return "", true
 }
 
-func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) {
+type transactionDispatchResult struct {
+	charge        resource.Charge
+	chargeContext string
+	submitResult  openledger.Result
+	submitError   error
+	relayed       bool
+}
+
+func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) (dispatch transactionDispatchResult) {
 	defer r.recoverFrame(msg, "transaction")
 
 	// Frames fanned out from a TMTransactions batch arrive already
@@ -614,7 +625,7 @@ func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) {
 		decoded, err := message.Decode(message.TypeTransaction, msg.Payload)
 		if err != nil {
 			r.logger.Warn("failed to decode transaction", "error", err, "peer", msg.PeerID)
-			return
+			return dispatch
 		}
 		var ok bool
 		txMsg, ok = decoded.(*message.Transaction)
@@ -622,7 +633,7 @@ func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) {
 			r.logger.Warn("decoded transaction has unexpected type",
 				"peer", msg.PeerID,
 				"got", fmt.Sprintf("%T", decoded))
-			return
+			return dispatch
 		}
 	}
 
@@ -631,22 +642,70 @@ func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) {
 		r.logger.Warn("inbound transaction has empty blob",
 			"peer", msg.PeerID,
 			"status", txMsg.Status)
-		return
+		return dispatch
+	}
+	pending, pendingErr := openledger.ParsePendingTx(blob)
+	canonicalBlob := blob
+	if pendingErr == nil {
+		canonicalBlob = pending.Blob
+	}
+	if pendingErr == nil && pending.Parsed.GetCommon().GetFlags()&tx.TfInnerBatchTxn != 0 {
+		dispatch.charge = resource.FeeModerateBurdenPeer()
+		dispatch.chargeContext = "inner batch txn"
+		msg.SelectPeerCharge(dispatch.charge, dispatch.chargeContext)
+		return dispatch
+	}
+	admittedBad := false
+	if pendingErr == nil && r.txSeen != nil {
+		shouldProcess, bad := r.txSeen.claim(pending.Hash)
+		if !shouldProcess {
+			if bad {
+				dispatch.charge = resource.FeeUselessData()
+				dispatch.chargeContext = "transaction-known-bad"
+				msg.SelectPeerCharge(dispatch.charge, dispatch.chargeContext)
+			}
+			return dispatch
+		}
+		admittedBad = bad
+	}
+	if pendingErr == nil && pending.Parsed.GetCommon().LastLedgerSequence != nil &&
+		r.adaptor != nil && r.adaptor.ledgerService != nil &&
+		*pending.Parsed.GetCommon().LastLedgerSequence < r.adaptor.ledgerService.GetValidatedLedgerIndex() {
+		if r.txSeen != nil {
+			r.txSeen.markBad(pending.Hash)
+		}
+		dispatch.charge = resource.FeeUselessData()
+		dispatch.chargeContext = "transaction-expired"
+		msg.SelectPeerCharge(dispatch.charge, dispatch.chargeContext)
+		return dispatch
+	}
+	if admittedBad {
+		dispatch.charge = resource.FeeInvalidSignature()
+		dispatch.chargeContext = "transaction-known-bad-signature"
+		msg.SelectPeerCharge(dispatch.charge, dispatch.chargeContext)
+		return dispatch
 	}
 
 	// Peer-relay path — the originating peer manages its own resends,
 	// so we don't pin the blob in our LocalTxs held pool.
-	res, err := r.adaptor.SubmitPendingTx(blob, false)
-	// Debug, not Info: at thousands of tx/s an unconditional Info write here
-	// is a per-transaction blocking syscall on the submit hot path.
-	r.logger.Debug("inbound tx accepted into pending pool",
-		"t", "consensus",
-		"event", "tx-inbound",
-		"peer", msg.PeerID,
-		"blob_size", len(blob),
-		"status", txMsg.Status,
-	)
-
+	res, err := r.adaptor.SubmitPendingTx(canonicalBlob, false)
+	dispatch.submitResult = res
+	dispatch.submitError = err
+	if errors.Is(err, txengine.ErrInvalidSignature) {
+		if pendingErr == nil && r.txSeen != nil {
+			r.txSeen.markBad(pending.Hash)
+		}
+		dispatch.charge = resource.FeeInvalidSignature()
+		dispatch.chargeContext = "transaction-invalid-signature"
+		msg.SelectPeerCharge(dispatch.charge, dispatch.chargeContext)
+	} else if errors.Is(err, ledgerservice.ErrInvalidLocalTransaction) {
+		if pendingErr == nil && r.txSeen != nil {
+			r.txSeen.markBad(pending.Hash)
+		}
+		dispatch.charge = resource.FeeInvalidSignature()
+		dispatch.chargeContext = "transaction-local-checks"
+		msg.SelectPeerCharge(dispatch.charge, dispatch.chargeContext)
+	}
 	// Relay immediately on the inbound job, not one ledger later via
 	// OpenLedger.Accept's once-per-LCL callback; that one-ledger lag is a
 	// direct contributor to tx-propagation latency.
@@ -656,8 +715,29 @@ func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) {
 	// the exact superset that should relay. ResultRetry (non-queued ter*)
 	// and ResultFailure (tef/tem/tel) do NOT relay.
 	if err == nil && res == openledger.ResultSuccess {
-		r.relayTransaction(msg.PeerID, blob)
+		// Debug, not Info: at thousands of tx/s an unconditional Info write here
+		// is a per-transaction blocking syscall on the submit hot path.
+		r.logger.Debug("inbound tx accepted into pending pool",
+			"t", "consensus",
+			"event", "tx-inbound",
+			"peer", msg.PeerID,
+			"blob_size", len(canonicalBlob),
+			"status", txMsg.Status,
+		)
+		r.relayTransaction(msg.PeerID, canonicalBlob)
+		dispatch.relayed = true
+	} else {
+		r.logger.Debug("inbound tx rejected by pending pool",
+			"t", "consensus",
+			"event", "tx-inbound-rejected",
+			"peer", msg.PeerID,
+			"blob_size", len(canonicalBlob),
+			"status", txMsg.Status,
+			"result", res,
+			"error", err,
+		)
 	}
+	return dispatch
 }
 
 // relayTransaction rebroadcasts an accepted peer-originated TMTransaction,

--- a/internal/consensus/adaptor/router_test.go
+++ b/internal/consensus/adaptor/router_test.go
@@ -301,6 +301,45 @@ func TestRouterDispatchesPreDecodedTransaction(t *testing.T) {
 		"router must accept a pre-decoded (batch-fanned) transaction")
 }
 
+func TestRouterRelaysQueuedTransactionAsDeferred(t *testing.T) {
+	a := newTestAdaptor(t)
+	router := newTestRouter(&mockEngine{}, a, nil)
+
+	env := jtx.NewTestEnv(t)
+	env.SetVerifySignatures(true)
+	master := jtx.MasterAccount()
+	alice := jtx.NewAccount("queued-relay-destination")
+	txn := payment.Pay(master, alice, 100_000_000).Fee(1).Sequence(1).Build()
+	env.SignWith(txn, master)
+	txMap, err := txn.Flatten()
+	require.NoError(t, err)
+	hexStr, err := binarycodec.Encode(txMap)
+	require.NoError(t, err)
+	blob, err := hex.DecodeString(hexStr)
+	require.NoError(t, err)
+
+	dispatch := router.handleTransaction(&peermanagement.InboundMessage{
+		PeerID: 3,
+		Type:   message.TypeTransaction,
+		Tx: &message.Transaction{
+			RawTransaction: blob,
+			Status:         message.TxStatusNew,
+		},
+	})
+	require.NoError(t, dispatch.submitError)
+	require.Equal(t, openledger.ResultSuccess, dispatch.submitResult)
+	require.True(t, dispatch.deferred)
+	require.True(t, dispatch.relayed)
+
+	frame, err := message.EncodeFrame(relayTransactionMessage(blob, dispatch.deferred))
+	require.NoError(t, err)
+	msgType, decoded := decodeFrame(t, frame)
+	require.Equal(t, message.TypeTransaction, msgType)
+	relayed := decoded.(*message.Transaction)
+	require.Equal(t, message.TxStatusCurrent, relayed.Status)
+	require.True(t, relayed.Deferred)
+}
+
 func TestRouterDropsStandaloneBatchInnerTransaction(t *testing.T) {
 	engine := &mockEngine{}
 	a := newTestAdaptor(t)

--- a/internal/consensus/adaptor/router_test.go
+++ b/internal/consensus/adaptor/router_test.go
@@ -390,7 +390,7 @@ func TestRouterDropsStandaloneBatchInnerTransaction(t *testing.T) {
 	require.Equal(t, "inner batch txn", dispatch.chargeContext)
 	require.False(t, dispatch.relayed)
 	assert.False(t, adaptorHasTx(t, a, consensus.TxID(txHash)))
-	shouldProcess, bad := router.txSeen.claim(txHash)
+	shouldProcess, bad := router.txSeen.claim(txHash, 0)
 	require.True(t, shouldProcess)
 	require.False(t, bad)
 }

--- a/internal/consensus/adaptor/router_test.go
+++ b/internal/consensus/adaptor/router_test.go
@@ -7,13 +7,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
+	"github.com/LeJamon/go-xrpl/internal/ledger/openledger"
+	ledgerservice "github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	batchtest "github.com/LeJamon/go-xrpl/internal/testing/batch"
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	batchtx "github.com/LeJamon/go-xrpl/internal/tx/batch"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -292,6 +299,228 @@ func TestRouterDispatchesPreDecodedTransaction(t *testing.T) {
 
 	assert.True(t, adaptorHasTx(t, a, consensus.TxID(txHash)),
 		"router must accept a pre-decoded (batch-fanned) transaction")
+}
+
+func TestRouterDropsStandaloneBatchInnerTransaction(t *testing.T) {
+	engine := &mockEngine{}
+	a := newTestAdaptor(t)
+	router := newTestRouter(engine, a, nil)
+
+	env := jtx.NewTestEnv(t)
+	env.SetVerifySignatures(true)
+	master := jtx.MasterAccount()
+	alice := jtx.NewAccount("batch-inner-destination")
+	txn := payment.Pay(master, alice, 100_000_000).Sequence(1).Build()
+	env.SignWith(txn, master)
+	txn.GetCommon().SetFlags(tx.TfInnerBatchTxn)
+	txMap, err := txn.Flatten()
+	require.NoError(t, err)
+	hexStr, err := binarycodec.Encode(txMap)
+	require.NoError(t, err)
+	blob, err := hex.DecodeString(hexStr)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(blob), 8)
+	require.Equal(t, byte(0x12), blob[0])
+	require.Equal(t, byte(0x22), blob[3])
+	reorderedBlob := make([]byte, 0, len(blob))
+	reorderedBlob = append(reorderedBlob, blob[3:8]...)
+	reorderedBlob = append(reorderedBlob, blob[:3]...)
+	reorderedBlob = append(reorderedBlob, blob[8:]...)
+	require.NotEqual(t, blob, reorderedBlob)
+	_, err = binarycodec.DecodeBytes(reorderedBlob)
+	require.NoError(t, err)
+	parsed, err := tx.ParseFromBinary(blob)
+	require.NoError(t, err)
+	txHash, err := tx.ComputeTransactionHash(parsed)
+	require.NoError(t, err)
+
+	msg := &peermanagement.InboundMessage{
+		PeerID: 3,
+		Type:   message.TypeTransaction,
+		Tx: &message.Transaction{
+			RawTransaction: reorderedBlob,
+			Status:         message.TxStatusNew,
+		},
+	}
+	dispatch := router.handleTransaction(msg)
+	require.Equal(t, resource.FeeModerateBurdenPeer(), dispatch.charge)
+	require.Equal(t, "inner batch txn", dispatch.chargeContext)
+	require.False(t, dispatch.relayed)
+	dispatch = router.handleTransaction(msg)
+	require.Equal(t, resource.FeeModerateBurdenPeer(), dispatch.charge)
+	require.Equal(t, "inner batch txn", dispatch.chargeContext)
+	require.False(t, dispatch.relayed)
+	assert.False(t, adaptorHasTx(t, a, consensus.TxID(txHash)))
+	shouldProcess, bad := router.txSeen.claim(txHash)
+	require.True(t, shouldProcess)
+	require.False(t, bad)
+}
+
+func TestRouterRelaysSignedDirectBatchSignerOuterOnly(t *testing.T) {
+	master := jtx.MasterAccount()
+	bob := jtx.NewAccount("batch-relay-bob")
+	genesisConfig := genesis.DefaultConfig()
+	genesisConfig.Amendments = append(genesisConfig.Amendments, amendment.FeatureBatchV1_1)
+	genesisConfig.InitialAccounts = append(genesisConfig.InitialAccounts, genesis.InitialAccount{
+		Address:  bob.Address,
+		Balance:  uint64(jtx.XRP(1_000)),
+		Sequence: 1,
+	})
+	svc, err := ledgerservice.New(ledgerservice.Config{
+		Standalone:    true,
+		Startup:       ledgerservice.StartupConfig{Mode: ledgerservice.StartupFresh},
+		GenesisConfig: genesisConfig,
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	require.True(t, svc.TransactionRules().Enabled(amendment.FeatureBatchV1_1))
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	a := New(Config{LedgerService: svc, Identity: identity})
+	router := newTestRouter(&mockEngine{}, a, nil)
+
+	batch := batchtest.NewBatchBuilder(master, 1, 50, batchtx.BatchFlagAllOrNothing).
+		AddInnerTx(batchtest.MakeInnerPaymentXRP(master, bob, 1, 2)).
+		AddInnerTx(batchtest.MakeInnerPaymentXRP(bob, master, 1, 1)).
+		AddSigner(bob, "DEADBEEF").
+		Build()
+	env := jtx.NewTestEnv(t)
+	env.SetVerifySignatures(true)
+	env.SignWith(batch, master)
+	txMap, err := batch.Flatten()
+	require.NoError(t, err)
+	hexStr, err := binarycodec.Encode(txMap)
+	require.NoError(t, err)
+	blob, err := hex.DecodeString(hexStr)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(blob), 8)
+	require.Equal(t, byte(0x12), blob[0])
+	require.Equal(t, byte(0x22), blob[3])
+	reorderedBlob := make([]byte, 0, len(blob))
+	reorderedBlob = append(reorderedBlob, blob[3:8]...)
+	reorderedBlob = append(reorderedBlob, blob[:3]...)
+	reorderedBlob = append(reorderedBlob, blob[8:]...)
+	require.NotEqual(t, blob, reorderedBlob)
+	_, err = binarycodec.DecodeBytes(reorderedBlob)
+	require.NoError(t, err)
+	parsed, err := tx.ParseFromBinary(blob)
+	require.NoError(t, err)
+	parsedBatch, ok := parsed.(*batchtx.Batch)
+	require.True(t, ok)
+	require.Len(t, parsedBatch.BatchSigners, 1)
+	require.NotEmpty(t, parsedBatch.BatchSigners[0].BatchSigner.BatchTxnSignature)
+	outerHash, err := tx.ComputeTransactionHash(parsedBatch)
+	require.NoError(t, err)
+	innerHashes := make([][32]byte, len(parsedBatch.RawTransactions))
+	for i := range parsedBatch.RawTransactions {
+		innerHashes[i], err = tx.ComputeTransactionHash(parsedBatch.RawTransactions[i].RawTransaction.InnerTx)
+		require.NoError(t, err)
+	}
+
+	dispatch := router.handleTransaction(&peermanagement.InboundMessage{
+		PeerID: 3,
+		Type:   message.TypeTransaction,
+		Tx: &message.Transaction{
+			RawTransaction: reorderedBlob,
+			Status:         message.TxStatusNew,
+		},
+	})
+	require.Zero(t, dispatch.charge.Cost())
+	require.Empty(t, dispatch.chargeContext)
+	require.NoError(t, dispatch.submitError)
+	if dispatch.submitResult != openledger.ResultSuccess {
+		simulated, simErr := svc.SimulateTransaction(parsedBatch)
+		require.NoError(t, simErr)
+		t.Fatalf("submit result %v, simulated TER %s (%s)", dispatch.submitResult, simulated.Result, simulated.Message)
+	}
+	require.Equal(t, openledger.ResultSuccess, dispatch.submitResult)
+	require.True(t, dispatch.relayed)
+	relayBlob, _, _, ok := svc.TransactionForRelay(outerHash)
+	require.True(t, ok)
+	require.Equal(t, blob, relayBlob)
+	require.True(t, adaptorHasTx(t, a, consensus.TxID(outerHash)))
+	for _, innerHash := range innerHashes {
+		require.False(t, adaptorHasTx(t, a, consensus.TxID(innerHash)))
+	}
+
+	duplicate := router.handleTransaction(&peermanagement.InboundMessage{
+		PeerID: 4,
+		Type:   message.TypeTransaction,
+		Tx: &message.Transaction{
+			RawTransaction: blob,
+			Status:         message.TxStatusNew,
+		},
+	})
+	require.Zero(t, duplicate.charge.Cost())
+	require.Empty(t, duplicate.chargeContext)
+	require.NoError(t, duplicate.submitError)
+	require.False(t, duplicate.relayed)
+
+	parsedBatch.BatchSigners[0].BatchSigner.BatchTxnSignature = "DEADBEEF"
+	badMap, err := parsedBatch.Flatten()
+	require.NoError(t, err)
+	badHex, err := binarycodec.Encode(badMap)
+	require.NoError(t, err)
+	badBlob, err := hex.DecodeString(badHex)
+	require.NoError(t, err)
+	badMessage := &peermanagement.InboundMessage{
+		PeerID: 5,
+		Type:   message.TypeTransaction,
+		Tx: &message.Transaction{
+			RawTransaction: badBlob,
+			Status:         message.TxStatusNew,
+		},
+	}
+	badDispatch := router.handleTransaction(badMessage)
+	require.Error(t, badDispatch.submitError)
+	require.Equal(t, resource.FeeInvalidSignature(), badDispatch.charge)
+	require.Equal(t, "transaction-invalid-signature", badDispatch.chargeContext)
+	require.False(t, badDispatch.relayed)
+
+	knownBad := router.handleTransaction(badMessage)
+	require.NoError(t, knownBad.submitError)
+	require.Equal(t, resource.FeeUselessData(), knownBad.charge)
+	require.Equal(t, "transaction-known-bad", knownBad.chargeContext)
+	require.False(t, knownBad.relayed)
+	router.txSeen.now = func() time.Time {
+		return time.Now().Add(transactionProcessInterval)
+	}
+	admittedKnownBad := router.handleTransaction(badMessage)
+	require.NoError(t, admittedKnownBad.submitError)
+	require.Equal(t, resource.FeeInvalidSignature(), admittedKnownBad.charge)
+	require.Equal(t, "transaction-known-bad-signature", admittedKnownBad.chargeContext)
+	require.False(t, admittedKnownBad.relayed)
+	router.txSeen.now = time.Now
+
+	validatedIndex := svc.GetValidatedLedgerIndex()
+	require.NotZero(t, validatedIndex)
+	expired := uint32(0)
+	parsedBatch.LastLedgerSequence = &expired
+	expiredMap, err := parsedBatch.Flatten()
+	require.NoError(t, err)
+	expiredHex, err := binarycodec.Encode(expiredMap)
+	require.NoError(t, err)
+	expiredBlob, err := hex.DecodeString(expiredHex)
+	require.NoError(t, err)
+	expiredMessage := &peermanagement.InboundMessage{
+		PeerID: 6,
+		Type:   message.TypeTransaction,
+		Tx: &message.Transaction{
+			RawTransaction: expiredBlob,
+			Status:         message.TxStatusNew,
+		},
+	}
+	expiredDispatch := router.handleTransaction(expiredMessage)
+	require.NoError(t, expiredDispatch.submitError)
+	require.Equal(t, resource.FeeUselessData(), expiredDispatch.charge)
+	require.Equal(t, "transaction-expired", expiredDispatch.chargeContext)
+	require.False(t, expiredDispatch.relayed)
+
+	expiredRepeat := router.handleTransaction(expiredMessage)
+	require.NoError(t, expiredRepeat.submitError)
+	require.Equal(t, resource.FeeUselessData(), expiredRepeat.charge)
+	require.Equal(t, "transaction-known-bad", expiredRepeat.chargeContext)
+	require.False(t, expiredRepeat.relayed)
 }
 
 func TestRouterIgnoresUnknownMessages(t *testing.T) {

--- a/internal/consensus/adaptor/router_txset.go
+++ b/internal/consensus/adaptor/router_txset.go
@@ -304,7 +304,11 @@ func (r *Router) learnTxFromLeaf(originPeer uint64, wire []byte) {
 		return
 	}
 	if outcome, err := r.adaptor.SubmitPendingTx(item.Data(), false); err == nil && outcome.Class == openledger.ResultSuccess {
-		r.relayTransaction(peermanagement.PeerID(originPeer), item.Data(), outcome.Queued)
+		r.relayTransaction(
+			map[peermanagement.PeerID]struct{}{peermanagement.PeerID(originPeer): {}},
+			item.Data(),
+			outcome.Queued,
+		)
 	}
 }
 

--- a/internal/consensus/adaptor/router_txset.go
+++ b/internal/consensus/adaptor/router_txset.go
@@ -279,9 +279,9 @@ func (r *Router) setTxSetRetryKnobsForTest(knobs txSetRetryKnobs) {
 // skipped by the trailing-type-byte check, and a tx the open ledger already
 // holds is not resubmitted. The submit is peer-sourced and the relay reuses
 // relayTransaction exactly as handleTransaction does for an inbound
-// TMTransaction (see handleTransaction), excluding originPeer as the tx's
-// source — so a set the node only holds transiently still pushes its novel
-// txs to peers instead of relying on the slower TMHaveTransactions announce.
+// TMTransaction (see handleTransaction), excluding originPeer and every other
+// recorded source — so a set the node only holds transiently still pushes its
+// novel txs to peers instead of relying on the slower TMHaveTransactions announce.
 //
 // We deliberately do not keep a per-acquisition node cache: the acquired
 // node is already held in txMap and the missing-leaf local-fill (below)

--- a/internal/consensus/adaptor/router_txset.go
+++ b/internal/consensus/adaptor/router_txset.go
@@ -303,8 +303,8 @@ func (r *Router) learnTxFromLeaf(originPeer uint64, wire []byte) {
 	if err != nil || exists {
 		return
 	}
-	if res, err := r.adaptor.SubmitPendingTx(item.Data(), false); err == nil && res == openledger.ResultSuccess {
-		r.relayTransaction(peermanagement.PeerID(originPeer), item.Data())
+	if outcome, err := r.adaptor.SubmitPendingTx(item.Data(), false); err == nil && outcome.Class == openledger.ResultSuccess {
+		r.relayTransaction(peermanagement.PeerID(originPeer), item.Data(), outcome.Queued)
 	}
 }
 

--- a/internal/consensus/adaptor/router_txset.go
+++ b/internal/consensus/adaptor/router_txset.go
@@ -305,7 +305,7 @@ func (r *Router) learnTxFromLeaf(originPeer uint64, wire []byte) {
 	}
 	if outcome, err := r.adaptor.SubmitPendingTx(item.Data(), false); err == nil && outcome.Class == openledger.ResultSuccess {
 		r.relayTransaction(
-			map[peermanagement.PeerID]struct{}{peermanagement.PeerID(originPeer): {}},
+			r.transactionRelaySkip(item.Key(), peermanagement.PeerID(originPeer)),
 			item.Data(),
 			outcome.Queued,
 		)

--- a/internal/consensus/adaptor/router_txset_learn_test.go
+++ b/internal/consensus/adaptor/router_txset_learn_test.go
@@ -58,6 +58,7 @@ func TestRouter_TxSetAcquire_LearnsTransaction(t *testing.T) {
 	require.NoError(t, err)
 	txHash, err := tx.ComputeTransactionHash(txn)
 	require.NoError(t, err)
+	_, _ = router.txSeen.claim(txHash, 6)
 
 	require.False(t, adaptorHasTx(t, a, consensus.TxID(txHash)),
 		"precondition: the tx must be unknown before acquisition")
@@ -92,6 +93,8 @@ func TestRouter_TxSetAcquire_LearnsTransaction(t *testing.T) {
 		return adaptorHasTx(t, a, consensus.TxID(txHash))
 	}, time.Second, 10*time.Millisecond,
 		"tx-set acquisition must learn the carried transaction into the open ledger")
+	require.Empty(t, router.txSeen.releasePeers(txHash),
+		"acquired relay must consume peers already known to hold the transaction")
 }
 
 func TestRouterLearnTxFromLeafStopsOnMembershipError(t *testing.T) {

--- a/internal/ledger/openledger/types.go
+++ b/internal/ledger/openledger/types.go
@@ -20,7 +20,7 @@ import (
 // canonical-sorted slices into ApplyTxs (rippled RCLConsensus.cpp:512
 // uses the SHAMap root of the agreed tx set as the salt).
 type PendingTx struct {
-	// Blob is the raw signed binary transaction.
+	// Blob is the canonical signed binary transaction.
 	Blob []byte
 	// Hash is SHA-512Half of the TXN prefix concatenated with Blob.
 	Hash [32]byte
@@ -61,14 +61,14 @@ const (
 	ResultRetry
 )
 
-// ParsePendingTx creates a PendingTx from a raw transaction blob,
-// extracting the account ID, sequence proxy, and tx hash.
+// ParsePendingTx creates a PendingTx from a transaction blob, canonicalizing
+// its field order before extracting the account ID, sequence proxy, and hash.
 func ParsePendingTx(blob []byte) (PendingTx, error) {
 	transaction, err := tx.ParseFromBinary(blob)
 	if err != nil {
 		return PendingTx{}, err
 	}
-	transaction.SetRawBytes(blob)
+	canonicalBlob := transaction.GetRawBytes()
 
 	common := transaction.GetCommon()
 
@@ -92,7 +92,7 @@ func ParsePendingTx(blob []byte) (PendingTx, error) {
 	}
 
 	return PendingTx{
-		Blob:                  blob,
+		Blob:                  canonicalBlob,
 		Hash:                  txHash,
 		Account:               accountID,
 		Sequence:              common.SeqProxy(),

--- a/internal/ledger/service/loadfee_autofill_test.go
+++ b/internal/ledger/service/loadfee_autofill_test.go
@@ -130,6 +130,24 @@ func TestGetAutofillFee_ConfidentialMPTSigners(t *testing.T) {
 	}
 }
 
+func TestGetAutofillFee_MalformedTransactionUsesReferenceFee(t *testing.T) {
+	svc, err := service.New(defaultServiceConfig())
+	if err != nil {
+		t.Fatalf("service.New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("service.Start: %v", err)
+	}
+
+	fee, err := svc.GetAutofillFee(nil, false, 10, 1)
+	if err != nil {
+		t.Fatalf("GetAutofillFee(nil): %v", err)
+	}
+	if fee != 10 {
+		t.Fatalf("malformed transaction autofill fee = %d; want reference fee 10", fee)
+	}
+}
+
 // TestGetAutofillFee_LoadedLocal verifies the LoadFeeTrack integration:
 // raising the local factor inflates the autofilled fee by exactly
 // localFee/LoadBase, matching rippled scaleFeeLoad (LoadFeeTrack.cpp:106-110).

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -880,23 +880,31 @@ func (s *Service) TransactionRules() *amendment.Rules {
 // or it ages out. local=false (peer relay) doesn't pin the blob — the peer
 // manages its own resends.
 func (s *Service) SubmitOpenLedgerTx(blob []byte, local bool) (openledger.Result, error) {
+	outcome, err := s.SubmitOpenLedgerTxDetailed(blob, local)
+	return outcome.Class, err
+}
+
+// SubmitOpenLedgerTxDetailed is SubmitOpenLedgerTx with the queue disposition
+// retained for callers that must distinguish applied from deferred transactions.
+func (s *Service) SubmitOpenLedgerTxDetailed(blob []byte, local bool) (openledger.SubmitOutcome, error) {
+	failure := openledger.SubmitOutcome{Class: openledger.ResultFailure}
 	s.mu.RLock()
 	cfg, cfgErr := s.applyConfigLocked()
 	haveOpenLedger := s.openLedgerView != nil
 	s.mu.RUnlock()
 
 	if !haveOpenLedger {
-		return openledger.ResultFailure, errors.New("openLedgerView not initialised")
+		return failure, errors.New("openLedgerView not initialised")
 	}
 	if cfgErr != nil {
-		return openledger.ResultFailure, cfgErr
+		return failure, cfgErr
 	}
 	ptx, err := openledger.ParsePendingTx(blob)
 	if err != nil {
-		return openledger.ResultFailure, err
+		return failure, err
 	}
 	if ptx.Parsed.GetCommon().GetFlags()&tx.TfInnerBatchTxn != 0 {
-		return openledger.ResultFailure, fmt.Errorf(
+		return failure, fmt.Errorf(
 			"%w: Batch inner transactions are never considered validly signed.",
 			txengine.ErrInvalidSignature,
 		)
@@ -906,20 +914,20 @@ func (s *Service) SubmitOpenLedgerTx(blob []byte, local bool) (openledger.Result
 	// under modifyMu; the in-strand check then reuses the cached verdict (#1105).
 	if !cfg.SkipSignatureVerification {
 		if err := txengine.PrewarmSignature(ptx.Parsed); err != nil {
-			return openledger.ResultFailure, err
+			return failure, err
 		}
 	}
 	if reason := tx.TransactionLocalChecksFailureReason(ptx.Parsed); reason != "" {
-		return openledger.ResultFailure, fmt.Errorf("%w: %s", ErrInvalidLocalTransaction, reason)
+		return failure, fmt.Errorf("%w: %s", ErrInvalidLocalTransaction, reason)
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.openLedgerView == nil {
-		return openledger.ResultFailure, errors.New("openLedgerView not initialised")
+		return failure, errors.New("openLedgerView not initialised")
 	}
 	cfg, cfgErr = s.applyConfigLocked()
 	if cfgErr != nil {
-		return openledger.ResultFailure, cfgErr
+		return failure, cfgErr
 	}
 	outcome := s.openLedgerView.SubmitDetailed(ptx, cfg, s.txQueue)
 	if outcome.Class == openledger.ResultSuccess {
@@ -933,7 +941,7 @@ func (s *Service) SubmitOpenLedgerTx(blob []byte, local bool) (openledger.Result
 	if outcome.Applied {
 		s.eventPublisher.dispatchServerStatusEvent()
 	}
-	return outcome.Class, nil
+	return outcome, nil
 }
 
 // PrewarmSignatures verifies all signatures on raw tx blobs in parallel

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -48,6 +48,7 @@ var (
 var (
 	ErrConsensusParentMismatch = errors.New("consensus parent does not match the closed ledger")
 	ErrPreferredChainSwitch    = errors.New("invalid preferred chain switch")
+	ErrInvalidLocalTransaction = errors.New("transaction failed local checks")
 )
 
 // Config holds configuration for the LedgerService
@@ -894,11 +895,22 @@ func (s *Service) SubmitOpenLedgerTx(blob []byte, local bool) (openledger.Result
 	if err != nil {
 		return openledger.ResultFailure, err
 	}
+	if ptx.Parsed.GetCommon().GetFlags()&tx.TfInnerBatchTxn != 0 {
+		return openledger.ResultFailure, fmt.Errorf(
+			"%w: Batch inner transactions are never considered validly signed.",
+			txengine.ErrInvalidSignature,
+		)
+	}
 	// Verify the signature off the open-ledger apply mutex so the dominant
 	// per-tx cost runs concurrently across ingress workers instead of serialising
 	// under modifyMu; the in-strand check then reuses the cached verdict (#1105).
 	if !cfg.SkipSignatureVerification {
-		txengine.PrewarmSignature(ptx.Parsed)
+		if err := txengine.PrewarmSignature(ptx.Parsed); err != nil {
+			return openledger.ResultFailure, err
+		}
+	}
+	if reason := tx.TransactionLocalChecksFailureReason(ptx.Parsed); reason != "" {
+		return openledger.ResultFailure, fmt.Errorf("%w: %s", ErrInvalidLocalTransaction, reason)
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -917,14 +929,14 @@ func (s *Service) SubmitOpenLedgerTx(blob []byte, local bool) (openledger.Result
 	if local && s.localTxs != nil {
 		s.localTxs.PushBack(current.Sequence(), ptx)
 	}
-	s.dispatchProposedTransaction(ptx, blob, outcome, current)
+	s.dispatchProposedTransaction(ptx, ptx.Blob, outcome, current)
 	if outcome.Applied {
 		s.eventPublisher.dispatchServerStatusEvent()
 	}
 	return outcome.Class, nil
 }
 
-// PrewarmSignatures verifies the outer signatures of raw tx blobs in parallel
+// PrewarmSignatures verifies all signatures on raw tx blobs in parallel
 // and caches the verdicts, so a consensus build over an acquired tx set hits the
 // sig-cache instead of paying cold checks in-strand under the apply mutex. The
 // per-relayed-tx prewarm in SubmitOpenLedgerTx (#1105) covers only individually-

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -98,12 +98,11 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte, 
 		return nil, ErrNoOpenLedger
 	}
 	if rawBlob != nil {
-		transaction.SetRawBytes(rawBlob)
+		if err := tx.BindRawBytes(transaction, rawBlob); err != nil {
+			return nil, err
+		}
 	}
-	blob := rawBlob
-	if blob == nil {
-		blob = transaction.GetRawBytes()
-	}
+	blob := transaction.GetRawBytes()
 
 	cfg, cfgErr := s.applyConfigLocked()
 	if cfgErr != nil {
@@ -125,10 +124,9 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte, 
 		}, nil
 	}
 	// Local submission checks (rippled STTx::passesLocalChecks via NetworkOPs):
-	// memo size/charset limits are enforced only here, on the local ingress, not
-	// in the consensus-critical engine preflight. A relayed or consensus-applied
-	// transaction carrying an oversized/invalid memo still applies, so this
-	// refusal cannot fork the ledger.
+	// memo size/charset limits are enforced on RPC and peer ingress, not in the
+	// consensus-critical engine preflight. A transaction already admitted to a
+	// consensus set remains governed only by consensus-critical checks.
 	if localResult := tx.PassesTransactionLocalChecks(ptx.Parsed); localResult != ter.TesSUCCESS {
 		return &SubmitResult{
 			Result:        localResult,
@@ -199,7 +197,7 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte, 
 		s.pendingTxs = append(s.pendingTxs, ptx)
 	}
 
-	s.dispatchProposedTransaction(ptx, rawBlob, outcome, s.openLedgerView.Current())
+	s.dispatchProposedTransaction(ptx, ptx.Blob, outcome, s.openLedgerView.Current())
 	if outcome.Applied {
 		s.eventPublisher.dispatchServerStatusEvent()
 	}
@@ -420,7 +418,10 @@ func (s *Service) GetAutofillFee(parsedTx tx.Transaction, unlimited bool, mult, 
 		Rules:            rulesFromLedger(s.closedLedger, s.logger),
 	}
 
-	feeDefault := computeBaseFeeForTx(s.openLedger, parsedTx, feeCfg)
+	feeDefault := baseFee
+	if parsedTx != nil && tx.PassesTransactionLocalChecks(parsedTx) == ter.TesSUCCESS {
+		feeDefault = computeBaseFeeForTx(s.openLedger, parsedTx, feeCfg)
+	}
 
 	loadFee, scaleErr := feetrack.ScaleFeeLoad(feeDefault, s.feeTrack, unlimited)
 	if scaleErr != nil {

--- a/internal/ledger/service/tx_query_submit_test.go
+++ b/internal/ledger/service/tx_query_submit_test.go
@@ -205,7 +205,7 @@ func TestService_SubmitTransaction_BadSignatureIsNotQueryable(t *testing.T) {
 	}
 }
 
-func TestService_SubmitTransaction_BatchSignerFailureRemainsQueryable(t *testing.T) {
+func TestService_SubmitTransaction_BatchSignerFailureIsNotHeld(t *testing.T) {
 	cfg := defaultServiceConfig()
 	cfg.Standalone = false
 	cfg.Startup.Mode = service.StartupFresh
@@ -270,19 +270,8 @@ func TestService_SubmitTransaction_BatchSignerFailureRemainsQueryable(t *testing
 	if result.Applied {
 		t.Fatal("invalid BatchSigner signature must not apply")
 	}
-	hold, err := svc.GetTransaction(hash)
-	if err != nil {
-		t.Fatalf("GetTransaction(held batch) = %v", err)
-	}
-	if hold.Validated || hold.LedgerIndex != 0 || hold.TxIndex != ^uint32(0) {
-		t.Fatalf("held batch advertised validated-ledger state: %+v", hold)
-	}
-	heldBlob, metaBlob, err := tx.SplitTxWithMetaBlob(hold.TxData)
-	if err != nil {
-		t.Fatalf("split held batch: %v", err)
-	}
-	if string(heldBlob) != string(blob) || metaBlob != nil {
-		t.Fatalf("held batch payload = (%x, %x), want tx-only input", heldBlob, metaBlob)
+	if _, err := svc.GetTransaction(hash); !errors.Is(err, service.ErrTxnNotFound) {
+		t.Fatalf("GetTransaction(bad BatchSigner) = %v, want ErrTxnNotFound", err)
 	}
 }
 

--- a/internal/peermanagement/relay_transaction.go
+++ b/internal/peermanagement/relay_transaction.go
@@ -27,14 +27,15 @@ func peerTxReduceRelayEnabled(p *Peer) bool {
 // the feature plus a TxRelayPercentage share of the enabled peers; the
 // remaining enabled peers learn of the transaction via their per-peer
 // TMHaveTransactions queue, drained by the periodic sendTxQueueAnnounce tick.
-//
-// except is the originating peer: go-xrpl's single-element toSkip. rippled also
-// skips peers a HashRouter marks as already holding the tx, which go-xrpl does
-// not track (see router.relayTransaction); suppressed is therefore reported as
-// the single origin peer.
 func (o *Overlay) RelayTransaction(except PeerID, frame []byte) {
+	o.RelayTransactionSkipping(map[PeerID]struct{}{except: {}}, frame)
+}
+
+// RelayTransactionSkipping relays a transaction while excluding every peer
+// known to already hold it.
+func (o *Overlay) RelayTransactionSkipping(toSkip map[PeerID]struct{}, frame []byte) {
 	hash, ok := transactionHashFromFrame(frame)
-	o.relayTransaction(except, hash, ok, frame)
+	o.relayTransaction(toSkip, hash, ok, frame)
 }
 
 // transactionHashFromFrame extracts the canonical transaction blob from a
@@ -62,7 +63,7 @@ func transactionHashFromFrame(frame []byte) ([32]byte, bool) {
 	return sha512half.Sum(protocol.HashPrefixTransactionID().Bytes(), txn.RawTransaction), true
 }
 
-func (o *Overlay) relayTransaction(except PeerID, hash [32]byte, hashOK bool, frame []byte) {
+func (o *Overlay) relayTransaction(toSkip map[PeerID]struct{}, hash [32]byte, hashOK bool, frame []byte) {
 	// getActivePeers (OverlayImpl.cpp:1062-1094): total counts every active
 	// peer; disabled counts peers without the feature; candidates are the
 	// peers not in toSkip; enabledInSkip counts skipped peers that have the
@@ -80,7 +81,7 @@ func (o *Overlay) relayTransaction(except PeerID, hash [32]byte, hashOK bool, fr
 		if !enabled {
 			disabled++
 		}
-		if id == except {
+		if _, skipped := toSkip[id]; skipped {
 			if enabled {
 				enabledInSkip++
 			}
@@ -99,7 +100,7 @@ func (o *Overlay) relayTransaction(except PeerID, hash [32]byte, hashOK bool, fr
 		return err == nil
 	}
 
-	const suppressed = 1 // go-xrpl's toSkip is the single originating peer
+	suppressed := uint64(len(toSkip))
 
 	minPeers := uint64(o.cfg.TxReduceRelayMinPeers)
 	if minPeers == 0 {

--- a/internal/peermanagement/relay_transaction_test.go
+++ b/internal/peermanagement/relay_transaction_test.go
@@ -87,6 +87,29 @@ func TestRelayTransaction_BelowMinRelaysToAll(t *testing.T) {
 	assert.Equal(t, uint64(0), o.txm.notEnabled.accum)
 }
 
+func TestRelayTransactionSkippingMultiplePeers(t *testing.T) {
+	ident, err := NewIdentity()
+	require.NoError(t, err)
+
+	o := &Overlay{
+		cfg:   Config{EnableTxReduceRelay: true, TxReduceRelayMinPeers: 20, TxRelayPercentage: 25},
+		peers: make(map[PeerID]*Peer),
+	}
+	for id := PeerID(1); id <= 4; id++ {
+		o.peers[id] = relayTestPeer(t, ident, id, true)
+	}
+
+	o.RelayTransactionSkipping(map[PeerID]struct{}{1: {}, 3: {}}, relayTestFrame(t))
+
+	assert.False(t, gotFrame(o.peers[1]))
+	assert.True(t, gotFrame(o.peers[2]))
+	assert.False(t, gotFrame(o.peers[3]))
+	assert.True(t, gotFrame(o.peers[4]))
+	assert.Equal(t, uint64(4), o.txm.selected.accum)
+	assert.Equal(t, uint64(2), o.txm.suppressed.accum)
+	assert.Equal(t, uint64(0), o.txm.notEnabled.accum)
+}
+
 // TestRelayTransaction_ReducePathSelectsSubset pins the reduce-relay
 // selection (OverlayImpl.cpp:1261-1293): every disabled peer is relayed to in
 // full, plus enabledTarget enabled peers; the rest are left for the

--- a/internal/peermanagement/relay_transaction_test.go
+++ b/internal/peermanagement/relay_transaction_test.go
@@ -142,7 +142,7 @@ func TestRelayTransactionSkippingMultiplePeersReducePath(t *testing.T) {
 	}
 	assert.Equal(t, 1, enabledSent)
 	assert.Equal(t, 2, enabledQueued)
-	assert.Equal(t, uint64(7), o.txm.selected.accum)
+	assert.Equal(t, uint64(3), o.txm.selected.accum)
 	assert.Equal(t, uint64(3), o.txm.suppressed.accum)
 	assert.Equal(t, uint64(2), o.txm.notEnabled.accum)
 }

--- a/internal/peermanagement/relay_transaction_test.go
+++ b/internal/peermanagement/relay_transaction_test.go
@@ -110,6 +110,43 @@ func TestRelayTransactionSkippingMultiplePeers(t *testing.T) {
 	assert.Equal(t, uint64(0), o.txm.notEnabled.accum)
 }
 
+func TestRelayTransactionSkippingMultiplePeersReducePath(t *testing.T) {
+	ident, err := NewIdentity()
+	require.NoError(t, err)
+
+	o := &Overlay{
+		cfg:   Config{EnableTxReduceRelay: true, TxReduceRelayMinPeers: 2, TxRelayPercentage: 50},
+		peers: make(map[PeerID]*Peer),
+	}
+	for id := PeerID(1); id <= 5; id++ {
+		o.peers[id] = relayTestPeer(t, ident, id, true)
+	}
+	for id := PeerID(6); id <= 7; id++ {
+		o.peers[id] = relayTestPeer(t, ident, id, false)
+	}
+
+	o.RelayTransactionSkipping(map[PeerID]struct{}{1: {}, 2: {}, 6: {}}, relayTestFrame(t))
+
+	for _, id := range []PeerID{1, 2, 6} {
+		assert.False(t, gotFrame(o.peers[id]))
+		assert.Zero(t, o.peers[id].txQueueLen())
+	}
+	assert.True(t, gotFrame(o.peers[7]))
+	enabledSent, enabledQueued := 0, 0
+	for _, id := range []PeerID{3, 4, 5} {
+		if gotFrame(o.peers[id]) {
+			enabledSent++
+		} else if o.peers[id].txQueueLen() == 1 {
+			enabledQueued++
+		}
+	}
+	assert.Equal(t, 1, enabledSent)
+	assert.Equal(t, 2, enabledQueued)
+	assert.Equal(t, uint64(7), o.txm.selected.accum)
+	assert.Equal(t, uint64(3), o.txm.suppressed.accum)
+	assert.Equal(t, uint64(2), o.txm.notEnabled.accum)
+}
+
 // TestRelayTransaction_ReducePathSelectsSubset pins the reduce-relay
 // selection (OverlayImpl.cpp:1261-1293): every disabled peer is relayed to in
 // full, plus enabledTarget enabled peers; the rest are left for the

--- a/internal/replaytool/replay_execute.go
+++ b/internal/replaytool/replay_execute.go
@@ -116,6 +116,7 @@ func executeBlock(ctx context.Context, input blockExecution) (*executedBlock, er
 		TxResults: make([]txApplyInfo, 0, len(input.Transactions)),
 		Errors:    make([]string, 0),
 	}
+	var expectedBatchInners []tx.AppliedInnerTransaction
 	for _, transaction := range input.Transactions {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -125,6 +126,21 @@ func executeBlock(ctx context.Context, input blockExecution) (*executedBlock, er
 			Hash:  hex.EncodeToString(transaction.Hash[:]),
 		}
 		fillTxDisplay(&txInfo, transaction.Blob, transaction.Transaction, input.WantTxDetail)
+		isBatchInner := transaction.Transaction.GetCommon().GetFlags()&tx.TfInnerBatchTxn != 0
+		if isBatchInner {
+			if len(expectedBatchInners) == 0 {
+				return nil, fmt.Errorf("tx %d is an unexpected batch inner transaction", transaction.Index)
+			}
+			if err := fillExpectedBatchInner(&txInfo, transaction, expectedBatchInners[0]); err != nil {
+				return nil, err
+			}
+			result.TxResults = append(result.TxResults, txInfo)
+			expectedBatchInners = expectedBatchInners[1:]
+			continue
+		}
+		if len(expectedBatchInners) != 0 {
+			return nil, fmt.Errorf("tx %d appears before all batch inner transactions", transaction.Index)
+		}
 		blockTxResult, err := processor.ApplyLedgerTransaction(transaction.Transaction, transaction.Blob)
 		if err != nil {
 			return nil, fmt.Errorf("tx %d apply: %w", transaction.Index, err)
@@ -145,6 +161,10 @@ func executeBlock(ctx context.Context, input blockExecution) (*executedBlock, er
 			txInfo.MetaBlob = metadata
 		}
 		result.TxResults = append(result.TxResults, txInfo)
+		expectedBatchInners = append(expectedBatchInners, applyResult.AppliedInnerTransactions...)
+	}
+	if len(expectedBatchInners) != 0 {
+		return nil, fmt.Errorf("replay ended before all batch inner transactions")
 	}
 
 	if err := ctx.Err(); err != nil {
@@ -176,6 +196,24 @@ func executeBlock(ctx context.Context, input blockExecution) (*executedBlock, er
 		}
 	}
 	return result, nil
+}
+
+func fillExpectedBatchInner(info *txApplyInfo, input blockTransaction, expected tx.AppliedInnerTransaction) error {
+	expectedHash, hashErr := tx.ComputeTransactionHash(expected.Transaction)
+	if hashErr != nil || expectedHash != input.Hash || expected.Metadata == nil ||
+		expected.Metadata.TransactionIndex != uint32(input.Index) ||
+		expected.Metadata.ParentBatchID == nil {
+		return fmt.Errorf("tx %d batch inner does not match outer execution", input.Index)
+	}
+	metadata, err := tx.SerializeMetadata(expected.Metadata)
+	if err != nil {
+		return fmt.Errorf("tx %d serializing batch inner metadata: %w", input.Index, err)
+	}
+	info.Result = expected.Metadata.TransactionResult.String()
+	info.ResultCode = int(expected.Metadata.TransactionResult)
+	info.Applied = true
+	info.MetaBlob = metadata
+	return nil
 }
 
 func (r *replayRangeRunner) processBlockShared(

--- a/internal/replaytool/replay_execute_test.go
+++ b/internal/replaytool/replay_execute_test.go
@@ -9,9 +9,145 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/account"
+	batchtx "github.com/LeJamon/go-xrpl/internal/tx/batch"
 	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
+
+func TestFillExpectedBatchInnerValidatesCanonicalLeaf(t *testing.T) {
+	inner := tx.NewBaseTx(tx.TypeAccountSet, "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh")
+	inner.Fee = "0"
+	inner.SigningPubKey = ""
+	inner.SetFlags(tx.TfInnerBatchTxn)
+	inner.SetRawBytes(bytes.Repeat([]byte{0x42}, 40))
+	hash, err := tx.ComputeTransactionHash(inner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parent := [32]byte{1}
+	expected := tx.AppliedInnerTransaction{
+		Transaction: inner,
+		Metadata: &tx.Metadata{
+			TransactionIndex:  3,
+			TransactionResult: ter.TesSUCCESS,
+			ParentBatchID:     &parent,
+		},
+	}
+	input := blockTransaction{Index: 3, Hash: hash, Transaction: inner}
+	var info txApplyInfo
+	if err := fillExpectedBatchInner(&info, input, expected); err != nil {
+		t.Fatalf("valid inner rejected: %v", err)
+	}
+	if !info.Applied || info.Result != ter.TesSUCCESS.String() || len(info.MetaBlob) == 0 {
+		t.Fatalf("inner result not synthesized from outer execution: %+v", info)
+	}
+
+	badHash := input
+	badHash.Hash[0] ^= 0xff
+	if err := fillExpectedBatchInner(&txApplyInfo{}, badHash, expected); err == nil {
+		t.Fatal("hash mismatch accepted")
+	}
+	badIndex := input
+	badIndex.Index++
+	if err := fillExpectedBatchInner(&txApplyInfo{}, badIndex, expected); err == nil {
+		t.Fatal("index mismatch accepted")
+	}
+	expected.Metadata.ParentBatchID = nil
+	if err := fillExpectedBatchInner(&txApplyInfo{}, input, expected); err == nil {
+		t.Fatal("missing ParentBatchID accepted")
+	}
+}
+
+func TestExecuteBlockSkipsRecordedBatchInnerLeaves(t *testing.T) {
+	seed, err := genesis.Create(genesis.DefaultConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	outer := batchtx.NewBatch(seed.GenesisAddress)
+	outer.Fee = "40"
+	outer.SetSequence(1)
+	outer.SetFlags(batchtx.BatchFlagAllOrNothing)
+	inners := make([]tx.Transaction, 2)
+	for i := range inners {
+		inner := account.NewAccountSet(seed.GenesisAddress)
+		inner.Fee = "0"
+		inner.SigningPubKey = ""
+		inner.SetSequence(uint32(i + 2))
+		inner.SetFlags(tx.TfInnerBatchTxn)
+		outer.AddInnerTransaction(inner)
+		inners[i] = inner
+	}
+
+	transactions := make([]blockTransaction, 0, 3)
+	for index, transaction := range append([]tx.Transaction{outer}, inners...) {
+		blob, serializeErr := tx.SerializeTransaction(transaction)
+		if serializeErr != nil {
+			t.Fatal(serializeErr)
+		}
+		hash, hashErr := tx.ComputeTransactionHash(transaction)
+		if hashErr != nil {
+			t.Fatal(hashErr)
+		}
+		transactions = append(transactions, blockTransaction{
+			Index:       index,
+			Hash:        hash,
+			Blob:        blob,
+			Transaction: transaction,
+		})
+	}
+
+	execute := func(replayTransactions []blockTransaction) (*executedBlock, error) {
+		stateMap, snapshotErr := seed.StateMap.SnapshotMutable()
+		if snapshotErr != nil {
+			t.Fatal(snapshotErr)
+		}
+		return executeBlock(context.Background(), blockExecution{
+			StateMap:            stateMap,
+			LedgerIndex:         2,
+			ParentCloseTime:     time.Unix(10, 0),
+			CloseTime:           time.Unix(20, 0),
+			CloseTimeResolution: 10,
+			TotalCoins:          seed.Header.Drops,
+			Fees:                drops.DefaultFees(),
+			Rules:               amendment.AllSupportedRules(),
+			Transactions:        replayTransactions,
+		})
+	}
+	if _, err := execute(transactions[:2]); err == nil {
+		t.Fatal("replay accepted a missing trailing batch inner")
+	}
+	reordered := append([]blockTransaction(nil), transactions...)
+	reordered[1], reordered[2] = reordered[2], reordered[1]
+	if _, err := execute(reordered); err == nil {
+		t.Fatal("replay accepted reordered batch inner leaves")
+	}
+	if _, err := execute(transactions[1:]); err == nil {
+		t.Fatal("replay accepted a batch inner without its outer")
+	}
+
+	result, err := execute(transactions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.TxResults) != 3 {
+		t.Fatalf("transaction results = %d, want outer + 2 inner", len(result.TxResults))
+	}
+	for i, txResult := range result.TxResults {
+		if !txResult.Applied || txResult.Result != ter.TesSUCCESS.String() {
+			t.Fatalf("transaction %d was reapplied or rejected: %+v", i, txResult)
+		}
+	}
+	accountRoot, err := tx.ReadAccountRoot(result.Ledger, seed.GenesisAccount)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if accountRoot == nil || accountRoot.Sequence != 4 {
+		t.Fatalf("genesis sequence = %+v, want outer and each inner applied exactly once", accountRoot)
+	}
+}
 
 func TestExecuteBlockCarriesParentHash(t *testing.T) {
 	seed, err := genesis.Create(genesis.DefaultConfig())

--- a/internal/rpc/adapter/submission.go
+++ b/internal/rpc/adapter/submission.go
@@ -103,7 +103,9 @@ func (a *LedgerServiceAdapter) submitTransaction(txJSON []byte, txBlobHex string
 		if canonicalErr != nil {
 			return nil, fmt.Errorf("decode canonical tx_blob: %w", canonicalErr)
 		}
-		transaction.SetRawBytes(rawBlob)
+		if bindErr := tx.BindRawBytes(transaction, rawBlob); bindErr != nil {
+			return malformedSubmitResult(), nil
+		}
 	} else {
 		var parseErr error
 		transaction, parseErr = tx.ParseJSON(txJSON)

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -61,7 +61,9 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (re
 		if canonicalDecodeErr != nil {
 			return nil, rpcInternalError("submit: canonical transaction decoding failed", canonicalDecodeErr)
 		}
-		parsed.SetRawBytes(canonicalBlob)
+		if bindErr := tx.BindRawBytes(parsed, canonicalBlob); bindErr != nil {
+			return nil, types.RpcErrorInvalidTransaction(bindErr.Error())
+		}
 
 		signatureReason := ""
 		signatureChecked := false

--- a/internal/testing/batch/batch_test.go
+++ b/internal/testing/batch/batch_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	ledgerservice "github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/tx"
@@ -1842,6 +1843,88 @@ func TestBatchTxQueue(t *testing.T) {
 		jtx.RequireTxFail(t, result, "terQUEUED")
 		checkMetrics(t, env, 1, nil, 3, 2)
 	})
+
+	t.Run("batch behind queued sequence chain is rejected", func(t *testing.T) {
+		cfg := makeSmallQueueConfig(2)
+		env := jtx.NewTestEnvWithTxQ(t, cfg)
+		env.EnableFeatureNow("BatchV1_1")
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.FundAmountNoRipple(alice, uint64(jtx.XRP(10000)))
+		env.FundAmountNoRipple(bob, uint64(jtx.XRP(10000)))
+		env.Close()
+
+		env.Noop(alice)
+		env.Noop(alice)
+		env.Noop(alice)
+		checkMetrics(t, env, 0, nil, 3, 2)
+
+		aliceSeq := env.Seq(alice)
+		queued0 := makeNoopWithFee(alice, env.BaseFee())
+		queued0.SetSequence(aliceSeq)
+		result := env.Submit(queued0)
+		jtx.RequireTxFail(t, result, "terQUEUED")
+		queued1 := makeNoopWithFee(alice, env.BaseFee())
+		queued1.SetSequence(aliceSeq + 1)
+		result = env.Submit(queued1)
+		jtx.RequireTxFail(t, result, "terQUEUED")
+		checkMetrics(t, env, 2, nil, 3, 2)
+
+		bobSeq := env.Seq(bob)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(alice, aliceSeq+2, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, aliceSeq+3)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, bobSeq)).
+			AddSigner(bob, "").
+			Build()
+		result = env.Submit(batch)
+		jtx.RequireTxFail(t, result, "telCAN_NOT_QUEUE")
+		checkMetrics(t, env, 2, nil, 3, 2)
+	})
+}
+
+func TestClosedLedgerIndexesBatchInnerTransactions(t *testing.T) {
+	env := newBatchEnv(t)
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	env.Fund(alice, bob)
+	env.Close()
+
+	aliceSeq := env.Seq(alice)
+	batch := NewBatchBuilder(alice, aliceSeq, CalcBatchFeeFromEnv(env, 0, 2), batchtx.BatchFlagAllOrNothing).
+		AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, aliceSeq+1)).
+		AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, aliceSeq+2)).
+		Build()
+	result := env.Submit(batch)
+	jtx.RequireTxSuccess(t, result)
+	outerHash, err := tx.ComputeTransactionHash(batch)
+	require.NoError(t, err)
+	innerHashes := make([][32]byte, len(batch.RawTransactions))
+	for i := range batch.RawTransactions {
+		innerHashes[i], err = tx.ComputeTransactionHash(batch.RawTransactions[i].RawTransaction.InnerTx)
+		require.NoError(t, err)
+	}
+
+	env.Close()
+	closed := env.LastClosedLedger()
+	for i, innerHash := range innerHashes {
+		raw, found, err := closed.GetTransaction(innerHash)
+		require.NoError(t, err)
+		require.True(t, found, "inner transaction %d is missing from the closed ledger", i)
+		accepted := ledgerservice.ParseAcceptedTransaction(raw)
+		require.NoError(t, accepted.ParseError())
+		require.Equal(t, "Payment", accepted.Transaction()["TransactionType"])
+		require.Equal(t, fmt.Sprintf("%X", outerHash[:]), accepted.Metadata()["ParentBatchID"])
+		index, ok := accepted.TransactionIndex()
+		require.True(t, ok)
+		require.Equal(t, uint32(i+1), index)
+		parsed, err := tx.ParseFromBinary(accepted.TransactionBlob())
+		require.NoError(t, err)
+		storedHash, err := tx.ComputeTransactionHash(parsed)
+		require.NoError(t, err)
+		require.Equal(t, innerHash, storedHash)
+	}
 }
 
 // makeSmallQueueConfig creates a TxQ config matching rippled's Batch_test
@@ -1902,7 +1985,15 @@ func checkMetrics(t *testing.T, env *jtx.TestEnv, expectedQueueSize uint64, expe
 // =============================================================================
 
 func TestBatchNetworkOps(t *testing.T) {
-	t.Skip("Skipped: Network operations not available in go-xrpl test environment")
+	env := newBatchEnv(t)
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	env.Fund(alice, bob)
+	env.Close()
+
+	inner := MakeInnerPaymentXRP(alice, bob, 1, env.Seq(alice))
+	result := env.Submit(inner)
+	jtx.RequireTxFail(t, result, "temINVALID_INNER_BATCH")
 }
 
 // =============================================================================
@@ -1915,11 +2006,8 @@ func TestSequenceOpenLedger(t *testing.T) {
 	// Tests interactions between batch inner transactions advancing sequences
 	// and standalone transactions with future sequences or the same sequences.
 	//
-	// Key difference from rippled: In our Go implementation, batch inner
-	// transactions are applied immediately to the open view (unlike rippled
-	// which defers them to consensus). The replay-on-close mechanism ensures
-	// the final closed ledger state matches rippled. We verify final state
-	// (sequences, balances) rather than per-ledger transaction inclusion.
+	// Batch inner transactions are deferred until canonical closed-ledger
+	// construction, matching rippled's open-ledger behavior.
 
 	t.Run("before batch txn with retry following ledger", func(t *testing.T) {
 		// Reference: rippled testSequenceOpenLedger() "Before Batch Txn w/ retry following ledger"
@@ -2685,6 +2773,29 @@ func TestPreclaim(t *testing.T) {
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1000, seq+1)).
 			AddInnerTx(MakeInnerAccountSet(bob, env.LedgerSeq())).
 			AddSignerWithRegKey(bob, carol, "DEADBEEF").
+			Build()
+		result := env.Submit(batch)
+		require.Equal(t, "tefBAD_AUTH", result.Code)
+		env.Close()
+	})
+
+	t.Run("checkBatchSign checks authorization after phantom signer", func(t *testing.T) {
+		first := jtx.NewAccount("ordered-batch-signer-one")
+		second := jtx.NewAccount("ordered-batch-signer-two")
+		phantomSigner, unauthorizedSigner := first, second
+		if phantomSigner.Address > unauthorizedSigner.Address {
+			phantomSigner, unauthorizedSigner = unauthorizedSigner, phantomSigner
+		}
+		env.FundAmount(unauthorizedSigner, uint64(jtx.XRP(1000)))
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 2, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerAccountSet(phantomSigner, 1)).
+			AddInnerTx(MakeInnerAccountSet(unauthorizedSigner, env.Seq(unauthorizedSigner))).
+			AddSigner(phantomSigner, "DEADBEEF").
+			AddSignerWithRegKey(unauthorizedSigner, carol, "DEADBEEF").
 			Build()
 		result := env.Submit(batch)
 		require.Equal(t, "tefBAD_AUTH", result.Code)

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -361,7 +361,9 @@ func (e *TestEnv) applyStaged(
 		}
 		return applyResult
 	}
-	txn.SetRawBytes(blob)
+	if err := tx.BindRawBytes(txn, blob); err != nil {
+		e.t.Fatalf("bind serialized transaction: %v", err)
+	}
 	engine := txengine.NewEngine(e.ledger, config)
 	engine.SetBaseTxCount(transactionCount)
 	if e.invariantViolationHook != nil {

--- a/internal/testing/p2p/replay_delta_apply_integration_test.go
+++ b/internal/testing/p2p/replay_delta_apply_integration_test.go
@@ -75,7 +75,7 @@ func TestReplayDelta_Apply_Integration(t *testing.T) {
 	require.NoError(t, err)
 	txBlob, err := hex.DecodeString(hexStr)
 	require.NoError(t, err)
-	pay.SetRawBytes(txBlob)
+	require.NoError(t, tx.BindRawBytes(pay, txBlob))
 	txHash, err := tx.ComputeTransactionHash(pay)
 	require.NoError(t, err)
 
@@ -147,7 +147,7 @@ func TestReplayDelta_Apply_PseudoTransaction(t *testing.T) {
 	require.NoError(t, err)
 	txn, err := tx.ParseFromBinary(txBlob)
 	require.NoError(t, err)
-	txn.SetRawBytes(txBlob)
+	require.NoError(t, tx.BindRawBytes(txn, txBlob))
 	txHash, err := tx.ComputeTransactionHash(txn)
 	require.NoError(t, err)
 
@@ -210,7 +210,7 @@ func TestReplay_RejectsDuplicateTransaction(t *testing.T) {
 	require.NoError(t, err)
 	txBlob, err := hex.DecodeString(hexStr)
 	require.NoError(t, err)
-	pay.SetRawBytes(txBlob)
+	require.NoError(t, tx.BindRawBytes(pay, txBlob))
 	txHash, err := tx.ComputeTransactionHash(pay)
 	require.NoError(t, err)
 

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -78,8 +78,34 @@ type BatchSigner struct {
 type BatchSignerData struct {
 	Account           string             `json:"Account"`
 	SigningPubKey     string             `json:"SigningPubKey"`
-	BatchTxnSignature string             `json:"BatchTxnSignature"`
+	BatchTxnSignature string             `json:"TxnSignature,omitempty"`
 	Signers           []tx.SignerWrapper `json:"Signers,omitempty"`
+	txnSignatureSet   bool
+	signersSet        bool
+}
+
+func (s *BatchSignerData) UnmarshalJSON(data []byte) error {
+	type signerAlias BatchSignerData
+	var decoded signerAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	*s = BatchSignerData(decoded)
+	_, s.txnSignatureSet = fields["TxnSignature"]
+	_, s.signersSet = fields["Signers"]
+	return nil
+}
+
+func (s BatchSignerData) hasTxnSignature() bool {
+	return s.txnSignatureSet || s.BatchTxnSignature != ""
+}
+
+func (s BatchSignerData) hasSigners() bool {
+	return s.signersSet || len(s.Signers) > 0
 }
 
 // Batch flags. The mode-flag bit positions match rippled TxFlags.h exactly so
@@ -200,8 +226,8 @@ func (b *Batch) InnerTransactions() []tx.Transaction {
 // TxnSignature yields temBAD_SIGNATURE, a Signers array temBAD_SIGNER, and a
 // non-empty SigningPubKey temBAD_REGKEY. It is applied to every inner
 // transaction and to its nested CounterpartySignature/SponsorSignature.
-func checkInnerSignatureFields(signingPubKey, txnSignature string, hasSigners bool) error {
-	if txnSignature != "" {
+func checkInnerSignatureFields(signingPubKey string, hasTxnSignature, hasSigners bool) error {
+	if hasTxnSignature {
 		return ErrBatchInnerHasTxnSignature
 	}
 	if hasSigners {
@@ -213,12 +239,11 @@ func checkInnerSignatureFields(signingPubKey, txnSignature string, hasSigners bo
 	return nil
 }
 
-// validateInnerTransactions runs the per-inner checks.
-// Reference: rippled Batch.cpp:249-380 (per-inner checks in Batch::preflight).
-func (b *Batch) validateInnerTransactions() error {
+// PreflightInnerTransactions validates and preflights each inner transaction in
+// protocol order before advancing to the next one.
+func (b *Batch) PreflightInnerTransactions(preflight func(tx.Transaction) ter.Result) error {
 	flags := b.GetFlags()
 	enforceUnique := flags&(BatchFlagAllOrNothing|BatchFlagUntilFailure) != 0
-
 	uniqueHashes := make(map[[32]byte]struct{}, len(b.RawTransactions))
 	accountSeqTicket := make(map[string]map[uint32]struct{})
 	for _, rt := range b.RawTransactions {
@@ -254,21 +279,35 @@ func (b *Batch) validateInnerTransactions() error {
 		if innerCommon.GetFlags()&tx.TfInnerBatchTxn == 0 {
 			return ErrBatchInnerMissingFlag
 		}
-		if err := checkInnerSignatureFields(innerCommon.SigningPubKey, innerCommon.TxnSignature, len(innerCommon.Signers) > 0); err != nil {
+		if err := checkInnerSignatureFields(
+			innerCommon.SigningPubKey,
+			innerCommon.HasField("TxnSignature") || innerCommon.TxnSignature != "",
+			innerCommon.HasField("Signers") || len(innerCommon.Signers) > 0,
+		); err != nil {
 			return err
+		}
+		var wireFields map[string]any
+		if raw := inner.GetRawBytes(); len(raw) != 0 {
+			wireFields, _ = binarycodec.DecodeBytes(raw)
 		}
 		// A CounterpartySignature is optional on an inner transaction and should
 		// not be present, but if it is it must not carry any signature material.
 		if cp := innerCommon.CounterpartySignature; cp != nil {
-			if err := checkInnerSignatureFields(cp.SigningPubKey, cp.TxnSignature, len(cp.Signers) > 0); err != nil {
+			hasTxnSignature, hasSigners := nestedSignatureFieldPresence(wireFields, "CounterpartySignature")
+			if err := checkInnerSignatureFields(
+				cp.SigningPubKey,
+				hasTxnSignature || cp.TxnSignature != "",
+				hasSigners || len(cp.Signers) > 0,
+			); err != nil {
 				return err
 			}
 		}
 		if sponsor := innerCommon.SponsorSignature; sponsor != nil {
+			hasTxnSignature, hasSigners := nestedSignatureFieldPresence(wireFields, "SponsorSignature")
 			if err := checkInnerSignatureFields(
 				sponsor.SigningPubKey,
-				sponsor.TxnSignature,
-				len(sponsor.Signers) > 0,
+				hasTxnSignature || sponsor.TxnSignature != "",
+				hasSigners || len(sponsor.Signers) > 0,
 			); err != nil {
 				return err
 			}
@@ -283,20 +322,11 @@ func (b *Batch) validateInnerTransactions() error {
 			*innerCommon.SponsorFlags&tx.SpfSponsorFee != 0 {
 			return ErrBatchInnerFeeSponsored
 		}
-
-		// The inner's own preflight1 rejects a ticket combined with AccountTxnID
-		// (getSeqProxy().isTicket() && sfAccountTxnID present -> temINVALID, surfaced
-		// on the outer as temINVALID_INNER_BATCH). rippled runs the full inner
-		// preflight here, after the fee check; go-xrpl folds this specific rule into
-		// the inner loop since it never reaches the deferred engine inner-preflight
-		// otherwise. Reference: rippled Batch.cpp inner preflight -> Transactor.cpp preflight1.
-		usesTicket := innerCommon.TicketSequence != nil && (innerCommon.Sequence == nil || *innerCommon.Sequence == 0)
-		if usesTicket && innerCommon.AccountTxnID != "" {
-			return ErrBatchInnerTicketAndTxnID
+		if preflight(inner) != ter.TesSUCCESS {
+			return ErrBatchInvalidInnerTx
 		}
 
-		// rippled treats sfSequence absent and sfSequence==0 identically via
-		// getFieldU32; Go's *uint32 nil and *0 collapse the same way here.
+		// sfSequence absent and sfSequence==0 are equivalent here.
 		seqVal := uint32(0)
 		if innerCommon.Sequence != nil {
 			seqVal = *innerCommon.Sequence
@@ -332,6 +362,13 @@ func (b *Batch) validateInnerTransactions() error {
 		}
 	}
 	return nil
+}
+
+func nestedSignatureFieldPresence(fields map[string]any, name string) (hasTxnSignature, hasSigners bool) {
+	object, _ := fields[name].(map[string]any)
+	_, hasTxnSignature = object["TxnSignature"]
+	_, hasSigners = object["Signers"]
+	return hasTxnSignature, hasSigners
 }
 
 func (b *Batch) requiredBatchSigners() map[string]struct{} {
@@ -387,8 +424,7 @@ func (b *Batch) validateBatchSignerBounds() error {
 	return nil
 }
 
-// Reference: rippled Batch.cpp preflight()
-func (b *Batch) Validate() error {
+func (b *Batch) ValidateBatchOuter() error {
 	if err := b.BaseTx.Validate(); err != nil {
 		return err
 	}
@@ -422,13 +458,17 @@ func (b *Batch) Validate() error {
 		return ErrBatchTooManySigners
 	}
 
-	// Runs before the engine's BatchOuter loop so malformed inners surface
-	// with their specific TER instead of generic temINVALID_INNER_BATCH.
-	// Reference: rippled Batch.cpp:249-380.
-	if err := b.validateInnerTransactions(); err != nil {
+	return nil
+}
+
+// Reference: rippled Batch.cpp preflight()
+func (b *Batch) Validate() error {
+	if err := b.ValidateBatchOuter(); err != nil {
 		return err
 	}
-	return nil
+	return b.PreflightInnerTransactions(func(tx.Transaction) ter.Result {
+		return ter.TesSUCCESS
+	})
 }
 
 // PreflightSigValidated checks exact signer coverage only after all cryptographic
@@ -473,11 +513,11 @@ func (b *Batch) Flatten() (map[string]any, error) {
 				"Account":       s.BatchSigner.Account,
 				"SigningPubKey": s.BatchSigner.SigningPubKey,
 			}
-			if s.BatchSigner.BatchTxnSignature != "" {
+			if s.BatchSigner.hasTxnSignature() {
 				signerMap["TxnSignature"] = s.BatchSigner.BatchTxnSignature
 			}
 			// Include nested Signers for multi-sign batch signers
-			if len(s.BatchSigner.Signers) > 0 {
+			if s.BatchSigner.hasSigners() {
 				nestedSigners := make([]map[string]any, len(s.BatchSigner.Signers))
 				for j, nested := range s.BatchSigner.Signers {
 					nestedMap := map[string]any{
@@ -503,8 +543,9 @@ func (b *Batch) Flatten() (map[string]any, error) {
 	return m, nil
 }
 
-// CalculateMinimumFee mirrors rippled Batch::calculateBaseFee
-// (Batch.cpp:53-150). The total fee a batch must pay is the sum of:
+// CalculateMinimumFee returns the transaction's base fee. Preclaim performs the
+// same calculation and rejects malformed or overflowing totals.
+// The total fee a batch must pay is the sum of:
 //   - batchBase   = view.fees().base + Transactor::calculateBaseFee(view, tx)
 //     = baseFee + (1 + len(outer.Signers) + len(sponsor.Signers)) * baseFee
 //   - txnFees     = Σ inner-tx dispatched base fees
@@ -513,49 +554,87 @@ func (b *Batch) Flatten() (map[string]any, error) {
 // effectiveSignerCount counts each BatchSigner once when it carries a
 // direct BatchTxnSignature and as len(Signers) when the entry is a
 // multi-signed batch signer (Batch.cpp:128-134). Inner transactions use the
-// same per-type fee dispatch as standalone transactions. Inner Batch
-// transactions return the overflow sentinel as a defense-in-depth fallback.
+// same per-type fee dispatch as standalone transactions.
 func (b *Batch) CalculateMinimumFee(view tx.LedgerView, config tx.EngineConfig) uint64 {
-	baseFee := config.BaseFee
-	outerSigners := uint64(len(b.Common.Signers) + sign.SponsorSignerCount(b))
-	batchBase := baseFee + (1+outerSigners)*baseFee
+	if fee, ok := b.calculateMinimumFee(view, config); ok {
+		return fee
+	}
+	return config.BaseFee
+}
+
+func (b *Batch) calculateMinimumFee(view tx.LedgerView, config tx.EngineConfig) (uint64, bool) {
+	const maxAmount = uint64(^uint64(0) >> 1)
+
+	if len(b.RawTransactions) > MaxBatchTransactions || len(b.BatchSigners) > MaxBatchSigners {
+		return 0, false
+	}
+
+	outerSignerCount := uint64(len(b.Common.Signers) + sign.SponsorSignerCount(b))
+	baseFee, ok := batchFeeMul(config.BaseFee, outerSignerCount+1, maxAmount)
+	if !ok {
+		return 0, false
+	}
+	batchBase, ok := batchFeeAdd(config.BaseFee, baseFee, maxAmount)
+	if !ok {
+		return 0, false
+	}
 
 	var txnFees uint64
-	for _, rt := range b.RawTransactions {
-		inner := rt.RawTransaction.InnerTx
-		if inner == nil {
-			continue
+	for _, raw := range b.RawTransactions {
+		inner := raw.RawTransaction.InnerTx
+		if inner == nil || inner.TxType() == tx.TypeBatch {
+			return 0, false
 		}
-		txnFees += innerBaseFee(inner, view, config)
+		innerFee := sign.CalculateBaseFee(inner, view, config)
+		txnFees, ok = batchFeeAdd(txnFees, innerFee, maxAmount)
+		if !ok {
+			return 0, false
+		}
 	}
 
 	var signerCount uint64
-	for _, bs := range b.BatchSigners {
-		if bs.BatchSigner.BatchTxnSignature != "" {
+	for _, wrapper := range b.BatchSigners {
+		signer := wrapper.BatchSigner
+		switch {
+		case signer.hasTxnSignature():
 			signerCount++
-		} else if len(bs.BatchSigner.Signers) > 0 {
-			signerCount += uint64(len(bs.BatchSigner.Signers))
+		case len(signer.Signers) > sign.MaxMultiSigners:
+			return 0, false
+		case len(signer.Signers) > 0:
+			signerCount += uint64(len(signer.Signers))
 		}
 	}
-
-	return batchBase + txnFees + signerCount*baseFee
-}
-
-// innerBaseFee dispatches the same per-transaction fee override used for a
-// standalone transaction. Inner Batch transactions return the overflow sentinel.
-func innerBaseFee(inner tx.Transaction, view tx.LedgerView, config tx.EngineConfig) uint64 {
-	if inner.TxType() == tx.TypeBatch {
-		return overflowFee
+	signerFees, ok := batchFeeMul(config.BaseFee, signerCount, maxAmount)
+	if !ok {
+		return 0, false
 	}
-	return sign.CalculateBaseFee(inner, view, config)
+	innerFees, ok := batchFeeAdd(txnFees, signerFees, maxAmount)
+	if !ok {
+		return 0, false
+	}
+	return batchFeeAdd(batchBase, innerFees, maxAmount)
 }
 
-// overflowFee is the sentinel fee returned when fee calculation hits an
-// impossible condition (inner ttBATCH, overflow). It is larger than any
-// legitimate batch fee can ever be, ensuring the outer tx fails the
-// minimum-fee gate. Mirrors rippled Batch.cpp:66 returning INITIAL_XRP
-// (100 billion XRP) — we use a similarly impossible drops sentinel.
-const overflowFee uint64 = 100_000_000_000 * 1_000_000 // 100 billion XRP in drops
+func batchFeeAdd(a, b, max uint64) (uint64, bool) {
+	if a > max || b > max-a {
+		return 0, false
+	}
+	return a + b, true
+}
+
+func batchFeeMul(a, b, max uint64) (uint64, bool) {
+	if a != 0 && b > max/a {
+		return 0, false
+	}
+	return a * b, true
+}
+
+func (b *Batch) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Result {
+	if _, ok := b.calculateMinimumFee(view, config); !ok {
+		return ter.TecINSUFF_FEE
+	}
+	return ter.TesSUCCESS
+}
 
 // AddInnerTransaction adds an inner transaction to the batch.
 // The transaction should have Fee="0", SigningPubKey="", and tfInnerBatchTxn flag set.

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -523,9 +523,7 @@ func (b *Batch) Flatten() (map[string]any, error) {
 					nestedMap := map[string]any{
 						"Account":       nested.Signer.Account,
 						"SigningPubKey": nested.Signer.SigningPubKey,
-					}
-					if nested.Signer.TxnSignature != "" {
-						nestedMap["TxnSignature"] = nested.Signer.TxnSignature
+						"TxnSignature":  nested.Signer.TxnSignature,
 					}
 					nestedSigners[j] = map[string]any{
 						"Signer": nestedMap,

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -563,7 +563,7 @@ func (b *Batch) CalculateMinimumFee(view tx.LedgerView, config tx.EngineConfig) 
 }
 
 func (b *Batch) calculateMinimumFee(view tx.LedgerView, config tx.EngineConfig) (uint64, bool) {
-	const maxAmount = uint64(^uint64(0) >> 1)
+	const maxAmount = ^uint64(0) >> 1
 
 	if len(b.RawTransactions) > MaxBatchTransactions || len(b.BatchSigners) > MaxBatchSigners {
 		return 0, false

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -80,6 +80,7 @@ type BatchSignerData struct {
 	SigningPubKey     string             `json:"SigningPubKey"`
 	BatchTxnSignature string             `json:"TxnSignature,omitempty"`
 	Signers           []tx.SignerWrapper `json:"Signers,omitempty"`
+	signingPubKeySet  bool
 	txnSignatureSet   bool
 	signersSet        bool
 }
@@ -95,6 +96,7 @@ func (s *BatchSignerData) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	*s = BatchSignerData(decoded)
+	_, s.signingPubKeySet = fields["SigningPubKey"]
 	_, s.txnSignatureSet = fields["TxnSignature"]
 	_, s.signersSet = fields["Signers"]
 	return nil
@@ -296,8 +298,8 @@ func (b *Batch) PreflightInnerTransactions(preflight func(tx.Transaction) ter.Re
 			hasTxnSignature, hasSigners := nestedSignatureFieldPresence(wireFields, "CounterpartySignature")
 			if err := checkInnerSignatureFields(
 				cp.SigningPubKey,
-				hasTxnSignature || cp.TxnSignature != "",
-				hasSigners || len(cp.Signers) > 0,
+				hasTxnSignature || cp.HasField("TxnSignature") || cp.TxnSignature != "",
+				hasSigners || cp.HasField("Signers") || len(cp.Signers) > 0,
 			); err != nil {
 				return err
 			}
@@ -306,8 +308,8 @@ func (b *Batch) PreflightInnerTransactions(preflight func(tx.Transaction) ter.Re
 			hasTxnSignature, hasSigners := nestedSignatureFieldPresence(wireFields, "SponsorSignature")
 			if err := checkInnerSignatureFields(
 				sponsor.SigningPubKey,
-				hasTxnSignature || sponsor.TxnSignature != "",
-				hasSigners || len(sponsor.Signers) > 0,
+				hasTxnSignature || sponsor.HasField("TxnSignature") || sponsor.TxnSignature != "",
+				hasSigners || sponsor.HasField("Signers") || len(sponsor.Signers) > 0,
 			); err != nil {
 				return err
 			}
@@ -510,8 +512,10 @@ func (b *Batch) Flatten() (map[string]any, error) {
 		signers := make([]map[string]any, len(b.BatchSigners))
 		for i, s := range b.BatchSigners {
 			signerMap := map[string]any{
-				"Account":       s.BatchSigner.Account,
-				"SigningPubKey": s.BatchSigner.SigningPubKey,
+				"Account": s.BatchSigner.Account,
+			}
+			if s.BatchSigner.SigningPubKey != "" || s.BatchSigner.signingPubKeySet {
+				signerMap["SigningPubKey"] = s.BatchSigner.SigningPubKey
 			}
 			if s.BatchSigner.hasTxnSignature() {
 				signerMap["TxnSignature"] = s.BatchSigner.BatchTxnSignature

--- a/internal/tx/batch/batch_test.go
+++ b/internal/tx/batch/batch_test.go
@@ -2,6 +2,7 @@ package batch
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx/clawback"
 	"github.com/LeJamon/go-xrpl/internal/tx/lending"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 func TestMain(m *testing.M) {
@@ -32,6 +34,11 @@ func TestBatchBinaryRoundTripPreservesInnerTransactions(t *testing.T) {
 	outer.Flags = &flags
 	outer.AddInnerTransaction(makeTestPayment())
 	outer.AddInnerTransaction(makeTestPayment())
+	outer.BatchSigners = []BatchSigner{{BatchSigner: BatchSignerData{
+		Account:           testSigner1,
+		SigningPubKey:     "ED0000000000000000000000000000000000000000000000000000000000000000",
+		BatchTxnSignature: "ABCD",
+	}}}
 
 	flat, err := outer.Flatten()
 	require.NoError(t, err)
@@ -46,6 +53,8 @@ func TestBatchBinaryRoundTripPreservesInnerTransactions(t *testing.T) {
 	parsedBatch, ok := parsed.(*Batch)
 	require.True(t, ok)
 	require.Len(t, parsedBatch.RawTransactions, 2)
+	require.Len(t, parsedBatch.BatchSigners, 1)
+	require.Equal(t, "ABCD", parsedBatch.BatchSigners[0].BatchSigner.BatchTxnSignature)
 
 	for i, rawTransaction := range parsedBatch.RawTransactions {
 		inner := rawTransaction.RawTransaction.InnerTx
@@ -64,6 +73,80 @@ func TestBatchBinaryRoundTripPreservesInnerTransactions(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, originalHash, parsedHash)
 	}
+}
+
+func TestBatchBinaryParseRejectsStructuralAbuseBeforeInnerConstruction(t *testing.T) {
+	outer := NewBatch(testOuter)
+	outer.Fee = "40"
+	outerSequence := uint32(1)
+	outer.Sequence = &outerSequence
+	flags := BatchFlagAllOrNothing
+	outer.Flags = &flags
+	for range MaxBatchTransactions + 1 {
+		outer.AddInnerTransaction(makeTestPayment())
+	}
+
+	flat, err := outer.Flatten()
+	require.NoError(t, err)
+	encoded, err := binarycodec.Encode(flat)
+	require.NoError(t, err)
+	blob, err := hex.DecodeString(encoded)
+	require.NoError(t, err)
+	_, err = tx.ParseFromBinary(blob)
+	require.ErrorContains(t, err, "Raw Transactions array exceeds max entries")
+	jsonBlob, err := json.Marshal(flat)
+	require.NoError(t, err)
+	_, err = tx.ParseJSON(jsonBlob)
+	require.ErrorContains(t, err, "Raw Transactions array exceeds max entries")
+
+	nested := NewBatch(testOuter)
+	nested.Fee = "0"
+	nested.Sequence = &outerSequence
+	nested.Flags = &flags
+	nested.AddInnerTransaction(makeTestPayment())
+	nested.AddInnerTransaction(makeTestPayment())
+	outer = NewBatch(testOuter)
+	outer.Fee = "40"
+	outer.Sequence = &outerSequence
+	outer.Flags = &flags
+	outer.AddInnerTransaction(nested)
+	outer.AddInnerTransaction(makeTestPayment())
+	flat, err = outer.Flatten()
+	require.NoError(t, err)
+	encoded, err = binarycodec.Encode(flat)
+	require.NoError(t, err)
+	blob, err = hex.DecodeString(encoded)
+	require.NoError(t, err)
+	_, err = tx.ParseFromBinary(blob)
+	require.ErrorContains(t, err, "Raw Transactions may not contain batch transactions")
+	jsonBlob, err = json.Marshal(flat)
+	require.NoError(t, err)
+	_, err = tx.ParseJSON(jsonBlob)
+	require.ErrorContains(t, err, "Raw Transactions may not contain batch transactions")
+}
+
+func TestBatchLocalChecksRecurseIntoBinaryInners(t *testing.T) {
+	outer := NewBatch(testOuter)
+	outer.Fee = "40"
+	outerSequence := uint32(1)
+	outer.Sequence = &outerSequence
+	flags := BatchFlagAllOrNothing
+	outer.Flags = &flags
+	inner := makeTestPayment()
+	inner.GetCommon().Memos = []tx.MemoWrapper{{Memo: tx.Memo{MemoData: strings.Repeat("AA", 1100)}}}
+	outer.AddInnerTransaction(inner)
+	outer.AddInnerTransaction(makeTestPayment())
+
+	flat, err := outer.Flatten()
+	require.NoError(t, err)
+	encoded, err := binarycodec.Encode(flat)
+	require.NoError(t, err)
+	blob, err := hex.DecodeString(encoded)
+	require.NoError(t, err)
+	parsed, err := tx.ParseFromBinary(blob)
+	require.NoError(t, err)
+	require.Equal(t, ter.TemMALFORMED, tx.PassesTransactionLocalChecks(parsed))
+	require.Contains(t, tx.TransactionLocalChecksFailureReason(parsed), "memo exceeds")
 }
 
 func TestBatchBinaryRoundTripPreservesTicketedInnerSequence(t *testing.T) {
@@ -710,15 +793,110 @@ func TestCalculateMinimumFee_OuterMultiSign(t *testing.T) {
 	require.Equal(t, uint64(50), b.CalculateMinimumFee(nil, tx.EngineConfig{BaseFee: 10}))
 }
 
-// TestCalculateMinimumFee_InnerBatchSentinel pins
-// Batch.cpp:92-97 — an inner that is itself ttBATCH (forbidden) is
-// surfaced via an overflow sentinel so the outer minimum-fee gate
-// rejects, rather than silently computing a normal fee.
-func TestCalculateMinimumFee_InnerBatchSentinel(t *testing.T) {
+func TestCalculateMinimumFee_InvalidStructureFallsBackAndPreclaimRejects(t *testing.T) {
 	outer := NewBatch(testOuter)
 	innerBatch := NewBatch("rInner")
 	outer.AddInnerTransaction(innerBatch)
-	fee := outer.CalculateMinimumFee(nil, tx.EngineConfig{BaseFee: 10})
-	// Sentinel is ≥ 100B XRP in drops; any realistic caller will reject.
-	require.Greater(t, fee, uint64(100_000_000_000), "inner ttBATCH must surface as overflow sentinel")
+	config := tx.EngineConfig{BaseFee: 10}
+	require.Equal(t, uint64(10), outer.CalculateMinimumFee(nil, config))
+	require.Equal(t, ter.TecINSUFF_FEE, outer.Preclaim(nil, config))
+}
+
+func TestCalculateMinimumFeeCountsPresentEmptyBatchTxnSignature(t *testing.T) {
+	outer := NewBatch(testOuter)
+	outer.Fee = "50"
+	seq := uint32(1)
+	outer.Sequence = &seq
+	flags := BatchFlagAllOrNothing
+	outer.Flags = &flags
+	outer.AddInnerTransaction(makeTestPayment())
+	outer.AddInnerTransaction(makeTestPayment())
+	flat, err := outer.Flatten()
+	require.NoError(t, err)
+	flat["BatchSigners"] = []map[string]any{{"BatchSigner": map[string]any{
+		"Account":       testSigner1,
+		"SigningPubKey": "",
+		"TxnSignature":  "",
+	}}}
+	encoded, err := binarycodec.Encode(flat)
+	require.NoError(t, err)
+	blob, err := hex.DecodeString(encoded)
+	require.NoError(t, err)
+	parsed, err := tx.ParseFromBinary(blob)
+	require.NoError(t, err)
+	parsedBatch := parsed.(*Batch)
+	require.True(t, parsedBatch.BatchSigners[0].BatchSigner.hasTxnSignature())
+	require.Equal(t, uint64(50), parsedBatch.CalculateMinimumFee(nil, tx.EngineConfig{BaseFee: 10}))
+}
+
+func TestInnerExplicitEmptySignatureFieldsAreRejected(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   string
+		value   any
+		wantErr error
+	}{
+		{name: "TxnSignature", field: "TxnSignature", value: "", wantErr: ErrBatchInnerHasTxnSignature},
+		{name: "Signers", field: "Signers", value: []any{}, wantErr: ErrBatchInnerHasSigners},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			outer := NewBatch(testOuter)
+			outer.Fee = "40"
+			outer.SetSequence(1)
+			outer.SetFlags(BatchFlagAllOrNothing)
+			outer.AddInnerTransaction(makeTestPayment())
+			outer.AddInnerTransaction(makeTestPayment())
+			fields, err := outer.Flatten()
+			require.NoError(t, err)
+			rawTransactions := fields["RawTransactions"].([]map[string]any)
+			inner := rawTransactions[0]["RawTransaction"].(map[string]any)
+			inner[test.field] = test.value
+			encoded, err := binarycodec.Encode(fields)
+			require.NoError(t, err)
+			blob, err := hex.DecodeString(encoded)
+			require.NoError(t, err)
+			parsed, err := tx.ParseFromBinary(blob)
+			require.NoError(t, err)
+			require.ErrorIs(t, parsed.(*Batch).Validate(), test.wantErr)
+		})
+	}
+}
+
+func TestBindRawBytesRejectsExplicitEmptyInnerFieldMismatch(t *testing.T) {
+	tests := []struct {
+		name  string
+		field string
+		value any
+	}{
+		{name: "TxnSignature", field: "TxnSignature", value: ""},
+		{name: "Signers", field: "Signers", value: []map[string]any{}},
+		{name: "CounterpartySignature", field: "CounterpartySignature", value: map[string]any{
+			"SigningPubKey": "",
+			"TxnSignature":  "",
+		}},
+		{name: "SponsorSignature", field: "SponsorSignature", value: map[string]any{
+			"SigningPubKey": "",
+			"TxnSignature":  "",
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			outer := NewBatch(testOuter)
+			outer.SetFlags(BatchFlagAllOrNothing)
+			outer.AddInnerTransaction(makeTestPayment())
+			outer.AddInnerTransaction(makeTestPayment())
+			fields, err := outer.Flatten()
+			require.NoError(t, err)
+			rawTransactions := fields["RawTransactions"].([]map[string]any)
+			rawTransactions[0]["RawTransaction"].(map[string]any)[test.field] = test.value
+			encoded, err := binarycodec.Encode(fields)
+			require.NoError(t, err)
+			blob, err := hex.DecodeString(encoded)
+			require.NoError(t, err)
+			require.Error(t, tx.BindRawBytes(outer, blob))
+			require.Empty(t, outer.GetRawBytes())
+		})
+	}
 }

--- a/internal/tx/batch/batch_test.go
+++ b/internal/tx/batch/batch_test.go
@@ -111,6 +111,19 @@ func TestBatchBinaryRoundTripPreservesEmptyNestedSignature(t *testing.T) {
 	require.NotContains(t, batchSigner, "SigningPubKey")
 	nestedSigner := batchSigner["Signers"].([]map[string]any)[0]["Signer"].(map[string]any)
 	require.Contains(t, nestedSigner, "TxnSignature")
+
+	flatBatchSigner["SigningPubKey"] = ""
+	encoded, err = binarycodec.Encode(flat)
+	require.NoError(t, err)
+	blob, err = hex.DecodeString(encoded)
+	require.NoError(t, err)
+	parsed, err = tx.ParseFromBinary(blob)
+	require.NoError(t, err)
+	flattened, err = parsed.(*Batch).Flatten()
+	require.NoError(t, err)
+	batchSigner = flattened["BatchSigners"].([]map[string]any)[0]["BatchSigner"].(map[string]any)
+	require.Contains(t, batchSigner, "SigningPubKey")
+	require.Equal(t, "", batchSigner["SigningPubKey"])
 }
 
 func TestBatchBinaryParseRejectsStructuralAbuseBeforeInnerConstruction(t *testing.T) {

--- a/internal/tx/batch/batch_test.go
+++ b/internal/tx/batch/batch_test.go
@@ -75,6 +75,41 @@ func TestBatchBinaryRoundTripPreservesInnerTransactions(t *testing.T) {
 	}
 }
 
+func TestBatchBinaryRoundTripPreservesEmptyNestedSignature(t *testing.T) {
+	outer := NewBatch(testOuter)
+	outer.Fee = "50"
+	outer.SetSequence(1)
+	outer.SetFlags(BatchFlagAllOrNothing)
+	outer.AddInnerTransaction(makeTestPayment())
+	outer.AddInnerTransaction(makeTestPayment())
+	outer.BatchSigners = []BatchSigner{{BatchSigner: BatchSignerData{
+		Account:       testSigner1,
+		SigningPubKey: "",
+		Signers: []tx.SignerWrapper{{Signer: tx.Signer{
+			Account:       testSigner2,
+			SigningPubKey: "",
+			TxnSignature:  "",
+		}}},
+	}}}
+
+	flat, err := outer.Flatten()
+	require.NoError(t, err)
+	encoded, err := binarycodec.Encode(flat)
+	require.NoError(t, err)
+	blob, err := hex.DecodeString(encoded)
+	require.NoError(t, err)
+
+	parsed, err := tx.ParseFromBinary(blob)
+	require.NoError(t, err)
+	parsedBatch := parsed.(*Batch)
+	require.Equal(t, "", parsedBatch.BatchSigners[0].BatchSigner.Signers[0].Signer.TxnSignature)
+	flattened, err := parsedBatch.Flatten()
+	require.NoError(t, err)
+	batchSigner := flattened["BatchSigners"].([]map[string]any)[0]["BatchSigner"].(map[string]any)
+	nestedSigner := batchSigner["Signers"].([]map[string]any)[0]["Signer"].(map[string]any)
+	require.Contains(t, nestedSigner, "TxnSignature")
+}
+
 func TestBatchBinaryParseRejectsStructuralAbuseBeforeInnerConstruction(t *testing.T) {
 	outer := NewBatch(testOuter)
 	outer.Fee = "40"

--- a/internal/tx/batch/batch_test.go
+++ b/internal/tx/batch/batch_test.go
@@ -94,6 +94,8 @@ func TestBatchBinaryRoundTripPreservesEmptyNestedSignature(t *testing.T) {
 
 	flat, err := outer.Flatten()
 	require.NoError(t, err)
+	flatBatchSigner := flat["BatchSigners"].([]map[string]any)[0]["BatchSigner"].(map[string]any)
+	require.NotContains(t, flatBatchSigner, "SigningPubKey")
 	encoded, err := binarycodec.Encode(flat)
 	require.NoError(t, err)
 	blob, err := hex.DecodeString(encoded)
@@ -106,6 +108,7 @@ func TestBatchBinaryRoundTripPreservesEmptyNestedSignature(t *testing.T) {
 	flattened, err := parsedBatch.Flatten()
 	require.NoError(t, err)
 	batchSigner := flattened["BatchSigners"].([]map[string]any)[0]["BatchSigner"].(map[string]any)
+	require.NotContains(t, batchSigner, "SigningPubKey")
 	nestedSigner := batchSigner["Signers"].([]map[string]any)[0]["Signer"].(map[string]any)
 	require.Contains(t, nestedSigner, "TxnSignature")
 }
@@ -895,6 +898,35 @@ func TestInnerExplicitEmptySignatureFieldsAreRejected(t *testing.T) {
 			require.NoError(t, err)
 			require.ErrorIs(t, parsed.(*Batch).Validate(), test.wantErr)
 		})
+	}
+}
+
+func TestInnerProgrammaticEmptyNestedSignatureFieldsAreRejected(t *testing.T) {
+	for _, container := range []string{"CounterpartySignature", "SponsorSignature"} {
+		for _, test := range []struct {
+			field   string
+			wantErr error
+		}{
+			{field: "TxnSignature", wantErr: ErrBatchInnerHasTxnSignature},
+			{field: "Signers", wantErr: ErrBatchInnerHasSigners},
+		} {
+			t.Run(container+"/"+test.field, func(t *testing.T) {
+				outer := NewBatch(testOuter)
+				outer.SetFlags(BatchFlagAllOrNothing)
+				outer.AddInnerTransaction(makeTestPayment())
+				outer.AddInnerTransaction(makeTestPayment())
+				common := outer.RawTransactions[0].RawTransaction.InnerTx.GetCommon()
+				switch container {
+				case "CounterpartySignature":
+					common.CounterpartySignature = &tx.CounterpartySignature{}
+					common.CounterpartySignature.MarkFieldPresent(test.field)
+				case "SponsorSignature":
+					common.SponsorSignature = &tx.SponsorSignature{}
+					common.SponsorSignature.MarkFieldPresent(test.field)
+				}
+				require.ErrorIs(t, outer.Validate(), test.wantErr)
+			})
+		}
 	}
 }
 

--- a/internal/tx/batch/confidential_fee_test.go
+++ b/internal/tx/batch/confidential_fee_test.go
@@ -6,7 +6,7 @@ import (
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 )
 
-func TestInnerBaseFeeConfidentialMPT(t *testing.T) {
+func TestCalculateMinimumFeeConfidentialMPT(t *testing.T) {
 	for _, transactionType := range []txcore.Type{
 		txcore.TypeConfidentialMPTConvert,
 		txcore.TypeConfidentialMPTMergeInbox,
@@ -16,8 +16,10 @@ func TestInnerBaseFeeConfidentialMPT(t *testing.T) {
 	} {
 		t.Run(transactionType.String(), func(t *testing.T) {
 			txn := txcore.NewBaseTx(transactionType, "account")
-			if got := innerBaseFee(txn, nil, txcore.EngineConfig{BaseFee: 10}); got != 100 {
-				t.Fatalf("innerBaseFee() = %d, want 100", got)
+			batch := NewBatch("account")
+			batch.AddInnerTransaction(txn)
+			if got := batch.CalculateMinimumFee(nil, txcore.EngineConfig{BaseFee: 10}); got != 120 {
+				t.Fatalf("CalculateMinimumFee() = %d, want 120", got)
 			}
 		})
 	}

--- a/internal/tx/batch/sign.go
+++ b/internal/tx/batch/sign.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"sort"
 
 	"github.com/LeJamon/go-xrpl/crypto/ed25519"
@@ -71,6 +72,10 @@ func (b *Batch) batchTransactionIDs() ([][32]byte, error) {
 		if inner == nil {
 			return nil, ErrBatchNilInnerTx
 		}
+		matches, err := tx.CurrentFieldsMatchRaw(inner)
+		if err != nil || !matches {
+			return nil, ErrBatchInnerHashUncomputable
+		}
 		id, err := tx.ComputeTransactionHash(inner)
 		if err != nil {
 			return nil, ErrBatchInnerHashUncomputable
@@ -89,6 +94,9 @@ func (b *Batch) batchTransactionIDs() ([][32]byte, error) {
 // signer coverage is checked afterward in PreflightSigValidated.
 // Reference: rippled STTx::checkBatchSign, checkBatchSingleSign, checkBatchMultiSign.
 func (b *Batch) VerifyBatchSignatures() error {
+	if len(b.BatchSigners) > MaxBatchSigners {
+		return errors.New("BatchSigners array exceeds max entries.")
+	}
 	if err := b.validateBatchSignerBounds(); err != nil {
 		return err
 	}
@@ -117,7 +125,7 @@ func (b *Batch) VerifyBatchSignatures() error {
 // carries nested Signers is signed two ways and rejected.
 // Reference: rippled singleSignHelper.
 func verifyBatchSingleSign(message []byte, signer BatchSignerData) error {
-	if len(signer.Signers) > 0 {
+	if signer.hasSigners() {
 		return ErrBatchInvalidSignature
 	}
 	signerID, err := state.DecodeAccountID(signer.Account)
@@ -144,7 +152,7 @@ func verifyBatchMultiSign(message []byte, signer BatchSignerData) error {
 	// A multi-signed BatchSigner carries its signatures in the nested Signers
 	// array; a direct BatchTxnSignature alongside it would mean the entry is
 	// signed two ways, which is rejected.
-	if signer.BatchTxnSignature != "" {
+	if signer.hasTxnSignature() {
 		return ErrBatchInvalidSignature
 	}
 
@@ -271,10 +279,10 @@ func (b *Batch) validateBatchSigners(requiredSigners map[string]struct{}) error 
 		for i := range b.BatchSigners {
 			signer := b.BatchSigners[i].BatchSigner
 			if signer.SigningPubKey == "" {
-				if len(signer.Signers) == 0 || signer.BatchTxnSignature != "" {
+				if len(signer.Signers) == 0 || signer.hasTxnSignature() {
 					return ErrBatchInvalidSignature
 				}
-			} else if len(signer.Signers) > 0 {
+			} else if signer.hasSigners() {
 				return ErrBatchInvalidSignature
 			}
 		}

--- a/internal/tx/batch/sign_test.go
+++ b/internal/tx/batch/sign_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/crypto/ed25519"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
@@ -79,6 +80,7 @@ func TestBatchSignerSigningDataBindings(t *testing.T) {
 	require.NoError(t, err)
 
 	b := NewBatch(testOuter)
+	b.Fee = "50"
 	b.SetSequence(7)
 	b.SetFlags(BatchFlagAllOrNothing)
 	b.AddInnerTransaction(makeTestPaymentFrom(signerAccount))
@@ -99,6 +101,24 @@ func TestBatchSignerSigningDataBindings(t *testing.T) {
 
 	require.NoError(t, b.Validate())
 	require.NoError(t, b.VerifyBatchSignatures())
+	t.Run("explicit empty Signers", func(t *testing.T) {
+		fields, err := b.Flatten()
+		require.NoError(t, err)
+		batchSigners := fields["BatchSigners"].([]map[string]any)
+		batchSigner := batchSigners[0]["BatchSigner"].(map[string]any)
+		batchSigner["Signers"] = []map[string]any{}
+
+		encoded, err := binarycodec.Encode(fields)
+		require.NoError(t, err)
+		blob, err := hex.DecodeString(encoded)
+		require.NoError(t, err)
+		parsed, err := tx.ParseFromBinary(blob)
+		require.NoError(t, err)
+		parsedBatch := parsed.(*Batch)
+
+		require.True(t, parsedBatch.BatchSigners[0].BatchSigner.hasSigners())
+		require.Error(t, parsedBatch.VerifyBatchSignatures())
+	})
 
 	t.Run("outer account", func(t *testing.T) {
 		original := b.Account

--- a/internal/tx/canonical_order_test.go
+++ b/internal/tx/canonical_order_test.go
@@ -1,0 +1,57 @@
+package tx
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+)
+
+func TestParseFromBinaryCanonicalizesFieldOrder(t *testing.T) {
+	const account = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	fields := map[string]any{
+		"TransactionType": "AccountSet",
+		"Account":         account,
+		"Sequence":        uint32(1),
+		"Fee":             "10",
+		"SigningPubKey":   "",
+	}
+	canonical, err := binarycodec.EncodeBytes(fields)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(canonical), 8)
+	require.Equal(t, byte(0x12), canonical[0])
+	require.Equal(t, byte(0x24), canonical[3])
+
+	reordered := make([]byte, 0, len(canonical))
+	reordered = append(reordered, canonical[3:8]...)
+	reordered = append(reordered, canonical[:3]...)
+	reordered = append(reordered, canonical[8:]...)
+	require.False(t, bytes.Equal(canonical, reordered))
+	_, err = binarycodec.DecodeBytes(reordered)
+	require.NoError(t, err)
+
+	canonicalTx, err := ParseFromBinary(canonical)
+	require.NoError(t, err)
+	reorderedTx, err := ParseFromBinary(reordered)
+	require.NoError(t, err)
+
+	canonicalID, err := ComputeTransactionHash(canonicalTx)
+	require.NoError(t, err)
+	reorderedID, err := ComputeTransactionHash(reorderedTx)
+	require.NoError(t, err)
+	require.Equal(t, canonicalID, reorderedID)
+	require.Equal(t, canonical, reorderedTx.GetRawBytes())
+
+	programmatic := NewBaseTx(TypeAccountSet, account)
+	programmatic.Fee = "10"
+	programmatic.Sequence = ptrTo(uint32(1))
+	require.NoError(t, BindRawBytes(programmatic, reordered))
+	require.Equal(t, canonical, programmatic.GetRawBytes())
+	boundID, err := ComputeTransactionHash(programmatic)
+	require.NoError(t, err)
+	require.Equal(t, canonicalID, boundID)
+}
+
+func ptrTo[T any](value T) *T { return &value }

--- a/internal/tx/canonical_order_test.go
+++ b/internal/tx/canonical_order_test.go
@@ -54,4 +54,37 @@ func TestParseFromBinaryCanonicalizesFieldOrder(t *testing.T) {
 	require.Equal(t, canonicalID, boundID)
 }
 
+func TestParseFromBinaryPreservesExplicitEmptyMemoFields(t *testing.T) {
+	fields := map[string]any{
+		"TransactionType": "AccountSet",
+		"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"Sequence":        uint32(1),
+		"Fee":             "10",
+		"SigningPubKey":   "",
+		"Memos": []any{map[string]any{
+			"Memo": map[string]any{"MemoData": ""},
+		}},
+	}
+	blob, err := binarycodec.EncodeBytes(fields)
+	require.NoError(t, err)
+
+	parsed, err := ParseFromBinary(blob)
+	require.NoError(t, err)
+	require.Equal(t, blob, parsed.GetRawBytes())
+	matches, err := CurrentFieldsMatchRaw(parsed)
+	require.NoError(t, err)
+	require.True(t, matches)
+
+	flattened, err := parsed.Flatten()
+	require.NoError(t, err)
+	memos := flattened["Memos"].([]map[string]any)
+	require.Contains(t, memos[0]["Memo"], "MemoData")
+	require.Empty(t, memos[0]["Memo"].(map[string]any)["MemoData"])
+
+	parsed.GetCommon().Memos[0].Memo.MemoData = "AA"
+	matches, err = CurrentFieldsMatchRaw(parsed)
+	require.NoError(t, err)
+	require.False(t, matches)
+}
+
 func ptrTo[T any](value T) *T { return &value }

--- a/internal/tx/clawback/clawback_test.go
+++ b/internal/tx/clawback/clawback_test.go
@@ -312,8 +312,20 @@ func TestMPTokenClawbackWireGolden(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "5C251B4B59260C9A86355912E7767860BAFF08E6E9FD93202B305202A4ECE3A1", strings.ToUpper(hex.EncodeToString(hash[:])))
 
-	_, err = tx.ParseFromBinary(wire)
+	parsed, err := tx.ParseFromBinary(wire)
 	require.NoError(t, err)
+	parsedFields, err := parsed.Flatten()
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{
+		"value":           "100",
+		"mpt_issuance_id": testMPTIssuanceID,
+	}, parsedFields["Amount"])
+	currentHash, err := tx.ComputeCurrentTransactionHash(parsed)
+	require.NoError(t, err)
+	assert.Equal(t, hash, currentHash)
+	matches, err := tx.CurrentFieldsMatchRaw(parsed)
+	require.NoError(t, err)
+	assert.True(t, matches)
 	flat, err := binarycodec.DecodeBytes(wire)
 	require.NoError(t, err)
 	assert.NotContains(t, flat, "MPTokenIssuanceID")

--- a/internal/tx/engine/batch_preflight_order_test.go
+++ b/internal/tx/engine/batch_preflight_order_test.go
@@ -150,7 +150,7 @@ func TestBatchInnerRunsSigValidatedPreflight(t *testing.T) {
 	}
 }
 
-func TestBatchInnerRunsUniversalPreflight(t *testing.T) {
+func TestPreflightInnerRunsUniversalPreflight(t *testing.T) {
 	const account = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
 
 	oversized := check.NewCheckCreate(
@@ -163,22 +163,8 @@ func TestBatchInnerRunsUniversalPreflight(t *testing.T) {
 	oversized.SetSequence(2)
 	oversized.SetFlags(txcore.TfInnerBatchTxn)
 
-	second := payment.NewPayment(account, account, txcore.NewXRPAmount(1))
-	second.Fee = "0"
-	second.SigningPubKey = ""
-	second.SetSequence(3)
-	second.SetFlags(txcore.TfInnerBatchTxn)
-
-	outer := batch.NewBatch(account)
-	outer.Fee = "40"
-	outer.SetSequence(1)
-	outer.SigningPubKey = ""
-	outer.SetFlags(batch.BatchFlagAllOrNothing)
-	outer.AddInnerTransaction(oversized)
-	outer.AddInnerTransaction(second)
-
 	engine := dedupEngine(amendment.AllSupportedRules())
-	if got := engine.preflight(outer); got != ter.TemINVALID_INNER_BATCH {
-		t.Fatalf("preflight = %v, want TemINVALID_INNER_BATCH", got)
+	if got := engine.preflightInner(oversized); got != ter.TemBAD_AMOUNT {
+		t.Fatalf("preflightInner = %v, want TemBAD_AMOUNT", got)
 	}
 }

--- a/internal/tx/engine/batch_preflight_order_test.go
+++ b/internal/tx/engine/batch_preflight_order_test.go
@@ -1,0 +1,118 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/batch"
+	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+func TestBatchInnerPreflightPrecedesSequenceAndDuplicateChecks(t *testing.T) {
+	const (
+		account     = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+		destination = "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"
+	)
+
+	makeInner := func(amount int64, sequence *uint32) txcore.Transaction {
+		inner := payment.NewPayment(account, destination, txcore.NewXRPAmount(amount))
+		inner.Fee = "0"
+		inner.SigningPubKey = ""
+		inner.Sequence = sequence
+		inner.SetFlags(txcore.TfInnerBatchTxn)
+		return inner
+	}
+	makeBatch := func(first, second txcore.Transaction) *batch.Batch {
+		outer := batch.NewBatch(account)
+		outer.Fee = "40"
+		outer.SetSequence(1)
+		outer.SigningPubKey = ""
+		outer.SetFlags(batch.BatchFlagAllOrNothing)
+		outer.AddInnerTransaction(first)
+		outer.AddInnerTransaction(second)
+		return outer
+	}
+	seq1 := uint32(1)
+	seq2 := uint32(2)
+	tests := []struct {
+		name  string
+		batch *batch.Batch
+	}{
+		{
+			name:  "missing sequence",
+			batch: makeBatch(makeInner(0, nil), makeInner(1, &seq2)),
+		},
+		{
+			name:  "duplicate sequence",
+			batch: makeBatch(makeInner(1, &seq1), makeInner(0, &seq1)),
+		},
+	}
+
+	engine := dedupEngine(amendment.AllSupportedRules())
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := engine.preflight(test.batch); got != ter.TemINVALID_INNER_BATCH {
+				t.Fatalf("preflight = %v, want TemINVALID_INNER_BATCH", got)
+			}
+		})
+	}
+}
+
+func TestBatchPreflightInterleavesChecksPerInner(t *testing.T) {
+	const (
+		account     = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+		destination = "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"
+	)
+
+	makeInner := func(amount int64, sequence *uint32) *payment.Payment {
+		inner := payment.NewPayment(account, destination, txcore.NewXRPAmount(amount))
+		inner.Fee = "0"
+		inner.SigningPubKey = ""
+		inner.Sequence = sequence
+		inner.SetFlags(txcore.TfInnerBatchTxn)
+		return inner
+	}
+	makeBatch := func(first, second txcore.Transaction) *batch.Batch {
+		outer := batch.NewBatch(account)
+		outer.Fee = "40"
+		outer.SetSequence(1)
+		outer.SigningPubKey = ""
+		outer.SetFlags(batch.BatchFlagAllOrNothing)
+		outer.AddInnerTransaction(first)
+		outer.AddInnerTransaction(second)
+		return outer
+	}
+
+	seq1 := uint32(1)
+	seq2 := uint32(2)
+	badLaterSignature := makeInner(1, &seq2)
+	badLaterSignature.TxnSignature = "00"
+
+	tests := []struct {
+		name string
+		tx   *batch.Batch
+		want ter.Result
+	}{
+		{
+			name: "first inner sequence error precedes later signature error",
+			tx:   makeBatch(makeInner(1, nil), badLaterSignature),
+			want: ter.TemSEQ_AND_TICKET,
+		},
+		{
+			name: "first inner preflight error precedes later signature error",
+			tx:   makeBatch(makeInner(0, &seq1), badLaterSignature),
+			want: ter.TemINVALID_INNER_BATCH,
+		},
+	}
+
+	engine := dedupEngine(amendment.AllSupportedRules())
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := engine.preflight(test.tx); got != test.want {
+				t.Fatalf("preflight = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/tx/engine/batch_preflight_order_test.go
+++ b/internal/tx/engine/batch_preflight_order_test.go
@@ -4,8 +4,10 @@ import (
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/drops"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/batch"
+	"github.com/LeJamon/go-xrpl/internal/tx/check"
 	"github.com/LeJamon/go-xrpl/internal/tx/escrow"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
@@ -140,6 +142,39 @@ func TestBatchInnerRunsSigValidatedPreflight(t *testing.T) {
 	outer.SigningPubKey = ""
 	outer.SetFlags(batch.BatchFlagAllOrNothing)
 	outer.AddInnerTransaction(credentialIDsPresent)
+	outer.AddInnerTransaction(second)
+
+	engine := dedupEngine(amendment.AllSupportedRules())
+	if got := engine.preflight(outer); got != ter.TemINVALID_INNER_BATCH {
+		t.Fatalf("preflight = %v, want TemINVALID_INNER_BATCH", got)
+	}
+}
+
+func TestBatchInnerRunsUniversalPreflight(t *testing.T) {
+	const account = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+
+	oversized := check.NewCheckCreate(
+		account,
+		account,
+		txcore.NewXRPAmount(int64(drops.MaxDrops)+1),
+	)
+	oversized.Fee = "0"
+	oversized.SigningPubKey = ""
+	oversized.SetSequence(2)
+	oversized.SetFlags(txcore.TfInnerBatchTxn)
+
+	second := payment.NewPayment(account, account, txcore.NewXRPAmount(1))
+	second.Fee = "0"
+	second.SigningPubKey = ""
+	second.SetSequence(3)
+	second.SetFlags(txcore.TfInnerBatchTxn)
+
+	outer := batch.NewBatch(account)
+	outer.Fee = "40"
+	outer.SetSequence(1)
+	outer.SigningPubKey = ""
+	outer.SetFlags(batch.BatchFlagAllOrNothing)
+	outer.AddInnerTransaction(oversized)
 	outer.AddInnerTransaction(second)
 
 	engine := dedupEngine(amendment.AllSupportedRules())

--- a/internal/tx/engine/batch_preflight_order_test.go
+++ b/internal/tx/engine/batch_preflight_order_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/batch"
+	"github.com/LeJamon/go-xrpl/internal/tx/escrow"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
@@ -114,5 +115,35 @@ func TestBatchPreflightInterleavesChecksPerInner(t *testing.T) {
 				t.Fatalf("preflight = %v, want %v", got, test.want)
 			}
 		})
+	}
+}
+
+func TestBatchInnerRunsSigValidatedPreflight(t *testing.T) {
+	const account = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+
+	credentialIDsPresent := escrow.NewEscrowFinish(account, account, 1)
+	credentialIDsPresent.Fee = "0"
+	credentialIDsPresent.SigningPubKey = ""
+	credentialIDsPresent.SetSequence(2)
+	credentialIDsPresent.SetFlags(txcore.TfInnerBatchTxn)
+	credentialIDsPresent.SetPresentFields(map[string]bool{"CredentialIDs": true})
+
+	second := payment.NewPayment(account, account, txcore.NewXRPAmount(1))
+	second.Fee = "0"
+	second.SigningPubKey = ""
+	second.SetSequence(3)
+	second.SetFlags(txcore.TfInnerBatchTxn)
+
+	outer := batch.NewBatch(account)
+	outer.Fee = "40"
+	outer.SetSequence(1)
+	outer.SigningPubKey = ""
+	outer.SetFlags(batch.BatchFlagAllOrNothing)
+	outer.AddInnerTransaction(credentialIDsPresent)
+	outer.AddInnerTransaction(second)
+
+	engine := dedupEngine(amendment.AllSupportedRules())
+	if got := engine.preflight(outer); got != ter.TemINVALID_INNER_BATCH {
+		t.Fatalf("preflight = %v, want TemINVALID_INNER_BATCH", got)
 	}
 }

--- a/internal/tx/engine/batch_preflight_order_test.go
+++ b/internal/tx/engine/batch_preflight_order_test.go
@@ -152,10 +152,11 @@ func TestBatchInnerRunsSigValidatedPreflight(t *testing.T) {
 
 func TestPreflightInnerRunsUniversalPreflight(t *testing.T) {
 	const account = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	const destination = "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn"
 
 	oversized := check.NewCheckCreate(
 		account,
-		account,
+		destination,
 		txcore.NewXRPAmount(int64(drops.MaxDrops)+1),
 	)
 	oversized.Fee = "0"

--- a/internal/tx/engine/batch_sigcache_test.go
+++ b/internal/tx/engine/batch_sigcache_test.go
@@ -1,0 +1,107 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/crypto/ed25519"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/batch"
+	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/sigcache"
+	"github.com/LeJamon/go-xrpl/internal/tx/sign"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+func TestBatchSigCacheCoversEverySignature(t *testing.T) {
+	batch.Register()
+	payment.Register()
+	outerPrivate, outerPublic, err := ed25519.Algorithm{}.DeriveKeypair([]byte("batch-cache-outer"), false)
+	require.NoError(t, err)
+	outerAccount, err := addresscodec.EncodeClassicAddressFromPublicKeyHex(outerPublic)
+	require.NoError(t, err)
+	signerPrivate, signerPublic, err := ed25519.Algorithm{}.DeriveKeypair([]byte("batch-cache-signer"), false)
+	require.NoError(t, err)
+	signerAccount, err := addresscodec.EncodeClassicAddressFromPublicKeyHex(signerPublic)
+	require.NoError(t, err)
+
+	makeInner := func(account, destination string, sequence uint32) txcore.Transaction {
+		inner := payment.NewPayment(account, destination, txcore.NewXRPAmount(1))
+		inner.Fee = "0"
+		inner.SigningPubKey = ""
+		inner.Sequence = &sequence
+		inner.SetFlags(txcore.TfInnerBatchTxn)
+		return inner
+	}
+	b := batch.NewBatch(outerAccount)
+	b.Fee = "60"
+	b.SetSequence(1)
+	b.SetFlags(batch.BatchFlagAllOrNothing)
+	b.AddInnerTransaction(makeInner(signerAccount, outerAccount, 1))
+	b.AddInnerTransaction(makeInner(outerAccount, signerAccount, 2))
+	message, err := b.BatchSigningMessage()
+	require.NoError(t, err)
+	signerID, err := state.DecodeAccountID(signerAccount)
+	require.NoError(t, err)
+	batchSignature, err := ed25519.Algorithm{}.Sign(string(append(message, signerID[:]...)), signerPrivate)
+	require.NoError(t, err)
+	b.BatchSigners = []batch.BatchSigner{{BatchSigner: batch.BatchSignerData{
+		Account:           signerAccount,
+		SigningPubKey:     signerPublic,
+		BatchTxnSignature: batchSignature,
+	}}}
+	b.SigningPubKey = outerPublic
+	b.TxnSignature, err = sign.SignTransaction(b, outerPrivate)
+	require.NoError(t, err)
+	blob, err := txcore.SerializeTransaction(b)
+	require.NoError(t, err)
+	parsed, err := txcore.ParseFromBinary(blob)
+	require.NoError(t, err)
+	parsedBatch := parsed.(*batch.Batch)
+	sigcache.Reset()
+	engine := verifyingEngine(amendment.AllSupportedRules())
+	require.Equal(t, ter.TesSUCCESS, engine.verifySignatures(parsedBatch))
+	id, err := txcore.ComputeTransactionHash(parsedBatch)
+	require.NoError(t, err)
+	require.True(t, sigcache.Verified(id))
+	require.True(t, parsedBatch.GetCommon().SignatureVerified())
+	require.Equal(t, ter.TesSUCCESS, engine.verifySignatures(parsedBatch), "unchanged transaction must reuse its whole-signature verdict")
+
+	innerSequence := uint32(9)
+	_, _, replacementInnerAccount := cacheMutationKeypair(t, "batch-cache-inner-account")
+	_, _, innerDelegate := cacheMutationKeypair(t, "batch-cache-inner-delegate")
+	innerMutations := []struct {
+		name   string
+		mutate func(txcore.Transaction)
+	}{
+		{name: "amount", mutate: func(inner txcore.Transaction) {
+			inner.(*payment.Payment).Amount = txcore.NewXRPAmount(2)
+		}},
+		{name: "fee", mutate: func(inner txcore.Transaction) { inner.GetCommon().Fee = "1" }},
+		{name: "sequence", mutate: func(inner txcore.Transaction) { inner.GetCommon().Sequence = &innerSequence }},
+		{name: "account", mutate: func(inner txcore.Transaction) { inner.GetCommon().Account = replacementInnerAccount }},
+		{name: "delegate", mutate: func(inner txcore.Transaction) { inner.GetCommon().Delegate = innerDelegate }},
+	}
+	for _, test := range innerMutations {
+		t.Run("inner "+test.name, func(t *testing.T) {
+			sigcache.Reset()
+			fresh, err := txcore.ParseFromBinary(blob)
+			require.NoError(t, err)
+			freshBatch := fresh.(*batch.Batch)
+			require.Equal(t, ter.TesSUCCESS, engine.verifySignatures(freshBatch))
+			test.mutate(freshBatch.RawTransactions[0].RawTransaction.InnerTx)
+			require.Equal(t, ter.TemINVALID, engine.verifySignatures(freshBatch))
+		})
+	}
+
+	parsedBatch.BatchSigners[0].BatchSigner.BatchTxnSignature = "00"
+	require.Equal(t, ter.TemINVALID, engine.verifySignatures(parsedBatch), "a cached verdict must not authorize a mutated BatchSigner")
+	mutatedID, err := txcore.ComputeCurrentTransactionHash(parsedBatch)
+	require.NoError(t, err)
+	require.NotEqual(t, id, mutatedID)
+	require.False(t, sigcache.Verified(mutatedID))
+}

--- a/internal/tx/engine/block_processor.go
+++ b/internal/tx/engine/block_processor.go
@@ -88,6 +88,15 @@ func (bp *BlockProcessor) applyTransaction(
 			err = fmt.Errorf("apply panic: %v", r)
 		}
 	}()
+	if canonical := transaction.GetRawBytes(); len(canonical) != 0 {
+		txBlob = canonical
+	} else {
+		canonical, err := txcore.SerializeTransaction(transaction)
+		if err != nil {
+			return result, err
+		}
+		txBlob = canonical
+	}
 
 	result = BlockTxResult{
 		Index:     transactionIndex,
@@ -172,23 +181,20 @@ type ParsedTx struct {
 	// Transaction is the parsed transaction
 	Transaction txcore.Transaction
 
-	// RawBlob is the original binary blob
+	// RawBlob is the canonical binary blob.
 	RawBlob []byte
 }
 
 // ParseAndPrepare parses a transaction blob and returns a ParsedTx ready for processing.
-// It also sets the raw bytes on the transaction for hash computation.
+// The returned transaction and blob retain the canonical field order.
 func ParseAndPrepare(txBlob []byte) (*ParsedTx, error) {
 	transaction, err := txcore.ParseFromBinary(txBlob)
 	if err != nil {
 		return nil, err
 	}
 
-	// Store the raw bytes for hash computation
-	transaction.SetRawBytes(txBlob)
-
 	return &ParsedTx{
 		Transaction: transaction,
-		RawBlob:     txBlob,
+		RawBlob:     transaction.GetRawBytes(),
 	}, nil
 }

--- a/internal/tx/engine/block_processor.go
+++ b/internal/tx/engine/block_processor.go
@@ -181,7 +181,6 @@ type ParsedTx struct {
 	// Transaction is the parsed transaction
 	Transaction txcore.Transaction
 
-	// RawBlob is the canonical binary blob.
 	RawBlob []byte
 }
 

--- a/internal/tx/engine/preclaim.go
+++ b/internal/tx/engine/preclaim.go
@@ -573,7 +573,7 @@ func (e *Engine) checkBatchSign(signers []txcore.BatchSignerInfo) ter.Result {
 		if err != nil {
 			return ter.TefBAD_AUTH
 		}
-		if result := e.checkPseudoAccount(signer.Account); result != ter.TesSUCCESS {
+		if result := e.rejectPseudoAccount(signer.Account); result != ter.TesSUCCESS {
 			return result
 		}
 

--- a/internal/tx/engine/preclaim.go
+++ b/internal/tx/engine/preclaim.go
@@ -573,6 +573,9 @@ func (e *Engine) checkBatchSign(signers []txcore.BatchSignerInfo) ter.Result {
 		if err != nil {
 			return ter.TefBAD_AUTH
 		}
+		if result := e.checkPseudoAccount(signer.Account); result != ter.TesSUCCESS {
+			return result
+		}
 
 		if signer.SigningPubKey == "" {
 			// Multi-sign batch signer: check nested Signers against the account's SignerList.

--- a/internal/tx/engine/preclaim.go
+++ b/internal/tx/engine/preclaim.go
@@ -23,6 +23,8 @@ import (
 //	tx-type preclaim.
 //
 // Delegated permission is established before signature and fee validation.
+// The signature stage precedes the fee check so that no fee-charging TER is
+// returned before the signature has been verified.
 func (e *Engine) preclaim(tx txcore.Transaction, txHash [32]byte) (result ter.Result) {
 	// Any panic reachable from adversarial ledger state — most commonly an
 	// IOUAmount / XRPLNumber arithmetic overflow while reading a crafted balance
@@ -58,11 +60,15 @@ func (e *Engine) preclaim(tx txcore.Transaction, txHash [32]byte) (result ter.Re
 	if result := e.checkSponsor(common); result != ter.TesSUCCESS {
 		return result
 	}
-
 	if result := e.checkPermission(tx, common, accountID); result != ter.TesSUCCESS {
 		return result
 	}
 
+	// The signature is verified before the fee check so that a transaction that
+	// fails both reports the signature failure. No fee-charging TER
+	// (terINSUF_FEE_B, ...) may precede the signature check, which would risk
+	// charging a fee on an unauthorized transaction.
+	// Reference: rippled applySteps.cpp invoke_preclaim (PR #6192).
 	if result := e.checkSign(tx, common); result != ter.TesSUCCESS {
 		return result
 	}
@@ -125,10 +131,10 @@ func (e *Engine) preclaimInner(tx txcore.Transaction, txHash [32]byte) (result t
 	if result := e.checkSponsor(common); result != ter.TesSUCCESS {
 		return result
 	}
-	if result := e.checkPseudoAccountSign(common); result != ter.TesSUCCESS {
+	if result := e.checkPermission(tx, common, accountID); result != ter.TesSUCCESS {
 		return result
 	}
-	if result := e.checkPermission(tx, common, accountID); result != ter.TesSUCCESS {
+	if result := e.checkPseudoAccountSign(common); result != ter.TesSUCCESS {
 		return result
 	}
 	if preclaimer, ok := tx.(txcore.Preclaimer); ok {

--- a/internal/tx/engine/preclaim_precedence_test.go
+++ b/internal/tx/engine/preclaim_precedence_test.go
@@ -236,3 +236,23 @@ func TestPreclaimInnerPrecedence_PermissionBeforePseudoAccountAuthorization(t *t
 		t.Fatalf("combined pseudo delegate+permission failure = %v, want TerNO_DELEGATE_PERMISSION", got)
 	}
 }
+
+func TestBatchSignerPseudoAccountAuthorizationRejected(t *testing.T) {
+	pseudoID := [32]byte{1}
+	e := precedenceEngine(t, map[string]*state.AccountRoot{
+		precedenceGenesisAddr: {
+			Account:  precedenceGenesisAddr,
+			Balance:  1_000_000,
+			Sequence: 1,
+			AMMID:    pseudoID,
+		},
+	})
+
+	got := e.checkBatchSign([]txcore.BatchSignerInfo{{
+		Account:       precedenceGenesisAddr,
+		SigningPubKey: precedenceGenesisPubKey,
+	}})
+	if got != ter.TefBAD_AUTH {
+		t.Fatalf("pseudo-account Batch signer = %v, want TefBAD_AUTH", got)
+	}
+}

--- a/internal/tx/engine/preclaim_precedence_test.go
+++ b/internal/tx/engine/preclaim_precedence_test.go
@@ -105,13 +105,13 @@ func TestPreclaimPrecedence_SignBeforeFee(t *testing.T) {
 	})
 }
 
-// TestPreclaimPrecedence_PermissionBeforeSign pins the delegated permission
-// check before signature and fee validation.
-func TestPreclaimPrecedence_PermissionBeforeSign(t *testing.T) {
+// TestPreclaimPrecedence_PermissionBeforeSignAndFee pins delegated permission
+// ahead of signature authorization and fee checks.
+func TestPreclaimPrecedence_PermissionBeforeSignAndFee(t *testing.T) {
 	// Source delegates to the genesis account. No Delegate SLE exists, so
 	// checkPermission yields terNO_DELEGATE_PERMISSION. Signature is verified
 	// against the delegate (genesis); disabling its master key makes checkSign
-	// yield tefMASTER_DISABLED. The delegate funds the fee, so checkFee passes.
+	// yield tefMASTER_DISABLED.
 	makeTx := func() *txcore.BaseTx {
 		tx := txcore.NewBaseTx(txcore.TypeAccountSet, precedenceSourceAddr)
 		tx.Fee = "10"
@@ -152,4 +152,87 @@ func TestPreclaimPrecedence_PermissionBeforeSign(t *testing.T) {
 			t.Fatalf("permission-only failure = %v, want TerNO_DELEGATE_PERMISSION", got)
 		}
 	})
+
+	t.Run("insufficient fee + no delegate permission returns permission error", func(t *testing.T) {
+		tx := makeTx()
+		tx.Fee = "100"
+		e := precedenceEngine(t, map[string]*state.AccountRoot{
+			precedenceSourceAddr: source,
+			precedenceGenesisAddr: {
+				Account:  precedenceGenesisAddr,
+				Balance:  0,
+				Sequence: 1,
+			},
+		})
+		if got := e.preclaim(tx, [32]byte{}); got != ter.TerNO_DELEGATE_PERMISSION {
+			t.Fatalf("combined fee+permission failure = %v, want TerNO_DELEGATE_PERMISSION", got)
+		}
+	})
+}
+
+type batchSignerPrecedenceTx struct {
+	txcore.BaseTx
+	signers []txcore.BatchSignerInfo
+}
+
+func (t *batchSignerPrecedenceTx) GetBatchSigners() []txcore.BatchSignerInfo {
+	return t.signers
+}
+
+func TestPreclaimPrecedence_PermissionBeforeBatchSignerAuthorization(t *testing.T) {
+	base := txcore.NewBaseTx(txcore.TypeBatch, precedenceSourceAddr)
+	base.Fee = "10"
+	base.Sequence = u32(5)
+	base.SigningPubKey = precedenceGenesisPubKey
+	base.Delegate = precedenceGenesisAddr
+	txn := &batchSignerPrecedenceTx{
+		BaseTx: *base,
+		signers: []txcore.BatchSignerInfo{{
+			Account:       precedenceSourceAddr,
+			SigningPubKey: precedenceGenesisPubKey,
+		}},
+	}
+	e := precedenceEngine(t, map[string]*state.AccountRoot{
+		precedenceSourceAddr: {
+			Account:  precedenceSourceAddr,
+			Balance:  1_000_000,
+			Sequence: 5,
+		},
+		precedenceGenesisAddr: {
+			Account:  precedenceGenesisAddr,
+			Balance:  1_000_000,
+			Sequence: 1,
+		},
+	})
+
+	if got := e.preclaim(txn, [32]byte{}); got != ter.TerNO_DELEGATE_PERMISSION {
+		t.Fatalf("combined Batch signer+permission failure = %v, want TerNO_DELEGATE_PERMISSION", got)
+	}
+}
+
+func TestPreclaimInnerPrecedence_PermissionBeforePseudoAccountAuthorization(t *testing.T) {
+	txn := txcore.NewBaseTx(txcore.TypeAccountSet, precedenceSourceAddr)
+	txn.Fee = "0"
+	txn.Sequence = u32(5)
+	txn.SigningPubKey = ""
+	txn.Delegate = precedenceGenesisAddr
+
+	pseudoID := [32]byte{1}
+	e := precedenceEngine(t, map[string]*state.AccountRoot{
+		precedenceSourceAddr: {
+			Account:  precedenceSourceAddr,
+			Balance:  1_000_000,
+			Sequence: 5,
+		},
+		precedenceGenesisAddr: {
+			Account:  precedenceGenesisAddr,
+			Balance:  1_000_000,
+			Sequence: 1,
+			AMMID:    pseudoID,
+		},
+	})
+
+	if got := e.preclaimInner(txn, [32]byte{1}); got != ter.TerNO_DELEGATE_PERMISSION {
+		t.Fatalf("combined pseudo delegate+permission failure = %v, want TerNO_DELEGATE_PERMISSION", got)
+	}
 }

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -305,7 +305,15 @@ func (e *Engine) preflightInner(innerTx txcore.Transaction) ter.Result {
 	if result := checkSponsorFields(innerTx, common, rules); result != ter.TesSUCCESS {
 		return result
 	}
-	return runTypePreflight(innerTx, rules)
+	if result := runTypePreflight(innerTx, rules); result != ter.TesSUCCESS {
+		return result
+	}
+	if svp, ok := innerTx.(txcore.SigValidatedPreflighter); ok {
+		if err := svp.PreflightSigValidated(); err != nil {
+			return parseValidationError(err)
+		}
+	}
+	return ter.TesSUCCESS
 }
 
 // preflightInnerBatchFlag rejects a transaction reaching the outer preflight

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -305,6 +305,9 @@ func (e *Engine) preflightInner(innerTx txcore.Transaction) ter.Result {
 	if result := checkSponsorFields(innerTx, common, rules); result != ter.TesSUCCESS {
 		return result
 	}
+	if rules.FixCleanup3_2_0Enabled() && hasInvalidAmount(innerTx) {
+		return ter.TemBAD_AMOUNT
+	}
 	if result := runTypePreflight(innerTx, rules); result != ter.TesSUCCESS {
 		return result
 	}

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 
 	"github.com/LeJamon/go-xrpl/amendment"
@@ -37,17 +38,20 @@ func (e *Engine) preflight(tx txcore.Transaction) (result ter.Result) {
 
 	common := tx.GetCommon()
 	rules := e.rules()
+	currentTxID, currentTxIDErr := txcore.ComputeCurrentTransactionHash(tx)
 
 	// Structural preflight is ledger-state-independent, so its verdict is
 	// memoised on the transaction and a re-preflight under the same rules skips
 	// the repeat (see Common.preflightedRules). Signature verification stays out
 	// of the memo and always runs below, so a multi-signed tx's view-dependent
 	// signer-list check is never cached.
-	if !common.PreflightVerified(rules) {
+	if currentTxIDErr != nil || !common.PreflightVerified(rules, currentTxID) {
 		if result := e.preflightStructure(tx, common); result != ter.TesSUCCESS {
 			return result
 		}
-		common.MarkPreflightVerified(rules)
+		if currentTxIDErr == nil {
+			common.MarkPreflightVerified(rules, currentTxID)
+		}
 	}
 
 	// preflight2 — cryptographic signature verification runs LAST, after the
@@ -120,17 +124,9 @@ func (e *Engine) preflightStructure(tx txcore.Transaction, common *txcore.Common
 	if result := runTypePreflight(tx, rules); result != ter.TesSUCCESS {
 		return result
 	}
-	// Batch runs each inner transaction's full structural preflight before
-	// preflight2 verifies any signature.
-	// Reference: rippled Batch.cpp:303-312.
-	if outer, ok := tx.(BatchOuter); ok {
-		for _, inner := range outer.InnerTransactions() {
-			if inner == nil {
-				return ter.TemINVALID_INNER_BATCH
-			}
-			if r := e.preflightInner(inner); r != ter.TesSUCCESS {
-				return ter.TemINVALID_INNER_BATCH
-			}
+	if outer, ok := tx.(txcore.BatchInnerPreflightRunner); ok {
+		if err := outer.PreflightInnerTransactions(e.preflightInner); err != nil {
+			return parseValidationError(err)
 		}
 	}
 
@@ -245,6 +241,12 @@ func checkPreflightRules(tx txcore.Transaction, rules *amendment.Rules) ter.Resu
 }
 
 func runTypePreflight(tx txcore.Transaction, rules *amendment.Rules) ter.Result {
+	if batch, ok := tx.(txcore.BatchInnerPreflightRunner); ok {
+		if err := batch.ValidateBatchOuter(); err != nil {
+			return parseValidationError(err)
+		}
+		return checkPreflightRules(tx, rules)
+	}
 	if rp, ok := tx.(txcore.RulesAwarePreflighter); ok {
 		if err := rp.PreflightWithRules(rules); err != nil {
 			return parseValidationError(err)
@@ -255,14 +257,6 @@ func runTypePreflight(tx txcore.Transaction, rules *amendment.Rules) ter.Result 
 		return parseValidationError(err)
 	}
 	return checkPreflightRules(tx, rules)
-}
-
-// BatchOuter is implemented by transaction types whose inner transactions
-// each need to pass preflight as part of the outer's preflight pipeline.
-// Reference: rippled Batch.cpp preflight() — `ripple::preflight(..., tapBATCH)`
-// per inner STTx; any failure → temINVALID_INNER_BATCH on the outer.
-type BatchOuter interface {
-	InnerTransactions() []txcore.Transaction
 }
 
 // preflightInner runs the structural checks for an inner batch tx. rippled routes
@@ -300,6 +294,10 @@ func (e *Engine) preflightInner(innerTx txcore.Transaction) ter.Result {
 	}
 	if result := checkSigningKeyShape(common); result != ter.TesSUCCESS {
 		return result
+	}
+	usesTicket := (common.Sequence == nil || *common.Sequence == 0) && common.TicketSequence != nil
+	if usesTicket && common.AccountTxnID != "" {
+		return ter.TemINVALID
 	}
 	if result := checkDelegate(innerTx, common, rules); result != ter.TesSUCCESS {
 		return result
@@ -587,6 +585,16 @@ func (e *Engine) verifySignatures(tx txcore.Transaction) ter.Result {
 	if e.config.SkipSignatureVerification {
 		return ter.TesSUCCESS
 	}
+	if matches, err := txcore.CurrentFieldsMatchRaw(tx); err != nil || !matches {
+		return ter.TemINVALID
+	}
+	txID, idErr := txcore.ComputeCurrentTransactionHash(tx)
+	if idErr == nil && tx.GetCommon().SignatureVerified(txID) {
+		return ter.TesSUCCESS
+	}
+	if idErr == nil && sigcache.Verified(txID) {
+		return ter.TesSUCCESS
+	}
 	// Verify the outer single/multi-sign signature first, mirroring rippled's
 	// preflight2 (checkValidity) which precedes the batch-signer check.
 	if result := e.verifyOuterSignature(tx); result != ter.TesSUCCESS {
@@ -618,6 +626,10 @@ func (e *Engine) verifySignatures(tx txcore.Transaction) ter.Result {
 		if err := bsv.VerifyBatchSignatures(); err != nil {
 			return ter.TemINVALID
 		}
+	}
+	if idErr == nil {
+		tx.GetCommon().MarkSignatureVerified(txID)
+		sigcache.MarkVerified(txID)
 	}
 	return ter.TesSUCCESS
 }
@@ -653,64 +665,46 @@ func (e *Engine) verifyOuterSignature(tx txcore.Transaction) ter.Result {
 	// malformed-key-type case that does warrant temBAD_SIGNATURE is already
 	// caught unconditionally in preflight1 (preflightCommon).
 	//
-	// A verdict cached off-strand (PrewarmSignature) means this same signature
-	// was already verified under the same rules, so the verify is skipped here to
-	// keep it off the open-ledger apply mutex (issue #1105). Only positive
-	// verdicts are cached, so a cold cache still runs the full verify below.
-	if tx.GetCommon().SignatureVerified() {
-		return ter.TesSUCCESS
-	}
-	// tx-ID-keyed verified-good cache (rippled SF_SIGGOOD analog): the object
-	// SignatureVerified flag is cold after the consensus build re-parses the
-	// agreed tx set, but the tx ID survives, so a hit skips the redundant
-	// re-verify. Positive-only — a miss still runs the full verify below.
-	txID, idErr := txcore.ComputeTransactionHash(tx)
-	if idErr == nil && sigcache.Verified(txID) {
-		return ter.TesSUCCESS
-	}
 	if err := sign.VerifySignature(tx, mustBeFullyCanonical); err != nil {
 		return ter.TemINVALID
-	}
-	if idErr == nil {
-		sigcache.MarkVerified(txID)
 	}
 	return ter.TesSUCCESS
 }
 
-// PrewarmSignature cryptographically verifies a single-signed transaction's
-// signature ahead of the open-ledger apply strand and caches a positive verdict
-// on the transaction, so the in-strand signature check skips the repeat verify.
+// PrewarmSignature cryptographically verifies all signatures ahead of the
+// open-ledger apply strand and caches a positive verdict on the transaction, so
+// the in-strand signature check skips the repeat verification.
 // This moves the dominant per-tx cost — ECDSA/EdDSA verification — off the
 // apply mutex onto the ingress workers, where it runs concurrently, mirroring
 // rippled caching SF_SIGGOOD in checkValidity before the apply strand (#1105).
 //
-// It never rejects and never caches a negative verdict: multi-signed, unsigned,
-// and bad-signature transactions leave the cache cold so the in-strand preflight
-// runs unchanged and reports the canonical, ordered result. Multi-signed
-// transactions stay on the in-strand path because go-xrpl interleaves their
-// crypto check with ledger-state signer-list authorization, which must observe
-// the apply view.
-func PrewarmSignature(txn txcore.Transaction) {
+// It returns a signature error to ingress callers and never caches a negative
+// verdict. Authorization against ledger signer lists remains in preclaim.
+var ErrInvalidSignature = errors.New("invalid transaction signature")
+
+func PrewarmSignature(txn txcore.Transaction) error {
 	if txn == nil {
-		return
+		return nil
 	}
 	common := txn.GetCommon()
-	if common == nil || common.SignatureVerified() {
-		return
+	if common == nil {
+		return nil
 	}
-	// Only single-signed transactions are verified off-strand; an empty
-	// SigningPubKey marks a multi-signed or unsigned (inner-batch) transaction.
-	if common.SigningPubKey == "" {
-		return
+	txID, idErr := txcore.ComputeCurrentTransactionHash(txn)
+	if idErr == nil && common.SignatureVerified(txID) {
+		return nil
 	}
-	if sign.VerifySignature(txn, true) == nil {
-		common.MarkSignatureVerified()
-		// Publish to the tx-ID cache so the consensus build path (fresh object,
-		// cold flag) skips the redundant verify.
-		if txID, err := txcore.ComputeTransactionHash(txn); err == nil {
-			sigcache.MarkVerified(txID)
-		}
+	if reason := sign.CheckSTTxSignature(txn, nil, true); reason != "" {
+		return fmt.Errorf("%w: %s", ErrInvalidSignature, reason)
 	}
+	if idErr != nil {
+		return nil
+	}
+	common.MarkSignatureVerified(txID)
+	// Publish to the tx-ID cache so the consensus build path (fresh object,
+	// cold flag) skips the redundant whole-transaction signature verify.
+	sigcache.MarkVerified(txID)
+	return nil
 }
 
 // hasInvalidAmount reports whether the transaction carries a non-canonical

--- a/internal/tx/engine/preflight_dedup_test.go
+++ b/internal/tx/engine/preflight_dedup_test.go
@@ -28,13 +28,9 @@ func dedupEngine(rules *amendment.Rules) *Engine {
 	})
 }
 
-// TestPreflight_SkipsRepeatStructural proves the structural verdict is memoised:
-// once preflight succeeds under a set of rules, a second preflight of the same
-// parsed transaction under those same rules skips the structural pass — shown by
-// corrupting a structural field afterwards and observing the check still passes.
-// This is the open-ledger apply strand's double preflight (TxQ.Apply then
-// Engine.Apply) collapsing to a single structural pass (#1153).
-func TestPreflight_SkipsRepeatStructural(t *testing.T) {
+// TestPreflight_CacheRejectsMutatedStructure proves the structural verdict is
+// bound to the fields that produced it.
+func TestPreflight_CacheRejectsMutatedStructure(t *testing.T) {
 	rules := amendment.AllSupportedRules()
 	txn := newDedupTx()
 	eng := dedupEngine(rules)
@@ -49,12 +45,12 @@ func TestPreflight_SkipsRepeatStructural(t *testing.T) {
 		t.Fatal("a successful preflight must cache the structural verdict")
 	}
 
-	// Corrupt a structural field; the cached verdict must short-circuit the
-	// structural pass so the second preflight still passes.
+	// Corrupt a structural field. The changed transaction identity invalidates
+	// the verdict and forces the structural checks to run again.
 	txn.GetCommon().Sequence = nil
 	txn.GetCommon().TicketSequence = nil
-	if res := eng.preflight(txn); res != ter.TesSUCCESS {
-		t.Fatalf("cached structural verdict must skip the repeat; got %s", res)
+	if res := eng.preflight(txn); res != ter.TemBAD_SEQUENCE {
+		t.Fatalf("mutated transaction must not reuse structural verdict; got %s", res)
 	}
 }
 

--- a/internal/tx/engine/prewarm_test.go
+++ b/internal/tx/engine/prewarm_test.go
@@ -45,11 +45,9 @@ func verifyingEngine(rules *amendment.Rules) *Engine {
 	})
 }
 
-// TestPrewarmSignature_SkipsRepeatVerify proves the off-strand verdict is
-// honoured: once PrewarmSignature has cached a positive verdict, the in-strand
-// signature check trusts it and does not re-verify — demonstrated by corrupting
-// the signature after prewarming and observing the check still passes.
-func TestPrewarmSignature_SkipsRepeatVerify(t *testing.T) {
+// TestPrewarmSignature_MutationInvalidatesVerdict proves the off-strand verdict
+// is bound to the exact transaction contents that were verified.
+func TestPrewarmSignature_MutationInvalidatesVerdict(t *testing.T) {
 	rules := amendment.AllSupportedRules()
 	txn := newSignedSingleSignTx(t)
 
@@ -61,10 +59,10 @@ func TestPrewarmSignature_SkipsRepeatVerify(t *testing.T) {
 		t.Fatal("PrewarmSignature must cache a positive verdict for a valid single-signed tx")
 	}
 
-	// Corrupt the signature; the cached verdict must short-circuit the verify.
+	// Corrupt the signature; the changed transaction identity must force a verify.
 	txn.GetCommon().TxnSignature = "00"
-	if res := verifyingEngine(rules).verifySignatures(txn); res != ter.TesSUCCESS {
-		t.Fatalf("cached-good signature must skip re-verify; got %s", res)
+	if res := verifyingEngine(rules).verifySignatures(txn); res != ter.TemINVALID {
+		t.Fatalf("mutated signature must invalidate cached verdict; got %s", res)
 	}
 }
 

--- a/internal/tx/engine/sigcache_verify_test.go
+++ b/internal/tx/engine/sigcache_verify_test.go
@@ -22,7 +22,7 @@ func TestSigCache_PopulatesOnVerifySuccess(t *testing.T) {
 	if sigcache.Verified(id) {
 		t.Fatal("cache must start cold for a never-verified tx")
 	}
-	if res := verifyingEngine(rules).verifyOuterSignature(txn); res != ter.TesSUCCESS {
+	if res := verifyingEngine(rules).verifySignatures(txn); res != ter.TesSUCCESS {
 		t.Fatalf("a good signature must verify; got %s", res)
 	}
 	if !sigcache.Verified(id) {
@@ -45,7 +45,7 @@ func TestSigCache_MissRejectsBadSignature(t *testing.T) {
 	if sigcache.Verified(id) {
 		t.Fatal("a forged/never-verified tx must not be pre-cached")
 	}
-	if res := verifyingEngine(rules).verifyOuterSignature(txn); res != ter.TemINVALID {
+	if res := verifyingEngine(rules).verifySignatures(txn); res != ter.TemINVALID {
 		t.Fatalf("a cache miss must run the full verify and reject the bad signature; got %s", res)
 	}
 	if sigcache.Verified(id) {
@@ -72,7 +72,7 @@ func TestSigCache_HitSkipsVerify(t *testing.T) {
 	if txn.GetCommon().SignatureVerified() {
 		t.Fatal("object-level flag must be cold so the pass can only come from the tx-ID cache")
 	}
-	if res := verifyingEngine(rules).verifyOuterSignature(txn); res != ter.TesSUCCESS {
+	if res := verifyingEngine(rules).verifySignatures(txn); res != ter.TesSUCCESS {
 		t.Fatalf("a tx-ID cache hit must skip the crypto verify and pass; got %s", res)
 	}
 	sigcache.Reset()

--- a/internal/tx/engine/signature_cache_mutation_test.go
+++ b/internal/tx/engine/signature_cache_mutation_test.go
@@ -1,0 +1,277 @@
+package engine
+
+import (
+	"bytes"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/crypto/ed25519"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/account"
+	"github.com/LeJamon/go-xrpl/internal/tx/sigcache"
+	"github.com/LeJamon/go-xrpl/internal/tx/sign"
+)
+
+var cacheMutationRegisterAccount sync.Once
+
+func registerCacheMutationAccount() {
+	cacheMutationRegisterAccount.Do(account.Register)
+}
+
+func cacheMutationKeypair(t *testing.T, seed string) (privateKey, publicKey, account string) {
+	t.Helper()
+	privateKey, publicKey, err := ed25519.Algorithm{}.DeriveKeypair([]byte(seed), false)
+	if err != nil {
+		t.Fatalf("derive keypair: %v", err)
+	}
+	account, err = addresscodec.EncodeClassicAddressFromPublicKeyHex(publicKey)
+	if err != nil {
+		t.Fatalf("derive account: %v", err)
+	}
+	return privateKey, publicKey, account
+}
+
+func cacheMutationBaseTx(t *testing.T) *txcore.BaseTx {
+	t.Helper()
+	privateKey, publicKey, account := cacheMutationKeypair(t, "cache-mutation-primary")
+	txn := txcore.NewBaseTx(txcore.TypeAccountSet, account)
+	txn.Fee = "10"
+	txn.SetSequence(1)
+	txn.SigningPubKey = publicKey
+	var err error
+	txn.TxnSignature, err = sign.SignTransaction(txn, privateKey)
+	if err != nil {
+		t.Fatalf("sign transaction: %v", err)
+	}
+	return txn
+}
+
+func TestPrewarmSignatureVerdictRejectsSignatureObjectMutation(t *testing.T) {
+	tests := []struct {
+		name   string
+		makeTx func(*testing.T) txcore.Transaction
+		mutate func(txcore.Transaction)
+	}{
+		{
+			name: "outer",
+			makeTx: func(t *testing.T) txcore.Transaction {
+				return cacheMutationBaseTx(t)
+			},
+			mutate: func(txn txcore.Transaction) {
+				txn.GetCommon().TxnSignature = "00"
+			},
+		},
+		{
+			name: "counterparty",
+			makeTx: func(t *testing.T) txcore.Transaction {
+				txn := cacheMutationBaseTx(t)
+				privateKey, publicKey, _ := cacheMutationKeypair(t, "cache-mutation-counterparty")
+				counterparty, err := sign.SignCounterparty(txn, publicKey, privateKey)
+				if err != nil {
+					t.Fatalf("sign counterparty: %v", err)
+				}
+				txn.CounterpartySignature = counterparty
+				return txn
+			},
+			mutate: func(txn txcore.Transaction) {
+				txn.GetCommon().CounterpartySignature.TxnSignature = "00"
+			},
+		},
+		{
+			name: "sponsor",
+			makeTx: func(t *testing.T) txcore.Transaction {
+				primaryPrivate, primaryPublic, primaryAccount := cacheMutationKeypair(t, "cache-mutation-sponsored-primary")
+				sponsorPrivate, sponsorPublic, sponsorAccount := cacheMutationKeypair(t, "cache-mutation-sponsor")
+				txn := txcore.NewBaseTx(txcore.TypeAccountSet, primaryAccount)
+				txn.Fee = "20"
+				txn.SetSequence(1)
+				txn.SigningPubKey = primaryPublic
+				txn.Sponsor = sponsorAccount
+				flags := txcore.SpfSponsorFee
+				txn.SponsorFlags = &flags
+				var err error
+				txn.TxnSignature, err = sign.SignTransaction(txn, primaryPrivate)
+				if err != nil {
+					t.Fatalf("sign transaction: %v", err)
+				}
+				txn.SponsorSignature, err = sign.SignSponsor(txn, sponsorPublic, sponsorPrivate)
+				if err != nil {
+					t.Fatalf("sign sponsor: %v", err)
+				}
+				return txn
+			},
+			mutate: func(txn txcore.Transaction) {
+				txn.GetCommon().SponsorSignature.TxnSignature = "00"
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sigcache.Reset()
+			txn := test.makeTx(t)
+			if err := PrewarmSignature(txn); err != nil {
+				t.Fatalf("prewarm valid transaction: %v", err)
+			}
+			verifiedID, err := txcore.ComputeCurrentTransactionHash(txn)
+			if err != nil {
+				t.Fatalf("compute verified transaction ID: %v", err)
+			}
+			test.mutate(txn)
+			mutatedID, err := txcore.ComputeCurrentTransactionHash(txn)
+			if err != nil {
+				t.Fatalf("compute mutated transaction ID: %v", err)
+			}
+			if verifiedID == mutatedID {
+				t.Fatal("signature mutation did not change transaction identity")
+			}
+			if err := PrewarmSignature(txn); !errors.Is(err, ErrInvalidSignature) {
+				t.Fatalf("mutated signature error = %v, want ErrInvalidSignature", err)
+			}
+			if sigcache.Verified(mutatedID) {
+				t.Fatal("invalid mutated transaction populated signature cache")
+			}
+		})
+	}
+}
+
+func TestSetRawBytesInvalidatesCachedVerdicts(t *testing.T) {
+	txn := cacheMutationBaseTx(t)
+	if err := PrewarmSignature(txn); err != nil {
+		t.Fatalf("prewarm: %v", err)
+	}
+	rules := amendment.AllSupportedRules()
+	txID, err := txcore.ComputeCurrentTransactionHash(txn)
+	if err != nil {
+		t.Fatalf("compute transaction ID: %v", err)
+	}
+	txn.GetCommon().MarkPreflightVerified(rules, txID)
+	txn.SetRawBytes([]byte{0x01})
+	if txn.GetCommon().SignatureVerified() {
+		t.Fatal("SetRawBytes retained signature verdict")
+	}
+	if txn.GetCommon().PreflightVerified(rules) {
+		t.Fatal("SetRawBytes retained preflight verdict")
+	}
+}
+
+func TestSetRawBytesRequiresBindingBeforeSignatureVerification(t *testing.T) {
+	registerCacheMutationAccount()
+	original := cacheMutationBaseTx(t)
+	blob, err := txcore.SerializeTransaction(original)
+	if err != nil {
+		t.Fatalf("serialize signed transaction: %v", err)
+	}
+	parsed, err := txcore.ParseFromBinary(blob)
+	if err != nil {
+		t.Fatalf("parse signed transaction: %v", err)
+	}
+	parsed.SetRawBytes(blob)
+	if err := PrewarmSignature(parsed); err != nil {
+		t.Fatalf("setting identical raw bytes lost field binding: %v", err)
+	}
+
+	replacement := append([]byte(nil), blob...)
+	replacement[len(replacement)-1] ^= 1
+	parsed.SetRawBytes(replacement)
+	if err := PrewarmSignature(parsed); !errors.Is(err, ErrInvalidSignature) {
+		t.Fatalf("unbound replacement raw bytes error = %v, want ErrInvalidSignature", err)
+	}
+}
+
+func TestBindRawBytesRejectsMismatchedFieldsAndOwnsBytes(t *testing.T) {
+	registerCacheMutationAccount()
+	first := cacheMutationBaseTx(t)
+	firstRaw, err := txcore.SerializeTransaction(first)
+	if err != nil {
+		t.Fatalf("serialize first transaction: %v", err)
+	}
+
+	privateKey, publicKey, accountID := cacheMutationKeypair(t, "cache-binding-second")
+	second := txcore.NewBaseTx(txcore.TypeAccountSet, accountID)
+	second.Fee = "12"
+	second.SetSequence(3)
+	second.SigningPubKey = publicKey
+	second.TxnSignature, err = sign.SignTransaction(second, privateKey)
+	if err != nil {
+		t.Fatalf("sign second transaction: %v", err)
+	}
+	secondRaw, err := txcore.SerializeTransaction(second)
+	if err != nil {
+		t.Fatalf("serialize second transaction: %v", err)
+	}
+
+	if err := txcore.BindRawBytes(second, firstRaw); err == nil {
+		t.Fatal("mismatched raw transaction was bound")
+	}
+	if len(second.GetRawBytes()) != 0 {
+		t.Fatal("failed binding changed stored raw bytes")
+	}
+
+	input := append([]byte(nil), secondRaw...)
+	if err := txcore.BindRawBytes(second, input); err != nil {
+		t.Fatalf("bind matching raw transaction: %v", err)
+	}
+	input[0] ^= 1
+	if got := second.GetRawBytes(); !bytes.Equal(got, secondRaw) {
+		t.Fatal("mutating BindRawBytes input changed stored raw bytes")
+	}
+	returned := second.GetRawBytes()
+	returned[0] ^= 1
+	if got := second.GetRawBytes(); !bytes.Equal(got, secondRaw) {
+		t.Fatal("mutating GetRawBytes result changed stored raw bytes")
+	}
+	if err := PrewarmSignature(second); err != nil {
+		t.Fatalf("matching bound transaction did not verify: %v", err)
+	}
+}
+
+func TestParsedSignatureVerificationUsesCurrentSignedFields(t *testing.T) {
+	registerCacheMutationAccount()
+	_, _, replacementAccount := cacheMutationKeypair(t, "cache-mutation-replacement")
+	_, _, delegateAccount := cacheMutationKeypair(t, "cache-mutation-delegate")
+	sequence := uint32(2)
+	ticket := uint32(7)
+	zero := uint32(0)
+	tests := []struct {
+		name   string
+		mutate func(txcore.Transaction)
+	}{
+		{name: "fee", mutate: func(txn txcore.Transaction) { txn.GetCommon().Fee = "11" }},
+		{name: "sequence", mutate: func(txn txcore.Transaction) { txn.GetCommon().Sequence = &sequence }},
+		{name: "ticket", mutate: func(txn txcore.Transaction) {
+			txn.GetCommon().Sequence = &zero
+			txn.GetCommon().TicketSequence = &ticket
+		}},
+		{name: "account", mutate: func(txn txcore.Transaction) { txn.GetCommon().Account = replacementAccount }},
+		{name: "delegate", mutate: func(txn txcore.Transaction) { txn.GetCommon().Delegate = delegateAccount }},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sigcache.Reset()
+			original := cacheMutationBaseTx(t)
+			blob, err := txcore.SerializeTransaction(original)
+			if err != nil {
+				t.Fatalf("serialize signed transaction: %v", err)
+			}
+			parsed, err := txcore.ParseFromBinary(blob)
+			if err != nil {
+				t.Fatalf("parse signed transaction: %v", err)
+			}
+			if err := PrewarmSignature(parsed); err != nil {
+				t.Fatalf("unchanged parsed transaction did not verify: %v", err)
+			}
+			test.mutate(parsed)
+			if err := txcore.BindRawBytes(parsed, blob); err != nil {
+				t.Fatalf("rebind identical raw transaction: %v", err)
+			}
+			if err := PrewarmSignature(parsed); !errors.Is(err, ErrInvalidSignature) {
+				t.Fatalf("mutated signed field error = %v, want ErrInvalidSignature", err)
+			}
+		})
+	}
+}

--- a/internal/tx/engine_config.go
+++ b/internal/tx/engine_config.go
@@ -1,7 +1,9 @@
 package tx
 
 import (
+	"bytes"
 	"encoding/hex"
+	"errors"
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
@@ -284,6 +286,99 @@ func SerializeTransaction(tx Transaction) ([]byte, error) {
 		}
 		return append([]byte(nil), rawBytes...), nil
 	}
+	return serializeCurrentTransaction(tx)
+}
+
+// ComputeCurrentTransactionHash computes the transaction ID from the current
+// parsed fields, ignoring any original wire bytes retained on the object.
+func ComputeCurrentTransactionHash(tx Transaction) ([32]byte, error) {
+	txBytes, err := serializeCurrentTransaction(tx)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	return hashWithTxnPrefix(txBytes), nil
+}
+
+// CurrentFieldsMatchRaw reports whether the transaction's current parsed fields
+// still describe the retained wire transaction.
+func CurrentFieldsMatchRaw(tx Transaction) (bool, error) {
+	if len(tx.GetRawBytes()) == 0 {
+		return true, nil
+	}
+	originalID, ok := tx.GetCommon().RawFieldsIdentity()
+	if !ok {
+		return false, nil
+	}
+	currentID, err := ComputeCurrentTransactionHash(tx)
+	if err != nil {
+		return false, err
+	}
+	return currentID == originalID, nil
+}
+
+// BindRawBytes associates wire bytes with the transaction's current parsed
+// fields so later signature verification can detect object mutation.
+func BindRawBytes(tx Transaction, raw []byte) error {
+	if len(raw) == 0 {
+		tx.SetRawBytes(nil)
+		return nil
+	}
+	rawFields, err := binarycodec.DecodeBytes(raw)
+	if err != nil {
+		return err
+	}
+	canonical, err := binarycodec.EncodeBytes(rawFields)
+	if err != nil {
+		return err
+	}
+	return bindCanonicalRawBytes(tx, rawFields, canonical)
+}
+
+func bindCanonicalRawBytes(tx Transaction, rawFields map[string]any, canonical []byte) error {
+	_, alreadyBound := tx.GetCommon().RawFieldsIdentity()
+	sameRaw := bytes.Equal(tx.GetRawBytes(), canonical)
+	if alreadyBound && sameRaw {
+		tx.SetRawBytes(canonical)
+		return nil
+	}
+	currentFields, err := tx.Flatten()
+	if err != nil {
+		return err
+	}
+	PopulateRequiredWireFields(currentFields, tx.GetCommon())
+	currentProjectionID, err := transactionFieldProjectionID(currentFields)
+	if err != nil {
+		return err
+	}
+	rawProjectionID, err := transactionFieldProjectionID(rawFields)
+	if err != nil {
+		return err
+	}
+	if currentProjectionID != rawProjectionID {
+		return errors.New("raw transaction fields do not match transaction")
+	}
+	currentID, err := ComputeCurrentTransactionHash(tx)
+	if err != nil {
+		return err
+	}
+	tx.SetRawBytes(canonical)
+	tx.GetCommon().MarkRawFieldsIdentity(currentID)
+	return nil
+}
+
+func transactionFieldProjectionID(fields map[string]any) ([32]byte, error) {
+	hexValue, err := binarycodec.Encode(fields)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	encoded, err := hex.DecodeString(hexValue)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	return hashWithTxnPrefix(encoded), nil
+}
+
+func serializeCurrentTransaction(tx Transaction) ([]byte, error) {
 	txMap, err := tx.Flatten()
 	if err != nil {
 		return nil, err

--- a/internal/tx/flatten.go
+++ b/internal/tx/flatten.go
@@ -288,7 +288,11 @@ func flattenAsset(a Asset) map[string]any {
 }
 
 func flattenMemos(memos []MemoWrapper) []map[string]any {
-	return flattenStructSlice(reflect.ValueOf(memos))
+	result := make([]map[string]any, len(memos))
+	for i, wrapper := range memos {
+		result[i] = map[string]any{"Memo": wrapper.Memo.toMap()}
+	}
+	return result
 }
 
 // flattenStructSlice converts a slice of structs to []map[string]any for STArray serialization.

--- a/internal/tx/local_checks.go
+++ b/internal/tx/local_checks.go
@@ -40,6 +40,9 @@ func PassesTransactionLocalChecks(transaction Transaction) ter.Result {
 // TransactionLocalChecksFailureReason returns the first local-submission
 // rejection reason in protocol order.
 func TransactionLocalChecksFailureReason(transaction Transaction) string {
+	if transaction == nil {
+		return "Invalid transaction."
+	}
 	if raw := transaction.GetRawBytes(); len(raw) != 0 {
 		if fields, err := binarycodec.DecodeBytes(raw); err == nil {
 			return TransactionMapLocalChecksFailureReason(transaction.TxType(), fields)
@@ -58,7 +61,7 @@ func TransactionLocalChecksFailureReason(transaction Transaction) string {
 	}
 	if transaction.TxType() == TypeBatch {
 		if signers, ok := transaction.(BatchSignerProvider); ok && len(signers.GetBatchSigners()) > MaxBatchSigners {
-			return "Batch Signers array exceeds max entries."
+			return "BatchSigners array exceeds max entries."
 		}
 		if outer, ok := transaction.(interface{ InnerTransactions() []Transaction }); ok {
 			inners := outer.InnerTransactions()
@@ -66,8 +69,14 @@ func TransactionLocalChecksFailureReason(transaction Transaction) string {
 				return "Raw Transactions array exceeds max entries."
 			}
 			for _, inner := range inners {
-				if inner != nil && inner.TxType() == TypeBatch {
+				if inner == nil {
+					continue
+				}
+				if inner.TxType() == TypeBatch {
 					return "Raw Transactions may not contain batch transactions."
+				}
+				if reason := TransactionLocalChecksFailureReason(inner); reason != "" {
+					return reason
 				}
 			}
 		}
@@ -88,43 +97,71 @@ func TransactionMapLocalChecksFailureReason(txType Type, fields map[string]any) 
 		return reason
 	}
 	if txType == TypeBatch {
-		if batchSigners, ok := fields["BatchSigners"].([]any); ok && len(batchSigners) > MaxBatchSigners {
-			return "Batch Signers array exceeds max entries."
-		}
-		rawTransactions, ok := fields["RawTransactions"].([]any)
+		return batchMapLocalChecksFailureReason(fields)
+	}
+	return ""
+}
+
+func batchMapLocalChecksFailureReason(fields map[string]any) string {
+	if reason := batchMapStructuralChecksFailureReason(fields); reason != "" {
+		return reason
+	}
+	rawTransactions, _ := fields["RawTransactions"].([]any)
+	for _, raw := range rawTransactions {
+		wrapper, _ := raw.(map[string]any)
+		inner, _ := wrapper["RawTransaction"].(map[string]any)
+		innerType, ok := transactionTypeFromCanonicalMap(inner)
 		if !ok {
-			return ""
+			continue
 		}
-		if len(rawTransactions) > MaxBatchTransactions {
-			return "Raw Transactions array exceeds max entries."
+		if reason := TransactionMapLocalChecksFailureReason(innerType, inner); reason != "" {
+			return reason
 		}
-		for _, raw := range rawTransactions {
-			wrapper, ok := raw.(map[string]any)
-			if !ok {
-				continue
+	}
+	return ""
+}
+
+func batchMapStructuralChecksFailureReason(fields map[string]any) string {
+	if batchSigners, ok := fields["BatchSigners"].([]any); ok && len(batchSigners) > MaxBatchSigners {
+		return "BatchSigners array exceeds max entries."
+	}
+	return batchMapConstructionChecksFailureReason(fields)
+}
+
+func batchMapConstructionChecksFailureReason(fields map[string]any) string {
+	rawTransactions, ok := fields["RawTransactions"].([]any)
+	if !ok {
+		return ""
+	}
+	if len(rawTransactions) > MaxBatchTransactions {
+		return "Raw Transactions array exceeds max entries."
+	}
+	for _, raw := range rawTransactions {
+		wrapper, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		inner, ok := wrapper["RawTransaction"].(map[string]any)
+		if !ok {
+			continue
+		}
+		innerTypeValue, present := inner["TransactionType"]
+		if !present {
+			return "Field not found: TransactionType"
+		}
+		innerType, ok := transactionTypeFromCanonicalMap(inner)
+		if !ok {
+			if code, numeric := innerTypeValue.(uint16); numeric {
+				return fmt.Sprintf("Invalid transaction type %d", code)
 			}
-			inner, ok := wrapper["RawTransaction"].(map[string]any)
-			if !ok {
-				continue
-			}
-			innerTypeValue, present := inner["TransactionType"]
-			if !present {
-				return "Field not found: TransactionType"
-			}
-			innerType, ok := transactionTypeFromCanonicalMap(inner)
-			if !ok {
-				if code, numeric := innerTypeValue.(uint16); numeric {
-					return fmt.Sprintf("Invalid transaction type %d", code)
-				}
-				return "Field 'TransactionType' has invalid data."
-			}
-			if innerType == TypeBatch {
-				return "Raw Transactions may not contain batch transactions."
-			}
-			inner["TransactionType"] = innerType.String()
-			if err := ValidateTemplateFields(innerType, inner); err != nil {
-				return err.Error()
-			}
+			return "Field 'TransactionType' has invalid data."
+		}
+		if innerType == TypeBatch {
+			return "Raw Transactions may not contain batch transactions."
+		}
+		inner["TransactionType"] = innerType.String()
+		if err := ValidateTemplateFields(innerType, inner); err != nil {
+			return err.Error()
 		}
 	}
 	return ""

--- a/internal/tx/local_checks_test.go
+++ b/internal/tx/local_checks_test.go
@@ -253,7 +253,7 @@ func TestTransactionLocalChecksBatchLimits(t *testing.T) {
 				localChecksTransaction: newLocalChecksTransaction(TypeBatch, map[string]any{}),
 				signers:                make([]BatchSignerInfo, MaxBatchSigners+1),
 			},
-			want: "Batch Signers array exceeds max entries.",
+			want: "BatchSigners array exceeds max entries.",
 		},
 		{
 			name: "raw transactions at limit",
@@ -302,7 +302,7 @@ func TestTransactionMapLocalChecksBatchLimits(t *testing.T) {
 		{
 			name:   "batch signers over limit",
 			fields: map[string]any{"BatchSigners": make([]any, MaxBatchSigners+1)},
-			want:   "Batch Signers array exceeds max entries.",
+			want:   "BatchSigners array exceeds max entries.",
 		},
 		{
 			name:   "raw transactions at limit",

--- a/internal/tx/parse.go
+++ b/internal/tx/parse.go
@@ -13,22 +13,22 @@ import (
 // Uses the registry-based FromJSON for all registered types, with a fallback
 // to BaseTx for unregistered types.
 func ParseJSON(data []byte) (Transaction, error) {
+	var header struct {
+		TransactionType string `json:"TransactionType"`
+	}
+	if err := json.Unmarshal(data, &header); err != nil {
+		return nil, fmt.Errorf("failed to parse transaction: %w", err)
+	}
 	tx, err := FromJSON(data)
 	if err == ErrUnknownTransactionType {
 		// Fallback: parse as generic BaseTx for unregistered types
-		var header struct {
-			TransactionType string `json:"TransactionType"`
-		}
-		if err := json.Unmarshal(data, &header); err != nil {
-			return nil, fmt.Errorf("failed to parse transaction: %w", err)
-		}
 		txType, knownType := TypeFromName(header.TransactionType)
 		presentFields, err := jsonPresentFields(data)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse transaction fields: %w", err)
 		}
+		var values map[string]any
 		if knownType {
-			var values map[string]any
 			if err := json.Unmarshal(data, &values); err != nil {
 				return nil, fmt.Errorf("failed to parse transaction fields: %w", err)
 			}
@@ -42,6 +42,12 @@ func ParseJSON(data []byte) (Transaction, error) {
 		}
 		baseTx.SetPresentFields(presentFields)
 		baseTx.txType = txType
+		if values == nil {
+			if err := json.Unmarshal(data, &values); err != nil {
+				return nil, fmt.Errorf("failed to parse transaction fields: %w", err)
+			}
+		}
+		baseTx.setFallbackFields(values)
 		return &baseTx, nil
 	}
 	return tx, err
@@ -62,14 +68,25 @@ func ParseHash256NonZero(s string) ([32]byte, error) {
 	return h, nil
 }
 
-// ParseFromBinary parses a binary transaction blob into a Transaction
+// ParseFromBinary parses a binary transaction blob and retains its canonical encoding.
 func ParseFromBinary(blob []byte) (Transaction, error) {
+	parsed, decoded, canonical, err := parseFromBinaryUnbound(blob)
+	if err != nil {
+		return nil, err
+	}
+	if err := bindCanonicalRawBytes(parsed, decoded, canonical); err != nil {
+		return nil, err
+	}
+	return parsed, nil
+}
+
+func parseFromBinaryUnbound(blob []byte) (Transaction, map[string]any, []byte, error) {
 	const (
 		minTransactionBytes = 32
 		maxTransactionBytes = 1 << 20
 	)
 	if len(blob) < minTransactionBytes || len(blob) > maxTransactionBytes {
-		return nil, ter.Errorf(ter.TemMALFORMED, "transaction length invalid")
+		return nil, nil, nil, ter.Errorf(ter.TemMALFORMED, "transaction length invalid")
 	}
 
 	// Decode the canonical binary directly; the blob is already bytes, so
@@ -77,7 +94,11 @@ func ParseFromBinary(blob []byte) (Transaction, error) {
 	// this per-transaction hot path.
 	jsonMap, err := binarycodec.DecodeBytes(blob)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode binary transaction: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to decode binary transaction: %w", err)
+	}
+	canonical, err := binarycodec.EncodeBytes(jsonMap)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to canonicalize binary transaction: %w", err)
 	}
 
 	// Extract present fields from the decoded map
@@ -90,16 +111,21 @@ func ParseFromBinary(blob []byte) (Transaction, error) {
 	typeName, _ := jsonMap["TransactionType"].(string)
 	txType, knownType := TypeFromName(typeName)
 	if _, hasTemplate := txTemplates[txType]; !knownType || !hasTemplate {
-		return nil, ter.Errorf(ter.TemMALFORMED, "invalid transaction type %q", typeName)
+		return nil, nil, nil, ter.Errorf(ter.TemMALFORMED, "invalid transaction type %q", typeName)
 	}
 	if err := ValidateTemplateFields(txType, jsonMap); err != nil {
-		return nil, ter.Errorf(ter.TemMALFORMED, "%s", err)
+		return nil, nil, nil, ter.Errorf(ter.TemMALFORMED, "%s", err)
+	}
+	if txType == TypeBatch {
+		if reason := batchMapConstructionChecksFailureReason(jsonMap); reason != "" {
+			return nil, nil, nil, ter.Errorf(ter.TemMALFORMED, "%s", reason)
+		}
 	}
 
 	// Convert map to JSON bytes
 	jsonBytes, err := json.Marshal(jsonMap)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal decoded transaction: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to marshal decoded transaction: %w", err)
 	}
 
 	// The TransactionType is already known from the decoded map, so build the
@@ -110,7 +136,7 @@ func ParseFromBinary(blob []byte) (Transaction, error) {
 	if knownType {
 		if t, nerr := NewFromType(txType); nerr == nil {
 			if err := json.Unmarshal(jsonBytes, t); err != nil {
-				return nil, fmt.Errorf("failed to parse transaction: %w", err)
+				return nil, nil, nil, fmt.Errorf("failed to parse transaction: %w", err)
 			}
 			parsed = t
 		}
@@ -118,16 +144,11 @@ func ParseFromBinary(blob []byte) (Transaction, error) {
 	if parsed == nil {
 		parsed, err = ParseJSON(jsonBytes)
 		if err != nil {
-			return nil, err
+			return nil, nil, nil, err
 		}
 	}
 
 	parsed.GetCommon().SetPresentFields(presentFields)
 
-	// Preserve the original serialized bytes so that downstream consumers
-	// (e.g. sortCanonicalSalted) can use them for hash/SHAMap computation
-	// without re-encoding, ensuring byte-exact fidelity with the source.
-	parsed.SetRawBytes(blob)
-
-	return parsed, nil
+	return parsed, jsonMap, canonical, nil
 }

--- a/internal/tx/registry.go
+++ b/internal/tx/registry.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // ErrUnknownTransactionType is returned when a transaction type is unknown
@@ -52,6 +54,15 @@ func FromJSON(data []byte) (Transaction, error) {
 	txType, ok := TypeFromName(raw.TransactionType)
 	if !ok {
 		return nil, ErrUnknownTransactionType
+	}
+	if txType == TypeBatch {
+		var fields map[string]any
+		if err := json.Unmarshal(data, &fields); err != nil {
+			return nil, err
+		}
+		if reason := batchMapConstructionChecksFailureReason(fields); reason != "" {
+			return nil, ter.Errorf(ter.TemMALFORMED, "%s", reason)
+		}
 	}
 	presentFields, err := jsonPresentFields(data)
 	if err != nil {

--- a/internal/tx/sign/signature.go
+++ b/internal/tx/sign/signature.go
@@ -95,10 +95,13 @@ func IsMultiSigned(tx txcore.Transaction) bool {
 }
 
 // CheckSTTxSignature mirrors the signature portion of rippled's checkValidity.
-// It returns rippled's failure reason, or an empty string when the outer and
-// optional counterparty signatures are valid.
+// It returns rippled's failure reason, or an empty string when every signature
+// carried by the transaction is valid.
 func CheckSTTxSignature(transaction txcore.Transaction, rules *amendment.Rules, checkSigs bool) string {
 	common := transaction.GetCommon()
+	if common.GetFlags()&txcore.TfInnerBatchTxn != 0 {
+		return "Batch inner transactions are never considered validly signed."
+	}
 	if !checkSigs {
 		return ""
 	}
@@ -123,12 +126,22 @@ func CheckSTTxSignature(transaction txcore.Transaction, rules *amendment.Rules, 
 			return reason
 		}
 	}
+	if common.SponsorSignature != nil {
+		if reason := checkSTTxSponsorSignature(transaction, common.SponsorSignature); reason != "" {
+			return reason
+		}
+	}
+	if verifier, ok := transaction.(txcore.BatchSignatureVerifier); ok {
+		if err := verifier.VerifyBatchSignatures(); err != nil {
+			return err.Error()
+		}
+	}
 	return ""
 }
 
 func checkSTTxCounterpartySignature(transaction txcore.Transaction, cp *txcore.CounterpartySignature) string {
-	hasSigners := len(cp.Signers) > 0
-	hasTxnSignature := cp.TxnSignature != ""
+	hasSigners := len(cp.Signers) > 0 || cp.HasField("Signers")
+	hasTxnSignature := cp.TxnSignature != "" || cp.HasField("TxnSignature")
 	if raw := transaction.GetRawBytes(); len(raw) > 0 {
 		if fields, err := binarycodec.DecodeBytes(raw); err == nil {
 			if object, ok := fields["CounterpartySignature"].(map[string]any); ok {
@@ -157,6 +170,42 @@ func checkSTTxCounterpartySignature(transaction txcore.Transaction, cp *txcore.C
 		return counterpartyPrefix + "Invalid Signers array size."
 	}
 	if err := VerifyCounterpartySignature(transaction, cp, true); err != nil {
+		return err.Error()
+	}
+	return ""
+}
+
+func checkSTTxSponsorSignature(transaction txcore.Transaction, sponsor *txcore.SponsorSignature) string {
+	hasSigners := len(sponsor.Signers) > 0 || sponsor.HasField("Signers")
+	hasTxnSignature := sponsor.TxnSignature != "" || sponsor.HasField("TxnSignature")
+	if raw := transaction.GetRawBytes(); len(raw) > 0 {
+		if fields, err := binarycodec.DecodeBytes(raw); err == nil {
+			if object, ok := fields["SponsorSignature"].(map[string]any); ok {
+				_, hasSigners = object["Signers"]
+				_, hasTxnSignature = object["TxnSignature"]
+			}
+		}
+	}
+
+	if sponsor.SigningPubKey != "" {
+		if hasSigners {
+			return sponsorPrefix + "Cannot both single- and multi-sign."
+		}
+		if err := VerifySponsorSignature(transaction, sponsor, true); err != nil {
+			return err.Error()
+		}
+		return ""
+	}
+	if !hasSigners {
+		return sponsorPrefix + "Empty SigningPubKey."
+	}
+	if hasTxnSignature {
+		return sponsorPrefix + "Cannot both single- and multi-sign."
+	}
+	if len(sponsor.Signers) < MinMultiSigners || len(sponsor.Signers) > MaxMultiSigners {
+		return sponsorPrefix + "Invalid Signers array size."
+	}
+	if err := VerifySponsorSignature(transaction, sponsor, true); err != nil {
 		return err.Error()
 	}
 	return ""
@@ -664,6 +713,10 @@ func copyMap(m map[string]any) map[string]any {
 
 func flattenForSigning(tx txcore.Transaction) (map[string]any, error) {
 	if raw := tx.GetRawBytes(); len(raw) > 0 {
+		matches, err := txcore.CurrentFieldsMatchRaw(tx)
+		if err != nil || !matches {
+			return nil, errors.New("transaction fields do not match retained wire transaction")
+		}
 		txMap, err := binarycodec.DecodeBytes(raw)
 		if err != nil {
 			return nil, err

--- a/internal/tx/sign/signature_wire_presence_test.go
+++ b/internal/tx/sign/signature_wire_presence_test.go
@@ -120,6 +120,9 @@ func TestVerifySignaturePreservesExplicitEmptyMemos(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			transaction := primarySignedTx(t)
+			for field := range test.counterparty {
+				test.parsed.MarkFieldPresent(field)
+			}
 			transaction.GetCommon().CounterpartySignature = test.parsed
 			candidate, err := transaction.Flatten()
 			if err != nil {
@@ -130,7 +133,9 @@ func TestVerifySignaturePreservesExplicitEmptyMemos(t *testing.T) {
 			if err != nil {
 				t.Fatalf("encode transaction: %v", err)
 			}
-			transaction.SetRawBytes(blob)
+			if err := txcore.BindRawBytes(transaction, blob); err != nil {
+				t.Fatalf("bind raw transaction: %v", err)
+			}
 			if reason := CheckSTTxSignature(transaction, nil, true); reason != test.want {
 				t.Fatalf("counterparty signature reason = %q, want %q", reason, test.want)
 			}

--- a/internal/tx/sponsor_protocol_test.go
+++ b/internal/tx/sponsor_protocol_test.go
@@ -141,7 +141,7 @@ func TestSponsorTransactionCodecRoundTrip(t *testing.T) {
 			if parsed.TxType() != wantType {
 				t.Fatalf("parsed type = %v, want %v", parsed.TxType(), wantType)
 			}
-			if !bytes.Equal(parsed.GetCommon().RawBytes, raw) {
+			if !bytes.Equal(parsed.GetRawBytes(), raw) {
 				t.Fatal("ParseFromBinary did not preserve canonical bytes")
 			}
 		})
@@ -278,8 +278,13 @@ func TestSponsorCommonFieldsJSONRoundTrip(t *testing.T) {
 	if got.Sponsor != tx.Sponsor || got.SponsorFlags == nil || *got.SponsorFlags != flags {
 		t.Fatalf("Sponsor fields = (%q, %#v), want (%q, %d)", got.Sponsor, got.SponsorFlags, tx.Sponsor, flags)
 	}
-	if !reflect.DeepEqual(got.SponsorSignature, tx.SponsorSignature) {
-		t.Fatalf("SponsorSignature = %#v, want %#v", got.SponsorSignature, tx.SponsorSignature)
+	if got.SponsorSignature == nil ||
+		got.SponsorSignature.SigningPubKey != tx.SponsorSignature.SigningPubKey ||
+		got.SponsorSignature.TxnSignature != tx.SponsorSignature.TxnSignature {
+		t.Fatalf("SponsorSignature = %#v, want values from %#v", got.SponsorSignature, tx.SponsorSignature)
+	}
+	if !got.SponsorSignature.HasField("SigningPubKey") || !got.SponsorSignature.HasField("TxnSignature") {
+		t.Fatal("parsed SponsorSignature did not retain field presence")
 	}
 }
 

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -224,9 +224,46 @@ func NewIssuedAmountFromFloat64(value float64, currency, issuer string) Amount {
 
 // Memo represents a memo attached to a transaction
 type Memo struct {
-	MemoType   string `json:"MemoType,omitempty"`
-	MemoData   string `json:"MemoData,omitempty"`
-	MemoFormat string `json:"MemoFormat,omitempty"`
+	MemoType      string `json:"MemoType,omitempty"`
+	MemoData      string `json:"MemoData,omitempty"`
+	MemoFormat    string `json:"MemoFormat,omitempty"`
+	presentFields map[string]bool
+}
+
+func (m *Memo) UnmarshalJSON(data []byte) error {
+	type memoAlias Memo
+	var decoded memoAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	*m = Memo(decoded)
+	m.presentFields = make(map[string]bool, len(fields))
+	for name := range fields {
+		m.presentFields[name] = true
+	}
+	return nil
+}
+
+func (m Memo) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.toMap())
+}
+
+func (m Memo) toMap() map[string]any {
+	fields := make(map[string]any, len(m.presentFields))
+	if m.MemoType != "" || m.presentFields["MemoType"] {
+		fields["MemoType"] = m.MemoType
+	}
+	if m.MemoData != "" || m.presentFields["MemoData"] {
+		fields["MemoData"] = m.MemoData
+	}
+	if m.MemoFormat != "" || m.presentFields["MemoFormat"] {
+		fields["MemoFormat"] = m.MemoFormat
+	}
+	return fields
 }
 
 // MemoWrapper wraps a Memo for JSON serialization

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -1,6 +1,8 @@
 package tx
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 
 	"github.com/LeJamon/go-xrpl/amendment"
@@ -33,11 +35,11 @@ type Transaction interface {
 	// Flatten returns a flat map of all transaction fields for serialization
 	Flatten() (map[string]any, error)
 
-	// GetRawBytes returns the original serialized bytes (for hash computation)
-	// Returns nil if transaction was not parsed from bytes
+	// GetRawBytes returns the canonical serialized bytes retained for hashing.
+	// It returns nil if the transaction has not been parsed or bound to bytes.
 	GetRawBytes() []byte
 
-	// SetRawBytes stores the original serialized bytes
+	// SetRawBytes stores canonical serialized bytes retained by the transaction.
 	SetRawBytes([]byte)
 
 	// RequiredAmendments returns the list of amendment feature IDs that must be enabled
@@ -123,6 +125,14 @@ type FlagsMasker interface {
 // the signature. A non-nil error carries a tem* code via ter.Errorf.
 type SigValidatedPreflighter interface {
 	PreflightSigValidated() error
+}
+
+// BatchInnerPreflightRunner owns the ordered validation of a Batch's inner
+// transactions. The callback runs the engine's common and type-specific
+// preflight for exactly one inner transaction.
+type BatchInnerPreflightRunner interface {
+	ValidateBatchOuter() error
+	PreflightInnerTransactions(func(Transaction) ter.Result) error
 }
 
 // Preclaimer is implemented by transaction types that need additional
@@ -246,6 +256,7 @@ type CounterpartySignature struct {
 	SigningPubKey string          `json:"SigningPubKey,omitempty"`
 	TxnSignature  string          `json:"TxnSignature,omitempty"`
 	Signers       []SignerWrapper `json:"Signers,omitempty"`
+	presentFields map[string]bool
 }
 
 // SponsorSignature is the nested signature object attached by a transaction's
@@ -256,6 +267,60 @@ type SponsorSignature struct {
 	SigningPubKey string          `json:"SigningPubKey,omitempty"`
 	TxnSignature  string          `json:"TxnSignature,omitempty"`
 	Signers       []SignerWrapper `json:"Signers,omitempty"`
+	presentFields map[string]bool
+}
+
+func (cs *CounterpartySignature) UnmarshalJSON(data []byte) error {
+	type signatureAlias CounterpartySignature
+	var decoded signatureAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	*cs = CounterpartySignature(decoded)
+	cs.presentFields = make(map[string]bool, len(fields))
+	for name := range fields {
+		cs.presentFields[name] = true
+	}
+	return nil
+}
+
+func (ss *SponsorSignature) UnmarshalJSON(data []byte) error {
+	type signatureAlias SponsorSignature
+	var decoded signatureAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	*ss = SponsorSignature(decoded)
+	ss.presentFields = make(map[string]bool, len(fields))
+	for name := range fields {
+		ss.presentFields[name] = true
+	}
+	return nil
+}
+
+func (cs *CounterpartySignature) HasField(name string) bool { return cs.presentFields[name] }
+func (ss *SponsorSignature) HasField(name string) bool      { return ss.presentFields[name] }
+
+func (cs *CounterpartySignature) MarkFieldPresent(name string) {
+	if cs.presentFields == nil {
+		cs.presentFields = make(map[string]bool)
+	}
+	cs.presentFields[name] = true
+}
+
+func (ss *SponsorSignature) MarkFieldPresent(name string) {
+	if ss.presentFields == nil {
+		ss.presentFields = make(map[string]bool)
+	}
+	ss.presentFields[name] = true
 }
 
 // ToMap serializes the counterparty object for the binary codec. SigningPubKey
@@ -264,10 +329,10 @@ type SponsorSignature struct {
 // reproduces the original wire bytes.
 func (cs *CounterpartySignature) ToMap() map[string]any {
 	m := map[string]any{"SigningPubKey": cs.SigningPubKey}
-	if cs.TxnSignature != "" {
+	if cs.TxnSignature != "" || cs.HasField("TxnSignature") {
 		m["TxnSignature"] = cs.TxnSignature
 	}
-	if len(cs.Signers) > 0 {
+	if len(cs.Signers) > 0 || cs.HasField("Signers") {
 		signers := make([]map[string]any, len(cs.Signers))
 		for i, sw := range cs.Signers {
 			signers[i] = map[string]any{
@@ -285,10 +350,10 @@ func (cs *CounterpartySignature) ToMap() map[string]any {
 
 func (ss *SponsorSignature) ToMap() map[string]any {
 	m := map[string]any{"SigningPubKey": ss.SigningPubKey}
-	if ss.TxnSignature != "" {
+	if ss.TxnSignature != "" || ss.HasField("TxnSignature") {
 		m["TxnSignature"] = ss.TxnSignature
 	}
-	if len(ss.Signers) > 0 {
+	if len(ss.Signers) > 0 || ss.HasField("Signers") {
 		signers := make([]map[string]any, len(ss.Signers))
 		for i, sw := range ss.Signers {
 			signers[i] = map[string]any{
@@ -343,8 +408,8 @@ type Common struct {
 	SponsorFlags     *uint32           `json:"SponsorFlags,omitempty"`
 	SponsorSignature *SponsorSignature `json:"SponsorSignature,omitempty"`
 
-	// RawBytes stores the original serialized bytes for hash computation
-	RawBytes []byte `json:"-"`
+	// rawBytes stores the canonical serialized bytes retained after parse or bind.
+	rawBytes []byte
 
 	// PresentFields tracks which fields were present in the original parsed data.
 	// This is used to distinguish between a field being absent vs explicitly set to empty.
@@ -357,7 +422,8 @@ type Common struct {
 	// guards it: ingress writes the verdict (PrewarmSignature) and then submits
 	// on the same goroutine, so the write happens-before the in-strand read and
 	// before the parsed transaction is shared with any other goroutine.
-	sigVerified bool
+	sigVerified     bool
+	sigVerifiedTxID [32]byte
 
 	// cachedTxID memoises this transaction's id. The id is a pure function of
 	// RawBytes, so the cache stays valid until SetRawBytes replaces them (which
@@ -380,6 +446,9 @@ type Common struct {
 	// amendment change. Same single-goroutine, unsynchronised contract as
 	// cachedTxID.
 	preflightedRules *amendment.Rules
+	preflightedTxID  [32]byte
+	rawFieldsID      [32]byte
+	rawFieldsIDSet   bool
 }
 
 // Validate validates the common fields. preflightCommonFields catches these
@@ -410,16 +479,37 @@ func (c *Common) SetPresentFields(fields map[string]bool) {
 	c.PresentFields = fields
 }
 
-// GetRawBytes returns the original serialized bytes
+// GetRawBytes returns the retained canonical serialized bytes.
 func (c *Common) GetRawBytes() []byte {
-	return c.RawBytes
+	return append([]byte(nil), c.rawBytes...)
 }
 
-// SetRawBytes stores the original serialized bytes, invalidating any memoised
-// transaction id since the id is derived from these bytes.
+// SetRawBytes stores canonical serialized bytes and invalidates every
+// verdict derived from the prior transaction contents.
 func (c *Common) SetRawBytes(data []byte) {
-	c.RawBytes = data
+	sameRaw := bytes.Equal(c.rawBytes, data)
+	c.rawBytes = append([]byte(nil), data...)
+	c.sigVerified = false
+	c.sigVerifiedTxID = [32]byte{}
 	c.txIDCached = false
+	c.cachedTxID = [32]byte{}
+	c.preflightedRules = nil
+	c.preflightedTxID = [32]byte{}
+	if !sameRaw {
+		c.rawFieldsID = [32]byte{}
+		c.rawFieldsIDSet = false
+	}
+}
+
+// MarkRawFieldsIdentity records the current-field identity associated with RawBytes.
+func (c *Common) MarkRawFieldsIdentity(txID [32]byte) {
+	c.rawFieldsID = txID
+	c.rawFieldsIDSet = true
+}
+
+// RawFieldsIdentity returns the current-field identity bound to RawBytes.
+func (c *Common) RawFieldsIdentity() ([32]byte, bool) {
+	return c.rawFieldsID, c.rawFieldsIDSet
 }
 
 // SetFlags sets the flags field
@@ -437,27 +527,35 @@ func (c *Common) GetFlags() uint32 {
 
 // MarkSignatureVerified records that the transaction's cryptographic signature
 // has been verified, so a later in-strand check can skip re-verifying it.
-func (c *Common) MarkSignatureVerified() {
+func (c *Common) MarkSignatureVerified(txID [32]byte) {
 	c.sigVerified = true
+	c.sigVerifiedTxID = txID
 }
 
 // SignatureVerified reports whether the transaction's signature was already
 // verified off-strand (see MarkSignatureVerified).
-func (c *Common) SignatureVerified() bool {
-	return c.sigVerified
+func (c *Common) SignatureVerified(txID ...[32]byte) bool {
+	if !c.sigVerified {
+		return false
+	}
+	return len(txID) == 0 || c.sigVerifiedTxID == txID[0]
 }
 
 // PreflightVerified reports whether this transaction's structural preflight
 // already succeeded under the given rules (see preflightedRules). A nil rules
 // never matches, so the cache is a no-op on paths that do not supply rules.
-func (c *Common) PreflightVerified(rules *amendment.Rules) bool {
-	return c.preflightedRules != nil && c.preflightedRules == rules
+func (c *Common) PreflightVerified(rules *amendment.Rules, txID ...[32]byte) bool {
+	if c.preflightedRules == nil || c.preflightedRules != rules {
+		return false
+	}
+	return len(txID) == 0 || c.preflightedTxID == txID[0]
 }
 
 // MarkPreflightVerified records that the structural preflight succeeded under
 // the given rules so a later in-strand preflight can skip the repeat.
-func (c *Common) MarkPreflightVerified(rules *amendment.Rules) {
+func (c *Common) MarkPreflightVerified(rules *amendment.Rules, txID [32]byte) {
 	c.preflightedRules = rules
+	c.preflightedTxID = txID
 }
 
 // SetSequence sets the sequence number
@@ -520,13 +618,13 @@ func (c *Common) ToMap() map[string]any {
 	if c.LastLedgerSequence != nil {
 		m["LastLedgerSequence"] = *c.LastLedgerSequence
 	}
-	if len(c.Memos) > 0 {
+	if len(c.Memos) > 0 || c.HasField("Memos") {
 		m["Memos"] = flattenMemos(c.Memos)
 	}
 	if c.NetworkID != nil {
 		m["NetworkID"] = *c.NetworkID
 	}
-	if len(c.Signers) > 0 {
+	if len(c.Signers) > 0 || c.HasField("Signers") {
 		signers := make([]map[string]any, len(c.Signers))
 		for i, sw := range c.Signers {
 			signers[i] = map[string]any{
@@ -548,7 +646,7 @@ func (c *Common) ToMap() map[string]any {
 	if c.TicketSequence != nil {
 		m["TicketSequence"] = *c.TicketSequence
 	}
-	if c.TxnSignature != "" {
+	if c.TxnSignature != "" || c.HasField("TxnSignature") {
 		m["TxnSignature"] = c.TxnSignature
 	}
 	if c.CounterpartySignature != nil {
@@ -603,7 +701,8 @@ func (c *Common) SeqProxyKey() uint64 {
 // BaseTx provides a base implementation for transactions
 type BaseTx struct {
 	Common
-	txType Type
+	txType         Type
+	fallbackFields map[string]any
 }
 
 func (b *BaseTx) TxType() Type {
@@ -620,7 +719,49 @@ func (b *BaseTx) Validate() error {
 }
 
 func (b *BaseTx) Flatten() (map[string]any, error) {
-	return b.Common.ToMap(), nil
+	fields := make(map[string]any, len(b.fallbackFields)+len(commonFields))
+	for name, value := range b.fallbackFields {
+		fields[name] = cloneTransactionFieldValue(value)
+	}
+	for name, value := range b.Common.ToMap() {
+		fields[name] = value
+	}
+	return fields, nil
+}
+
+func (b *BaseTx) setFallbackFields(fields map[string]any) {
+	b.fallbackFields = make(map[string]any)
+	for name, value := range fields {
+		if _, common := commonFieldStyles[name]; common {
+			continue
+		}
+		b.fallbackFields[name] = cloneTransactionFieldValue(value)
+	}
+}
+
+func cloneTransactionFieldValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		copy := make(map[string]any, len(typed))
+		for name, nested := range typed {
+			copy[name] = cloneTransactionFieldValue(nested)
+		}
+		return copy
+	case []any:
+		copy := make([]any, len(typed))
+		for i, nested := range typed {
+			copy[i] = cloneTransactionFieldValue(nested)
+		}
+		return copy
+	case []map[string]any:
+		copy := make([]map[string]any, len(typed))
+		for i, nested := range typed {
+			copy[i] = cloneTransactionFieldValue(nested).(map[string]any)
+		}
+		return copy
+	default:
+		return value
+	}
 }
 
 // RequiredAmendments returns no required amendments by default.

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -445,7 +445,6 @@ type Common struct {
 	SponsorFlags     *uint32           `json:"SponsorFlags,omitempty"`
 	SponsorSignature *SponsorSignature `json:"SponsorSignature,omitempty"`
 
-	// rawBytes stores the canonical serialized bytes retained after parse or bind.
 	rawBytes []byte
 
 	// PresentFields tracks which fields were present in the original parsed data.


### PR DESCRIPTION
## Summary

- complete BatchV1_1 fee accounting and per-inner preflight/preclaim ordering
- apply closed-ledger inner transactions atomically while keeping open-ledger and TxQ behavior aligned with rippled
- harden peer pre-verification, signature caching, BAD suppression, canonical serialization, and outer-only relay
- prevent replay from applying recorded inner transactions twice and validate inner hash/index/parent/result metadata
- remove retired Batch amendment definitions and expose BatchV1_1 as Supported/DefaultNo

## Verification

- direct, queued, relayed, failed-inner, replay, history, signature-cache, canonical-order, and all Batch-mode matrices against rippled v3.3.0
- focused race suites plus full build/vet/lint gates
- `just build`, `just vet`, and `just lint`

Stack 2/2. Depends on #1619. Base of the complete stack: `v3.3.0`.

Fixes #1373
