### PR TITLE
feat: add confidential crypto and fees (#1375)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,8 @@ xrpld
 docs/
 tasks/
 testdata/
-scripts/
+scripts/*
+!scripts/setup-mpt-crypto.sh
+.conan-home/
+.mpt-crypto/
 .git/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,11 +220,12 @@ jobs:
       - name: Build goxrpl docker image
         run: docker build --build-arg "VERSION=${{ github.sha }}" -t goxrpl:latest .
 
-      - name: Verify goxrpl image version
+      - name: Verify goxrpl image
         run: |
-          set -o pipefail
-          docker run --rm goxrpl:latest version |
-            grep --fixed-strings --line-regexp "go-xrpl version ${{ github.sha }}"
+          set -euo pipefail
+          output="$(docker run --rm goxrpl:latest version)"
+          grep --fixed-strings --line-regexp "go-xrpl version ${{ github.sha }}" <<<"$output"
+          grep --fixed-strings --line-regexp "Confidential MPT crypto: available" <<<"$output"
 
       - name: Run consensus smoke
         run: bash scripts/consensus-smoke/smoke.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,21 @@ jobs:
       # cgo, and no CGO dev headers are installed for this leg.
       - run: CGO_ENABLED=0 go test -count=1 -timeout 15m ./crypto/...
 
+  test-mpt-crypto:
+    name: Test (Confidential MPT native backend, ${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup
+      - name: Install Conan
+        run: pipx install conan==2.18.1
+      - name: Build and test native backend
+        run: ./scripts/setup-mpt-crypto.sh test ./crypto/mptcrypto/...
+
   consensus-smoke:
     name: Consensus smoke (2 rippled + 1 goxrpl)
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -90,11 +90,12 @@ jobs:
       - name: Build goxrpl docker image
         run: docker build --build-arg "VERSION=${{ github.sha }}" -t goxrpl:latest .
 
-      - name: Verify goxrpl image version
+      - name: Verify goxrpl image
         run: |
-          set -o pipefail
-          docker run --rm goxrpl:latest version |
-            grep --fixed-strings --line-regexp "go-xrpl version ${{ github.sha }}"
+          set -euo pipefail
+          output="$(docker run --rm goxrpl:latest version)"
+          grep --fixed-strings --line-regexp "go-xrpl version ${{ github.sha }}" <<<"$output"
+          grep --fixed-strings --line-regexp "Confidential MPT crypto: available" <<<"$output"
 
       - name: Run extended consensus soak
         run: bash scripts/consensus-smoke/smoke.sh

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ main
 .worktrees/
 worktrees/
 tasks/
+
+# Optional native Confidential MPT dependency state.
+.conan-home/
+.mpt-crypto/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,23 @@
 # Stage 1: Build
 FROM golang:1.24-alpine AS builder
 
-# Alpine ships libsecp256k1 only as a shared .so, so build the static .a
-# from upstream for the distroless static-linked binary.
-ARG LIBSECP256K1_VERSION=v0.5.0
-
 RUN apk add --no-cache \
-    git gcc make musl-dev pkgconf autoconf automake libtool \
-    openssl-dev openssl-libs-static \
- && git clone --depth 1 --branch ${LIBSECP256K1_VERSION} \
-    https://github.com/bitcoin-core/secp256k1.git /tmp/secp256k1 \
- && cd /tmp/secp256k1 \
- && ./autogen.sh \
- && ./configure --disable-shared --enable-static \
-    --disable-tests --disable-benchmark --disable-exhaustive-tests \
-    --enable-module-recovery=no \
- && make -j"$(nproc)" install \
- && rm -rf /tmp/secp256k1
+    autoconf automake bash cmake g++ git libtool linux-headers make \
+    musl-dev perl pipx pkgconf \
+ && pipx install conan==2.18.1
 
 WORKDIR /src
 
+ENV CGO_ENABLED=1 \
+    PATH="/root/.local/bin:${PATH}" \
+    PKG_CONFIG_PATH="/src/.mpt-crypto"
+
 COPY go.mod go.sum ./
 RUN go mod download
+
+COPY conan-mpt-crypto.txt conan-mpt-crypto.lock ./
+COPY scripts/setup-mpt-crypto.sh ./scripts/setup-mpt-crypto.sh
+RUN ./scripts/setup-mpt-crypto.sh setup
 
 COPY . .
 
@@ -31,10 +27,11 @@ RUN if [ -z "${VERSION}" ] || [ "${VERSION}" = "dev" ]; then \
       echo "VERSION must identify a release or commit" >&2; \
       exit 2; \
     fi \
- && CGO_ENABLED=1 go build \
+ && go build -tags mptcrypto \
     -trimpath \
     -ldflags="-s -w -linkmode external -extldflags '-static' -X=github.com/LeJamon/go-xrpl/version.Version=${VERSION}" \
-    -o /usr/local/bin/goxrpl ./cmd/xrpld
+    -o /usr/local/bin/goxrpl ./cmd/xrpld \
+ && /usr/local/bin/goxrpl version | grep -Fx "Confidential MPT crypto: available"
 
 # Stage 2: Runtime
 FROM gcr.io/distroless/static:nonroot

--- a/codec/binarycodec/definitions/definitions.json
+++ b/codec/binarycodec/definitions/definitions.json
@@ -3981,6 +3981,7 @@
     "temBAD_ISSUER": -294,
     "temBAD_LIMIT": -293,
     "temBAD_MPT": -249,
+    "temBAD_CIPHERTEXT": -248,
     "temBAD_NFTOKEN_TRANSFER_FEE": -262,
     "temBAD_OFFER": -292,
     "temBAD_PATH": -291,

--- a/conan-mpt-crypto.lock
+++ b/conan-mpt-crypto.lock
@@ -1,0 +1,12 @@
+{
+    "version": "0.5",
+    "requires": [
+        "zlib/1.3.2#1cb806da49011867778ffb6ac7190fcb%1782392402.122708",
+        "secp256k1/0.7.1#b1f450b7f78a36fff75bb6934a356f3a%1782338841.3729",
+        "openssl/3.6.3#f806de8933e3bf6f01016c6a888cee2e%1783945160.863288",
+        "mpt-crypto/1.0.2#b313cef0c1a493eb970ad185b2e9bab7%1784285108.866483"
+    ],
+    "build_requires": [],
+    "python_requires": [],
+    "config_requires": []
+}

--- a/conan-mpt-crypto.txt
+++ b/conan-mpt-crypto.txt
@@ -1,0 +1,10 @@
+[requires]
+mpt-crypto/1.0.2#b313cef0c1a493eb970ad185b2e9bab7
+
+[options]
+mpt-crypto/*:shared=False
+mpt-crypto/*:fPIC=True
+mpt-crypto/*:tests=True
+
+[generators]
+PkgConfigDeps

--- a/crypto/mptcrypto/README.md
+++ b/crypto/mptcrypto/README.md
@@ -1,0 +1,28 @@
+# Confidential MPT native backend
+
+The optional `mptcrypto` build tag links the official XRPLF `mpt-crypto` 1.0.2
+package through a fixed C ABI. The dependency graph is the graph locked by
+rippled 3.3.0:
+
+- `mpt-crypto/1.0.2#b313cef0c1a493eb970ad185b2e9bab7`
+- source tag object `bec300394509a0d1bc82fee63b5365dc9e5db20e`
+- peeled source commit `376691c5fca7898bd1161b0ac6646109d069ceb9`
+- source archive SHA-256 `171f27d8acf88a030bb2480f0aedbfdc523445e429729b824fdd7384cdd730b1`
+- `secp256k1/0.7.1#b1f450b7f78a36fff75bb6934a356f3a`
+- `openssl/3.6.3#f806de8933e3bf6f01016c6a888cee2e`
+
+Run `just setup-mpt-crypto`, then `just test-mpt-crypto`. The test recipe runs
+the complete upstream 1.0.2 C/C++ suite before the Go bridge tests. Setup uses the
+repository-local `.conan-home` as `CONAN_HOME`, so it neither reads
+nor changes the user's global Conan remotes or cache.
+
+The upstream source archive does not contain a license or notice. This
+repository therefore does not vendor or redistribute its sources, headers,
+libraries, or linked binaries. Obtain legal clearance before distributing an
+`mptcrypto`-linked artifact.
+
+Without both the build tag and cgo, the backend is unavailable and the
+ConfidentialTransfer amendment remains unsupported. Builds with both
+`mptcrypto` and cgo advertise the complete transaction family as supported only
+when the native secp256k1 context initializes successfully; the amendment
+remains vote-default-no in every build.

--- a/crypto/mptcrypto/backend_native.go
+++ b/crypto/mptcrypto/backend_native.go
@@ -1,0 +1,168 @@
+//go:build mptcrypto && cgo
+
+package mptcrypto
+
+import "github.com/LeJamon/go-xrpl/crypto/mptcrypto/internal/native"
+
+// Available reports whether the native confidential MPT backend is available.
+func Available() bool { return native.Available() }
+
+// ValidPublicKey reports whether value is a valid confidential MPT public key.
+func ValidPublicKey(value []byte) bool { return native.ValidPublicKey(value) }
+
+// ValidCommitment reports whether value is a valid Pedersen commitment.
+func ValidCommitment(value []byte) bool { return native.ValidCommitment(value) }
+
+// ValidCiphertext reports whether value is a valid encrypted balance.
+func ValidCiphertext(value []byte) bool { return native.ValidCiphertext(value) }
+
+// AddCiphertexts adds two encrypted balances.
+func AddCiphertexts(a, b []byte) ([]byte, bool) { return native.AddCiphertexts(a, b) }
+
+// SubtractCiphertexts subtracts one encrypted balance from another.
+func SubtractCiphertexts(a, b []byte) ([]byte, bool) {
+	return native.SubtractCiphertexts(a, b)
+}
+
+// CanonicalZero creates the canonical encrypted zero for an account and issuance.
+func CanonicalZero(pub []byte, account [20]byte, issuance [24]byte) ([]byte, bool) {
+	return native.CanonicalZero(pub, account, issuance)
+}
+
+// ConvertContext derives the proof context for a confidential conversion.
+func ConvertContext(account [20]byte, issuance [24]byte, sequence uint32) ([32]byte, bool) {
+	return native.ConvertContext(account, issuance, sequence)
+}
+
+// ConvertBackContext derives the proof context for a conversion back to a public balance.
+func ConvertBackContext(account [20]byte, issuance [24]byte, sequence, version uint32) ([32]byte, bool) {
+	return native.ConvertBackContext(account, issuance, sequence, version)
+}
+
+// SendContext derives the proof context for a confidential transfer.
+func SendContext(account [20]byte, issuance [24]byte, sequence uint32, destination [20]byte, version uint32) ([32]byte, bool) {
+	return native.SendContext(account, issuance, sequence, destination, version)
+}
+
+// ClawbackContext derives the proof context for a confidential clawback.
+func ClawbackContext(account [20]byte, issuance [24]byte, sequence uint32, holder [20]byte) ([32]byte, bool) {
+	return native.ClawbackContext(account, issuance, sequence, holder)
+}
+
+func nativeParticipant(value Participant) native.Participant {
+	return native.Participant{PublicKey: value.PublicKey, Ciphertext: value.Ciphertext}
+}
+
+func nativeAuditor(value *Participant) *native.Participant {
+	if value == nil {
+		return nil
+	}
+	converted := nativeParticipant(*value)
+	return &converted
+}
+
+// VerifyRevealed verifies that revealed balance data matches every participant ciphertext.
+func VerifyRevealed(amount uint64, blind [32]byte, holder, issuer Participant, auditor *Participant) bool {
+	return native.VerifyRevealed(
+		amount,
+		blind,
+		nativeParticipant(holder),
+		nativeParticipant(issuer),
+		nativeAuditor(auditor),
+	)
+}
+
+// VerifyConvert verifies a confidential conversion proof.
+func VerifyConvert(proof, pub []byte, context [32]byte) bool {
+	return native.VerifyConvert(proof, pub, context)
+}
+
+// VerifyConvertBack verifies a confidential conversion-back proof.
+func VerifyConvertBack(proof, pub, spending, commitment []byte, amount uint64, context [32]byte) bool {
+	return native.VerifyConvertBack(proof, pub, spending, commitment, amount, context)
+}
+
+// VerifySend verifies a confidential transfer proof.
+func VerifySend(proof []byte, sender, destination, issuer Participant, auditor *Participant, spending, amountCommitment, balanceCommitment []byte, context [32]byte) bool {
+	return native.VerifySend(
+		proof,
+		nativeParticipant(sender),
+		nativeParticipant(destination),
+		nativeParticipant(issuer),
+		nativeAuditor(auditor),
+		spending,
+		amountCommitment,
+		balanceCommitment,
+		context,
+	)
+}
+
+// VerifyClawback verifies a confidential clawback proof.
+func VerifyClawback(proof, pub, ciphertext []byte, amount uint64, context [32]byte) bool {
+	return native.VerifyClawback(proof, pub, ciphertext, amount, context)
+}
+
+// RerandomizeCiphertext rerandomizes an encrypted balance.
+func RerandomizeCiphertext(ciphertext, pub []byte, randomness [32]byte) ([]byte, bool) {
+	return native.RerandomizeCiphertext(ciphertext, pub, randomness)
+}
+
+// GenerateKeyPair creates a confidential MPT private and public key pair.
+func GenerateKeyPair() ([32]byte, []byte, bool) { return native.GenerateKeyPair() }
+
+// GenerateBlindingFactor creates a cryptographically secure blinding factor.
+func GenerateBlindingFactor() ([32]byte, bool) { return native.GenerateBlindingFactor() }
+
+// EncryptAmount encrypts an amount for a public key with the supplied blinding factor.
+func EncryptAmount(amount uint64, public []byte, blind [32]byte) ([]byte, bool) {
+	return native.EncryptAmount(amount, public, blind)
+}
+
+// GenerateConvertProof creates a confidential conversion proof.
+func GenerateConvertProof(public []byte, private [32]byte, context [32]byte) ([]byte, bool) {
+	return native.GenerateConvertProof(public, private, context)
+}
+
+// PedersenCommitment creates a commitment to an amount and blinding factor.
+func PedersenCommitment(amount uint64, blind [32]byte) ([]byte, bool) {
+	return native.PedersenCommitment(amount, blind)
+}
+
+// GenerateConvertBackProof creates a confidential conversion-back proof.
+func GenerateConvertBackProof(private [32]byte, public []byte, context [32]byte, amount uint64, balanceCommitment []byte, balance uint64, spending []byte, balanceBlind [32]byte) ([]byte, bool) {
+	return native.GenerateConvertBackProof(
+		private,
+		public,
+		context,
+		amount,
+		balanceCommitment,
+		balance,
+		spending,
+		balanceBlind,
+	)
+}
+
+// GenerateSendProof creates a confidential transfer proof.
+func GenerateSendProof(private [32]byte, amount uint64, participants []Participant, transactionBlind [32]byte, context [32]byte, amountCommitment, balanceCommitment []byte, balance uint64, spending []byte, balanceBlind [32]byte) ([]byte, bool) {
+	converted := make([]native.Participant, len(participants))
+	for i := range participants {
+		converted[i] = nativeParticipant(participants[i])
+	}
+	return native.GenerateSendProof(
+		private,
+		amount,
+		converted,
+		transactionBlind,
+		context,
+		amountCommitment,
+		balanceCommitment,
+		balance,
+		spending,
+		balanceBlind,
+	)
+}
+
+// GenerateClawbackProof creates a confidential clawback proof.
+func GenerateClawbackProof(private [32]byte, public []byte, context [32]byte, amount uint64, ciphertext []byte) ([]byte, bool) {
+	return native.GenerateClawbackProof(private, public, context, amount, ciphertext)
+}

--- a/crypto/mptcrypto/backend_native_test.go
+++ b/crypto/mptcrypto/backend_native_test.go
@@ -1,0 +1,106 @@
+//go:build mptcrypto && cgo
+
+package mptcrypto
+
+import "testing"
+
+func mustKeyPair(t *testing.T) ([32]byte, []byte) {
+	t.Helper()
+	private, public, ok := GenerateKeyPair()
+	if !ok {
+		t.Fatal("generate key pair")
+	}
+	return private, public
+}
+
+func mustBlind(t *testing.T) [32]byte {
+	t.Helper()
+	blind, ok := GenerateBlindingFactor()
+	if !ok {
+		t.Fatal("generate blinding factor")
+	}
+	return blind
+}
+
+func mustEncrypt(t *testing.T, amount uint64, public []byte, blind [32]byte) []byte {
+	t.Helper()
+	ciphertext, ok := EncryptAmount(amount, public, blind)
+	if !ok {
+		t.Fatal("encrypt amount")
+	}
+	return ciphertext
+}
+
+func TestNativeBackendProofsAndArithmetic(t *testing.T) {
+	if !Available() {
+		t.Fatal("native backend unavailable")
+	}
+	holderPrivate, holderPublic := mustKeyPair(t)
+	_, issuerPublic := mustKeyPair(t)
+	_, auditorPublic := mustKeyPair(t)
+
+	var account [20]byte
+	var issuance [24]byte
+	for i := range account {
+		account[i] = byte(i + 1)
+	}
+	for i := range issuance {
+		issuance[i] = byte(i + 2)
+	}
+
+	context, ok := ConvertContext(account, issuance, 7)
+	if !ok {
+		t.Fatal("convert context")
+	}
+	convertProof, ok := GenerateConvertProof(holderPublic, holderPrivate, context)
+	if !ok || !VerifyConvert(convertProof, holderPublic, context) {
+		t.Fatal("convert proof")
+	}
+	wrongContext := context
+	wrongContext[0] ^= 1
+	if VerifyConvert(convertProof, holderPublic, wrongContext) {
+		t.Fatal("convert proof accepted wrong context")
+	}
+
+	amountBlind := mustBlind(t)
+	holderAmount := mustEncrypt(t, 40, holderPublic, amountBlind)
+	issuerAmount := mustEncrypt(t, 40, issuerPublic, amountBlind)
+	auditorAmount := mustEncrypt(t, 40, auditorPublic, amountBlind)
+	auditor := Participant{PublicKey: auditorPublic, Ciphertext: auditorAmount}
+	if !VerifyRevealed(40, amountBlind, Participant{holderPublic, holderAmount}, Participant{issuerPublic, issuerAmount}, &auditor) {
+		t.Fatal("revealed amount")
+	}
+	if VerifyRevealed(41, amountBlind, Participant{holderPublic, holderAmount}, Participant{issuerPublic, issuerAmount}, &auditor) {
+		t.Fatal("revealed amount accepted wrong amount")
+	}
+
+	secondBlind := mustBlind(t)
+	secondAmount := mustEncrypt(t, 2, holderPublic, secondBlind)
+	if sum, ok := AddCiphertexts(holderAmount, secondAmount); !ok || !ValidCiphertext(sum) {
+		t.Fatal("ciphertext addition")
+	}
+	if difference, ok := SubtractCiphertexts(holderAmount, secondAmount); !ok || !ValidCiphertext(difference) {
+		t.Fatal("ciphertext subtraction")
+	}
+	if zero, ok := CanonicalZero(holderPublic, account, issuance); !ok || !ValidCiphertext(zero) {
+		t.Fatal("canonical zero")
+	}
+
+	balanceBlind := mustBlind(t)
+	spending := mustEncrypt(t, 100, holderPublic, balanceBlind)
+	balanceCommitment, ok := PedersenCommitment(100, balanceBlind)
+	if !ok {
+		t.Fatal("balance commitment")
+	}
+	backContext, ok := ConvertBackContext(account, issuance, 8, 3)
+	if !ok {
+		t.Fatal("convert back context")
+	}
+	backProof, ok := GenerateConvertBackProof(holderPrivate, holderPublic, backContext, 40, balanceCommitment, 100, spending, balanceBlind)
+	if !ok || !VerifyConvertBack(backProof, holderPublic, spending, balanceCommitment, 40, backContext) {
+		t.Fatal("convert back proof")
+	}
+	if VerifyConvertBack(backProof, holderPublic, spending, balanceCommitment, 41, backContext) {
+		t.Fatal("convert back proof accepted wrong amount")
+	}
+}

--- a/crypto/mptcrypto/backend_unavailable.go
+++ b/crypto/mptcrypto/backend_unavailable.go
@@ -1,0 +1,94 @@
+//go:build !mptcrypto || !cgo
+
+package mptcrypto
+
+// Available reports whether the native confidential MPT backend is available.
+func Available() bool { return false }
+
+// ValidPublicKey reports whether value is a valid confidential MPT public key.
+func ValidPublicKey([]byte) bool { return false }
+
+// ValidCommitment reports whether value is a valid Pedersen commitment.
+func ValidCommitment([]byte) bool { return false }
+
+// ValidCiphertext reports whether value is a valid encrypted balance.
+func ValidCiphertext([]byte) bool { return false }
+
+// AddCiphertexts adds two encrypted balances.
+func AddCiphertexts([]byte, []byte) ([]byte, bool) { return nil, false }
+
+// SubtractCiphertexts subtracts one encrypted balance from another.
+func SubtractCiphertexts([]byte, []byte) ([]byte, bool) { return nil, false }
+
+// CanonicalZero creates the canonical encrypted zero for an account and issuance.
+func CanonicalZero([]byte, [20]byte, [24]byte) ([]byte, bool) { return nil, false }
+
+// ConvertContext derives the proof context for a confidential conversion.
+func ConvertContext([20]byte, [24]byte, uint32) ([32]byte, bool) { return [32]byte{}, false }
+
+// ConvertBackContext derives the proof context for a conversion back to a public balance.
+func ConvertBackContext([20]byte, [24]byte, uint32, uint32) ([32]byte, bool) {
+	return [32]byte{}, false
+}
+
+// SendContext derives the proof context for a confidential transfer.
+func SendContext([20]byte, [24]byte, uint32, [20]byte, uint32) ([32]byte, bool) {
+	return [32]byte{}, false
+}
+
+// ClawbackContext derives the proof context for a confidential clawback.
+func ClawbackContext([20]byte, [24]byte, uint32, [20]byte) ([32]byte, bool) {
+	return [32]byte{}, false
+}
+
+// VerifyRevealed verifies that revealed balance data matches every participant ciphertext.
+func VerifyRevealed(uint64, [32]byte, Participant, Participant, *Participant) bool { return false }
+
+// VerifyConvert verifies a confidential conversion proof.
+func VerifyConvert([]byte, []byte, [32]byte) bool { return false }
+
+// VerifyConvertBack verifies a confidential conversion-back proof.
+func VerifyConvertBack([]byte, []byte, []byte, []byte, uint64, [32]byte) bool { return false }
+
+// VerifySend verifies a confidential transfer proof.
+func VerifySend([]byte, Participant, Participant, Participant, *Participant, []byte, []byte, []byte, [32]byte) bool {
+	return false
+}
+
+// VerifyClawback verifies a confidential clawback proof.
+func VerifyClawback([]byte, []byte, []byte, uint64, [32]byte) bool { return false }
+
+// RerandomizeCiphertext rerandomizes an encrypted balance.
+func RerandomizeCiphertext([]byte, []byte, [32]byte) ([]byte, bool) { return nil, false }
+
+// GenerateKeyPair creates a confidential MPT private and public key pair.
+func GenerateKeyPair() ([32]byte, []byte, bool) { return [32]byte{}, nil, false }
+
+// GenerateBlindingFactor creates a cryptographically secure blinding factor.
+func GenerateBlindingFactor() ([32]byte, bool) { return [32]byte{}, false }
+
+// EncryptAmount encrypts an amount for a public key with the supplied blinding factor.
+func EncryptAmount(uint64, []byte, [32]byte) ([]byte, bool) { return nil, false }
+
+// GenerateConvertProof creates a confidential conversion proof.
+func GenerateConvertProof([]byte, [32]byte, [32]byte) ([]byte, bool) {
+	return nil, false
+}
+
+// PedersenCommitment creates a commitment to an amount and blinding factor.
+func PedersenCommitment(uint64, [32]byte) ([]byte, bool) { return nil, false }
+
+// GenerateConvertBackProof creates a confidential conversion-back proof.
+func GenerateConvertBackProof([32]byte, []byte, [32]byte, uint64, []byte, uint64, []byte, [32]byte) ([]byte, bool) {
+	return nil, false
+}
+
+// GenerateSendProof creates a confidential transfer proof.
+func GenerateSendProof([32]byte, uint64, []Participant, [32]byte, [32]byte, []byte, []byte, uint64, []byte, [32]byte) ([]byte, bool) {
+	return nil, false
+}
+
+// GenerateClawbackProof creates a confidential clawback proof.
+func GenerateClawbackProof([32]byte, []byte, [32]byte, uint64, []byte) ([]byte, bool) {
+	return nil, false
+}

--- a/crypto/mptcrypto/backend_unavailable_test.go
+++ b/crypto/mptcrypto/backend_unavailable_test.go
@@ -1,0 +1,34 @@
+//go:build !mptcrypto || !cgo
+
+package mptcrypto
+
+import "testing"
+
+func TestUnavailableBackendFailsClosed(t *testing.T) {
+	if Available() {
+		t.Fatal("unavailable backend reported available")
+	}
+
+	var account [20]byte
+	var issuance [24]byte
+	var scalar [32]byte
+	participant := Participant{PublicKey: make([]byte, PublicKeySize), Ciphertext: make([]byte, CiphertextSize)}
+	commitment := make([]byte, CommitmentSize)
+
+	if _, ok := ConvertContext(account, issuance, 1); ok {
+		t.Fatal("unavailable backend produced a context")
+	}
+	if VerifyRevealed(1, scalar, participant, participant, nil) ||
+		VerifyConvert(make([]byte, ConvertProofSize), participant.PublicKey, scalar) ||
+		VerifyConvertBack(make([]byte, ConvertBackProofSize), participant.PublicKey, participant.Ciphertext, commitment, 1, scalar) ||
+		VerifySend(make([]byte, SendProofSize), participant, participant, participant, nil, participant.Ciphertext, commitment, commitment, scalar) ||
+		VerifyClawback(make([]byte, ClawbackProofSize), participant.PublicKey, participant.Ciphertext, 1, scalar) {
+		t.Fatal("unavailable backend accepted a proof")
+	}
+	if out, ok := AddCiphertexts(participant.Ciphertext, participant.Ciphertext); ok || out != nil {
+		t.Fatal("unavailable backend produced a ciphertext")
+	}
+	if private, public, ok := GenerateKeyPair(); ok || private != [32]byte{} || public != nil {
+		t.Fatal("unavailable backend produced key material")
+	}
+}

--- a/crypto/mptcrypto/bounds_test.go
+++ b/crypto/mptcrypto/bounds_test.go
@@ -1,0 +1,84 @@
+package mptcrypto
+
+import "testing"
+
+func TestRejectsMalformedInputSizes(t *testing.T) {
+	var scalar [32]byte
+	participant := Participant{
+		PublicKey:  make([]byte, PublicKeySize),
+		Ciphertext: make([]byte, CiphertextSize),
+	}
+	commitment := make([]byte, CommitmentSize)
+	ciphertext := make([]byte, CiphertextSize)
+
+	for _, size := range []int{0, PublicKeySize - 1, PublicKeySize + 1} {
+		value := make([]byte, size)
+		if ValidPublicKey(value) || ValidCommitment(value) {
+			t.Fatalf("accepted %d-byte compressed point", size)
+		}
+		if _, ok := CanonicalZero(value, [20]byte{}, [24]byte{}); ok {
+			t.Fatalf("canonical zero accepted %d-byte key", size)
+		}
+		if _, ok := EncryptAmount(1, value, scalar); ok {
+			t.Fatalf("encryption accepted %d-byte key", size)
+		}
+	}
+
+	for _, size := range []int{0, CiphertextSize - 1, CiphertextSize + 1} {
+		value := make([]byte, size)
+		if ValidCiphertext(value) {
+			t.Fatalf("accepted %d-byte ciphertext", size)
+		}
+		if out, ok := AddCiphertexts(value, ciphertext); ok || out != nil {
+			t.Fatalf("addition accepted %d-byte ciphertext", size)
+		}
+		if out, ok := SubtractCiphertexts(ciphertext, value); ok || out != nil {
+			t.Fatalf("subtraction accepted %d-byte ciphertext", size)
+		}
+		if out, ok := RerandomizeCiphertext(value, participant.PublicKey, scalar); ok || out != nil {
+			t.Fatalf("rerandomization accepted %d-byte ciphertext", size)
+		}
+	}
+
+	for _, size := range []int{ConvertProofSize - 1, ConvertProofSize + 1} {
+		if VerifyConvert(make([]byte, size), participant.PublicKey, scalar) {
+			t.Fatalf("accepted %d-byte convert proof", size)
+		}
+	}
+	for _, size := range []int{ConvertBackProofSize - 1, ConvertBackProofSize + 1} {
+		if VerifyConvertBack(make([]byte, size), participant.PublicKey, ciphertext, commitment, 1, scalar) {
+			t.Fatalf("accepted %d-byte convert-back proof", size)
+		}
+	}
+	for _, size := range []int{SendProofSize - 1, SendProofSize + 1} {
+		if VerifySend(make([]byte, size), participant, participant, participant, nil, ciphertext, commitment, commitment, scalar) {
+			t.Fatalf("accepted %d-byte send proof", size)
+		}
+	}
+	for _, size := range []int{ClawbackProofSize - 1, ClawbackProofSize + 1} {
+		if VerifyClawback(make([]byte, size), participant.PublicKey, ciphertext, 1, scalar) {
+			t.Fatalf("accepted %d-byte clawback proof", size)
+		}
+	}
+
+	invalid := Participant{PublicKey: participant.PublicKey[:PublicKeySize-1], Ciphertext: ciphertext}
+	if VerifyRevealed(1, scalar, invalid, participant, nil) {
+		t.Fatal("accepted malformed revealed-amount participant")
+	}
+	if VerifySend(make([]byte, SendProofSize), invalid, participant, participant, nil, ciphertext, commitment, commitment, scalar) {
+		t.Fatal("accepted malformed send participant")
+	}
+
+	if out, ok := GenerateConvertProof(participant.PublicKey[:PublicKeySize-1], scalar, scalar); ok || out != nil {
+		t.Fatal("generated convert proof for malformed key")
+	}
+	if out, ok := GenerateConvertBackProof(scalar, participant.PublicKey, scalar, 1, commitment[:CommitmentSize-1], 1, ciphertext, scalar); ok || out != nil {
+		t.Fatal("generated convert-back proof for malformed commitment")
+	}
+	if out, ok := GenerateSendProof(scalar, 1, []Participant{participant, participant}, scalar, scalar, commitment, commitment, 1, ciphertext, scalar); ok || out != nil {
+		t.Fatal("generated send proof with invalid participant count")
+	}
+	if out, ok := GenerateClawbackProof(scalar, participant.PublicKey, scalar, 1, ciphertext[:CiphertextSize-1]); ok || out != nil {
+		t.Fatal("generated clawback proof for malformed ciphertext")
+	}
+}

--- a/crypto/mptcrypto/internal/native/native.go
+++ b/crypto/mptcrypto/internal/native/native.go
@@ -1,0 +1,249 @@
+//go:build mptcrypto && cgo
+
+package native
+
+/*
+#cgo pkg-config: goxrpl-mpt-crypto
+#include "shim.h"
+*/
+import "C"
+
+import (
+	_ "github.com/LeJamon/go-xrpl/crypto/secp256k1/shim"
+	"unsafe"
+)
+
+const (
+	PublicKeySize        = 33
+	CiphertextSize       = 66
+	BlindingFactorSize   = 32
+	ConvertProofSize     = 64
+	ConvertBackProofSize = 816
+	SendProofSize        = 946
+	ClawbackProofSize    = 64
+	CommitmentSize       = 33
+)
+
+type Participant struct {
+	PublicKey  []byte
+	Ciphertext []byte
+}
+
+func bytePtr(value []byte) *C.uint8_t { return (*C.uint8_t)(unsafe.Pointer(unsafe.SliceData(value))) }
+
+func Available() bool { return C.go_mpt_available() == 1 }
+
+func bytesResult(value []byte, ok bool) ([]byte, bool) {
+	if !ok {
+		return nil, false
+	}
+	return value, true
+}
+
+func ValidPublicKey(value []byte) bool {
+	return len(value) == PublicKeySize && C.go_mpt_valid_pubkey(bytePtr(value)) == 1
+}
+
+func ValidCommitment(value []byte) bool { return ValidPublicKey(value) }
+
+func ValidCiphertext(value []byte) bool {
+	return len(value) == CiphertextSize && C.go_mpt_valid_ciphertext(bytePtr(value)) == 1
+}
+
+func combine(a, b []byte, subtract bool) ([]byte, bool) {
+	if len(a) != CiphertextSize || len(b) != CiphertextSize {
+		return nil, false
+	}
+	out := make([]byte, CiphertextSize)
+	var ok C.int
+	if subtract {
+		ok = C.go_mpt_subtract(bytePtr(a), bytePtr(b), bytePtr(out))
+	} else {
+		ok = C.go_mpt_add(bytePtr(a), bytePtr(b), bytePtr(out))
+	}
+	return bytesResult(out, ok == 1)
+}
+
+func AddCiphertexts(a, b []byte) ([]byte, bool)      { return combine(a, b, false) }
+func SubtractCiphertexts(a, b []byte) ([]byte, bool) { return combine(a, b, true) }
+
+func CanonicalZero(pub []byte, account [20]byte, issuance [24]byte) ([]byte, bool) {
+	if len(pub) != PublicKeySize {
+		return nil, false
+	}
+	out := make([]byte, CiphertextSize)
+	ok := C.go_mpt_canonical_zero(bytePtr(pub), bytePtr(account[:]), bytePtr(issuance[:]), bytePtr(out)) == 1
+	return bytesResult(out, ok)
+}
+
+func ConvertContext(account [20]byte, issuance [24]byte, sequence uint32) ([32]byte, bool) {
+	var out [32]byte
+	ok := C.go_mpt_convert_context(bytePtr(account[:]), bytePtr(issuance[:]), C.uint32_t(sequence), bytePtr(out[:])) == 1
+	if !ok {
+		return [32]byte{}, false
+	}
+	return out, ok
+}
+
+func ConvertBackContext(account [20]byte, issuance [24]byte, sequence, version uint32) ([32]byte, bool) {
+	var out [32]byte
+	ok := C.go_mpt_convert_back_context(bytePtr(account[:]), bytePtr(issuance[:]), C.uint32_t(sequence), C.uint32_t(version), bytePtr(out[:])) == 1
+	if !ok {
+		return [32]byte{}, false
+	}
+	return out, ok
+}
+
+func SendContext(account [20]byte, issuance [24]byte, sequence uint32, destination [20]byte, version uint32) ([32]byte, bool) {
+	var out [32]byte
+	ok := C.go_mpt_send_context(bytePtr(account[:]), bytePtr(issuance[:]), C.uint32_t(sequence), bytePtr(destination[:]), C.uint32_t(version), bytePtr(out[:])) == 1
+	if !ok {
+		return [32]byte{}, false
+	}
+	return out, ok
+}
+
+func ClawbackContext(account [20]byte, issuance [24]byte, sequence uint32, holder [20]byte) ([32]byte, bool) {
+	var out [32]byte
+	ok := C.go_mpt_clawback_context(bytePtr(account[:]), bytePtr(issuance[:]), C.uint32_t(sequence), bytePtr(holder[:]), bytePtr(out[:])) == 1
+	if !ok {
+		return [32]byte{}, false
+	}
+	return out, ok
+}
+
+func validParticipant(p Participant) bool {
+	return len(p.PublicKey) == PublicKeySize && len(p.Ciphertext) == CiphertextSize
+}
+
+func VerifyRevealed(amount uint64, blind [32]byte, holder, issuer Participant, auditor *Participant) bool {
+	if !validParticipant(holder) || !validParticipant(issuer) {
+		return false
+	}
+	zeroPub := make([]byte, PublicKeySize)
+	zeroCT := make([]byte, CiphertextSize)
+	hasAuditor, auditorPub, auditorCT := C.int(0), zeroPub, zeroCT
+	if auditor != nil {
+		if !validParticipant(*auditor) {
+			return false
+		}
+		hasAuditor, auditorPub, auditorCT = 1, auditor.PublicKey, auditor.Ciphertext
+	}
+	return C.go_mpt_verify_revealed(C.uint64_t(amount), bytePtr(blind[:]), bytePtr(holder.PublicKey), bytePtr(holder.Ciphertext), bytePtr(issuer.PublicKey), bytePtr(issuer.Ciphertext), hasAuditor, bytePtr(auditorPub), bytePtr(auditorCT)) == 1
+}
+
+func VerifyConvert(proof, pub []byte, context [32]byte) bool {
+	return len(proof) == ConvertProofSize && len(pub) == PublicKeySize && C.go_mpt_verify_convert(bytePtr(proof), bytePtr(pub), bytePtr(context[:])) == 1
+}
+
+func VerifyConvertBack(proof, pub, spending, commitment []byte, amount uint64, context [32]byte) bool {
+	return len(proof) == ConvertBackProofSize && len(pub) == PublicKeySize && len(spending) == CiphertextSize && len(commitment) == CommitmentSize && C.go_mpt_verify_convert_back(bytePtr(proof), bytePtr(pub), bytePtr(spending), bytePtr(commitment), C.uint64_t(amount), bytePtr(context[:])) == 1
+}
+
+func VerifySend(proof []byte, sender, destination, issuer Participant, auditor *Participant, spending, amountCommitment, balanceCommitment []byte, context [32]byte) bool {
+	if len(proof) != SendProofSize || !validParticipant(sender) || !validParticipant(destination) || !validParticipant(issuer) || len(spending) != CiphertextSize || len(amountCommitment) != CommitmentSize || len(balanceCommitment) != CommitmentSize {
+		return false
+	}
+	participants := []Participant{sender, destination, issuer}
+	if auditor != nil {
+		if !validParticipant(*auditor) {
+			return false
+		}
+		participants = append(participants, *auditor)
+	}
+	var pubs [4 * PublicKeySize]byte
+	var ciphertexts [4 * CiphertextSize]byte
+	for i, value := range participants {
+		copy(pubs[i*PublicKeySize:], value.PublicKey)
+		copy(ciphertexts[i*CiphertextSize:], value.Ciphertext)
+	}
+	return C.go_mpt_verify_send(bytePtr(proof), bytePtr(pubs[:]), bytePtr(ciphertexts[:]), C.uint8_t(len(participants)), bytePtr(spending), bytePtr(amountCommitment), bytePtr(balanceCommitment), bytePtr(context[:])) == 1
+}
+
+func VerifyClawback(proof, pub, ciphertext []byte, amount uint64, context [32]byte) bool {
+	return len(proof) == ClawbackProofSize && len(pub) == PublicKeySize && len(ciphertext) == CiphertextSize && C.go_mpt_verify_clawback(bytePtr(proof), C.uint64_t(amount), bytePtr(pub), bytePtr(ciphertext), bytePtr(context[:])) == 1
+}
+
+func RerandomizeCiphertext(ciphertext, pub []byte, randomness [32]byte) ([]byte, bool) {
+	if len(ciphertext) != CiphertextSize || len(pub) != PublicKeySize {
+		return nil, false
+	}
+	out := make([]byte, CiphertextSize)
+	return bytesResult(out, C.go_mpt_rerandomize(bytePtr(ciphertext), bytePtr(pub), bytePtr(randomness[:]), bytePtr(out)) == 1)
+}
+
+func GenerateKeyPair() ([32]byte, []byte, bool) {
+	var private [32]byte
+	public := make([]byte, PublicKeySize)
+	ok := C.go_mpt_generate_keypair(bytePtr(private[:]), bytePtr(public)) == 1
+	if !ok {
+		return [32]byte{}, nil, false
+	}
+	return private, public, ok
+}
+
+func GenerateBlindingFactor() ([32]byte, bool) {
+	var blind [32]byte
+	ok := C.go_mpt_generate_blinding(bytePtr(blind[:])) == 1
+	if !ok {
+		return [32]byte{}, false
+	}
+	return blind, ok
+}
+
+func EncryptAmount(amount uint64, public []byte, blind [32]byte) ([]byte, bool) {
+	if len(public) != PublicKeySize {
+		return nil, false
+	}
+	out := make([]byte, CiphertextSize)
+	return bytesResult(out, C.go_mpt_encrypt(C.uint64_t(amount), bytePtr(public), bytePtr(blind[:]), bytePtr(out)) == 1)
+}
+
+func GenerateConvertProof(public []byte, private [32]byte, context [32]byte) ([]byte, bool) {
+	if len(public) != PublicKeySize {
+		return nil, false
+	}
+	out := make([]byte, ConvertProofSize)
+	return bytesResult(out, C.go_mpt_generate_convert_proof(bytePtr(public), bytePtr(private[:]), bytePtr(context[:]), bytePtr(out)) == 1)
+}
+
+func PedersenCommitment(amount uint64, blind [32]byte) ([]byte, bool) {
+	out := make([]byte, CommitmentSize)
+	return bytesResult(out, C.go_mpt_commitment(C.uint64_t(amount), bytePtr(blind[:]), bytePtr(out)) == 1)
+}
+
+func GenerateConvertBackProof(private [32]byte, public []byte, context [32]byte, amount uint64, balanceCommitment []byte, balance uint64, spending []byte, balanceBlind [32]byte) ([]byte, bool) {
+	if len(public) != PublicKeySize || len(balanceCommitment) != CommitmentSize || len(spending) != CiphertextSize {
+		return nil, false
+	}
+	out := make([]byte, ConvertBackProofSize)
+	ok := C.go_mpt_generate_convert_back_proof(bytePtr(private[:]), bytePtr(public), bytePtr(context[:]), C.uint64_t(amount), bytePtr(balanceCommitment), C.uint64_t(balance), bytePtr(spending), bytePtr(balanceBlind[:]), bytePtr(out)) == 1
+	return bytesResult(out, ok)
+}
+
+func GenerateSendProof(private [32]byte, amount uint64, participants []Participant, transactionBlind [32]byte, context [32]byte, amountCommitment, balanceCommitment []byte, balance uint64, spending []byte, balanceBlind [32]byte) ([]byte, bool) {
+	if (len(participants) != 3 && len(participants) != 4) || len(amountCommitment) != CommitmentSize || len(balanceCommitment) != CommitmentSize || len(spending) != CiphertextSize {
+		return nil, false
+	}
+	var pubs [4 * PublicKeySize]byte
+	var ciphertexts [4 * CiphertextSize]byte
+	for i, value := range participants {
+		if !validParticipant(value) {
+			return nil, false
+		}
+		copy(pubs[i*PublicKeySize:], value.PublicKey)
+		copy(ciphertexts[i*CiphertextSize:], value.Ciphertext)
+	}
+	out := make([]byte, SendProofSize)
+	ok := C.go_mpt_generate_send_proof(bytePtr(private[:]), C.uint64_t(amount), bytePtr(pubs[:]), bytePtr(ciphertexts[:]), C.uint8_t(len(participants)), bytePtr(transactionBlind[:]), bytePtr(context[:]), bytePtr(amountCommitment), bytePtr(balanceCommitment), C.uint64_t(balance), bytePtr(spending), bytePtr(balanceBlind[:]), bytePtr(out)) == 1
+	return bytesResult(out, ok)
+}
+
+func GenerateClawbackProof(private [32]byte, public []byte, context [32]byte, amount uint64, ciphertext []byte) ([]byte, bool) {
+	if len(public) != PublicKeySize || len(ciphertext) != CiphertextSize {
+		return nil, false
+	}
+	out := make([]byte, ClawbackProofSize)
+	ok := C.go_mpt_generate_clawback_proof(bytePtr(private[:]), bytePtr(public), bytePtr(context[:]), C.uint64_t(amount), bytePtr(ciphertext), bytePtr(out)) == 1
+	return bytesResult(out, ok)
+}

--- a/crypto/mptcrypto/internal/native/shim.cc
+++ b/crypto/mptcrypto/internal/native/shim.cc
@@ -1,0 +1,417 @@
+//go:build mptcrypto && cgo
+
+#include "shim.h"
+
+#include <cstring>
+#include <mpt_protocol.h>
+#include <secp256k1_mpt.h>
+#include <utility/mpt_utility.h>
+
+static_assert(kMPT_ACCOUNT_ID_SIZE == 20, "account size");
+static_assert(kMPT_ISSUANCE_ID_SIZE == 24, "issuance size");
+static_assert(kMPT_PUBKEY_SIZE == 33, "public key size");
+static_assert(kMPT_BLINDING_FACTOR_SIZE == 32, "blinding factor size");
+static_assert(kMPT_ELGAMAL_TOTAL_SIZE == 66, "ciphertext size");
+static_assert(kMPT_PEDERSEN_COMMIT_SIZE == 33, "commitment size");
+static_assert(kMPT_SCHNORR_PROOF_SIZE == 64, "convert proof size");
+static_assert(SECP256K1_COMPACT_STANDARD_PROOF_SIZE == 192,
+              "send sigma proof size");
+static_assert(kMPT_DOUBLE_BULLETPROOF_SIZE == 754, "send range proof size");
+static_assert(SECP256K1_COMPACT_STANDARD_PROOF_SIZE +
+                      kMPT_DOUBLE_BULLETPROOF_SIZE ==
+                  946,
+              "send proof size");
+static_assert(SECP256K1_COMPACT_CLAWBACK_PROOF_SIZE == 64,
+              "clawback proof size");
+static_assert(SECP256K1_COMPACT_CONVERTBACK_PROOF_SIZE +
+                      kMPT_SINGLE_BULLETPROOF_SIZE ==
+                  816,
+              "convert back proof size");
+
+static const secp256k1_context *mpt_context() {
+  return mpt_secp256k1_context();
+}
+
+extern "C" int go_mpt_available(void) noexcept {
+  try {
+    return mpt_context() != nullptr;
+  } catch (...) {
+    return 0;
+  }
+}
+
+extern "C" int go_mpt_valid_pubkey(const uint8_t pubkey[33]) noexcept {
+  try {
+    auto const *ctx = mpt_context();
+    if (ctx == nullptr)
+      return 0;
+    secp256k1_pubkey parsed;
+    return secp256k1_ec_pubkey_parse(ctx, &parsed, pubkey, 33) == 1;
+  } catch (...) {
+    return 0;
+  }
+}
+
+extern "C" int go_mpt_valid_ciphertext(const uint8_t ciphertext[66]) noexcept {
+  try {
+    if (mpt_context() == nullptr)
+      return 0;
+    secp256k1_pubkey c1, c2;
+    return mpt_make_ec_pair(ciphertext, &c1, &c2) ? 1 : 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
+static int combine(const uint8_t a[66], const uint8_t b[66], uint8_t out[66],
+                   bool subtract) {
+  auto const *ctx = mpt_context();
+  if (ctx == nullptr)
+    return 0;
+  secp256k1_pubkey a1, a2, b1, b2, r1, r2;
+  if (!mpt_make_ec_pair(a, &a1, &a2) || !mpt_make_ec_pair(b, &b1, &b2))
+    return 0;
+  int ok = subtract
+               ? secp256k1_elgamal_subtract(ctx, &r1, &r2, &a1, &a2, &b1, &b2)
+               : secp256k1_elgamal_add(ctx, &r1, &r2, &a1, &a2, &b1, &b2);
+  return ok == 1 && mpt_serialize_ec_pair(&r1, &r2, out) ? 1 : 0;
+}
+
+extern "C" int go_mpt_add(const uint8_t a[66], const uint8_t b[66],
+                          uint8_t out[66]) noexcept {
+  try {
+    return combine(a, b, out, false);
+  } catch (...) {
+    return 0;
+  }
+}
+extern "C" int go_mpt_subtract(const uint8_t a[66], const uint8_t b[66],
+                               uint8_t out[66]) noexcept {
+  try {
+    return combine(a, b, out, true);
+  } catch (...) {
+    return 0;
+  }
+}
+
+extern "C" int go_mpt_canonical_zero(const uint8_t pubkey[33],
+                                     const uint8_t account[20],
+                                     const uint8_t issuance[24],
+                                     uint8_t out[66]) noexcept {
+  try {
+    auto const *ctx = mpt_context();
+    if (ctx == nullptr)
+      return 0;
+    secp256k1_pubkey key, c1, c2;
+    if (secp256k1_ec_pubkey_parse(ctx, &key, pubkey, 33) != 1)
+      return 0;
+    if (generate_canonical_encrypted_zero(ctx, &c1, &c2, &key, account,
+                                          issuance) != 1)
+      return 0;
+    return mpt_serialize_ec_pair(&c1, &c2, out) ? 1 : 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
+static mpt_issuance_id issuance_id(const uint8_t in[24]) {
+  mpt_issuance_id value;
+  std::memcpy(value.bytes, in, 24);
+  return value;
+}
+
+static account_id account(const uint8_t in[20]) {
+  account_id value;
+  std::memcpy(value.bytes, in, 20);
+  return value;
+}
+
+extern "C" int go_mpt_convert_context(const uint8_t acc[20],
+                                      const uint8_t issuance[24],
+                                      uint32_t sequence,
+                                      uint8_t out[32]) noexcept {
+  try {
+    if (mpt_context() == nullptr)
+      return 0;
+    return mpt_get_convert_context_hash(account(acc), issuance_id(issuance),
+                                        sequence, out) == 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
+extern "C" int go_mpt_convert_back_context(const uint8_t acc[20],
+                                           const uint8_t issuance[24],
+                                           uint32_t sequence, uint32_t version,
+                                           uint8_t out[32]) noexcept {
+  try {
+    if (mpt_context() == nullptr)
+      return 0;
+    return mpt_get_convert_back_context_hash(account(acc),
+                                             issuance_id(issuance), sequence,
+                                             version, out) == 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
+extern "C" int go_mpt_send_context(const uint8_t acc[20],
+                                   const uint8_t issuance[24],
+                                   uint32_t sequence,
+                                   const uint8_t destination[20],
+                                   uint32_t version, uint8_t out[32]) noexcept {
+  try {
+    if (mpt_context() == nullptr)
+      return 0;
+    return mpt_get_send_context_hash(account(acc), issuance_id(issuance),
+                                     sequence, account(destination), version,
+                                     out) == 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
+extern "C" int go_mpt_clawback_context(const uint8_t acc[20],
+                                       const uint8_t issuance[24],
+                                       uint32_t sequence,
+                                       const uint8_t holder[20],
+                                       uint8_t out[32]) noexcept {
+  try {
+    if (mpt_context() == nullptr)
+      return 0;
+    return mpt_get_clawback_context_hash(account(acc), issuance_id(issuance),
+                                         sequence, account(holder), out) == 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
+static mpt_confidential_participant participant(const uint8_t pub[33],
+                                                const uint8_t ct[66]) {
+  mpt_confidential_participant value;
+  std::memcpy(value.pubkey, pub, 33);
+  std::memcpy(value.ciphertext, ct, 66);
+  return value;
+}
+
+extern "C" int go_mpt_verify_revealed(
+    uint64_t amount, const uint8_t blind[32], const uint8_t holder_pub[33],
+    const uint8_t holder_ct[66], const uint8_t issuer_pub[33],
+    const uint8_t issuer_ct[66], int has_auditor, const uint8_t auditor_pub[33],
+    const uint8_t auditor_ct[66]) noexcept {
+  try {
+    if (mpt_context() == nullptr)
+      return 0;
+    auto holder = participant(holder_pub, holder_ct);
+    auto issuer = participant(issuer_pub, issuer_ct);
+    auto auditor = participant(auditor_pub, auditor_ct);
+    return mpt_verify_revealed_amount(amount, blind, &holder, &issuer,
+                                      has_auditor ? &auditor : nullptr) == 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
+extern "C" int go_mpt_verify_convert(const uint8_t proof[64],
+                                     const uint8_t pubkey[33],
+                                     const uint8_t context[32]) noexcept {
+  try {
+    if (mpt_context() == nullptr)
+      return 0;
+    return mpt_verify_convert_proof(proof, pubkey, context) == 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
+extern "C" int go_mpt_verify_convert_back(const uint8_t proof[816],
+                                          const uint8_t pubkey[33],
+                                          const uint8_t spending[66],
+                                          const uint8_t commitment[33],
+                                          uint64_t amount,
+                                          const uint8_t context[32]) noexcept {
+  try {
+    if (mpt_context() == nullptr)
+      return 0;
+    return mpt_verify_convert_back_proof(proof, pubkey, spending, commitment,
+                                         amount, context) == 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
+extern "C" int go_mpt_verify_send(
+    const uint8_t proof[946], const uint8_t pubs[132],
+    const uint8_t ciphertexts[264], uint8_t participant_count,
+    const uint8_t spending[66], const uint8_t amount_commitment[33],
+    const uint8_t balance_commitment[33], const uint8_t context[32]) noexcept {
+  try {
+    if (mpt_context() == nullptr)
+      return 0;
+    if (participant_count != 3 && participant_count != 4)
+      return 0;
+    mpt_confidential_participant participants[4];
+    for (uint8_t i = 0; i < participant_count; ++i)
+      participants[i] = participant(pubs + i * 33, ciphertexts + i * 66);
+    return mpt_verify_send_proof(proof, participants, participant_count,
+                                 spending, amount_commitment,
+                                 balance_commitment, context) == 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
+extern "C" int go_mpt_verify_clawback(const uint8_t proof[64], uint64_t amount,
+                                      const uint8_t pubkey[33],
+                                      const uint8_t ciphertext[66],
+                                      const uint8_t context[32]) noexcept {
+  try {
+    if (mpt_context() == nullptr)
+      return 0;
+    return mpt_verify_clawback_proof(proof, amount, pubkey, ciphertext,
+                                     context) == 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
+extern "C" int go_mpt_rerandomize(const uint8_t ciphertext[66],
+                                  const uint8_t pubkey[33],
+                                  const uint8_t randomness[32],
+                                  uint8_t out[66]) noexcept {
+  try {
+    if (mpt_context() == nullptr)
+      return 0;
+    uint8_t zero[66];
+    if (mpt_encrypt_amount(0, pubkey, randomness, zero) != 0)
+      return 0;
+    return combine(ciphertext, zero, out, false);
+  } catch (...) {
+    return 0;
+  }
+}
+
+extern "C" int go_mpt_generate_keypair(uint8_t private_key[32],
+                                       uint8_t public_key[33]) noexcept {
+  try {
+    if (mpt_context() == nullptr)
+      return 0;
+    return mpt_generate_keypair(private_key, public_key) == 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
+extern "C" int go_mpt_generate_blinding(uint8_t blind[32]) noexcept {
+  try {
+    if (mpt_context() == nullptr)
+      return 0;
+    return mpt_generate_blinding_factor(blind) == 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
+extern "C" int go_mpt_encrypt(uint64_t amount, const uint8_t public_key[33],
+                              const uint8_t blind[32],
+                              uint8_t ciphertext[66]) noexcept {
+  try {
+    if (mpt_context() == nullptr)
+      return 0;
+    return mpt_encrypt_amount(amount, public_key, blind, ciphertext) == 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
+extern "C" int go_mpt_generate_convert_proof(const uint8_t public_key[33],
+                                             const uint8_t private_key[32],
+                                             const uint8_t context[32],
+                                             uint8_t proof[64]) noexcept {
+  try {
+    if (mpt_context() == nullptr)
+      return 0;
+    return mpt_get_convert_proof(public_key, private_key, context, proof) == 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
+extern "C" int go_mpt_commitment(uint64_t amount, const uint8_t blind[32],
+                                 uint8_t commitment[33]) noexcept {
+  try {
+    if (mpt_context() == nullptr)
+      return 0;
+    return mpt_get_pedersen_commitment(amount, blind, commitment) == 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
+extern "C" int go_mpt_generate_convert_back_proof(
+    const uint8_t private_key[32], const uint8_t public_key[33],
+    const uint8_t context[32], uint64_t amount,
+    const uint8_t balance_commitment[33], uint64_t balance,
+    const uint8_t spending[66], const uint8_t balance_blind[32],
+    uint8_t proof[816]) noexcept {
+  try {
+    if (mpt_context() == nullptr)
+      return 0;
+    mpt_pedersen_proof_params params;
+    std::memcpy(params.pedersen_commitment, balance_commitment, 33);
+    params.amount = balance;
+    std::memcpy(params.ciphertext, spending, 66);
+    std::memcpy(params.blinding_factor, balance_blind, 32);
+    return mpt_get_convert_back_proof(private_key, public_key, context, amount,
+                                      &params, proof) == 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
+extern "C" int go_mpt_generate_send_proof(
+    const uint8_t private_key[32], uint64_t amount, const uint8_t pubs[132],
+    const uint8_t ciphertexts[264], uint8_t participant_count,
+    const uint8_t transaction_blind[32], const uint8_t context[32],
+    const uint8_t amount_commitment[33], const uint8_t balance_commitment[33],
+    uint64_t balance, const uint8_t spending[66],
+    const uint8_t balance_blind[32], uint8_t proof[946]) noexcept {
+  try {
+    if (mpt_context() == nullptr)
+      return 0;
+    if (participant_count != 3 && participant_count != 4)
+      return 0;
+    mpt_confidential_participant participants[4];
+    for (uint8_t i = 0; i < participant_count; ++i)
+      participants[i] = participant(pubs + i * 33, ciphertexts + i * 66);
+    mpt_pedersen_proof_params balance_params;
+    std::memcpy(balance_params.pedersen_commitment, balance_commitment, 33);
+    balance_params.amount = balance;
+    std::memcpy(balance_params.ciphertext, spending, 66);
+    std::memcpy(balance_params.blinding_factor, balance_blind, 32);
+    size_t proof_len = 946;
+    return mpt_get_confidential_send_proof(
+               private_key, participants[0].pubkey, amount, participants,
+               participant_count, transaction_blind, context, amount_commitment,
+               &balance_params, proof, &proof_len) == 0 &&
+           proof_len == 946;
+  } catch (...) {
+    return 0;
+  }
+}
+
+extern "C" int go_mpt_generate_clawback_proof(const uint8_t private_key[32],
+                                              const uint8_t public_key[33],
+                                              const uint8_t context[32],
+                                              uint64_t amount,
+                                              const uint8_t ciphertext[66],
+                                              uint8_t proof[64]) noexcept {
+  try {
+    if (mpt_context() == nullptr)
+      return 0;
+    return mpt_get_clawback_proof(private_key, public_key, context, amount,
+                                  ciphertext, proof) == 0;
+  } catch (...) {
+    return 0;
+  }
+}

--- a/crypto/mptcrypto/internal/native/shim.h
+++ b/crypto/mptcrypto/internal/native/shim.h
@@ -1,0 +1,101 @@
+#ifndef GOXRPL_MPTCRYPTO_SHIM_H
+#define GOXRPL_MPTCRYPTO_SHIM_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+#define GOXRPL_MPT_NOEXCEPT noexcept
+extern "C" {
+#else
+#define GOXRPL_MPT_NOEXCEPT
+#endif
+
+int go_mpt_available(void) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_valid_pubkey(const uint8_t pubkey[33]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_valid_ciphertext(const uint8_t ciphertext[66]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_add(const uint8_t a[66], const uint8_t b[66],
+               uint8_t out[66]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_subtract(const uint8_t a[66], const uint8_t b[66],
+                    uint8_t out[66]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_canonical_zero(const uint8_t pubkey[33], const uint8_t account[20],
+                          const uint8_t issuance[24],
+                          uint8_t out[66]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_convert_context(const uint8_t account[20],
+                           const uint8_t issuance[24], uint32_t sequence,
+                           uint8_t out[32]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_convert_back_context(const uint8_t account[20],
+                                const uint8_t issuance[24], uint32_t sequence,
+                                uint32_t version,
+                                uint8_t out[32]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_send_context(const uint8_t account[20], const uint8_t issuance[24],
+                        uint32_t sequence, const uint8_t destination[20],
+                        uint32_t version, uint8_t out[32]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_clawback_context(const uint8_t account[20],
+                            const uint8_t issuance[24], uint32_t sequence,
+                            const uint8_t holder[20],
+                            uint8_t out[32]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_verify_revealed(uint64_t amount, const uint8_t blind[32],
+                           const uint8_t holder_pub[33],
+                           const uint8_t holder_ct[66],
+                           const uint8_t issuer_pub[33],
+                           const uint8_t issuer_ct[66], int has_auditor,
+                           const uint8_t auditor_pub[33],
+                           const uint8_t auditor_ct[66]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_verify_convert(const uint8_t proof[64], const uint8_t pubkey[33],
+                          const uint8_t context[32]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_verify_convert_back(const uint8_t proof[816],
+                               const uint8_t pubkey[33],
+                               const uint8_t spending[66],
+                               const uint8_t commitment[33], uint64_t amount,
+                               const uint8_t context[32]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_verify_send(const uint8_t proof[946], const uint8_t pubs[132],
+                       const uint8_t ciphertexts[264],
+                       uint8_t participant_count, const uint8_t spending[66],
+                       const uint8_t amount_commitment[33],
+                       const uint8_t balance_commitment[33],
+                       const uint8_t context[32]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_verify_clawback(const uint8_t proof[64], uint64_t amount,
+                           const uint8_t pubkey[33],
+                           const uint8_t ciphertext[66],
+                           const uint8_t context[32]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_rerandomize(const uint8_t ciphertext[66], const uint8_t pubkey[33],
+                       const uint8_t randomness[32],
+                       uint8_t out[66]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_generate_keypair(uint8_t private_key[32],
+                            uint8_t public_key[33]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_generate_blinding(uint8_t blind[32]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_encrypt(uint64_t amount, const uint8_t public_key[33],
+                   const uint8_t blind[32],
+                   uint8_t ciphertext[66]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_generate_convert_proof(const uint8_t public_key[33],
+                                  const uint8_t private_key[32],
+                                  const uint8_t context[32],
+                                  uint8_t proof[64]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_commitment(uint64_t amount, const uint8_t blind[32],
+                      uint8_t commitment[33]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_generate_convert_back_proof(
+    const uint8_t private_key[32], const uint8_t public_key[33],
+    const uint8_t context[32], uint64_t amount,
+    const uint8_t balance_commitment[33], uint64_t balance,
+    const uint8_t spending[66], const uint8_t balance_blind[32],
+    uint8_t proof[816]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_generate_send_proof(
+    const uint8_t private_key[32], uint64_t amount, const uint8_t pubs[132],
+    const uint8_t ciphertexts[264], uint8_t participant_count,
+    const uint8_t transaction_blind[32], const uint8_t context[32],
+    const uint8_t amount_commitment[33], const uint8_t balance_commitment[33],
+    uint64_t balance, const uint8_t spending[66],
+    const uint8_t balance_blind[32], uint8_t proof[946]) GOXRPL_MPT_NOEXCEPT;
+int go_mpt_generate_clawback_proof(const uint8_t private_key[32],
+                                   const uint8_t public_key[33],
+                                   const uint8_t context[32], uint64_t amount,
+                                   const uint8_t ciphertext[66],
+                                   uint8_t proof[64]) GOXRPL_MPT_NOEXCEPT;
+
+#ifdef __cplusplus
+}
+#endif
+
+#undef GOXRPL_MPT_NOEXCEPT
+
+#endif

--- a/crypto/mptcrypto/mptcrypto.go
+++ b/crypto/mptcrypto/mptcrypto.go
@@ -1,0 +1,22 @@
+// Package mptcrypto provides confidential MPT cryptographic operations.
+package mptcrypto
+
+// Protocol-defined serialized sizes for confidential MPT cryptographic values.
+const (
+	PublicKeySize        = 33
+	CiphertextSize       = 66
+	BlindingFactorSize   = 32
+	ConvertProofSize     = 64
+	ConvertBackProofSize = 816
+	SendProofSize        = 946
+	ClawbackProofSize    = 64
+	CommitmentSize       = 33
+)
+
+// Participant contains a public key and its encrypted balance.
+type Participant struct {
+	// PublicKey is the participant's compressed public key.
+	PublicKey []byte
+	// Ciphertext is the participant's encrypted balance.
+	Ciphertext []byte
+}

--- a/crypto/mptcrypto/send_clawback_native_test.go
+++ b/crypto/mptcrypto/send_clawback_native_test.go
@@ -1,0 +1,205 @@
+//go:build mptcrypto && cgo
+
+package mptcrypto
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestContextHashVectors(t *testing.T) {
+	var account, other [20]byte
+	var issuance [24]byte
+	for i := range account {
+		account[i] = byte(i + 1)
+		other[i] = byte(i + 31)
+	}
+	for i := range issuance {
+		issuance[i] = byte(i + 61)
+	}
+
+	tests := []struct {
+		name     string
+		expected string
+		context  func() ([32]byte, bool)
+	}{
+		{
+			name:     "convert",
+			expected: "74ad5b85b3e15e1b42552150ceccab860c7e887ba522f35e571333463c544270",
+			context: func() ([32]byte, bool) {
+				return ConvertContext(account, issuance, 0x01020304)
+			},
+		},
+		{
+			name:     "convert back",
+			expected: "f96c41e43ae1e567b39aa2d648453d64cdfed08844d7eaedebdfa76801439542",
+			context: func() ([32]byte, bool) {
+				return ConvertBackContext(account, issuance, 0x01020304, 0x05060708)
+			},
+		},
+		{
+			name:     "send",
+			expected: "bacac144a1d7d7836ea6d4badfe25f087803e1afdb6851dea4b1b11a080b4afd",
+			context: func() ([32]byte, bool) {
+				return SendContext(account, issuance, 0x01020304, other, 0x05060708)
+			},
+		},
+		{
+			name:     "clawback",
+			expected: "913803539c8be30ad32fc54f6e2042382c2f6fab97437f70b34ce0e3a83adf50",
+			context: func() ([32]byte, bool) {
+				return ClawbackContext(account, issuance, 0x01020304, other)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			expectedBytes, err := hex.DecodeString(test.expected)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var expected [32]byte
+			copy(expected[:], expectedBytes)
+			context, ok := test.context()
+			if !ok || context != expected {
+				t.Fatalf("context = %x, want %x", context, expected)
+			}
+		})
+	}
+}
+
+func TestNativeSendProof(t *testing.T) {
+	for _, withAuditor := range []bool{false, true} {
+		t.Run(map[bool]string{false: "three participants", true: "four participants"}[withAuditor], func(t *testing.T) {
+			senderPrivate, senderPublic := mustKeyPair(t)
+			_, destinationPublic := mustKeyPair(t)
+			_, issuerPublic := mustKeyPair(t)
+			_, auditorPublic := mustKeyPair(t)
+			amountBlind := mustBlind(t)
+			participants := []Participant{
+				{PublicKey: senderPublic, Ciphertext: mustEncrypt(t, 40, senderPublic, amountBlind)},
+				{PublicKey: destinationPublic, Ciphertext: mustEncrypt(t, 40, destinationPublic, amountBlind)},
+				{PublicKey: issuerPublic, Ciphertext: mustEncrypt(t, 40, issuerPublic, amountBlind)},
+			}
+			if withAuditor {
+				participants = append(participants, Participant{PublicKey: auditorPublic, Ciphertext: mustEncrypt(t, 40, auditorPublic, amountBlind)})
+			}
+			amountCommitment, ok := PedersenCommitment(40, amountBlind)
+			if !ok {
+				t.Fatal("amount commitment")
+			}
+			balanceBlind := mustBlind(t)
+			spending := mustEncrypt(t, 100, senderPublic, balanceBlind)
+			balanceCommitment, ok := PedersenCommitment(100, balanceBlind)
+			if !ok {
+				t.Fatal("balance commitment")
+			}
+			var account, destination [20]byte
+			var issuance [24]byte
+			account[0], destination[0], issuance[0] = 1, 2, 3
+			context, ok := SendContext(account, issuance, 7, destination, 9)
+			if !ok {
+				t.Fatal("send context")
+			}
+			proof, ok := GenerateSendProof(senderPrivate, 40, participants, amountBlind, context, amountCommitment, balanceCommitment, 100, spending, balanceBlind)
+			if !ok || len(proof) != SendProofSize {
+				t.Fatal("generate send proof")
+			}
+			var auditor *Participant
+			if withAuditor {
+				auditor = &participants[3]
+			}
+			verify := func(candidate []byte, sender, destination, issuer Participant, auditor *Participant, spending, amountCommitment, balanceCommitment []byte, context [32]byte) bool {
+				return VerifySend(candidate, sender, destination, issuer, auditor, spending, amountCommitment, balanceCommitment, context)
+			}
+			if !verify(proof, participants[0], participants[1], participants[2], auditor, spending, amountCommitment, balanceCommitment, context) {
+				t.Fatal("verify send proof")
+			}
+
+			for _, offset := range []int{0, 192} {
+				tampered := append([]byte(nil), proof...)
+				tampered[offset] ^= 1
+				if verify(tampered, participants[0], participants[1], participants[2], auditor, spending, amountCommitment, balanceCommitment, context) {
+					t.Fatalf("accepted proof tampered at offset %d", offset)
+				}
+			}
+			wrongContext := context
+			wrongContext[0] ^= 1
+			if verify(proof, participants[0], participants[1], participants[2], auditor, spending, amountCommitment, balanceCommitment, wrongContext) {
+				t.Fatal("accepted wrong context")
+			}
+			wrongSpending := mustEncrypt(t, 100, senderPublic, mustBlind(t))
+			if verify(proof, participants[0], participants[1], participants[2], auditor, wrongSpending, amountCommitment, balanceCommitment, context) {
+				t.Fatal("accepted wrong spending ciphertext")
+			}
+			wrongAmountCommitment, _ := PedersenCommitment(41, amountBlind)
+			if verify(proof, participants[0], participants[1], participants[2], auditor, spending, wrongAmountCommitment, balanceCommitment, context) {
+				t.Fatal("accepted wrong amount commitment")
+			}
+			wrongBalanceCommitment, _ := PedersenCommitment(99, balanceBlind)
+			if verify(proof, participants[0], participants[1], participants[2], auditor, spending, amountCommitment, wrongBalanceCommitment, context) {
+				t.Fatal("accepted wrong balance commitment")
+			}
+			wrongSender := participants[0]
+			wrongSender.PublicKey = destinationPublic
+			if verify(proof, wrongSender, participants[1], participants[2], auditor, spending, amountCommitment, balanceCommitment, context) {
+				t.Fatal("accepted wrong sender key")
+			}
+			commonC1Mismatch := participants[1]
+			commonC1Mismatch.Ciphertext = mustEncrypt(t, 40, destinationPublic, mustBlind(t))
+			if verify(proof, participants[0], commonC1Mismatch, participants[2], auditor, spending, amountCommitment, balanceCommitment, context) {
+				t.Fatal("accepted non-common ciphertext C1")
+			}
+
+			var randomness [32]byte
+			copy(randomness[:], proof[:32])
+			rerandomized, ok := RerandomizeCiphertext(participants[1].Ciphertext, destinationPublic, randomness)
+			if !ok || !ValidCiphertext(rerandomized) {
+				t.Fatal("rerandomize ciphertext")
+			}
+			if string(rerandomized) == string(participants[1].Ciphertext) {
+				t.Fatal("rerandomization did not change ciphertext")
+			}
+		})
+	}
+}
+
+func TestNativeClawbackProof(t *testing.T) {
+	private, public := mustKeyPair(t)
+	blind := mustBlind(t)
+	ciphertext := mustEncrypt(t, 75, public, blind)
+	var issuer, holder [20]byte
+	var issuance [24]byte
+	issuer[0], holder[0], issuance[0] = 1, 2, 3
+	context, ok := ClawbackContext(issuer, issuance, 11, holder)
+	if !ok {
+		t.Fatal("clawback context")
+	}
+	proof, ok := GenerateClawbackProof(private, public, context, 75, ciphertext)
+	if !ok || len(proof) != ClawbackProofSize || !VerifyClawback(proof, public, ciphertext, 75, context) {
+		t.Fatal("clawback proof")
+	}
+
+	tampered := append([]byte(nil), proof...)
+	tampered[0] ^= 1
+	if VerifyClawback(tampered, public, ciphertext, 75, context) {
+		t.Fatal("accepted tampered clawback proof")
+	}
+	if VerifyClawback(proof, public, ciphertext, 74, context) {
+		t.Fatal("accepted wrong clawback amount")
+	}
+	wrongContext := context
+	wrongContext[0] ^= 1
+	if VerifyClawback(proof, public, ciphertext, 75, wrongContext) {
+		t.Fatal("accepted wrong clawback context")
+	}
+	_, wrongPublic := mustKeyPair(t)
+	if VerifyClawback(proof, wrongPublic, ciphertext, 75, context) {
+		t.Fatal("accepted wrong clawback public key")
+	}
+	wrongCiphertext := mustEncrypt(t, 75, public, mustBlind(t))
+	if VerifyClawback(proof, public, wrongCiphertext, 75, context) {
+		t.Fatal("accepted wrong clawback ciphertext")
+	}
+}

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -6,6 +6,7 @@ import (
 	rdebug "runtime/debug" // aliased: the cli package has a `debug` flag variable
 	"strings"
 
+	"github.com/LeJamon/go-xrpl/crypto/mptcrypto"
 	"github.com/spf13/cobra"
 )
 
@@ -16,7 +17,7 @@ func newVersionCommand() *cobra.Command {
 		Long:  `Display version information for go-xrpl including build details and Go version.`,
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Fprint(cmd.OutOrStdout(), versionText(cmd.Root().Version))
+			fmt.Fprint(cmd.OutOrStdout(), versionText(cmd.Root().Version, mptcrypto.Available()))
 		},
 	}
 }
@@ -25,11 +26,16 @@ func newVersionCommand() *cobra.Command {
 // commit time, dirty marker) come from the binary's embedded build info
 // and are omitted when absent (e.g. `go run` or non-VCS builds), keeping
 // the base output stable.
-func versionText(version string) string {
+func versionText(version string, mptCryptoAvailable bool) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "go-xrpl version %s\n", version)
 	fmt.Fprintf(&b, "Go version: %s\n", runtime.Version())
 	fmt.Fprintf(&b, "OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	mptCryptoStatus := "unavailable"
+	if mptCryptoAvailable {
+		mptCryptoStatus = "available"
+	}
+	fmt.Fprintf(&b, "Confidential MPT crypto: %s\n", mptCryptoStatus)
 	if info, ok := rdebug.ReadBuildInfo(); ok {
 		b.WriteString(vcsText(info.Settings))
 	}

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -8,15 +8,23 @@ import (
 )
 
 func TestVersionText_BaseLines(t *testing.T) {
-	out := versionText("1.2.3")
+	out := versionText("1.2.3", true)
 	for _, want := range []string{
 		"go-xrpl version 1.2.3\n",
 		"Go version: " + runtime.Version() + "\n",
 		"OS/Arch: " + runtime.GOOS + "/" + runtime.GOARCH + "\n",
+		"Confidential MPT crypto: available\n",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("versionText missing %q in:\n%s", want, out)
 		}
+	}
+}
+
+func TestVersionText_MPTCryptoUnavailable(t *testing.T) {
+	out := versionText("1.2.3", false)
+	if !strings.Contains(out, "Confidential MPT crypto: unavailable\n") {
+		t.Fatalf("versionText missing unavailable MPT crypto status:\n%s", out)
 	}
 }
 

--- a/internal/ledger/service/loadfee_autofill_test.go
+++ b/internal/ledger/service/loadfee_autofill_test.go
@@ -37,6 +37,99 @@ func TestGetAutofillFee_NoLoad(t *testing.T) {
 	}
 }
 
+func TestGetAutofillFee_ConfidentialMPT(t *testing.T) {
+	svc, err := service.New(defaultServiceConfig())
+	if err != nil {
+		t.Fatalf("service.New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("service.Start: %v", err)
+	}
+
+	for _, txType := range []tx.Type{
+		tx.TypeConfidentialMPTConvert,
+		tx.TypeConfidentialMPTMergeInbox,
+		tx.TypeConfidentialMPTConvertBack,
+		tx.TypeConfidentialMPTSend,
+		tx.TypeConfidentialMPTClawback,
+	} {
+		t.Run(txType.String(), func(t *testing.T) {
+			parsed := tx.NewBaseTx(txType, "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh")
+			fee, err := svc.GetAutofillFee(parsed, false, 10, 1)
+			if err != nil {
+				t.Fatalf("GetAutofillFee: %v", err)
+			}
+			if fee != 100 {
+				t.Fatalf("confidential MPT autofill fee = %d; want 100", fee)
+			}
+		})
+	}
+}
+
+func TestGetAutofillFee_ConfidentialMPTSigners(t *testing.T) {
+	svc, err := service.New(defaultServiceConfig())
+	if err != nil {
+		t.Fatalf("service.New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("service.Start: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		prepare func(*tx.BaseTx)
+		want    uint64
+	}{
+		{
+			name: "transaction multisigned",
+			prepare: func(parsed *tx.BaseTx) {
+				parsed.Signers = make([]tx.SignerWrapper, 3)
+			},
+			want: 130,
+		},
+		{
+			name: "sponsor single signed",
+			prepare: func(parsed *tx.BaseTx) {
+				parsed.SponsorSignature = &tx.SponsorSignature{SigningPubKey: "key"}
+			},
+			want: 100,
+		},
+		{
+			name: "sponsor multisigned",
+			prepare: func(parsed *tx.BaseTx) {
+				parsed.SponsorSignature = &tx.SponsorSignature{
+					Signers: make([]tx.SignerWrapper, 2),
+				}
+			},
+			want: 120,
+		},
+		{
+			name: "transaction and sponsor multisigned",
+			prepare: func(parsed *tx.BaseTx) {
+				parsed.Signers = make([]tx.SignerWrapper, 3)
+				parsed.SponsorSignature = &tx.SponsorSignature{
+					Signers: make([]tx.SignerWrapper, 2),
+				}
+			},
+			want: 150,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parsed := tx.NewBaseTx(tx.TypeConfidentialMPTSend, "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh")
+			test.prepare(parsed)
+			fee, err := svc.GetAutofillFee(parsed, false, 10, 1)
+			if err != nil {
+				t.Fatalf("GetAutofillFee: %v", err)
+			}
+			if fee != test.want {
+				t.Fatalf("confidential MPT autofill fee = %d; want %d", fee, test.want)
+			}
+		})
+	}
+}
+
 // TestGetAutofillFee_LoadedLocal verifies the LoadFeeTrack integration:
 // raising the local factor inflates the autofilled fee by exactly
 // localFee/LoadBase, matching rippled scaleFeeLoad (LoadFeeTrack.cpp:106-110).

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -529,7 +529,13 @@ func computeBaseFeeForTx(view tx.LedgerView, parsedTx tx.Transaction, cfg tx.Eng
 	}
 	_, batchFee := parsedTx.(tx.BatchFeeCalculator)
 	_, customFee := parsedTx.(tx.CustomBaseFeeCalculator)
-	if batchFee || customFee || parsedTx.TxType() == tx.TypeRegularKeySet {
+	txType := parsedTx.TxType()
+	confidentialFee := txType == tx.TypeConfidentialMPTConvert ||
+		txType == tx.TypeConfidentialMPTMergeInbox ||
+		txType == tx.TypeConfidentialMPTConvertBack ||
+		txType == tx.TypeConfidentialMPTSend ||
+		txType == tx.TypeConfidentialMPTClawback
+	if batchFee || customFee || confidentialFee || txType == tx.TypeRegularKeySet {
 		defer func() {
 			if r := recover(); r != nil {
 				fee = cfg.BaseFee

--- a/internal/tx/batch/confidential_fee_test.go
+++ b/internal/tx/batch/confidential_fee_test.go
@@ -1,0 +1,24 @@
+package batch
+
+import (
+	"testing"
+
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+func TestInnerBaseFeeConfidentialMPT(t *testing.T) {
+	for _, transactionType := range []txcore.Type{
+		txcore.TypeConfidentialMPTConvert,
+		txcore.TypeConfidentialMPTMergeInbox,
+		txcore.TypeConfidentialMPTConvertBack,
+		txcore.TypeConfidentialMPTSend,
+		txcore.TypeConfidentialMPTClawback,
+	} {
+		t.Run(transactionType.String(), func(t *testing.T) {
+			txn := txcore.NewBaseTx(transactionType, "account")
+			if got := innerBaseFee(txn, nil, txcore.EngineConfig{BaseFee: 10}); got != 100 {
+				t.Fatalf("innerBaseFee() = %d, want 100", got)
+			}
+		})
+	}
+}

--- a/internal/tx/engine/confidential_fee_test.go
+++ b/internal/tx/engine/confidential_fee_test.go
@@ -1,0 +1,38 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+func TestCheckFeeConfidentialMPTMinimum(t *testing.T) {
+	account := &state.AccountRoot{Balance: 1_000_000}
+	engine := &Engine{config: txcore.EngineConfig{BaseFee: 10, OpenLedger: true}}
+
+	for _, transactionType := range []txcore.Type{
+		txcore.TypeConfidentialMPTConvert,
+		txcore.TypeConfidentialMPTMergeInbox,
+		txcore.TypeConfidentialMPTConvertBack,
+		txcore.TypeConfidentialMPTSend,
+		txcore.TypeConfidentialMPTClawback,
+	} {
+		t.Run(transactionType.String(), func(t *testing.T) {
+			for _, test := range []struct {
+				fee      string
+				expected ter.Result
+			}{
+				{fee: "99", expected: ter.TelINSUF_FEE_P},
+				{fee: "100", expected: ter.TesSUCCESS},
+			} {
+				txn := txcore.NewBaseTx(transactionType, "rTestAccount")
+				txn.Fee = test.fee
+				if got := engine.checkFee(txn, txn.GetCommon(), account); got != test.expected {
+					t.Fatalf("checkFee(%s) = %v, want %v", test.fee, got, test.expected)
+				}
+			}
+		})
+	}
+}

--- a/internal/tx/sign/confidential_fee_test.go
+++ b/internal/tx/sign/confidential_fee_test.go
@@ -1,0 +1,100 @@
+package sign
+
+import (
+	"testing"
+
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+func TestCalculateBaseFeeConfidentialMPT(t *testing.T) {
+	const ledgerBaseFee uint64 = 10
+	config := txcore.EngineConfig{BaseFee: ledgerBaseFee}
+
+	for _, transactionType := range []txcore.Type{
+		txcore.TypeConfidentialMPTConvert,
+		txcore.TypeConfidentialMPTMergeInbox,
+		txcore.TypeConfidentialMPTConvertBack,
+		txcore.TypeConfidentialMPTSend,
+		txcore.TypeConfidentialMPTClawback,
+	} {
+		t.Run(transactionType.String(), func(t *testing.T) {
+			txn := txcore.NewBaseTx(transactionType, "account")
+			if got := CalculateBaseFee(txn, nil, config); got != 100 {
+				t.Fatalf("CalculateBaseFee() = %d, want 100", got)
+			}
+		})
+	}
+
+	control := txcore.NewBaseTx(txcore.TypePayment, "account")
+	if got := CalculateBaseFee(control, nil, config); got != ledgerBaseFee {
+		t.Fatalf("non-confidential CalculateBaseFee() = %d, want %d", got, ledgerBaseFee)
+	}
+}
+
+func TestCalculateBaseFeeConfidentialMPTSigners(t *testing.T) {
+	const ledgerBaseFee uint64 = 10
+
+	tests := []struct {
+		name     string
+		prepare  func(*txcore.BaseTx)
+		expected uint64
+	}{
+		{name: "single signed", expected: 100},
+		{
+			name: "transaction multisigned",
+			prepare: func(txn *txcore.BaseTx) {
+				txn.Signers = make([]txcore.SignerWrapper, 3)
+			},
+			expected: 130,
+		},
+		{
+			name: "Sponsor single signed",
+			prepare: func(txn *txcore.BaseTx) {
+				txn.Sponsor = "sponsor"
+				txn.SponsorSignature = &txcore.SponsorSignature{SigningPubKey: "key"}
+			},
+			expected: 100,
+		},
+		{
+			name: "Sponsor multisigned",
+			prepare: func(txn *txcore.BaseTx) {
+				txn.Sponsor = "sponsor"
+				txn.SponsorSignature = &txcore.SponsorSignature{
+					Signers: make([]txcore.SignerWrapper, 2),
+				}
+			},
+			expected: 120,
+		},
+		{
+			name: "transaction and Sponsor multisigned",
+			prepare: func(txn *txcore.BaseTx) {
+				txn.Signers = make([]txcore.SignerWrapper, 3)
+				txn.Sponsor = "sponsor"
+				txn.SponsorSignature = &txcore.SponsorSignature{
+					Signers: make([]txcore.SignerWrapper, 2),
+				}
+			},
+			expected: 150,
+		},
+		{
+			name: "prefunded Sponsor",
+			prepare: func(txn *txcore.BaseTx) {
+				txn.Sponsor = "sponsor"
+			},
+			expected: 100,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			txn := txcore.NewBaseTx(txcore.TypeConfidentialMPTSend, "account")
+			if test.prepare != nil {
+				test.prepare(txn)
+			}
+			got := CalculateBaseFee(txn, nil, txcore.EngineConfig{BaseFee: ledgerBaseFee})
+			if got != test.expected {
+				t.Fatalf("CalculateBaseFee() = %d, want %d", got, test.expected)
+			}
+		})
+	}
+}

--- a/internal/tx/sign/signature.go
+++ b/internal/tx/sign/signature.go
@@ -19,6 +19,7 @@ import (
 	"github.com/LeJamon/go-xrpl/crypto/secp256k1"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 // Bounds on the size of a multi-signer array, mirroring rippled
@@ -819,6 +820,11 @@ func CalculateDefaultBaseFee(transaction txcore.Transaction, config txcore.Engin
 	)
 }
 
+func calculateConfidentialBaseFee(transaction txcore.Transaction, config txcore.EngineConfig) uint64 {
+	return CalculateDefaultBaseFee(transaction, config) +
+		protocol.ConfidentialMPTFeeMultiplier*config.BaseFee
+}
+
 // SponsorSignerCount returns the number of signatures in a sponsor's nested
 // multisignature. A direct sponsor signature adds no extra fee unit; each
 // nested Signer adds one base-fee unit.
@@ -847,6 +853,14 @@ func CalculateBaseFee(transaction txcore.Transaction, view txcore.LedgerView, co
 	}
 	if calculator, ok := transaction.(txcore.BatchFeeCalculator); ok {
 		return calculator.CalculateMinimumFee(view, config)
+	}
+	switch transaction.TxType() {
+	case txcore.TypeConfidentialMPTConvert,
+		txcore.TypeConfidentialMPTMergeInbox,
+		txcore.TypeConfidentialMPTConvertBack,
+		txcore.TypeConfidentialMPTSend,
+		txcore.TypeConfidentialMPTClawback:
+		return calculateConfidentialBaseFee(transaction, config)
 	}
 	if calculator, ok := transaction.(txcore.CustomBaseFeeCalculator); ok {
 		return calculator.CalculateBaseFee(view, config)

--- a/internal/tx/ter/result.go
+++ b/internal/tx/ter/result.go
@@ -233,6 +233,7 @@ const (
 	TemBAD_TRANSFER_FEE                            Result = -251
 	TemINVALID_INNER_BATCH                         Result = -250
 	TemBAD_MPT                                     Result = -249
+	TemBAD_CIPHERTEXT                              Result = -248
 
 	// terRETRY and related codes (-99 to -1)
 	// Retry later
@@ -439,6 +440,7 @@ var resultNames = map[Result]string{ //nolint:gosec // G101: TER result-code nam
 	TemBAD_TRANSFER_FEE:                            "temBAD_TRANSFER_FEE",
 	TemINVALID_INNER_BATCH:                         "temINVALID_INNER_BATCH",
 	TemBAD_MPT:                                     "temBAD_MPT",
+	TemBAD_CIPHERTEXT:                              "temBAD_CIPHERTEXT",
 	TerRETRY:                                       "terRETRY",
 	TerFUNDS_SPENT:                                 "terFUNDS_SPENT",
 	TerINSUF_FEE_B:                                 "terINSUF_FEE_B",
@@ -702,6 +704,7 @@ var resultMessages = map[Result]string{ //nolint:gosec // G101: TER result-code 
 	TemBAD_TRANSFER_FEE:                            "Malformed: Transfer fee is outside valid range.",
 	TemINVALID_INNER_BATCH:                         "Malformed: Invalid inner batch transaction.",
 	TemBAD_MPT:                                     "Malformed: Bad MPT.",
+	TemBAD_CIPHERTEXT:                              "Malformed: Invalid ciphertext.",
 	TerRETRY:                                       "Retry transaction.",
 	TerFUNDS_SPENT:                                 "DEPRECATED.",
 	TerINSUF_FEE_B:                                 "Account balance can't pay fee.",

--- a/justfile
+++ b/justfile
@@ -26,6 +26,18 @@ build-all:
 build-nocgo:
     CGO_ENABLED=0 go build ./...
 
+# Install the locked optional mpt-crypto dependency into a project-local cache.
+setup-mpt-crypto:
+    ./scripts/setup-mpt-crypto.sh setup
+
+# Print the environment needed by an mptcrypto-tagged build.
+mpt-crypto-env:
+    @./scripts/setup-mpt-crypto.sh env
+
+# Build mpt-crypto from its lockfile and run the native backend tests.
+test-mpt-crypto package="./crypto/mptcrypto/...":
+    ./scripts/setup-mpt-crypto.sh test {{package}}
+
 # Run every test in the module.
 test:
     go test ./...

--- a/protocol/mpt.go
+++ b/protocol/mpt.go
@@ -10,4 +10,8 @@ const (
 
 	// MaxMPTokenAmount is the maximum representable MPToken amount.
 	MaxMPTokenAmount uint64 = 0x7FFF_FFFF_FFFF_FFFF
+
+	// ConfidentialMPTFeeMultiplier is the number of additional ledger base fees
+	// charged for a confidential MPT transaction.
+	ConfidentialMPTFeeMultiplier uint64 = 9
 )

--- a/scripts/setup-mpt-crypto.sh
+++ b/scripts/setup-mpt-crypto.sh
@@ -287,6 +287,7 @@ check_static_link() {
     local cgo_cxxflags
     cgo_cxxflags="$(append_flag_string "${CGO_CXXFLAGS:-}" "$(cxx_compile_flags)")"
     PKG_CONFIG_PATH="$pkg_config_path" \
+        CGO_ENABLED=1 \
         CGO_LDFLAGS="$cgo_ldflags" \
         CGO_CXXFLAGS="$cgo_cxxflags" \
         go test -tags mptcrypto -run '^$' ./crypto/mptcrypto >/dev/null
@@ -329,6 +330,7 @@ run_tests() {
     check_pkg_config
     check_static_link
     PKG_CONFIG_PATH="$pkg_config_path" \
+        CGO_ENABLED=1 \
         CGO_LDFLAGS="$cgo_ldflags" \
         CGO_CXXFLAGS="$cgo_cxxflags" \
         go test -tags "$test_tags" "$package" "$@"

--- a/scripts/setup-mpt-crypto.sh
+++ b/scripts/setup-mpt-crypto.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The mpt-crypto package is a C++ static library. Keep Conan state inside the
+# checkout so configuring the XRPLF remote never changes a user's Conan home.
+
+readonly script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly repo_root="$(cd -- "$script_dir/.." && pwd)"
+readonly remote_name="${GOXRPL_MPT_CRYPTO_REMOTE_NAME:-xrplf}"
+readonly remote_url="${GOXRPL_MPT_CRYPTO_REMOTE_URL:-https://conan.xrplf.org/repository/conan/}"
+readonly conan_storage_home="${GOXRPL_MPT_CRYPTO_CONAN_HOME:-$repo_root/.conan-home}"
+readonly output_dir="${GOXRPL_MPT_CRYPTO_OUTPUT_DIR:-$repo_root/.mpt-crypto}"
+readonly requirements_file="$repo_root/conan-mpt-crypto.txt"
+readonly lock_file="$repo_root/conan-mpt-crypto.lock"
+conan_home="$conan_storage_home"
+
+usage() {
+    printf 'Usage: %s {setup|env|test} [package]\n' "$(basename "$0")" >&2
+    printf '\n' >&2
+    printf '  setup  Install the locked mpt-crypto graph and generate PkgConfigDeps.\n' >&2
+    printf '  env    Print shell exports for pkg-config and optional C++ overrides.\n' >&2
+    printf '  test   Run upstream 1.0.2 tests, validate linking, then run tagged Go tests.\n' >&2
+}
+
+die() {
+    printf 'setup-mpt-crypto: %s\n' "$*" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+require_files() {
+    [[ -f "$requirements_file" ]] || die "missing requirements file: $requirements_file"
+    [[ -f "$lock_file" ]] || die "missing lock file: $lock_file"
+}
+
+prepare_conan_home() {
+    mkdir -p "$conan_storage_home"
+    local physical_home
+    physical_home="$(cd -- "$conan_storage_home" && pwd -P)"
+    conan_home="$physical_home"
+
+    if [[ "$physical_home" != *[[:space:]]* ]]; then
+        return
+    fi
+
+    # The pinned OpenSSL recipe does not quote dependency include paths while
+    # building from source. Keep its storage project-local, but give Conan a
+    # stable no-space path to that same directory.
+    local alias_root="/tmp/goxrpl-mpt-crypto-$(id -u)"
+    if [[ -L "$alias_root" ]]; then
+        die "unsafe Conan alias root is a symlink: $alias_root"
+    fi
+    mkdir -p "$alias_root"
+    chmod 700 "$alias_root"
+
+    local checksum remainder
+    read -r checksum remainder < <(printf '%s' "$physical_home" | cksum)
+    local alias_home="$alias_root/conan-$checksum"
+    if [[ -e "$alias_home" || -L "$alias_home" ]]; then
+        [[ -L "$alias_home" ]] || die "Conan alias exists and is not a symlink: $alias_home"
+        [[ "$(readlink "$alias_home")" == "$physical_home" ]] || die \
+            "Conan alias points at an unexpected directory: $alias_home"
+    else
+        ln -s "$physical_home" "$alias_home"
+    fi
+    conan_home="$alias_home"
+}
+
+ensure_remote() {
+    mkdir -p "$conan_home"
+    CONAN_HOME="$conan_home" conan remote add \
+        --force \
+        --index 0 \
+        "$remote_name" \
+        "$remote_url" >/dev/null
+}
+
+ensure_profile() {
+    CONAN_HOME="$conan_home" conan profile detect --force >/dev/null
+
+    local profile="$conan_home/profiles/default"
+    local compiler compiler_version
+    compiler="$(awk -F= '$1 == "compiler" { print $2; exit }' "$profile")"
+    compiler_version="$(awk -F= '$1 == "compiler.version" { print $2; exit }' "$profile")"
+
+    # Conan 2.18 recognizes Apple Clang through version 17. Newer Apple Clang
+    # releases remain compatible with that settings model but must be capped
+    # before Conan validates the generated profile.
+    if [[ "$compiler" == "apple-clang" && "$compiler_version" =~ ^([0-9]+) ]] &&
+        (( BASH_REMATCH[1] > 17 )); then
+        local normalized_profile
+        normalized_profile="$(mktemp "${profile}.XXXXXX")"
+        awk '$0 ~ /^compiler.version=/ { print "compiler.version=17"; next } { print }' \
+            "$profile" > "$normalized_profile"
+        mv "$normalized_profile" "$profile"
+    fi
+}
+
+install_graph() {
+    require_command conan
+    require_command pkg-config
+    require_files
+    ensure_remote
+    ensure_profile
+    mkdir -p "$output_dir"
+
+    # The recipe is built with C++23 by XRPLF. Override only the host language
+    # standard; the detected compiler/libcxx/OS/architecture remain native to
+    # the current macOS or Linux host.
+    CONAN_HOME="$conan_home" conan install "$requirements_file" \
+        --lockfile "$lock_file" \
+        --output-folder "$output_dir" \
+        --profile:host default \
+        --profile:build default \
+        --settings:host compiler.cppstd=23 \
+        --build='*' \
+        --remote "$remote_name"
+
+    [[ -f "$output_dir/mpt-crypto.pc" ]] || die \
+        "Conan did not generate $output_dir/mpt-crypto.pc"
+    [[ -f "$output_dir/secp256k1.pc" ]] || die \
+        "Conan did not generate $output_dir/secp256k1.pc"
+
+    # The existing secp cgo shim uses the upstream pkg-config package name.
+    # Alias it to Conan's package so tagged builds cannot mix system and Conan
+    # copies of libsecp256k1 in one process.
+    cp "$output_dir/secp256k1.pc" "$output_dir/libsecp256k1.pc"
+
+    # mpt-crypto and the existing secp shim are separate cgo packages. The shim
+    # owns the secp link flag; this metadata keeps mpt-crypto's headers and
+    # remaining dependencies without adding a second copy of that flag.
+    local mpt_prefix mpt_libdir mpt_includedir mpt_version secp_includedir
+    mpt_prefix="$(PKG_CONFIG_PATH="$output_dir" pkg-config --variable=prefix mpt-crypto)"
+    mpt_libdir="$(PKG_CONFIG_PATH="$output_dir" pkg-config --variable=libdir mpt-crypto)"
+    mpt_includedir="$(PKG_CONFIG_PATH="$output_dir" pkg-config --variable=includedir mpt-crypto)"
+    mpt_version="$(PKG_CONFIG_PATH="$output_dir" pkg-config --modversion mpt-crypto)"
+    secp_includedir="$(PKG_CONFIG_PATH="$output_dir" pkg-config --variable=includedir secp256k1)"
+    {
+        printf 'prefix=%s\n' "$mpt_prefix"
+        printf 'libdir=%s\n' "$mpt_libdir"
+        printf 'includedir=%s\n' "$mpt_includedir"
+        printf '\nName: goxrpl-mpt-crypto\n'
+        printf 'Description: mpt-crypto linked with the project secp shim\n'
+        printf 'Version: %s\n' "$mpt_version"
+        printf 'Libs: -L"${libdir}" -lmpt-crypto\n'
+        printf 'Cflags: -I"${includedir}" -I"%s"\n' "$secp_includedir"
+        printf 'Requires: openssl\n'
+    } > "$output_dir/goxrpl-mpt-crypto.pc"
+}
+
+profile_libcxx() {
+    local profile="$conan_home/profiles/default"
+    if [[ -f "$profile" ]]; then
+        awk -F= '$1 == "compiler.libcxx" { print $2; exit }' "$profile"
+    fi
+}
+
+cxx_runtime_flags() {
+    printf '%s\n' "${GOXRPL_MPT_CRYPTO_CXX_RUNTIME:-}"
+}
+
+cxx_compile_flags() {
+    if [[ -n "${GOXRPL_MPT_CRYPTO_CXXFLAGS:-}" ]]; then
+        printf '%s\n' "$GOXRPL_MPT_CRYPTO_CXXFLAGS"
+        return
+    fi
+
+    case "$(uname -s)" in
+        Darwin)
+            printf '%s\n' '-stdlib=libc++'
+            ;;
+        Linux)
+            if [[ "$(profile_libcxx)" == "libc++" ]]; then
+                printf '%s\n' '-stdlib=libc++'
+            fi
+            ;;
+        *)
+            die "unsupported host OS $(uname -s); set GOXRPL_MPT_CRYPTO_CXXFLAGS"
+            ;;
+    esac
+}
+
+append_flag_string() {
+    local existing="$1"
+    local addition="$2"
+    if [[ -z "$addition" ]]; then
+        printf '%s\n' "$existing"
+        return
+    fi
+    local -a addition_flags=()
+    read -r -a addition_flags <<< "$addition"
+    local flag
+
+    for flag in "${addition_flags[@]}"; do
+        case " $existing " in
+            *" $flag "*) ;;
+            *) existing="${existing:+$existing }$flag" ;;
+        esac
+    done
+    printf '%s\n' "$existing"
+}
+
+prepend_path() {
+    local prefix="$1"
+    local existing="${2:-}"
+    case ":$existing:" in
+        *":$prefix:"*) printf '%s\n' "$existing" ;;
+        *) printf '%s\n' "$prefix${existing:+:$existing}" ;;
+    esac
+}
+
+print_env() {
+    require_command pkg-config
+    [[ -f "$output_dir/mpt-crypto.pc" ]] || die \
+        "mpt-crypto is not set up; run 'just setup-mpt-crypto' first"
+
+    local pkg_config_path
+    pkg_config_path="$(prepend_path "$output_dir" "${PKG_CONFIG_PATH:-}")"
+    local runtime_flags
+    runtime_flags="$(cxx_runtime_flags)"
+    local cgo_ldflags
+    cgo_ldflags="$(append_flag_string "${CGO_LDFLAGS:-}" "$runtime_flags")"
+    local cgo_cxxflags
+    cgo_cxxflags="$(append_flag_string "${CGO_CXXFLAGS:-}" "$(cxx_compile_flags)")"
+
+    # %q makes this output safe for `eval "$(just mpt-crypto-env)"`.
+    printf 'export CONAN_HOME=%q\n' "$conan_home"
+    printf 'export PKG_CONFIG_PATH=%q\n' "$pkg_config_path"
+    printf 'export GOXRPL_MPT_CRYPTO_CXX_RUNTIME=%q\n' "$runtime_flags"
+    printf 'export CGO_LDFLAGS=%q\n' "$cgo_ldflags"
+    printf 'export CGO_CXXFLAGS=%q\n' "$cgo_cxxflags"
+}
+
+check_pkg_config() {
+    require_command pkg-config
+    local pkg_config_path
+    pkg_config_path="$(prepend_path "$output_dir" "${PKG_CONFIG_PATH:-}")"
+    PKG_CONFIG_PATH="$pkg_config_path" pkg-config --exists mpt-crypto || die \
+        "pkg-config cannot resolve mpt-crypto; evaluate 'just mpt-crypto-env'"
+    PKG_CONFIG_PATH="$pkg_config_path" pkg-config --exists goxrpl-mpt-crypto || die \
+        "pkg-config cannot resolve the goXRPL mpt-crypto metadata"
+    PKG_CONFIG_PATH="$pkg_config_path" pkg-config --exists libsecp256k1 || die \
+        "pkg-config cannot resolve the Conan libsecp256k1 alias"
+    PKG_CONFIG_PATH="$pkg_config_path" pkg-config --validate mpt-crypto
+    PKG_CONFIG_PATH="$pkg_config_path" pkg-config --validate goxrpl-mpt-crypto
+    PKG_CONFIG_PATH="$pkg_config_path" pkg-config --validate libsecp256k1
+
+    local conan_mpt_prefix project_mpt_prefix conan_mpt_libdir project_mpt_libdir
+    conan_mpt_prefix="$(PKG_CONFIG_PATH="$pkg_config_path" pkg-config --variable=prefix mpt-crypto)"
+    project_mpt_prefix="$(PKG_CONFIG_PATH="$pkg_config_path" pkg-config --variable=prefix goxrpl-mpt-crypto)"
+    conan_mpt_libdir="$(PKG_CONFIG_PATH="$pkg_config_path" pkg-config --variable=libdir mpt-crypto)"
+    project_mpt_libdir="$(PKG_CONFIG_PATH="$pkg_config_path" pkg-config --variable=libdir goxrpl-mpt-crypto)"
+    [[ "$project_mpt_prefix" == "$conan_mpt_prefix" && "$project_mpt_libdir" == "$conan_mpt_libdir" ]] || die \
+        "goXRPL mpt-crypto metadata resolves outside the Conan package"
+
+    local conan_secp_prefix legacy_secp_prefix conan_secp_libdir legacy_secp_libdir
+    conan_secp_prefix="$(PKG_CONFIG_PATH="$pkg_config_path" pkg-config --variable=prefix secp256k1)"
+    legacy_secp_prefix="$(PKG_CONFIG_PATH="$pkg_config_path" pkg-config --variable=prefix libsecp256k1)"
+    conan_secp_libdir="$(PKG_CONFIG_PATH="$pkg_config_path" pkg-config --variable=libdir secp256k1)"
+    legacy_secp_libdir="$(PKG_CONFIG_PATH="$pkg_config_path" pkg-config --variable=libdir libsecp256k1)"
+    [[ "$legacy_secp_prefix" == "$conan_secp_prefix" ]] || die \
+        "libsecp256k1 resolves outside the Conan package prefix"
+    [[ "$legacy_secp_libdir" == "$conan_secp_libdir" ]] || die \
+        "libsecp256k1 resolves outside the Conan package library directory"
+    [[ "$conan_secp_prefix" == "$conan_home"/* ]] || die \
+        "secp256k1 resolves outside the project-local Conan cache"
+
+    printf 'mpt-crypto %s\n' "$(PKG_CONFIG_PATH="$pkg_config_path" pkg-config --modversion mpt-crypto)"
+    printf 'libsecp256k1 %s (%s)\n' \
+        "$(PKG_CONFIG_PATH="$pkg_config_path" pkg-config --modversion libsecp256k1)" \
+        "$legacy_secp_libdir"
+    printf 'pkg-config cflags: %s\n' "$(PKG_CONFIG_PATH="$pkg_config_path" pkg-config --cflags mpt-crypto)"
+    printf 'pkg-config static libs: %s\n' \
+        "$(PKG_CONFIG_PATH="$pkg_config_path" pkg-config --libs --static mpt-crypto)"
+}
+
+check_static_link() {
+    local pkg_config_path
+    pkg_config_path="$(prepend_path "$output_dir" "${PKG_CONFIG_PATH:-}")"
+    local runtime_flags
+    runtime_flags="$(cxx_runtime_flags)"
+    local cgo_ldflags
+    cgo_ldflags="$(append_flag_string "${CGO_LDFLAGS:-}" "$runtime_flags")"
+    local cgo_cxxflags
+    cgo_cxxflags="$(append_flag_string "${CGO_CXXFLAGS:-}" "$(cxx_compile_flags)")"
+    PKG_CONFIG_PATH="$pkg_config_path" \
+        CGO_LDFLAGS="$cgo_ldflags" \
+        CGO_CXXFLAGS="$cgo_cxxflags" \
+        go test -tags mptcrypto -run '^$' ./crypto/mptcrypto >/dev/null
+    printf '%s\n' 'mpt-crypto static link: ok'
+}
+
+run_upstream_tests() {
+    require_command ctest
+
+    local package_ref
+    package_ref="$(
+        CONAN_HOME="$conan_home" conan list 'mpt-crypto/1.0.2:*' \
+            --filter-options '&:tests=True' \
+            --format=compact |
+            awk '$1 ~ /^mpt-crypto\/1\.0\.2#[^%[:space:]]+:[0-9a-f]+$/ { print $1; exit }'
+    )"
+    [[ -n "$package_ref" ]] || die "could not locate the tested mpt-crypto package"
+
+    local build_dir
+    build_dir="$(CONAN_HOME="$conan_home" conan cache path "$package_ref" --folder=build)"
+    [[ -f "$build_dir/build/Release/CTestTestfile.cmake" ]] || die \
+        "mpt-crypto test manifest is missing from $build_dir"
+
+    ctest --test-dir "$build_dir/build/Release" --output-on-failure
+}
+
+run_tests() {
+    local package="${1:-./...}"
+    shift || true
+    local test_tags="${GOXRPL_MPT_CRYPTO_TEST_TAGS:-mptcrypto}"
+    local runtime_flags
+    runtime_flags="$(cxx_runtime_flags)"
+    local cgo_ldflags
+    cgo_ldflags="$(append_flag_string "${CGO_LDFLAGS:-}" "$runtime_flags")"
+    local cgo_cxxflags
+    cgo_cxxflags="$(append_flag_string "${CGO_CXXFLAGS:-}" "$(cxx_compile_flags)")"
+    local pkg_config_path
+    pkg_config_path="$(prepend_path "$output_dir" "${PKG_CONFIG_PATH:-}")"
+
+    check_pkg_config
+    check_static_link
+    PKG_CONFIG_PATH="$pkg_config_path" \
+        CGO_LDFLAGS="$cgo_ldflags" \
+        CGO_CXXFLAGS="$cgo_cxxflags" \
+        go test -tags "$test_tags" "$package" "$@"
+}
+
+main() {
+    local action="${1:-}"
+    prepare_conan_home
+    case "$action" in
+        setup)
+            install_graph
+            ;;
+        env)
+            print_env
+            ;;
+        test)
+            require_command go
+            install_graph
+            run_upstream_tests
+            shift
+            run_tests "$@"
+            ;;
+        *)
+            usage
+            return 2
+            ;;
+    esac
+}
+
+cd "$repo_root"
+main "$@"


### PR DESCRIPTION
## Summary

- pin and bridge `mpt-crypto/1.0.2` through a fail-closed, exception-safe C ABI
- keep default and no-CGO builds available while exposing native confidential operations only when the backend initializes
- implement v3.3.0 proof contexts, ciphertext validation, and fixed-size guards for all five confidential transaction families
- charge the exact ten-times-base confidential fee through the central signature fee dispatcher, including Batch inner transactions

## Testing

- pinned upstream `mpt-crypto` C/C++ suite and tagged native Go tests
- default and `CGO_ENABLED=0` crypto/fee tests
- `just vet`
- `just build-all`
- `just lint`
- `just docs-check`
- `git diff --check`

Depends on #1625.

Fixes #1375
