### PR TITLE
feat: complete confidential MPT transfers (#1372)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,7 @@ jobs:
       # path on signature accept/reject. No -race here: the detector needs
       # cgo, and no CGO dev headers are installed for this leg.
       - run: CGO_ENABLED=0 go test -count=1 -timeout 15m ./crypto/...
+      - run: CGO_ENABLED=0 go test -tags mptcrypto -count=1 -timeout 15m ./amendment/... ./crypto/mptcrypto/...
 
   test-mpt-crypto:
     name: Test (Confidential MPT native backend, ${{ matrix.os }})
@@ -209,7 +210,7 @@ jobs:
       - name: Install Conan
         run: pipx install conan==2.18.1
       - name: Build and test native backend
-        run: ./scripts/setup-mpt-crypto.sh test ./crypto/mptcrypto/...
+        run: ./scripts/setup-mpt-crypto.sh test ./amendment/... ./crypto/mptcrypto/... ./internal/tx/mpt/... ./internal/testing/mpt/...
 
   consensus-smoke:
     name: Consensus smoke (2 rippled + 1 goxrpl)

--- a/amendment/amendment_test.go
+++ b/amendment/amendment_test.go
@@ -9,6 +9,8 @@ import (
 	"encoding/hex"
 	"slices"
 	"testing"
+
+	"github.com/LeJamon/go-xrpl/crypto/mptcrypto"
 )
 
 func TestFeatureID(t *testing.T) {
@@ -126,16 +128,55 @@ func TestDynamicMPTFeatureRegistration(t *testing.T) {
 	if !AllSupportedRules().Enabled(FeatureDynamicMPT) {
 		t.Error("supported DynamicMPT amendment must be enabled by the all-supported preset")
 	}
+}
 
+func TestConfidentialTransferFeatureRegistration(t *testing.T) {
 	confidential := FeatureByName("ConfidentialTransfer")
 	if confidential == nil {
 		t.Fatal("ConfidentialTransfer feature not found")
 	}
-	if confidential.Supported != SupportedNo || confidential.Vote != VoteDefaultNo {
-		t.Errorf("ConfidentialTransfer support/vote = (%v, %v), want (SupportedNo, VoteDefaultNo)", confidential.Supported, confidential.Vote)
+	wantSupported := mptcrypto.Available()
+	wantSupport := SupportedNo
+	if wantSupported {
+		wantSupport = SupportedYes
 	}
-	if AllSupportedRules().Enabled(FeatureConfidentialTransfer) {
-		t.Error("unsupported ConfidentialTransfer amendment must not be enabled by the all-supported preset")
+	if confidential.Supported != wantSupport || confidential.Vote != VoteDefaultNo {
+		t.Errorf("ConfidentialTransfer support/vote = (%v, %v), want (%v, VoteDefaultNo)", confidential.Supported, confidential.Vote, wantSupport)
+	}
+	if got := AllSupportedRules().Enabled(FeatureConfidentialTransfer); got != wantSupported {
+		t.Errorf("ConfidentialTransfer all-supported state = %v, want %v", got, wantSupported)
+	}
+	foundSupported := false
+	for _, supported := range SupportedFeatures() {
+		if supported.ID == FeatureConfidentialTransfer {
+			foundSupported = true
+			break
+		}
+	}
+	if foundSupported != wantSupported {
+		t.Errorf("ConfidentialTransfer SupportedFeatures membership = %v, want %v", foundSupported, wantSupported)
+	}
+	table := NewTable()
+	if table.IsSupported(FeatureConfidentialTransfer) != wantSupported {
+		t.Errorf("ConfidentialTransfer table support = %v, want %v", table.IsSupported(FeatureConfidentialTransfer), wantSupported)
+	}
+	if slices.Contains(table.Desired(), FeatureConfidentialTransfer) {
+		t.Error("default-no ConfidentialTransfer was desired without an explicit upvote")
+	}
+	table.UpVote(FeatureConfidentialTransfer)
+	if got := slices.Contains(table.Desired(), FeatureConfidentialTransfer); got != wantSupported {
+		t.Errorf("upvoted ConfidentialTransfer desired state = %v, want %v", got, wantSupported)
+	}
+	table.Enable(FeatureConfidentialTransfer)
+	if got := table.HasUnsupportedEnabled(); got != !wantSupported {
+		t.Errorf("ConfidentialTransfer enabled table unsupported state = %v, want %v", got, !wantSupported)
+	}
+	if got := slices.Contains(table.UnsupportedEnabledIDs(), FeatureConfidentialTransfer); got != !wantSupported {
+		t.Errorf("ConfidentialTransfer unsupported-enabled state = %v, want %v", got, !wantSupported)
+	}
+	table.DoValidatedLedger(1, map[[32]byte]bool{FeatureConfidentialTransfer: true}, nil)
+	if got := table.IsBlocked(); got != !wantSupported {
+		t.Errorf("ConfidentialTransfer validated table blocked state = %v, want %v", got, !wantSupported)
 	}
 }
 

--- a/amendment/confidential_transfer_support.go
+++ b/amendment/confidential_transfer_support.go
@@ -1,0 +1,10 @@
+package amendment
+
+import "github.com/LeJamon/go-xrpl/crypto/mptcrypto"
+
+func confidentialTransferSupport() Supported {
+	if mptcrypto.Available() {
+		return SupportedYes
+	}
+	return SupportedNo
+}

--- a/amendment/registry.go
+++ b/amendment/registry.go
@@ -33,7 +33,7 @@ var (
 	FeatureFixCleanup3_1_3               = registerFix("fixCleanup3_1_3", SupportedYes, VoteDefaultYes)
 	FeatureMPTokensV2                    = registerFeature("MPTokensV2", SupportedNo, VoteDefaultNo)
 	FeatureFixBatchInnerSigs             = registerFix("fixBatchInnerSigs", SupportedNo, VoteDefaultNo)
-	FeatureConfidentialTransfer          = registerFeature("ConfidentialTransfer", SupportedNo, VoteDefaultNo)
+	FeatureConfidentialTransfer          = registerFeature("ConfidentialTransfer", confidentialTransferSupport(), VoteDefaultNo)
 	FeatureFixDirectoryLimit             = registerFix("fixDirectoryLimit", SupportedYes, VoteDefaultNo)
 	FeatureFixIncludeKeyletFields        = registerFix("fixIncludeKeyletFields", SupportedYes, VoteDefaultNo)
 	FeatureDynamicMPT                    = registerFeature("DynamicMPT", SupportedYes, VoteDefaultNo)

--- a/docs/supported-transactions.md
+++ b/docs/supported-transactions.md
@@ -6,7 +6,7 @@ Transaction types registered with the engine, generated from the `tx.Register`
 registry (`internal/tx`). Each runs the full Validate → Preflight → Preclaim →
 Apply pipeline. The numeric code is the XRPL `TransactionType` field value.
 
-Total: 80 transaction types.
+Total: 82 transaction types.
 
 | Transaction type | Type code |
 |------------------|-----------|
@@ -24,9 +24,11 @@ Total: 80 transaction types.
 | `CheckCash` | 17 |
 | `CheckCreate` | 16 |
 | `Clawback` | 30 |
+| `ConfidentialMPTClawback` | 89 |
 | `ConfidentialMPTConvert` | 85 |
 | `ConfidentialMPTConvertBack` | 87 |
 | `ConfidentialMPTMergeInbox` | 86 |
+| `ConfidentialMPTSend` | 88 |
 | `CredentialAccept` | 59 |
 | `CredentialCreate` | 58 |
 | `CredentialDelete` | 60 |

--- a/internal/testing/mpt/confidential_batch_native_test.go
+++ b/internal/testing/mpt/confidential_batch_native_test.go
@@ -4,22 +4,45 @@ package mpt_test
 
 import (
 	"encoding/hex"
+	"math/big"
+	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/LeJamon/go-xrpl/crypto/mptcrypto"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	batchtest "github.com/LeJamon/go-xrpl/internal/testing/batch"
+	credentialtest "github.com/LeJamon/go-xrpl/internal/testing/credential"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	batchtx "github.com/LeJamon/go-xrpl/internal/tx/batch"
 	mpttx "github.com/LeJamon/go-xrpl/internal/tx/mpt"
+	"github.com/LeJamon/go-xrpl/internal/tx/sign"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
-	"github.com/stretchr/testify/require"
 )
 
 func confidentialBatchKeyPair(t *testing.T) ([32]byte, []byte) {
+	return batchKeyPair(t)
+}
+
+type confidentialBatchFixture struct {
+	env            *jtx.TestEnv
+	issuer         *jtx.Account
+	sender         *jtx.Account
+	destination    *jtx.Account
+	id             [24]byte
+	senderKey      keylet.Keylet
+	senderPrivate  [32]byte
+	senderPublic   []byte
+	destinationPub []byte
+	issuerPublic   []byte
+	balanceBlind   [32]byte
+}
+
+func batchKeyPair(t *testing.T) ([32]byte, []byte) {
 	t.Helper()
 	private, public, ok := mptcrypto.GenerateKeyPair()
 	require.True(t, ok)
@@ -27,6 +50,10 @@ func confidentialBatchKeyPair(t *testing.T) ([32]byte, []byte) {
 }
 
 func confidentialBatchBlind(t *testing.T) [32]byte {
+	return batchBlind(t)
+}
+
+func batchBlind(t *testing.T) [32]byte {
 	t.Helper()
 	blind, ok := mptcrypto.GenerateBlindingFactor()
 	require.True(t, ok)
@@ -34,6 +61,10 @@ func confidentialBatchBlind(t *testing.T) [32]byte {
 }
 
 func confidentialBatchEncrypt(t *testing.T, amount uint64, public []byte, blind [32]byte) []byte {
+	return batchEncrypt(t, amount, public, blind)
+}
+
+func batchEncrypt(t *testing.T, amount uint64, public []byte, blind [32]byte) []byte {
 	t.Helper()
 	ciphertext, ok := mptcrypto.EncryptAmount(amount, public, blind)
 	require.True(t, ok)
@@ -128,4 +159,328 @@ func TestConfidentialMPTBatchAllOrNothingRollsBackStaleProof(t *testing.T) {
 	require.Equal(t, uint64(60), gotToken.MPTAmount)
 	require.Equal(t, uint32(3), gotToken.ConfidentialBalanceVersion)
 	require.Equal(t, spending, gotToken.ConfidentialBalanceSpending)
+}
+
+func batchZero(t *testing.T, public []byte, account [20]byte, id [24]byte) []byte {
+	t.Helper()
+	zero, ok := mptcrypto.CanonicalZero(public, account, id)
+	require.True(t, ok)
+	return zero
+}
+
+func newConfidentialBatchFixture(t *testing.T) *confidentialBatchFixture {
+	t.Helper()
+	env := jtx.NewTestEnv(t)
+	env.EnableFeatureNow("ConfidentialTransfer")
+	env.EnableFeatureNow("Batch")
+	issuer := jtx.NewAccount("confidential-batch-issuer")
+	sender := jtx.NewAccount("confidential-batch-sender")
+	destination := jtx.NewAccount("confidential-batch-destination")
+	env.Fund(issuer, sender, destination)
+	env.Close()
+
+	senderPrivate, senderPublic := batchKeyPair(t)
+	_, destinationPublic := batchKeyPair(t)
+	_, issuerPublic := batchKeyPair(t)
+	balanceBlind := batchBlind(t)
+	id := keylet.MakeMPTID(4, issuer.ID)
+	issuance := &state.MPTokenIssuanceData{
+		Issuer: issuer.ID, Sequence: 4,
+		Flags:                         entry.LsfMPTCanTransfer | entry.LsfMPTCanHoldConfidentialBalance,
+		OutstandingAmount:             100,
+		ConfidentialOutstandingAmount: 100,
+		IssuerEncryptionKey:           issuerPublic,
+	}
+	senderToken := &state.MPTokenData{
+		Account:                     sender.ID,
+		MPTokenIssuanceID:           id,
+		HolderEncryptionKey:         senderPublic,
+		ConfidentialBalanceInbox:    batchZero(t, senderPublic, sender.ID, id),
+		ConfidentialBalanceSpending: batchEncrypt(t, 100, senderPublic, balanceBlind),
+		IssuerEncryptedBalance:      batchEncrypt(t, 100, issuerPublic, balanceBlind),
+		ConfidentialBalanceVersion:  9,
+	}
+	destinationToken := &state.MPTokenData{
+		Account:                     destination.ID,
+		MPTokenIssuanceID:           id,
+		HolderEncryptionKey:         destinationPublic,
+		ConfidentialBalanceInbox:    batchZero(t, destinationPublic, destination.ID, id),
+		ConfidentialBalanceSpending: batchZero(t, destinationPublic, destination.ID, id),
+		IssuerEncryptedBalance:      batchZero(t, issuerPublic, destination.ID, id),
+		ConfidentialBalanceVersion:  3,
+	}
+	issuanceData, err := state.SerializeMPTokenIssuance(issuance)
+	require.NoError(t, err)
+	senderData, err := state.SerializeMPToken(senderToken)
+	require.NoError(t, err)
+	destinationData, err := state.SerializeMPToken(destinationToken)
+	require.NoError(t, err)
+	issuanceKey := keylet.MPTIssuance(id)
+	senderKey := keylet.MPToken(issuanceKey.Key, sender.ID)
+	destinationKey := keylet.MPToken(issuanceKey.Key, destination.ID)
+	require.NoError(t, env.Ledger().Insert(issuanceKey, issuanceData))
+	require.NoError(t, env.Ledger().Insert(senderKey, senderData))
+	require.NoError(t, env.Ledger().Insert(destinationKey, destinationData))
+
+	return &confidentialBatchFixture{
+		env: env, issuer: issuer, sender: sender, destination: destination, id: id,
+		senderKey: senderKey, senderPrivate: senderPrivate, senderPublic: senderPublic,
+		destinationPub: destinationPublic, issuerPublic: issuerPublic, balanceBlind: balanceBlind,
+	}
+}
+
+func (f *confidentialBatchFixture) send(t *testing.T, sequence uint32, version uint32, balance uint64, spending []byte, balanceBlind [32]byte, amount uint64, amountBlind [32]byte) *mpttx.ConfidentialMPTSend {
+	t.Helper()
+	participants := []mptcrypto.Participant{
+		{PublicKey: f.senderPublic, Ciphertext: batchEncrypt(t, amount, f.senderPublic, amountBlind)},
+		{PublicKey: f.destinationPub, Ciphertext: batchEncrypt(t, amount, f.destinationPub, amountBlind)},
+		{PublicKey: f.issuerPublic, Ciphertext: batchEncrypt(t, amount, f.issuerPublic, amountBlind)},
+	}
+	amountCommitment, ok := mptcrypto.PedersenCommitment(amount, amountBlind)
+	require.True(t, ok)
+	balanceCommitment, ok := mptcrypto.PedersenCommitment(balance, balanceBlind)
+	require.True(t, ok)
+	proofContext, ok := mptcrypto.SendContext(f.sender.ID, f.id, sequence, f.destination.ID, version)
+	require.True(t, ok)
+	proof, ok := mptcrypto.GenerateSendProof(f.senderPrivate, amount, participants, amountBlind, proofContext, amountCommitment, balanceCommitment, balance, spending, balanceBlind)
+	require.True(t, ok)
+	transaction := &mpttx.ConfidentialMPTSend{
+		BaseTx:                     *tx.NewBaseTx(tx.TypeConfidentialMPTSend, f.sender.Address),
+		MPTokenIssuanceID:          hex.EncodeToString(f.id[:]),
+		Destination:                f.destination.Address,
+		SenderEncryptedAmount:      hex.EncodeToString(participants[0].Ciphertext),
+		DestinationEncryptedAmount: hex.EncodeToString(participants[1].Ciphertext),
+		IssuerEncryptedAmount:      hex.EncodeToString(participants[2].Ciphertext),
+		ZKProof:                    hex.EncodeToString(proof),
+		AmountCommitment:           hex.EncodeToString(amountCommitment),
+		BalanceCommitment:          hex.EncodeToString(balanceCommitment),
+	}
+	transaction.Fee = "0"
+	transaction.SigningPubKey = ""
+	transaction.SetSequence(sequence)
+	transaction.SetFlags(tx.TfInnerBatchTxn)
+	return transaction
+}
+
+func subtractBlind(a, b [32]byte) [32]byte {
+	order, _ := new(big.Int).SetString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 16)
+	value := new(big.Int).Sub(new(big.Int).SetBytes(a[:]), new(big.Int).SetBytes(b[:]))
+	value.Mod(value, order)
+	var result [32]byte
+	value.FillBytes(result[:])
+	return result
+}
+
+func readBatchHolding(t *testing.T, env *jtx.TestEnv, key keylet.Keylet) *state.MPTokenData {
+	t.Helper()
+	data, err := env.LedgerEntry(key)
+	require.NoError(t, err)
+	holding, err := state.ParseMPToken(data)
+	require.NoError(t, err)
+	return holding
+}
+
+func TestConfidentialSendBatchStaleProofModes(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		flag         uint32
+		wantVersion  uint32
+		wantSequence uint32
+		wantApplied  int
+	}{
+		{name: "all or nothing rolls back the first send", flag: batchtx.BatchFlagAllOrNothing, wantVersion: 9, wantSequence: 1, wantApplied: 0},
+		{name: "independent retains the first send", flag: batchtx.BatchFlagIndependent, wantVersion: 10, wantSequence: 3, wantApplied: 2},
+		{name: "until failure stops after the stale proof", flag: batchtx.BatchFlagUntilFailure, wantVersion: 10, wantSequence: 3, wantApplied: 2},
+		{name: "only one accepts exactly one successful send", flag: batchtx.BatchFlagOnlyOne, wantVersion: 10, wantSequence: 2, wantApplied: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newConfidentialBatchFixture(t)
+			outerSequence := fixture.env.Seq(fixture.sender)
+			initial := readBatchHolding(t, fixture.env, fixture.senderKey)
+			first := fixture.send(t, outerSequence+1, initial.ConfidentialBalanceVersion, 100, initial.ConfidentialBalanceSpending, fixture.balanceBlind, 40, batchBlind(t))
+			second := fixture.send(t, outerSequence+2, initial.ConfidentialBalanceVersion, 100, initial.ConfidentialBalanceSpending, fixture.balanceBlind, 40, batchBlind(t))
+			batchFee := uint64(220)
+			batch := batchtest.NewBatchBuilder(fixture.sender, outerSequence, batchFee, test.flag).AddInnerTx(first).AddInnerTx(second).Build()
+			require.Equal(t, batchFee, batch.CalculateMinimumFee(fixture.env.Ledger(), tx.EngineConfig{BaseFee: fixture.env.BaseFee()}))
+			result := fixture.env.Submit(batch)
+			jtx.RequireTxSuccess(t, result)
+			require.Len(t, result.AppliedInnerTransactions, test.wantApplied)
+			if test.flag == batchtx.BatchFlagIndependent {
+				require.Equal(t, ter.TesSUCCESS, result.AppliedInnerTransactions[0].Metadata.TransactionResult)
+				require.Equal(t, ter.TecBAD_PROOF, result.AppliedInnerTransactions[1].Metadata.TransactionResult)
+				require.NotNil(t, result.AppliedInnerTransactions[0].Metadata.ParentBatchID)
+				require.NotNil(t, result.AppliedInnerTransactions[1].Metadata.ParentBatchID)
+			}
+			updated := readBatchHolding(t, fixture.env, fixture.senderKey)
+			require.Equal(t, test.wantVersion, updated.ConfidentialBalanceVersion)
+			require.Equal(t, outerSequence+test.wantSequence, fixture.env.Seq(fixture.sender))
+		})
+	}
+}
+
+func TestConfidentialSendBatchOuterTicketUsesInnerSequenceContext(t *testing.T) {
+	fixture := newConfidentialBatchFixture(t)
+	outerTicket := fixture.env.CreateTickets(fixture.sender, 1)
+	fixture.env.Close()
+	innerSequence := fixture.env.Seq(fixture.sender)
+	initial := readBatchHolding(t, fixture.env, fixture.senderKey)
+	firstBlind := batchBlind(t)
+	first := fixture.send(t, innerSequence, initial.ConfidentialBalanceVersion, 100, initial.ConfidentialBalanceSpending, fixture.balanceBlind, 40, firstBlind)
+	firstAmount, _ := hex.DecodeString(first.SenderEncryptedAmount)
+	predictedSpending, ok := mptcrypto.SubtractCiphertexts(initial.ConfidentialBalanceSpending, firstAmount)
+	require.True(t, ok)
+	predictedBlind := subtractBlind(fixture.balanceBlind, firstBlind)
+	second := fixture.send(t, innerSequence+1, initial.ConfidentialBalanceVersion+1, 60, predictedSpending, predictedBlind, 20, batchBlind(t))
+	batch := batchtest.NewBatchBuilderWithTicket(fixture.sender, outerTicket, 220, batchtx.BatchFlagAllOrNothing).AddInnerTx(first).AddInnerTx(second).Build()
+	result := fixture.env.Submit(batch)
+	jtx.RequireTxSuccess(t, result)
+	require.Len(t, result.AppliedInnerTransactions, 2)
+	require.Equal(t, uint32(11), readBatchHolding(t, fixture.env, fixture.senderKey).ConfidentialBalanceVersion)
+}
+
+func TestConfidentialMPTSendDelegatedExecution(t *testing.T) {
+	fixture := newConfidentialBatchFixture(t)
+	fixture.env.EnableFeature("PermissionDelegationV1_1")
+	delegate := jtx.NewAccount("confidential-send-delegate")
+	fixture.env.Fund(delegate)
+	fixture.env.Close()
+	standaloneSend := func(amount uint64, amountBlind [32]byte, balance uint64, balanceBlind [32]byte) *mpttx.ConfidentialMPTSend {
+		holding := readBatchHolding(t, fixture.env, fixture.senderKey)
+		send := fixture.send(t, fixture.env.Seq(fixture.sender), holding.ConfidentialBalanceVersion, balance, holding.ConfidentialBalanceSpending, balanceBlind, amount, amountBlind)
+		send.Flags = nil
+		send.Fee = strconv.FormatUint(sign.CalculateBaseFee(send, fixture.env.Ledger(), tx.EngineConfig{BaseFee: fixture.env.BaseFee()}), 10)
+		send.Delegate = delegate.Address
+		return send
+	}
+
+	missingPermission := standaloneSend(40, batchBlind(t), 100, fixture.balanceBlind)
+	require.Equal(t, "terNO_DELEGATE_PERMISSION", fixture.env.SubmitSignedWith(missingPermission, delegate).Code)
+
+	fixture.env.SetDelegate(fixture.sender, delegate, []string{"ConfidentialMPTSend"})
+	fixture.env.Close()
+
+	initial := readBatchHolding(t, fixture.env, fixture.senderKey)
+	amountBlind := batchBlind(t)
+	send := standaloneSend(40, amountBlind, 100, fixture.balanceBlind)
+	result := fixture.env.SubmitSignedWith(send, delegate)
+	jtx.RequireTxSuccess(t, result)
+	require.Equal(t, initial.ConfidentialBalanceVersion+1, readBatchHolding(t, fixture.env, fixture.senderKey).ConfidentialBalanceVersion)
+
+	fixture.env.SetDelegate(fixture.sender, delegate, nil)
+	fixture.env.Close()
+	remainingBlind := subtractBlind(fixture.balanceBlind, amountBlind)
+	revoked := standaloneSend(20, batchBlind(t), 60, remainingBlind)
+	require.Equal(t, "terNO_DELEGATE_PERMISSION", fixture.env.SubmitSignedWith(revoked, delegate).Code)
+}
+
+func TestConfidentialMPTSendExpiredCredentialCleanupPersists(t *testing.T) {
+	fixture := newConfidentialBatchFixture(t)
+	credentialIssuer := jtx.NewAccount("confidential-send-credential-issuer")
+	fixture.env.Fund(credentialIssuer)
+	fixture.env.Close()
+
+	const credentialType = "KYC"
+	expiration := fixture.env.NowRipple() + 100
+	jtx.RequireTxSuccess(t, fixture.env.Submit(credentialtest.CredentialCreateText(credentialIssuer, fixture.sender, credentialType).Expiration(expiration).Build()))
+	fixture.env.Close()
+	jtx.RequireTxSuccess(t, fixture.env.Submit(credentialtest.CredentialAcceptText(fixture.sender, credentialIssuer, credentialType).Build()))
+	fixture.env.CloseToParentCloseTime(expiration + 1)
+
+	initial := readBatchHolding(t, fixture.env, fixture.senderKey)
+	send := fixture.send(t, fixture.env.Seq(fixture.sender), initial.ConfidentialBalanceVersion, 100, initial.ConfidentialBalanceSpending, fixture.balanceBlind, 40, batchBlind(t))
+	send.Flags = nil
+	send.Fee = strconv.FormatUint(sign.CalculateBaseFee(send, fixture.env.Ledger(), tx.EngineConfig{BaseFee: fixture.env.BaseFee()}), 10)
+	credentialKey := jtx.CredentialKeylet(fixture.sender, credentialIssuer, credentialType)
+	send.CredentialIDs = []string{hex.EncodeToString(credentialKey.Key[:])}
+	jtx.RequireTxClaimed(t, fixture.env.Submit(send), jtx.TecEXPIRED)
+	require.False(t, fixture.env.LedgerEntryExists(credentialKey))
+	require.Equal(t, initial.ConfidentialBalanceVersion, readBatchHolding(t, fixture.env, fixture.senderKey).ConfidentialBalanceVersion)
+}
+
+func TestConfidentialClawbackBatchAndFeeDispatch(t *testing.T) {
+	fixture := newConfidentialBatchFixture(t)
+	issuerPrivate, issuerPublic := batchKeyPair(t)
+	holderPublic := fixture.senderPublic
+	blind := batchBlind(t)
+	issuerCiphertext := batchEncrypt(t, 75, issuerPublic, blind)
+	issuanceKey := keylet.MPTIssuance(fixture.id)
+	holdingKey := fixture.senderKey
+	issuance := &state.MPTokenIssuanceData{Issuer: fixture.issuer.ID, Sequence: 4, Flags: entry.LsfMPTCanClawback | entry.LsfMPTCanHoldConfidentialBalance, OutstandingAmount: 75, ConfidentialOutstandingAmount: 75, IssuerEncryptionKey: issuerPublic}
+	holding := &state.MPTokenData{Account: fixture.sender.ID, MPTokenIssuanceID: fixture.id, MPTAmount: 13, HolderEncryptionKey: holderPublic, ConfidentialBalanceInbox: batchEncrypt(t, 50, holderPublic, blind), ConfidentialBalanceSpending: batchEncrypt(t, 25, holderPublic, blind), IssuerEncryptedBalance: issuerCiphertext, ConfidentialBalanceVersion: 6}
+	issuanceData, err := state.SerializeMPTokenIssuance(issuance)
+	require.NoError(t, err)
+	holdingData, err := state.SerializeMPToken(holding)
+	require.NoError(t, err)
+	require.NoError(t, fixture.env.Ledger().Update(issuanceKey, issuanceData))
+	require.NoError(t, fixture.env.Ledger().Update(holdingKey, holdingData))
+	outerSequence := fixture.env.Seq(fixture.issuer)
+	innerSequence := outerSequence + 1
+	proofContext, ok := mptcrypto.ClawbackContext(fixture.issuer.ID, fixture.id, innerSequence, fixture.sender.ID)
+	require.True(t, ok)
+	proof, ok := mptcrypto.GenerateClawbackProof(issuerPrivate, issuerPublic, proofContext, 75, issuerCiphertext)
+	require.True(t, ok)
+	clawback := &mpttx.ConfidentialMPTClawback{BaseTx: *tx.NewBaseTx(tx.TypeConfidentialMPTClawback, fixture.issuer.Address), MPTokenIssuanceID: hex.EncodeToString(fixture.id[:]), Holder: fixture.sender.Address, MPTAmount: 75, ZKProof: hex.EncodeToString(proof)}
+	clawback.Fee = "0"
+	clawback.SigningPubKey = ""
+	clawback.SetSequence(innerSequence)
+	clawback.SetFlags(tx.TfInnerBatchTxn)
+	payment := batchtest.MakeInnerPaymentXRP(fixture.issuer, fixture.destination, 1, innerSequence+1)
+	batchFee := uint64(130)
+	batch := batchtest.NewBatchBuilder(fixture.issuer, outerSequence, batchFee, batchtx.BatchFlagAllOrNothing).AddInnerTx(clawback).AddInnerTx(payment).Build()
+	require.Equal(t, batchFee, batch.CalculateMinimumFee(fixture.env.Ledger(), tx.EngineConfig{BaseFee: fixture.env.BaseFee()}))
+	result := fixture.env.Submit(batch)
+	jtx.RequireTxSuccess(t, result)
+	require.Len(t, result.AppliedInnerTransactions, 2)
+	updated := readBatchHolding(t, fixture.env, holdingKey)
+	require.Equal(t, uint64(13), updated.MPTAmount)
+	require.Equal(t, uint32(7), updated.ConfidentialBalanceVersion)
+	updatedIssuanceData, err := fixture.env.LedgerEntry(issuanceKey)
+	require.NoError(t, err)
+	updatedIssuance, err := state.ParseMPTokenIssuance(updatedIssuanceData)
+	require.NoError(t, err)
+	require.Zero(t, updatedIssuance.OutstandingAmount)
+	require.Zero(t, updatedIssuance.ConfidentialOutstandingAmount)
+}
+
+func TestConfidentialMPTClawbackDelegatedExecution(t *testing.T) {
+	fixture := newConfidentialBatchFixture(t)
+	fixture.env.EnableFeature("PermissionDelegationV1_1")
+	delegate := jtx.NewAccount("confidential-clawback-delegate")
+	fixture.env.Fund(delegate)
+	fixture.env.Close()
+	fixture.env.SetDelegate(fixture.sender, delegate, []string{"ConfidentialMPTClawback"})
+	fixture.env.Close()
+
+	issuerPrivate, issuerPublic := batchKeyPair(t)
+	blind := batchBlind(t)
+	issuerCiphertext := batchEncrypt(t, 75, issuerPublic, blind)
+	issuanceKey := keylet.MPTIssuance(fixture.id)
+	issuance := &state.MPTokenIssuanceData{Issuer: fixture.issuer.ID, Sequence: 4, Flags: entry.LsfMPTCanClawback | entry.LsfMPTCanHoldConfidentialBalance, OutstandingAmount: 75, ConfidentialOutstandingAmount: 75, IssuerEncryptionKey: issuerPublic}
+	holding := &state.MPTokenData{Account: fixture.sender.ID, MPTokenIssuanceID: fixture.id, MPTAmount: 13, HolderEncryptionKey: fixture.senderPublic, ConfidentialBalanceInbox: batchEncrypt(t, 50, fixture.senderPublic, blind), ConfidentialBalanceSpending: batchEncrypt(t, 25, fixture.senderPublic, blind), IssuerEncryptedBalance: issuerCiphertext, ConfidentialBalanceVersion: 6}
+	issuanceData, err := state.SerializeMPTokenIssuance(issuance)
+	require.NoError(t, err)
+	holdingData, err := state.SerializeMPToken(holding)
+	require.NoError(t, err)
+	require.NoError(t, fixture.env.Ledger().Update(issuanceKey, issuanceData))
+	require.NoError(t, fixture.env.Ledger().Update(fixture.senderKey, holdingData))
+
+	makeClawback := func() *mpttx.ConfidentialMPTClawback {
+		sequence := fixture.env.Seq(fixture.issuer)
+		proofContext, ok := mptcrypto.ClawbackContext(fixture.issuer.ID, fixture.id, sequence, fixture.sender.ID)
+		require.True(t, ok)
+		proof, ok := mptcrypto.GenerateClawbackProof(issuerPrivate, issuerPublic, proofContext, 75, issuerCiphertext)
+		require.True(t, ok)
+		clawback := &mpttx.ConfidentialMPTClawback{BaseTx: *tx.NewBaseTx(tx.TypeConfidentialMPTClawback, fixture.issuer.Address), MPTokenIssuanceID: hex.EncodeToString(fixture.id[:]), Holder: fixture.sender.Address, MPTAmount: 75, ZKProof: hex.EncodeToString(proof)}
+		clawback.SetSequence(sequence)
+		clawback.Delegate = delegate.Address
+		clawback.Fee = strconv.FormatUint(sign.CalculateBaseFee(clawback, fixture.env.Ledger(), tx.EngineConfig{BaseFee: fixture.env.BaseFee()}), 10)
+		return clawback
+	}
+	require.Equal(t, "terNO_DELEGATE_PERMISSION", fixture.env.SubmitSignedWith(makeClawback(), delegate).Code)
+
+	fixture.env.SetDelegate(fixture.issuer, delegate, []string{"ConfidentialMPTClawback"})
+	fixture.env.Close()
+	result := fixture.env.SubmitSignedWith(makeClawback(), delegate)
+	jtx.RequireTxSuccess(t, result)
+	require.Equal(t, uint32(7), readBatchHolding(t, fixture.env, fixture.senderKey).ConfidentialBalanceVersion)
 }

--- a/internal/testing/mpt/dynamic_mpt_test.go
+++ b/internal/testing/mpt/dynamic_mpt_test.go
@@ -20,6 +20,7 @@ func dynamicMPTDisabledEnv(t *testing.T) *jtx.TestEnv {
 func dynamicMPTEnv(t *testing.T) *jtx.TestEnv {
 	t.Helper()
 	env := jtx.NewTestEnv(t)
+	env.DisableFeature("ConfidentialTransfer")
 	env.EnableFeature("DynamicMPT")
 	env.Close()
 	return env

--- a/internal/testing/mpt/mpt_test.go
+++ b/internal/testing/mpt/mpt_test.go
@@ -704,6 +704,7 @@ func TestMPT_SetValidation(t *testing.T) {
 		env.DisableFeature("MPTokensV1")
 		env.DisableFeature("SingleAssetVault")
 		env.DisableFeature("DynamicMPT")
+		env.DisableFeature("ConfidentialTransfer")
 		env.Close()
 		alice := jtx.NewAccount("alice")
 		bob := jtx.NewAccount("bob")

--- a/internal/tx/credential/credential_helpers.go
+++ b/internal/tx/credential/credential_helpers.go
@@ -211,10 +211,14 @@ func CheckFields(ids []string, present bool, dupDetail string) error {
 	}
 	seen := make(map[string]bool, len(ids))
 	for _, id := range ids {
-		if seen[id] {
+		canonical := id
+		if decoded, err := hex.DecodeString(id); err == nil && len(decoded) == 32 {
+			canonical = hex.EncodeToString(decoded)
+		}
+		if seen[canonical] {
 			return ter.Errorf(ter.TemMALFORMED, "%s", dupDetail)
 		}
-		seen[id] = true
+		seen[canonical] = true
 	}
 	return nil
 }
@@ -463,11 +467,28 @@ func VerifyDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, src, dst
 			if !credentialsPresent {
 				return ter.TecNO_PERMISSION
 			}
-			return authorizedDepositPreauth(ctx, credentialIDs, dst)
+			return authorizedDepositPreauth(ctx.View, credentialIDs, dst)
 		}
 	}
 
 	return ter.TesSUCCESS
+}
+
+func CheckDepositPreauth(view tx.LedgerView, credentialIDs []string, credentialsPresent bool, src, dst [20]byte, dstAccount *state.AccountRoot) ter.Result {
+	if dstAccount == nil || dstAccount.Flags&state.LsfDepositAuth == 0 || src == dst {
+		return ter.TesSUCCESS
+	}
+	exists, err := view.Exists(keylet.DepositPreauth(dst, src))
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if exists {
+		return ter.TesSUCCESS
+	}
+	if !credentialsPresent {
+		return ter.TecNO_PERMISSION
+	}
+	return authorizedDepositPreauth(view, credentialIDs, dst)
 }
 
 // authorizedDepositPreauth checks whether the (Issuer, CredentialType) pairs
@@ -476,7 +497,7 @@ func VerifyDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, src, dst
 // credentials that passed preflight and preclaim, since credential IDs are
 // deduplicated there and all credentials share the sender as Subject.
 // Reference: rippled CredentialHelpers.cpp credentials::authorizedDepositPreauth()
-func authorizedDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, dst [20]byte) ter.Result {
+func authorizedDepositPreauth(view tx.LedgerView, credentialIDs []string, dst [20]byte) ter.Result {
 	pairs := make([]keylet.CredentialPair, 0, len(credentialIDs))
 	seen := make(map[string]bool, len(credentialIDs))
 
@@ -489,7 +510,7 @@ func authorizedDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, dst 
 		copy(credID[:], credIDBytes)
 
 		// Credential existence was already checked in preclaim.
-		credData, err := ctx.View.Read(keylet.CredentialByID(credID))
+		credData, err := view.Read(keylet.CredentialByID(credID))
 		if err != nil || credData == nil {
 			return ter.TefINTERNAL
 		}
@@ -517,7 +538,9 @@ func authorizedDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, dst 
 		return bytes.Compare(pairs[i].CredentialType, pairs[j].CredentialType) < 0
 	})
 
-	if exists, _ := ctx.View.Exists(keylet.DepositPreauthCredentials(dst, pairs)); !exists {
+	if exists, err := view.Exists(keylet.DepositPreauthCredentials(dst, pairs)); err != nil {
+		return ter.TefINTERNAL
+	} else if !exists {
 		return ter.TecNO_PERMISSION
 	}
 

--- a/internal/tx/credential/credential_helpers.go
+++ b/internal/tx/credential/credential_helpers.go
@@ -211,10 +211,11 @@ func CheckFields(ids []string, present bool, dupDetail string) error {
 	}
 	seen := make(map[string]bool, len(ids))
 	for _, id := range ids {
-		canonical := id
-		if decoded, err := hex.DecodeString(id); err == nil && len(decoded) == 32 {
-			canonical = hex.EncodeToString(decoded)
+		decoded, err := hex.DecodeString(id)
+		if err != nil || len(decoded) != 32 {
+			return ter.Errorf(ter.TemMALFORMED, "CredentialID must be a 256-bit hex value")
 		}
+		canonical := hex.EncodeToString(decoded)
 		if seen[canonical] {
 			return ter.Errorf(ter.TemMALFORMED, "%s", dupDetail)
 		}

--- a/internal/tx/credential/credential_helpers_test.go
+++ b/internal/tx/credential/credential_helpers_test.go
@@ -3,6 +3,7 @@ package credential
 import (
 	"context"
 	"encoding/hex"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,6 +17,14 @@ import (
 	"github.com/LeJamon/go-xrpl/keylet"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 )
+
+func TestCheckFieldsTreatsHexCaseAsTheSameCredential(t *testing.T) {
+	lower := "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+	upper := "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789"
+	if result := CheckFields([]string{lower, upper}, true, "duplicate credential ID"); result == nil || !strings.Contains(result.Error(), "temMALFORMED") {
+		t.Fatalf("CheckFields() = %v, want temMALFORMED", result)
+	}
+}
 
 // mapView is a minimal in-memory tx.LedgerView for helper-level tests.
 type mapView struct{ data map[[32]byte][]byte }

--- a/internal/tx/delegate/registry_test.go
+++ b/internal/tx/delegate/registry_test.go
@@ -74,6 +74,8 @@ func TestDelegateSet_EveryRegisteredTypeHasDelegationDecision(t *testing.T) {
 		tx.TypeConfidentialMPTConvert:       false,
 		tx.TypeConfidentialMPTMergeInbox:    true,
 		tx.TypeConfidentialMPTConvertBack:   true,
+		tx.TypeConfidentialMPTSend:          true,
+		tx.TypeConfidentialMPTClawback:      true,
 		tx.TypeCredentialCreate:             true,
 		tx.TypeCredentialAccept:             true,
 		tx.TypeCredentialDelete:             true,

--- a/internal/tx/mpt/confidential_clawback.go
+++ b/internal/tx/mpt/confidential_clawback.go
@@ -1,0 +1,191 @@
+package mpt
+
+import (
+	"fmt"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/crypto/mptcrypto"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+	"github.com/LeJamon/go-xrpl/protocol"
+)
+
+type ConfidentialMPTClawback struct {
+	tx.BaseTx
+	MPTokenIssuanceID string `json:"MPTokenIssuanceID" xrpl:"MPTokenIssuanceID"`
+	Holder            string `json:"Holder" xrpl:"Holder"`
+	MPTAmount         uint64 `json:"MPTAmount" xrpl:"MPTAmount"`
+	ZKProof           string `json:"ZKProof" xrpl:"ZKProof"`
+}
+
+func (c *ConfidentialMPTClawback) UnmarshalJSON(data []byte) error {
+	type alias ConfidentialMPTClawback
+	var decoded alias
+	amount, err := unmarshalConfidential(data, &decoded)
+	if err != nil {
+		return err
+	}
+	decoded.MPTAmount = amount
+	*c = ConfidentialMPTClawback(decoded)
+	return nil
+}
+
+func (c *ConfidentialMPTClawback) TxType() tx.Type { return tx.TypeConfidentialMPTClawback }
+
+func (c *ConfidentialMPTClawback) GetFlagsMask(*amendment.Rules) uint32 { return tx.TfUniversalMask }
+
+func (c *ConfidentialMPTClawback) RequiredAmendments() [][32]byte {
+	return [][32]byte{amendment.FeatureConfidentialTransfer}
+}
+
+func (c *ConfidentialMPTClawback) Flatten() (map[string]any, error) {
+	result, err := tx.ReflectFlatten(c)
+	if err == nil {
+		result["MPTAmount"] = fmt.Sprintf("%d", c.MPTAmount)
+	}
+	return result, err
+}
+
+func (c *ConfidentialMPTClawback) Validate() error {
+	if err := c.BaseTx.Validate(); err != nil {
+		return err
+	}
+	if !confidentialRequiredFieldsPresent(c.GetCommon(), "MPTokenIssuanceID", "Holder", "MPTAmount", "ZKProof") {
+		return ter.Errorf(ter.TemMALFORMED, "required confidential clawback field is missing")
+	}
+	id, ok := parseConfidentialID(c.MPTokenIssuanceID)
+	if !ok {
+		return ter.Errorf(ter.TemINVALID, "invalid MPTokenIssuanceID")
+	}
+	accountID, accountErr := state.DecodeAccountID(c.Account)
+	holderID, holderErr := state.DecodeAccountID(c.Holder)
+	if accountErr != nil || holderErr != nil {
+		return ter.Errorf(ter.TemMALFORMED, "invalid clawback account")
+	}
+	if accountID != [20]byte(id[4:]) || accountID == holderID {
+		return ter.Errorf(ter.TemMALFORMED, "invalid confidential clawback participants")
+	}
+	if c.MPTAmount == 0 || c.MPTAmount > protocol.MaxMPTokenAmount {
+		return ter.Errorf(ter.TemBAD_AMOUNT, "invalid MPTAmount")
+	}
+	if _, valid := decodeConfidentialField(c.ZKProof, mptcrypto.ClawbackProofSize); !valid {
+		return ter.Errorf(ter.TemMALFORMED, "invalid ZKProof")
+	}
+	return nil
+}
+
+func (c *ConfidentialMPTClawback) Preclaim(view tx.LedgerView, _ tx.EngineConfig) ter.Result {
+	id, _ := parseConfidentialID(c.MPTokenIssuanceID)
+	accountID, err := state.DecodeAccountID(c.Account)
+	if err != nil {
+		return ter.TemBAD_SRC_ACCOUNT
+	}
+	account, err := tx.ReadAccountRoot(view, accountID)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if account == nil {
+		return ter.TerNO_ACCOUNT
+	}
+	holderID, err := state.DecodeAccountID(c.Holder)
+	if err != nil {
+		return ter.TemMALFORMED
+	}
+	holderAccount, err := tx.ReadAccountRoot(view, holderID)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if holderAccount == nil {
+		return ter.TecNO_TARGET
+	}
+
+	issuance, _, result := mptutil.ReadIssuance(view, id)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	if issuance.Issuer != accountID {
+		return ter.TefINTERNAL
+	}
+	if len(issuance.IssuerEncryptionKey) == 0 || issuance.Flags&entry.LsfMPTCanClawback == 0 || issuance.Flags&entry.LsfMPTCanHoldConfidentialBalance == 0 {
+		return ter.TecNO_PERMISSION
+	}
+	holder, _, result := readConfidentialHolding(view, id, holderID)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	if len(holder.IssuerEncryptedBalance) == 0 || len(holder.HolderEncryptionKey) == 0 {
+		return ter.TecNO_PERMISSION
+	}
+	if c.MPTAmount > issuance.ConfidentialOutstandingAmount || c.MPTAmount > issuance.OutstandingAmount {
+		return ter.TecINSUFFICIENT_FUNDS
+	}
+	if len(issuance.IssuerEncryptionKey) != mptcrypto.PublicKeySize ||
+		len(holder.IssuerEncryptedBalance) != mptcrypto.CiphertextSize {
+		return ter.TecINTERNAL
+	}
+	proof, _ := decodeConfidentialField(c.ZKProof, mptcrypto.ClawbackProofSize)
+	context, contextOK := mptcrypto.ClawbackContext(accountID, id, c.GetCommon().SeqProxy(), holderID)
+	if !contextOK || !mptcrypto.VerifyClawback(proof, issuance.IssuerEncryptionKey, holder.IssuerEncryptedBalance, c.MPTAmount, context) {
+		return ter.TecBAD_PROOF
+	}
+	return ter.TesSUCCESS
+}
+
+func (c *ConfidentialMPTClawback) Apply(ctx *tx.ApplyContext) ter.Result {
+	id, _ := parseConfidentialID(c.MPTokenIssuanceID)
+	holderID, _ := state.DecodeAccountID(c.Holder)
+	issuance, issuanceKey, result := mptutil.ReadIssuance(ctx.View, id)
+	if result != ter.TesSUCCESS {
+		return ter.TecINTERNAL
+	}
+	holder, holderKey, result := readConfidentialHolding(ctx.View, id, holderID)
+	if result != ter.TesSUCCESS {
+		return ter.TecINTERNAL
+	}
+	holderZero, ok := mptcrypto.CanonicalZero(holder.HolderEncryptionKey, holderID, id)
+	if !ok {
+		return ter.TecINTERNAL
+	}
+	issuerZero, ok := mptcrypto.CanonicalZero(issuance.IssuerEncryptionKey, holderID, id)
+	if !ok {
+		return ter.TecINTERNAL
+	}
+	holder.ConfidentialBalanceInbox = holderZero
+	holder.ConfidentialBalanceSpending = holderZero
+	holder.IssuerEncryptedBalance = issuerZero
+	holder.ConfidentialBalanceVersion++
+	if len(holder.AuditorEncryptedBalance) != 0 {
+		if len(issuance.AuditorEncryptionKey) == 0 {
+			return ter.TecINTERNAL
+		}
+		auditorZero, ok := mptcrypto.CanonicalZero(issuance.AuditorEncryptionKey, holderID, id)
+		if !ok {
+			return ter.TecINTERNAL
+		}
+		holder.AuditorEncryptedBalance = auditorZero
+	}
+	if c.MPTAmount > issuance.ConfidentialOutstandingAmount || c.MPTAmount > issuance.OutstandingAmount {
+		return ter.TecINTERNAL
+	}
+	issuance.ConfidentialOutstandingAmount -= c.MPTAmount
+	issuance.OutstandingAmount -= c.MPTAmount
+
+	issuanceData, err := state.SerializeMPTokenIssuance(issuance)
+	if err != nil {
+		return ter.TecINTERNAL
+	}
+	holderData, err := state.SerializeMPToken(holder)
+	if err != nil {
+		return ter.TecINTERNAL
+	}
+	if err := ctx.View.Update(holderKey, holderData); err != nil {
+		return ter.TecINTERNAL
+	}
+	if err := ctx.View.Update(issuanceKey, issuanceData); err != nil {
+		return ter.TecINTERNAL
+	}
+	return ter.TesSUCCESS
+}

--- a/internal/tx/mpt/confidential_send.go
+++ b/internal/tx/mpt/confidential_send.go
@@ -1,0 +1,310 @@
+package mpt
+
+import (
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/crypto/mptcrypto"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/credential"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+)
+
+type ConfidentialMPTSend struct {
+	tx.BaseTx
+	MPTokenIssuanceID          string   `json:"MPTokenIssuanceID" xrpl:"MPTokenIssuanceID"`
+	Destination                string   `json:"Destination" xrpl:"Destination"`
+	DestinationTag             *uint32  `json:"DestinationTag,omitempty" xrpl:"DestinationTag,omitempty"`
+	SenderEncryptedAmount      string   `json:"SenderEncryptedAmount" xrpl:"SenderEncryptedAmount"`
+	DestinationEncryptedAmount string   `json:"DestinationEncryptedAmount" xrpl:"DestinationEncryptedAmount"`
+	IssuerEncryptedAmount      string   `json:"IssuerEncryptedAmount" xrpl:"IssuerEncryptedAmount"`
+	AuditorEncryptedAmount     *string  `json:"AuditorEncryptedAmount,omitempty" xrpl:"AuditorEncryptedAmount,omitempty"`
+	ZKProof                    string   `json:"ZKProof" xrpl:"ZKProof"`
+	AmountCommitment           string   `json:"AmountCommitment" xrpl:"AmountCommitment"`
+	BalanceCommitment          string   `json:"BalanceCommitment" xrpl:"BalanceCommitment"`
+	CredentialIDs              []string `json:"CredentialIDs,omitempty" xrpl:"CredentialIDs,omitempty"`
+}
+
+func (c *ConfidentialMPTSend) TxType() tx.Type { return tx.TypeConfidentialMPTSend }
+
+func (c *ConfidentialMPTSend) GetFlagsMask(*amendment.Rules) uint32 { return tx.TfUniversalMask }
+
+func (c *ConfidentialMPTSend) RequiredAmendments() [][32]byte {
+	amendments := [][32]byte{amendment.FeatureConfidentialTransfer}
+	if c.CredentialIDs != nil || c.HasField("CredentialIDs") {
+		amendments = append(amendments, amendment.FeatureCredentials)
+	}
+	return amendments
+}
+
+func (c *ConfidentialMPTSend) Flatten() (map[string]any, error) { return tx.ReflectFlatten(c) }
+
+func (c *ConfidentialMPTSend) Validate() error {
+	if err := c.BaseTx.Validate(); err != nil {
+		return err
+	}
+	if !confidentialRequiredFieldsPresent(
+		c.GetCommon(),
+		"MPTokenIssuanceID",
+		"Destination",
+		"SenderEncryptedAmount",
+		"DestinationEncryptedAmount",
+		"IssuerEncryptedAmount",
+		"ZKProof",
+		"AmountCommitment",
+		"BalanceCommitment",
+	) {
+		return ter.Errorf(ter.TemMALFORMED, "required confidential send field is missing")
+	}
+	id, ok := parseConfidentialID(c.MPTokenIssuanceID)
+	if !ok {
+		return ter.Errorf(ter.TemINVALID, "invalid MPTokenIssuanceID")
+	}
+	accountID, accountErr := state.DecodeAccountID(c.Account)
+	destinationID, destinationErr := state.DecodeAccountID(c.Destination)
+	if accountErr != nil || destinationErr != nil {
+		return ter.Errorf(ter.TemMALFORMED, "invalid send account")
+	}
+	issuer := [20]byte(id[4:])
+	if accountID == issuer || accountID == destinationID || destinationID == issuer {
+		return ter.Errorf(ter.TemMALFORMED, "invalid confidential transfer participants")
+	}
+
+	for _, value := range []*string{&c.SenderEncryptedAmount, &c.DestinationEncryptedAmount, &c.IssuerEncryptedAmount, c.AuditorEncryptedAmount} {
+		if value == nil {
+			continue
+		}
+		if _, valid := decodeConfidentialField(*value, mptcrypto.CiphertextSize); !valid {
+			return ter.Errorf(ter.TemBAD_CIPHERTEXT, "invalid ciphertext length")
+		}
+	}
+	if _, valid := decodeConfidentialField(c.ZKProof, mptcrypto.SendProofSize); !valid {
+		return ter.Errorf(ter.TemMALFORMED, "invalid ZKProof")
+	}
+	for _, value := range []string{c.BalanceCommitment, c.AmountCommitment} {
+		commitment, valid := decodeConfidentialField(value, mptcrypto.CommitmentSize)
+		if !valid || !mptcrypto.ValidCommitment(commitment) {
+			return ter.Errorf(ter.TemMALFORMED, "invalid Pedersen commitment")
+		}
+	}
+	for _, value := range []*string{&c.SenderEncryptedAmount, &c.DestinationEncryptedAmount, &c.IssuerEncryptedAmount, c.AuditorEncryptedAmount} {
+		if value == nil {
+			continue
+		}
+		ciphertext, _ := decodeConfidentialField(*value, mptcrypto.CiphertextSize)
+		if !mptcrypto.ValidCiphertext(ciphertext) {
+			return ter.Errorf(ter.TemBAD_CIPHERTEXT, "invalid ciphertext")
+		}
+	}
+	credentialsPresent := c.CredentialIDs != nil || c.HasField("CredentialIDs")
+	return credential.CheckFields(c.CredentialIDs, credentialsPresent, "Duplicate credential ID")
+}
+
+func (c *ConfidentialMPTSend) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Result {
+	id, _ := parseConfidentialID(c.MPTokenIssuanceID)
+	accountID, err := state.DecodeAccountID(c.Account)
+	if err != nil {
+		return ter.TemBAD_SRC_ACCOUNT
+	}
+	senderAccount, err := tx.ReadAccountRoot(view, accountID)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if senderAccount == nil {
+		return ter.TerNO_ACCOUNT
+	}
+	destinationID, err := state.DecodeAccountID(c.Destination)
+	if err != nil {
+		return ter.TemMALFORMED
+	}
+	destinationAccount, err := tx.ReadAccountRoot(view, destinationID)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if destinationAccount == nil {
+		return ter.TecNO_TARGET
+	}
+	if destinationAccount.Flags&state.LsfRequireDestTag != 0 && c.DestinationTag == nil {
+		return ter.TecDST_TAG_NEEDED
+	}
+
+	issuance, _, result := mptutil.ReadIssuance(view, id)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	if issuance.Flags&entry.LsfMPTCanTransfer == 0 {
+		return ter.TecNO_AUTH
+	}
+	if issuance.Flags&entry.LsfMPTCanHoldConfidentialBalance == 0 || issuance.TransferFee > 0 || len(issuance.IssuerEncryptionKey) == 0 {
+		return ter.TecNO_PERMISSION
+	}
+	requiresAuditor := len(issuance.AuditorEncryptionKey) != 0
+	if requiresAuditor != (c.AuditorEncryptedAmount != nil) {
+		return ter.TecNO_PERMISSION
+	}
+	if issuance.Issuer == accountID {
+		return ter.TefINTERNAL
+	}
+
+	senderToken, _, result := readConfidentialHolding(view, id, accountID)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	if len(senderToken.HolderEncryptionKey) == 0 || len(senderToken.ConfidentialBalanceSpending) == 0 || len(senderToken.IssuerEncryptedBalance) == 0 {
+		return ter.TecNO_PERMISSION
+	}
+	destinationToken, _, result := readConfidentialHolding(view, id, destinationID)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	if len(destinationToken.HolderEncryptionKey) == 0 || len(destinationToken.ConfidentialBalanceInbox) == 0 || len(destinationToken.IssuerEncryptedBalance) == 0 {
+		return ter.TecNO_PERMISSION
+	}
+	if requiresAuditor && (len(senderToken.AuditorEncryptedBalance) == 0 || len(destinationToken.AuditorEncryptedBalance) == 0) {
+		return ter.TefINTERNAL
+	}
+	if mptutil.IsFrozen(view, id, accountID) {
+		return ter.TecLOCKED
+	}
+	if mptutil.IsFrozen(view, id, destinationID) {
+		return ter.TecLOCKED
+	}
+	if result := mptutil.RequireAuthWithTypeAt(view, id, accountID, mptutil.LegacyAuth, config.ParentCloseTime); result != ter.TesSUCCESS {
+		return result
+	}
+	if result := mptutil.RequireAuthWithTypeAt(view, id, destinationID, mptutil.LegacyAuth, config.ParentCloseTime); result != ter.TesSUCCESS {
+		return result
+	}
+	if result := credential.ValidCredentials(view, accountID, c.CredentialIDs); result != ter.TesSUCCESS {
+		return result
+	}
+	credentialsPresent := c.CredentialIDs != nil || c.HasField("CredentialIDs")
+	if result := credential.CheckDepositPreauth(view, c.CredentialIDs, credentialsPresent, accountID, destinationID, destinationAccount); result != ter.TesSUCCESS {
+		return result
+	}
+	if len(senderToken.HolderEncryptionKey) != mptcrypto.PublicKeySize ||
+		len(destinationToken.HolderEncryptionKey) != mptcrypto.PublicKeySize ||
+		len(issuance.IssuerEncryptionKey) != mptcrypto.PublicKeySize ||
+		len(senderToken.ConfidentialBalanceSpending) != mptcrypto.CiphertextSize ||
+		(requiresAuditor && len(issuance.AuditorEncryptionKey) != mptcrypto.PublicKeySize) {
+		return ter.TecINTERNAL
+	}
+
+	senderCiphertext, _ := decodeConfidentialField(c.SenderEncryptedAmount, mptcrypto.CiphertextSize)
+	destinationCiphertext, _ := decodeConfidentialField(c.DestinationEncryptedAmount, mptcrypto.CiphertextSize)
+	issuerCiphertext, _ := decodeConfidentialField(c.IssuerEncryptedAmount, mptcrypto.CiphertextSize)
+	proof, _ := decodeConfidentialField(c.ZKProof, mptcrypto.SendProofSize)
+	amountCommitment, _ := decodeConfidentialField(c.AmountCommitment, mptcrypto.CommitmentSize)
+	balanceCommitment, _ := decodeConfidentialField(c.BalanceCommitment, mptcrypto.CommitmentSize)
+	var auditor *mptcrypto.Participant
+	if c.AuditorEncryptedAmount != nil {
+		ciphertext, _ := decodeConfidentialField(*c.AuditorEncryptedAmount, mptcrypto.CiphertextSize)
+		value := confidentialParticipant(issuance.AuditorEncryptionKey, ciphertext)
+		auditor = &value
+	}
+	context, contextOK := mptcrypto.SendContext(accountID, id, c.GetCommon().SeqProxy(), destinationID, senderToken.ConfidentialBalanceVersion)
+	if !contextOK || !mptcrypto.VerifySend(
+		proof,
+		confidentialParticipant(senderToken.HolderEncryptionKey, senderCiphertext),
+		confidentialParticipant(destinationToken.HolderEncryptionKey, destinationCiphertext),
+		confidentialParticipant(issuance.IssuerEncryptionKey, issuerCiphertext),
+		auditor,
+		senderToken.ConfidentialBalanceSpending,
+		amountCommitment,
+		balanceCommitment,
+		context,
+	) {
+		return ter.TecBAD_PROOF
+	}
+	return ter.TesSUCCESS
+}
+
+func (c *ConfidentialMPTSend) Apply(ctx *tx.ApplyContext) ter.Result {
+	id, _ := parseConfidentialID(c.MPTokenIssuanceID)
+	destinationID, _ := state.DecodeAccountID(c.Destination)
+	issuance, _, result := mptutil.ReadIssuance(ctx.View, id)
+	if result != ter.TesSUCCESS {
+		return ter.TecINTERNAL
+	}
+	sender, senderKeylet, result := readConfidentialHolding(ctx.View, id, ctx.AccountID)
+	if result != ter.TesSUCCESS {
+		return ter.TecINTERNAL
+	}
+	destination, destinationKeylet, result := readConfidentialHolding(ctx.View, id, destinationID)
+	if result != ter.TesSUCCESS {
+		return ter.TecINTERNAL
+	}
+	if len(c.CredentialIDs) > 0 {
+		expired, cleanupResult := credential.RemoveExpiredCredentials(ctx, c.CredentialIDs)
+		if cleanupResult != ter.TesSUCCESS {
+			return cleanupResult
+		}
+		if expired {
+			return ter.TecEXPIRED
+		}
+	}
+
+	senderCiphertext, _ := decodeConfidentialField(c.SenderEncryptedAmount, mptcrypto.CiphertextSize)
+	destinationCiphertext, _ := decodeConfidentialField(c.DestinationEncryptedAmount, mptcrypto.CiphertextSize)
+	issuerCiphertext, _ := decodeConfidentialField(c.IssuerEncryptedAmount, mptcrypto.CiphertextSize)
+	proof, _ := decodeConfidentialField(c.ZKProof, mptcrypto.SendProofSize)
+	var challenge [mptcrypto.BlindingFactorSize]byte
+	copy(challenge[:], proof[:mptcrypto.BlindingFactorSize])
+
+	var ok bool
+	if sender.ConfidentialBalanceSpending, ok = mptcrypto.SubtractCiphertexts(sender.ConfidentialBalanceSpending, senderCiphertext); !ok {
+		return ter.TecINTERNAL
+	}
+	if sender.IssuerEncryptedBalance, ok = mptcrypto.SubtractCiphertexts(sender.IssuerEncryptedBalance, issuerCiphertext); !ok {
+		return ter.TecINTERNAL
+	}
+	if c.AuditorEncryptedAmount != nil {
+		auditorCiphertext, _ := decodeConfidentialField(*c.AuditorEncryptedAmount, mptcrypto.CiphertextSize)
+		if sender.AuditorEncryptedBalance, ok = mptcrypto.SubtractCiphertexts(sender.AuditorEncryptedBalance, auditorCiphertext); !ok {
+			return ter.TecINTERNAL
+		}
+	}
+
+	rerandomizedDestination, ok := mptcrypto.RerandomizeCiphertext(destinationCiphertext, destination.HolderEncryptionKey, challenge)
+	if !ok {
+		return ter.TecINTERNAL
+	}
+	if destination.ConfidentialBalanceInbox, ok = mptcrypto.AddCiphertexts(destination.ConfidentialBalanceInbox, rerandomizedDestination); !ok {
+		return ter.TecINTERNAL
+	}
+	rerandomizedIssuer, ok := mptcrypto.RerandomizeCiphertext(issuerCiphertext, issuance.IssuerEncryptionKey, challenge)
+	if !ok {
+		return ter.TecINTERNAL
+	}
+	if destination.IssuerEncryptedBalance, ok = mptcrypto.AddCiphertexts(destination.IssuerEncryptedBalance, rerandomizedIssuer); !ok {
+		return ter.TecINTERNAL
+	}
+	if c.AuditorEncryptedAmount != nil {
+		auditorCiphertext, _ := decodeConfidentialField(*c.AuditorEncryptedAmount, mptcrypto.CiphertextSize)
+		rerandomizedAuditor, rerandomized := mptcrypto.RerandomizeCiphertext(auditorCiphertext, issuance.AuditorEncryptionKey, challenge)
+		if !rerandomized {
+			return ter.TecINTERNAL
+		}
+		if destination.AuditorEncryptedBalance, ok = mptcrypto.AddCiphertexts(destination.AuditorEncryptedBalance, rerandomizedAuditor); !ok {
+			return ter.TecINTERNAL
+		}
+	}
+	sender.ConfidentialBalanceVersion++
+
+	senderData, err := state.SerializeMPToken(sender)
+	if err != nil {
+		return ter.TecINTERNAL
+	}
+	destinationData, err := state.SerializeMPToken(destination)
+	if err != nil {
+		return ter.TecINTERNAL
+	}
+	if err := ctx.View.Update(senderKeylet, senderData); err != nil {
+		return ter.TecINTERNAL
+	}
+	if err := ctx.View.Update(destinationKeylet, destinationData); err != nil {
+		return ter.TecINTERNAL
+	}
+	return ter.TesSUCCESS
+}

--- a/internal/tx/mpt/confidential_send.go
+++ b/internal/tx/mpt/confidential_send.go
@@ -235,6 +235,9 @@ func (c *ConfidentialMPTSend) Apply(ctx *tx.ApplyContext) ter.Result {
 	if result != ter.TesSUCCESS {
 		return ter.TecINTERNAL
 	}
+	if destinationAccount, err := tx.ReadAccountRoot(ctx.View, destinationID); err != nil || destinationAccount == nil {
+		return ter.TecINTERNAL
+	}
 	if len(c.CredentialIDs) > 0 {
 		expired, cleanupResult := credential.RemoveExpiredCredentials(ctx, c.CredentialIDs)
 		if cleanupResult != ter.TesSUCCESS {

--- a/internal/tx/mpt/confidential_send_clawback_native_test.go
+++ b/internal/tx/mpt/confidential_send_clawback_native_test.go
@@ -5,6 +5,7 @@ package mpt
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -621,6 +622,34 @@ func TestConfidentialMPTSendNativePreflight(t *testing.T) {
 	}
 }
 
+func TestConfidentialMPTSendJSONRejectsMalformedCredentialIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+	}{
+		{name: "not hex", id: strings.Repeat("z", 64)},
+		{name: "too short", id: strings.Repeat("01", 31)},
+		{name: "too long", id: strings.Repeat("01", 33)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := validNativeSend(t)
+			candidate.CredentialIDs = []string{test.id}
+			data, err := json.Marshal(candidate)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var decoded ConfidentialMPTSend
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatal(err)
+			}
+			if got := nativeValidationCode(t, decoded.Validate()); got != ter.TemMALFORMED {
+				t.Fatalf("Validate = %v, want %v", got, ter.TemMALFORMED)
+			}
+		})
+	}
+}
+
 func TestConfidentialMPTClawbackNativePreflight(t *testing.T) {
 	issuer := [20]byte{1}
 	holder := [20]byte{2}
@@ -773,6 +802,16 @@ func TestConfidentialMPTSendNativePreclaimAndApply(t *testing.T) {
 			if got := transaction.Preclaim(view, tx.EngineConfig{ParentCloseTime: 101}); got != ter.TecNO_AUTH {
 				t.Fatalf("Preclaim after domain credential expiration = %v, want %v", got, ter.TecNO_AUTH)
 			}
+			t.Run("missing destination account", func(t *testing.T) {
+				missingDestinationView := cloneConfidentialView(view)
+				delete(missingDestinationView.entries, keylet.Account(destination).Key)
+				if got := transaction.Apply(nativeApplyContext(missingDestinationView, sender, senderRoot)); got != ter.TecINTERNAL {
+					t.Fatalf("Apply = %v, want %v", got, ter.TecINTERNAL)
+				}
+				if missingDestinationView.mutations != 0 {
+					t.Fatalf("Apply performed %d mutations", missingDestinationView.mutations)
+				}
+			})
 			if got := transaction.Apply(nativeApplyContext(view, sender, senderRoot)); got != ter.TesSUCCESS {
 				t.Fatalf("Apply = %v", got)
 			}

--- a/internal/tx/mpt/confidential_send_clawback_native_test.go
+++ b/internal/tx/mpt/confidential_send_clawback_native_test.go
@@ -1,0 +1,1142 @@
+//go:build mptcrypto && cgo
+
+package mpt
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/crypto/mptcrypto"
+	"github.com/LeJamon/go-xrpl/drops"
+	ledgercore "github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/applystate"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
+)
+
+type confidentialPreclaimView struct {
+	entries        map[[32]byte][]byte
+	rules          *amendment.Rules
+	failMutationAt int
+	mutations      int
+}
+
+func cloneConfidentialView(view *confidentialPreclaimView) *confidentialPreclaimView {
+	entries := make(map[[32]byte][]byte, len(view.entries))
+	for key, value := range view.entries {
+		entries[key] = append([]byte(nil), value...)
+	}
+	return &confidentialPreclaimView{entries: entries, rules: view.rules}
+}
+
+func (v *confidentialPreclaimView) Read(k keylet.Keylet) ([]byte, error) {
+	return v.entries[k.Key], nil
+}
+
+func (v *confidentialPreclaimView) Exists(k keylet.Keylet) (bool, error) {
+	_, ok := v.entries[k.Key]
+	return ok, nil
+}
+
+var errConfidentialMutation = errors.New("injected confidential mutation failure")
+
+func (v *confidentialPreclaimView) Insert(k keylet.Keylet, data []byte) error {
+	v.mutations++
+	if v.failMutationAt == v.mutations {
+		return errConfidentialMutation
+	}
+	v.entries[k.Key] = data
+	return nil
+}
+
+func (v *confidentialPreclaimView) Update(k keylet.Keylet, data []byte) error {
+	v.mutations++
+	if v.failMutationAt == v.mutations {
+		return errConfidentialMutation
+	}
+	v.entries[k.Key] = data
+	return nil
+}
+
+func (v *confidentialPreclaimView) Erase(k keylet.Keylet) error {
+	v.mutations++
+	if v.failMutationAt == v.mutations {
+		return errConfidentialMutation
+	}
+	delete(v.entries, k.Key)
+	return nil
+}
+
+func (v *confidentialPreclaimView) ApplyAtomically(apply func(ledgercore.Writer) error) error {
+	staged := cloneConfidentialView(v)
+	staged.failMutationAt = v.failMutationAt
+	staged.mutations = v.mutations
+	if err := apply(staged); err != nil {
+		v.mutations = staged.mutations
+		return err
+	}
+	v.entries = staged.entries
+	v.mutations = staged.mutations
+	return nil
+}
+
+func (*confidentialPreclaimView) AdjustDropsDestroyed(drops.XRPAmount) error { return nil }
+func (*confidentialPreclaimView) TxExists([32]byte) (bool, error)            { return false, nil }
+func (v *confidentialPreclaimView) Rules() *amendment.Rules                  { return v.rules }
+func (*confidentialPreclaimView) LedgerSeq() uint32                          { return 0 }
+
+func (v *confidentialPreclaimView) ForEach(fn func([32]byte, []byte) bool) error {
+	for key, data := range v.entries {
+		if !fn(key, data) {
+			break
+		}
+	}
+	return nil
+}
+
+func (*confidentialPreclaimView) Succ([32]byte) ([32]byte, []byte, bool, error) {
+	return [32]byte{}, nil, false, nil
+}
+
+func mustSerializeConfidentialIssuance(t *testing.T, issuance *state.MPTokenIssuanceData) []byte {
+	t.Helper()
+	data, err := state.SerializeMPTokenIssuance(issuance)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func mustSerializeConfidentialHolding(t *testing.T, token *state.MPTokenData) []byte {
+	t.Helper()
+	data, err := state.SerializeMPToken(token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func confidentialMPTIDString(id [24]byte) string {
+	return strings.ToUpper(hex.EncodeToString(id[:]))
+}
+
+func nativeValidationCode(t *testing.T, err error) ter.Result {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	var result *ter.ResultError
+	if !errors.As(err, &result) {
+		t.Fatalf("validation error = %T %v", err, err)
+	}
+	return result.Code
+}
+
+func mustNativeKeyPair(t *testing.T) ([32]byte, []byte) {
+	t.Helper()
+	private, public, ok := mptcrypto.GenerateKeyPair()
+	if !ok {
+		t.Fatal("generate key pair")
+	}
+	return private, public
+}
+
+func mustNativeBlind(t *testing.T) [32]byte {
+	t.Helper()
+	blind, ok := mptcrypto.GenerateBlindingFactor()
+	if !ok {
+		t.Fatal("generate blinding factor")
+	}
+	return blind
+}
+
+func mustNativeEncrypt(t *testing.T, amount uint64, public []byte, blind [32]byte) []byte {
+	t.Helper()
+	ciphertext, ok := mptcrypto.EncryptAmount(amount, public, blind)
+	if !ok {
+		t.Fatal("encrypt amount")
+	}
+	return ciphertext
+}
+
+func mustNativeZero(t *testing.T, public []byte, account [20]byte, id [24]byte) []byte {
+	t.Helper()
+	zero, ok := mptcrypto.CanonicalZero(public, account, id)
+	if !ok {
+		t.Fatal("canonical zero")
+	}
+	return zero
+}
+
+func putConfidentialAccount(t *testing.T, view *confidentialPreclaimView, account [20]byte) *state.AccountRoot {
+	t.Helper()
+	root := &state.AccountRoot{Account: state.EncodeAccountIDSafe(account), Balance: 1_000_000_000, Sequence: 1}
+	data, err := state.SerializeAccountRoot(root)
+	if err != nil {
+		t.Fatalf("SerializeAccountRoot: %v", err)
+	}
+	view.entries[keylet.Account(account).Key] = data
+	return root
+}
+
+func putNativeCredential(t *testing.T, view *confidentialPreclaimView, subject, credentialIssuer [20]byte, credentialType []byte, expiration uint32, accepted bool) keylet.Keylet {
+	t.Helper()
+	flags := uint32(0)
+	if accepted {
+		flags = entry.LsfAccepted
+	}
+	credentialKey := keylet.Credential(subject, credentialIssuer, credentialType)
+	encoded, err := binarycodec.Encode(map[string]any{
+		"LedgerEntryType":   "Credential",
+		"Subject":           state.EncodeAccountIDSafe(subject),
+		"Issuer":            state.EncodeAccountIDSafe(credentialIssuer),
+		"CredentialType":    hex.EncodeToString(credentialType),
+		"Expiration":        expiration,
+		"Flags":             flags,
+		"IssuerNode":        "0",
+		"SubjectNode":       "0",
+		"PreviousTxnID":     strings.Repeat("0", 64),
+		"PreviousTxnLgrSeq": uint32(0),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := hex.DecodeString(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	view.entries[credentialKey.Key] = raw
+	return credentialKey
+}
+
+func putNativeDomainCredential(t *testing.T, view *confidentialPreclaimView, domainID [32]byte, domainOwner, subject, credentialIssuer [20]byte, credentialType []byte, expiration uint32) {
+	t.Helper()
+	if _, exists := view.entries[keylet.PermissionedDomainByID(domainID).Key]; !exists {
+		domain, err := state.SerializePermissionedDomain(&state.PermissionedDomainData{
+			Owner: domainOwner, Sequence: 1,
+			AcceptedCredentials: []state.PermissionedDomainCredential{{Issuer: credentialIssuer, CredentialType: credentialType}},
+		}, state.EncodeAccountIDSafe(domainOwner))
+		if err != nil {
+			t.Fatal(err)
+		}
+		view.entries[keylet.PermissionedDomainByID(domainID).Key] = domain
+	}
+	putNativeCredential(t, view, subject, credentialIssuer, credentialType, expiration, true)
+}
+
+func nativeApplyContext(view *confidentialPreclaimView, account [20]byte, root *state.AccountRoot) *tx.ApplyContext {
+	return &tx.ApplyContext{
+		View:      view,
+		Account:   root,
+		AccountID: account,
+		Config:    tx.EngineConfig{Rules: view.rules},
+		Metadata:  &tx.Metadata{},
+		Log:       xrpllog.Discard(),
+		Ctx:       context.Background(),
+	}
+}
+
+func TestConfidentialMPTPreclaimsUseParentCloseTime(t *testing.T) {
+	issuer := [20]byte{1}
+	holder := [20]byte{2}
+	credentialIssuer := [20]byte{8}
+	id := keylet.MakeMPTID(4, issuer)
+	domainID := [32]byte{4, 5, 6}
+	domainHex := strings.ToUpper(hex.EncodeToString(domainID[:]))
+	_, holderPublic := mustNativeKeyPair(t)
+	_, issuerPublic := mustNativeKeyPair(t)
+	blind := mustNativeBlind(t)
+	holderBalance := mustNativeEncrypt(t, 10, holderPublic, blind)
+	issuerBalance := mustNativeEncrypt(t, 10, issuerPublic, blind)
+	view := &confidentialPreclaimView{entries: make(map[[32]byte][]byte), rules: amendment.NewRulesBuilder().Enable(amendment.FeatureConfidentialTransfer).Build()}
+	putConfidentialAccount(t, view, holder)
+	issuance := &state.MPTokenIssuanceData{
+		Issuer: issuer, Sequence: 4, Flags: entry.LsfMPTCanHoldConfidentialBalance | entry.LsfMPTRequireAuth,
+		OutstandingAmount: 10, ConfidentialOutstandingAmount: 10, IssuerEncryptionKey: issuerPublic, DomainID: &domainHex,
+	}
+	holding := &state.MPTokenData{
+		Account: holder, MPTokenIssuanceID: id, MPTAmount: 10, HolderEncryptionKey: holderPublic,
+		ConfidentialBalanceInbox: holderBalance, ConfidentialBalanceSpending: holderBalance, IssuerEncryptedBalance: issuerBalance,
+	}
+	view.entries[keylet.MPTIssuance(id).Key] = mustSerializeConfidentialIssuance(t, issuance)
+	view.entries[keylet.MPToken(keylet.MPTIssuance(id).Key, holder).Key] = mustSerializeConfidentialHolding(t, holding)
+	putNativeDomainCredential(t, view, domainID, issuer, holder, credentialIssuer, []byte("KYC"), 100)
+	sequence := uint32(7)
+	base := *tx.NewBaseTx(tx.TypeConfidentialMPTConvert, state.EncodeAccountIDSafe(holder))
+	base.Sequence = &sequence
+	convert := &ConfidentialMPTConvert{
+		BaseTx: base, MPTokenIssuanceID: confidentialMPTIDString(id), MPTAmount: 1,
+		HolderEncryptedAmount: hex.EncodeToString(holderBalance), IssuerEncryptedAmount: hex.EncodeToString(issuerBalance), BlindingFactor: hex.EncodeToString(blind[:]),
+	}
+	mergeBase := *tx.NewBaseTx(tx.TypeConfidentialMPTMergeInbox, state.EncodeAccountIDSafe(holder))
+	mergeBase.Sequence = &sequence
+	merge := &ConfidentialMPTMergeInbox{BaseTx: mergeBase, MPTokenIssuanceID: confidentialMPTIDString(id)}
+	convertBackBase := *tx.NewBaseTx(tx.TypeConfidentialMPTConvertBack, state.EncodeAccountIDSafe(holder))
+	convertBackBase.Sequence = &sequence
+	convertBack := &ConfidentialMPTConvertBack{
+		BaseTx: convertBackBase, MPTokenIssuanceID: confidentialMPTIDString(id), MPTAmount: 1,
+		HolderEncryptedAmount: hex.EncodeToString(holderBalance), IssuerEncryptedAmount: hex.EncodeToString(issuerBalance), BlindingFactor: hex.EncodeToString(blind[:]),
+		ZKProof: hex.EncodeToString(make([]byte, mptcrypto.ConvertBackProofSize)), BalanceCommitment: hex.EncodeToString(make([]byte, mptcrypto.CommitmentSize)),
+	}
+	tests := []struct {
+		name       string
+		preclaim   func(tx.EngineConfig) ter.Result
+		atBoundary ter.Result
+	}{
+		{name: "convert", preclaim: func(config tx.EngineConfig) ter.Result { return convert.Preclaim(view, config) }, atBoundary: ter.TecBAD_PROOF},
+		{name: "merge inbox", preclaim: func(config tx.EngineConfig) ter.Result { return merge.Preclaim(view, config) }, atBoundary: ter.TesSUCCESS},
+		{name: "convert back", preclaim: func(config tx.EngineConfig) ter.Result { return convertBack.Preclaim(view, config) }, atBoundary: ter.TecBAD_PROOF},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.preclaim(tx.EngineConfig{ParentCloseTime: 100}); got != test.atBoundary {
+				t.Fatalf("Preclaim at expiration = %v, want %v", got, test.atBoundary)
+			}
+			if got := test.preclaim(tx.EngineConfig{ParentCloseTime: 101}); got != ter.TecNO_AUTH {
+				t.Fatalf("Preclaim after expiration = %v, want %v", got, ter.TecNO_AUTH)
+			}
+		})
+	}
+}
+
+func TestConfidentialMPTSendNativePreclaimFailures(t *testing.T) {
+	issuer := [20]byte{1}
+	sender := [20]byte{2}
+	destination := [20]byte{3}
+	id := keylet.MakeMPTID(4, issuer)
+	senderPrivate, senderPublic := mustNativeKeyPair(t)
+	_, destinationPublic := mustNativeKeyPair(t)
+	_, issuerPublic := mustNativeKeyPair(t)
+	_, auditorPublic := mustNativeKeyPair(t)
+	balanceBlind := mustNativeBlind(t)
+	amountBlind := mustNativeBlind(t)
+	issuance := &state.MPTokenIssuanceData{
+		Issuer: issuer, Sequence: 4,
+		Flags:                         entry.LsfMPTCanTransfer | entry.LsfMPTCanHoldConfidentialBalance,
+		OutstandingAmount:             100,
+		ConfidentialOutstandingAmount: 100,
+		IssuerEncryptionKey:           issuerPublic,
+		AuditorEncryptionKey:          auditorPublic,
+	}
+	senderToken := &state.MPTokenData{
+		Account: sender, MPTokenIssuanceID: id, HolderEncryptionKey: senderPublic,
+		ConfidentialBalanceInbox: mustNativeZero(t, senderPublic, sender, id), ConfidentialBalanceSpending: mustNativeEncrypt(t, 100, senderPublic, balanceBlind),
+		IssuerEncryptedBalance: mustNativeEncrypt(t, 100, issuerPublic, balanceBlind), AuditorEncryptedBalance: mustNativeEncrypt(t, 100, auditorPublic, balanceBlind),
+		ConfidentialBalanceVersion: 9,
+	}
+	destinationToken := &state.MPTokenData{
+		Account: destination, MPTokenIssuanceID: id, HolderEncryptionKey: destinationPublic,
+		ConfidentialBalanceInbox: mustNativeZero(t, destinationPublic, destination, id), ConfidentialBalanceSpending: mustNativeZero(t, destinationPublic, destination, id),
+		IssuerEncryptedBalance: mustNativeZero(t, issuerPublic, destination, id), AuditorEncryptedBalance: mustNativeZero(t, auditorPublic, destination, id),
+	}
+	view := &confidentialPreclaimView{entries: make(map[[32]byte][]byte), rules: amendment.NewRulesBuilder().Enable(amendment.FeatureConfidentialTransfer).Build()}
+	putConfidentialAccount(t, view, sender)
+	putConfidentialAccount(t, view, destination)
+	issuanceKey := keylet.MPTIssuance(id)
+	senderKey := keylet.MPToken(issuanceKey.Key, sender)
+	destinationKey := keylet.MPToken(issuanceKey.Key, destination)
+	view.entries[issuanceKey.Key] = mustSerializeConfidentialIssuance(t, issuance)
+	view.entries[senderKey.Key] = mustSerializeConfidentialHolding(t, senderToken)
+	view.entries[destinationKey.Key] = mustSerializeConfidentialHolding(t, destinationToken)
+	participants := []mptcrypto.Participant{
+		{PublicKey: senderPublic, Ciphertext: mustNativeEncrypt(t, 40, senderPublic, amountBlind)},
+		{PublicKey: destinationPublic, Ciphertext: mustNativeEncrypt(t, 40, destinationPublic, amountBlind)},
+		{PublicKey: issuerPublic, Ciphertext: mustNativeEncrypt(t, 40, issuerPublic, amountBlind)},
+		{PublicKey: auditorPublic, Ciphertext: mustNativeEncrypt(t, 40, auditorPublic, amountBlind)},
+	}
+	amountCommitment, _ := mptcrypto.PedersenCommitment(40, amountBlind)
+	balanceCommitment, _ := mptcrypto.PedersenCommitment(100, balanceBlind)
+	sequence := uint32(7)
+	proofContext, _ := mptcrypto.SendContext(sender, id, sequence, destination, senderToken.ConfidentialBalanceVersion)
+	proof, ok := mptcrypto.GenerateSendProof(senderPrivate, 40, participants, amountBlind, proofContext, amountCommitment, balanceCommitment, 100, senderToken.ConfidentialBalanceSpending, balanceBlind)
+	if !ok {
+		t.Fatal("send proof")
+	}
+	auditorAmount := hex.EncodeToString(participants[3].Ciphertext)
+	valid := &ConfidentialMPTSend{
+		BaseTx: *tx.NewBaseTx(tx.TypeConfidentialMPTSend, state.EncodeAccountIDSafe(sender)), MPTokenIssuanceID: confidentialMPTIDString(id), Destination: state.EncodeAccountIDSafe(destination),
+		SenderEncryptedAmount: hex.EncodeToString(participants[0].Ciphertext), DestinationEncryptedAmount: hex.EncodeToString(participants[1].Ciphertext), IssuerEncryptedAmount: hex.EncodeToString(participants[2].Ciphertext),
+		AuditorEncryptedAmount: &auditorAmount, ZKProof: hex.EncodeToString(proof), AmountCommitment: hex.EncodeToString(amountCommitment), BalanceCommitment: hex.EncodeToString(balanceCommitment),
+	}
+	valid.Sequence = &sequence
+
+	serializeAccount := func(t *testing.T, view *confidentialPreclaimView, id [20]byte, edit func(*state.AccountRoot)) {
+		root, err := state.ParseAccountRoot(view.entries[keylet.Account(id).Key])
+		if err != nil {
+			t.Fatal(err)
+		}
+		edit(root)
+		view.entries[keylet.Account(id).Key], err = state.SerializeAccountRoot(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	serializeIssuance := func(t *testing.T, view *confidentialPreclaimView, edit func(*state.MPTokenIssuanceData)) {
+		value, err := state.ParseMPTokenIssuance(view.entries[issuanceKey.Key])
+		if err != nil {
+			t.Fatal(err)
+		}
+		edit(value)
+		view.entries[issuanceKey.Key] = mustSerializeConfidentialIssuance(t, value)
+	}
+	serializeHolding := func(t *testing.T, view *confidentialPreclaimView, key keylet.Keylet, edit func(*state.MPTokenData)) {
+		value, err := state.ParseMPToken(view.entries[key.Key])
+		if err != nil {
+			t.Fatal(err)
+		}
+		edit(value)
+		view.entries[key.Key] = mustSerializeConfidentialHolding(t, value)
+	}
+	tests := []struct {
+		name string
+		want ter.Result
+		edit func(*testing.T, *confidentialPreclaimView, *ConfidentialMPTSend)
+	}{
+		{name: "missing source", want: ter.TerNO_ACCOUNT, edit: func(_ *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			delete(v.entries, keylet.Account(sender).Key)
+		}},
+		{name: "missing destination", want: ter.TecNO_TARGET, edit: func(_ *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			delete(v.entries, keylet.Account(destination).Key)
+		}},
+		{name: "destination tag", want: ter.TecDST_TAG_NEEDED, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeAccount(t, v, destination, func(a *state.AccountRoot) { a.Flags |= state.LsfRequireDestTag })
+		}},
+		{name: "missing issuance", want: ter.TecOBJECT_NOT_FOUND, edit: func(_ *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			delete(v.entries, issuanceKey.Key)
+		}},
+		{name: "transfer disabled", want: ter.TecNO_AUTH, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeIssuance(t, v, func(i *state.MPTokenIssuanceData) { i.Flags &^= entry.LsfMPTCanTransfer })
+		}},
+		{name: "privacy disabled", want: ter.TecNO_PERMISSION, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeIssuance(t, v, func(i *state.MPTokenIssuanceData) { i.Flags &^= entry.LsfMPTCanHoldConfidentialBalance })
+		}},
+		{name: "transfer fee", want: ter.TecNO_PERMISSION, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeIssuance(t, v, func(i *state.MPTokenIssuanceData) { i.TransferFee = 1 })
+		}},
+		{name: "issuer key missing", want: ter.TecNO_PERMISSION, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeIssuance(t, v, func(i *state.MPTokenIssuanceData) { i.IssuerEncryptionKey = nil })
+		}},
+		{name: "issuer key malformed", want: ter.TecINTERNAL, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeIssuance(t, v, func(i *state.MPTokenIssuanceData) { i.IssuerEncryptionKey = []byte{2} })
+		}},
+		{name: "auditor key malformed", want: ter.TecINTERNAL, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeIssuance(t, v, func(i *state.MPTokenIssuanceData) { i.AuditorEncryptionKey = []byte{2} })
+		}},
+		{name: "auditor amount missing", want: ter.TecNO_PERMISSION, edit: func(_ *testing.T, _ *confidentialPreclaimView, c *ConfidentialMPTSend) {
+			c.AuditorEncryptedAmount = nil
+		}},
+		{name: "unexpected auditor amount", want: ter.TecNO_PERMISSION, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeIssuance(t, v, func(i *state.MPTokenIssuanceData) { i.AuditorEncryptionKey = nil })
+		}},
+		{name: "sender holding missing", want: ter.TecOBJECT_NOT_FOUND, edit: func(_ *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			delete(v.entries, senderKey.Key)
+		}},
+		{name: "destination holding missing", want: ter.TecOBJECT_NOT_FOUND, edit: func(_ *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			delete(v.entries, destinationKey.Key)
+		}},
+		{name: "sender confidential state missing", want: ter.TecNO_PERMISSION, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeHolding(t, v, senderKey, func(h *state.MPTokenData) { h.ConfidentialBalanceSpending = nil })
+		}},
+		{name: "sender holder key malformed", want: ter.TecINTERNAL, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeHolding(t, v, senderKey, func(h *state.MPTokenData) { h.HolderEncryptionKey = []byte{2} })
+		}},
+		{name: "sender spending malformed", want: ter.TecINTERNAL, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeHolding(t, v, senderKey, func(h *state.MPTokenData) { h.ConfidentialBalanceSpending = []byte{2} })
+		}},
+		{name: "destination confidential state missing", want: ter.TecNO_PERMISSION, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeHolding(t, v, destinationKey, func(h *state.MPTokenData) { h.ConfidentialBalanceInbox = nil })
+		}},
+		{name: "destination holder key malformed", want: ter.TecINTERNAL, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeHolding(t, v, destinationKey, func(h *state.MPTokenData) { h.HolderEncryptionKey = []byte{2} })
+		}},
+		{name: "auditor balance missing", want: ter.TefINTERNAL, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeHolding(t, v, destinationKey, func(h *state.MPTokenData) { h.AuditorEncryptedBalance = nil })
+		}},
+		{name: "global frozen", want: ter.TecLOCKED, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeIssuance(t, v, func(i *state.MPTokenIssuanceData) { i.Flags |= entry.LsfMPTLocked })
+		}},
+		{name: "sender frozen", want: ter.TecLOCKED, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeHolding(t, v, senderKey, func(h *state.MPTokenData) { h.Flags |= entry.LsfMPTLocked })
+		}},
+		{name: "destination frozen", want: ter.TecLOCKED, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeHolding(t, v, destinationKey, func(h *state.MPTokenData) { h.Flags |= entry.LsfMPTLocked })
+		}},
+		{name: "sender unauthorized", want: ter.TecNO_AUTH, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeIssuance(t, v, func(i *state.MPTokenIssuanceData) { i.Flags |= entry.LsfMPTRequireAuth })
+		}},
+		{name: "destination unauthorized", want: ter.TecNO_AUTH, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeIssuance(t, v, func(i *state.MPTokenIssuanceData) { i.Flags |= entry.LsfMPTRequireAuth })
+			serializeHolding(t, v, senderKey, func(h *state.MPTokenData) { h.Flags |= entry.LsfMPTAuthorized })
+		}},
+		{name: "bad credentials", want: ter.TecBAD_CREDENTIALS, edit: func(_ *testing.T, _ *confidentialPreclaimView, c *ConfidentialMPTSend) {
+			c.CredentialIDs = []string{strings.Repeat("01", 32)}
+		}},
+		{name: "wrong credential subject", want: ter.TecBAD_CREDENTIALS, edit: func(t *testing.T, v *confidentialPreclaimView, c *ConfidentialMPTSend) {
+			credentialKey := putNativeCredential(t, v, destination, [20]byte{8}, []byte("KYC"), 100, true)
+			c.CredentialIDs = []string{hex.EncodeToString(credentialKey.Key[:])}
+		}},
+		{name: "unaccepted credential", want: ter.TecBAD_CREDENTIALS, edit: func(t *testing.T, v *confidentialPreclaimView, c *ConfidentialMPTSend) {
+			credentialKey := putNativeCredential(t, v, sender, [20]byte{8}, []byte("KYC"), 100, false)
+			c.CredentialIDs = []string{hex.EncodeToString(credentialKey.Key[:])}
+		}},
+		{name: "deposit auth", want: ter.TecNO_PERMISSION, edit: func(t *testing.T, v *confidentialPreclaimView, _ *ConfidentialMPTSend) {
+			serializeAccount(t, v, destination, func(a *state.AccountRoot) { a.Flags |= state.LsfDepositAuth })
+		}},
+		{name: "credential deposit preauth missing", want: ter.TecNO_PERMISSION, edit: func(t *testing.T, v *confidentialPreclaimView, c *ConfidentialMPTSend) {
+			credentialKey := putNativeCredential(t, v, sender, [20]byte{8}, []byte("KYC"), 100, true)
+			c.CredentialIDs = []string{hex.EncodeToString(credentialKey.Key[:])}
+			serializeAccount(t, v, destination, func(a *state.AccountRoot) { a.Flags |= state.LsfDepositAuth })
+		}},
+		{name: "encrypted amount exceeds spending balance", want: ter.TecBAD_PROOF, edit: func(t *testing.T, _ *confidentialPreclaimView, c *ConfidentialMPTSend) {
+			c.SenderEncryptedAmount = hex.EncodeToString(mustNativeEncrypt(t, 110, senderPublic, amountBlind))
+			c.DestinationEncryptedAmount = hex.EncodeToString(mustNativeEncrypt(t, 110, destinationPublic, amountBlind))
+			c.IssuerEncryptedAmount = hex.EncodeToString(mustNativeEncrypt(t, 110, issuerPublic, amountBlind))
+			auditorAmount := hex.EncodeToString(mustNativeEncrypt(t, 110, auditorPublic, amountBlind))
+			c.AuditorEncryptedAmount = &auditorAmount
+			commitment, ok := mptcrypto.PedersenCommitment(110, amountBlind)
+			if !ok {
+				t.Fatal("amount commitment")
+			}
+			c.AmountCommitment = hex.EncodeToString(commitment)
+		}},
+		{name: "bad proof", want: ter.TecBAD_PROOF, edit: func(_ *testing.T, _ *confidentialPreclaimView, c *ConfidentialMPTSend) {
+			raw, _ := hex.DecodeString(c.ZKProof)
+			raw[0] ^= 1
+			c.ZKProof = hex.EncodeToString(raw)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := *valid
+			candidateView := cloneConfidentialView(view)
+			test.edit(t, candidateView, &candidate)
+			if got := candidate.Preclaim(candidateView, tx.EngineConfig{}); got != test.want {
+				t.Fatalf("Preclaim = %v, want %v", got, test.want)
+			}
+		})
+	}
+	t.Run("account deposit preauth succeeds", func(t *testing.T) {
+		candidate := *valid
+		candidateView := cloneConfidentialView(view)
+		serializeAccount(t, candidateView, destination, func(a *state.AccountRoot) { a.Flags |= state.LsfDepositAuth })
+		candidateView.entries[keylet.DepositPreauth(destination, sender).Key] = []byte{1}
+		if got := candidate.Preclaim(candidateView, tx.EngineConfig{}); got != ter.TesSUCCESS {
+			t.Fatalf("Preclaim = %v, want %v", got, ter.TesSUCCESS)
+		}
+	})
+	t.Run("credential deposit preauth succeeds", func(t *testing.T) {
+		candidate := *valid
+		candidateView := cloneConfidentialView(view)
+		credentialIssuer := [20]byte{8}
+		credentialType := []byte("KYC")
+		credentialKey := putNativeCredential(t, candidateView, sender, credentialIssuer, credentialType, 100, true)
+		candidate.CredentialIDs = []string{hex.EncodeToString(credentialKey.Key[:])}
+		serializeAccount(t, candidateView, destination, func(a *state.AccountRoot) { a.Flags |= state.LsfDepositAuth })
+		preauth := keylet.DepositPreauthCredentials(destination, []keylet.CredentialPair{{Issuer: credentialIssuer, CredentialType: credentialType}})
+		candidateView.entries[preauth.Key] = []byte{1}
+		if got := candidate.Preclaim(candidateView, tx.EngineConfig{}); got != ter.TesSUCCESS {
+			t.Fatalf("Preclaim = %v, want %v", got, ter.TesSUCCESS)
+		}
+	})
+}
+
+func validNativeSend(t *testing.T) ConfidentialMPTSend {
+	t.Helper()
+	issuer := [20]byte{1}
+	sender := [20]byte{2}
+	destination := [20]byte{3}
+	id := keylet.MakeMPTID(4, issuer)
+	_, senderPublic := mustNativeKeyPair(t)
+	_, destinationPublic := mustNativeKeyPair(t)
+	_, issuerPublic := mustNativeKeyPair(t)
+	blind := mustNativeBlind(t)
+	amountCommitment, ok := mptcrypto.PedersenCommitment(40, blind)
+	if !ok {
+		t.Fatal("amount commitment")
+	}
+	balanceCommitment, ok := mptcrypto.PedersenCommitment(100, mustNativeBlind(t))
+	if !ok {
+		t.Fatal("balance commitment")
+	}
+	return ConfidentialMPTSend{
+		BaseTx:                     *tx.NewBaseTx(tx.TypeConfidentialMPTSend, state.EncodeAccountIDSafe(sender)),
+		MPTokenIssuanceID:          confidentialMPTIDString(id),
+		Destination:                state.EncodeAccountIDSafe(destination),
+		SenderEncryptedAmount:      hex.EncodeToString(mustNativeEncrypt(t, 40, senderPublic, blind)),
+		DestinationEncryptedAmount: hex.EncodeToString(mustNativeEncrypt(t, 40, destinationPublic, blind)),
+		IssuerEncryptedAmount:      hex.EncodeToString(mustNativeEncrypt(t, 40, issuerPublic, blind)),
+		ZKProof:                    hex.EncodeToString(make([]byte, mptcrypto.SendProofSize)),
+		AmountCommitment:           hex.EncodeToString(amountCommitment),
+		BalanceCommitment:          hex.EncodeToString(balanceCommitment),
+	}
+}
+
+func TestConfidentialMPTSendNativePreflight(t *testing.T) {
+	valid := validNativeSend(t)
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid send: %v", err)
+	}
+	issuerID, _ := parseConfidentialID(valid.MPTokenIssuanceID)
+	issuer := [20]byte(issuerID[4:])
+
+	tests := []struct {
+		name string
+		edit func(*ConfidentialMPTSend)
+		want ter.Result
+	}{
+		{name: "sender is issuer", edit: func(c *ConfidentialMPTSend) { c.Account = state.EncodeAccountIDSafe(issuer) }, want: ter.TemMALFORMED},
+		{name: "sender is destination", edit: func(c *ConfidentialMPTSend) { c.Destination = c.Account }, want: ter.TemMALFORMED},
+		{name: "destination is issuer", edit: func(c *ConfidentialMPTSend) { c.Destination = state.EncodeAccountIDSafe(issuer) }, want: ter.TemMALFORMED},
+		{name: "ciphertext length precedes proof", edit: func(c *ConfidentialMPTSend) { c.SenderEncryptedAmount = "00"; c.ZKProof = "00" }, want: ter.TemBAD_CIPHERTEXT},
+		{name: "proof length precedes commitments", edit: func(c *ConfidentialMPTSend) { c.ZKProof = "00"; c.BalanceCommitment = makeHex(33, 0) }, want: ter.TemMALFORMED},
+		{name: "balance commitment", edit: func(c *ConfidentialMPTSend) { c.BalanceCommitment = makeHex(33, 0) }, want: ter.TemMALFORMED},
+		{name: "amount commitment", edit: func(c *ConfidentialMPTSend) { c.AmountCommitment = makeHex(33, 0) }, want: ter.TemMALFORMED},
+		{name: "invalid ciphertext point", edit: func(c *ConfidentialMPTSend) { c.IssuerEncryptedAmount = makeHex(66, 0) }, want: ter.TemBAD_CIPHERTEXT},
+		{name: "empty credentials", edit: func(c *ConfidentialMPTSend) {
+			c.CredentialIDs = []string{}
+			c.SetPresentFields(map[string]bool{"CredentialIDs": true})
+		}, want: ter.TemMALFORMED},
+		{name: "too many credentials", edit: func(c *ConfidentialMPTSend) { c.CredentialIDs = make([]string, 9) }, want: ter.TemMALFORMED},
+		{name: "case-insensitive duplicate credential", edit: func(c *ConfidentialMPTSend) {
+			c.CredentialIDs = []string{"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789", "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789"}
+		}, want: ter.TemMALFORMED},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := valid
+			test.edit(&candidate)
+			if got := nativeValidationCode(t, candidate.Validate()); got != test.want {
+				t.Fatalf("Validate = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestConfidentialMPTClawbackNativePreflight(t *testing.T) {
+	issuer := [20]byte{1}
+	holder := [20]byte{2}
+	id := keylet.MakeMPTID(4, issuer)
+	valid := ConfidentialMPTClawback{
+		BaseTx:            *tx.NewBaseTx(tx.TypeConfidentialMPTClawback, state.EncodeAccountIDSafe(issuer)),
+		MPTokenIssuanceID: confidentialMPTIDString(id),
+		Holder:            state.EncodeAccountIDSafe(holder),
+		MPTAmount:         1,
+		ZKProof:           makeHex(mptcrypto.ClawbackProofSize, 1),
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid clawback: %v", err)
+	}
+	tests := []struct {
+		name string
+		edit func(*ConfidentialMPTClawback)
+		want ter.Result
+	}{
+		{name: "nonissuer", edit: func(c *ConfidentialMPTClawback) { c.Account = state.EncodeAccountIDSafe([20]byte{3}) }, want: ter.TemMALFORMED},
+		{name: "self", edit: func(c *ConfidentialMPTClawback) { c.Holder = c.Account }, want: ter.TemMALFORMED},
+		{name: "zero amount", edit: func(c *ConfidentialMPTClawback) { c.MPTAmount = 0 }, want: ter.TemBAD_AMOUNT},
+		{name: "over max amount", edit: func(c *ConfidentialMPTClawback) { c.MPTAmount = ^uint64(0) }, want: ter.TemBAD_AMOUNT},
+		{name: "proof length", edit: func(c *ConfidentialMPTClawback) { c.ZKProof = "00" }, want: ter.TemMALFORMED},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := valid
+			test.edit(&candidate)
+			if got := nativeValidationCode(t, candidate.Validate()); got != test.want {
+				t.Fatalf("Validate = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestConfidentialMPTSendNativePreclaimAndApply(t *testing.T) {
+	for _, withAuditor := range []bool{false, true} {
+		t.Run(map[bool]string{false: "without auditor", true: "with auditor"}[withAuditor], func(t *testing.T) {
+			issuer := [20]byte{1}
+			sender := [20]byte{2}
+			destination := [20]byte{3}
+			id := keylet.MakeMPTID(4, issuer)
+			domainID := [32]byte{4, 5, 6}
+			domainHex := strings.ToUpper(hex.EncodeToString(domainID[:]))
+			credentialIssuer := [20]byte{8}
+			credentialType := []byte("KYC")
+			senderPrivate, senderPublic := mustNativeKeyPair(t)
+			_, destinationPublic := mustNativeKeyPair(t)
+			_, issuerPublic := mustNativeKeyPair(t)
+			_, auditorPublic := mustNativeKeyPair(t)
+			balanceBlind := mustNativeBlind(t)
+			amountBlind := mustNativeBlind(t)
+
+			issuance := &state.MPTokenIssuanceData{
+				Issuer: issuer, Sequence: 4,
+				Flags:                         entry.LsfMPTCanTransfer | entry.LsfMPTCanHoldConfidentialBalance | entry.LsfMPTRequireAuth,
+				OutstandingAmount:             100,
+				ConfidentialOutstandingAmount: 100,
+				IssuerEncryptionKey:           issuerPublic,
+				DomainID:                      &domainHex,
+			}
+			if withAuditor {
+				issuance.AuditorEncryptionKey = auditorPublic
+			}
+			senderToken := &state.MPTokenData{
+				Account:                     sender,
+				MPTokenIssuanceID:           id,
+				HolderEncryptionKey:         senderPublic,
+				ConfidentialBalanceInbox:    mustNativeZero(t, senderPublic, sender, id),
+				ConfidentialBalanceSpending: mustNativeEncrypt(t, 100, senderPublic, balanceBlind),
+				IssuerEncryptedBalance:      mustNativeEncrypt(t, 100, issuerPublic, balanceBlind),
+				ConfidentialBalanceVersion:  9,
+				MPTAmount:                   7,
+			}
+			destinationToken := &state.MPTokenData{
+				Account:                     destination,
+				MPTokenIssuanceID:           id,
+				HolderEncryptionKey:         destinationPublic,
+				ConfidentialBalanceInbox:    mustNativeZero(t, destinationPublic, destination, id),
+				ConfidentialBalanceSpending: mustNativeZero(t, destinationPublic, destination, id),
+				IssuerEncryptedBalance:      mustNativeZero(t, issuerPublic, destination, id),
+				ConfidentialBalanceVersion:  5,
+				MPTAmount:                   11,
+			}
+			if withAuditor {
+				senderToken.AuditorEncryptedBalance = mustNativeEncrypt(t, 100, auditorPublic, balanceBlind)
+				destinationToken.AuditorEncryptedBalance = mustNativeZero(t, auditorPublic, destination, id)
+			}
+
+			rules := amendment.NewRulesBuilder().Enable(amendment.FeatureConfidentialTransfer).Build()
+			view := &confidentialPreclaimView{entries: make(map[[32]byte][]byte), rules: rules}
+			senderRoot := putConfidentialAccount(t, view, sender)
+			putConfidentialAccount(t, view, destination)
+			view.entries[keylet.MPTIssuance(id).Key] = mustSerializeConfidentialIssuance(t, issuance)
+			senderKey := keylet.MPToken(keylet.MPTIssuance(id).Key, sender)
+			destinationKey := keylet.MPToken(keylet.MPTIssuance(id).Key, destination)
+			view.entries[senderKey.Key] = mustSerializeConfidentialHolding(t, senderToken)
+			view.entries[destinationKey.Key] = mustSerializeConfidentialHolding(t, destinationToken)
+			putNativeDomainCredential(t, view, domainID, issuer, sender, credentialIssuer, credentialType, 100)
+			putNativeDomainCredential(t, view, domainID, issuer, destination, credentialIssuer, credentialType, 100)
+
+			participants := []mptcrypto.Participant{
+				{PublicKey: senderPublic, Ciphertext: mustNativeEncrypt(t, 40, senderPublic, amountBlind)},
+				{PublicKey: destinationPublic, Ciphertext: mustNativeEncrypt(t, 40, destinationPublic, amountBlind)},
+				{PublicKey: issuerPublic, Ciphertext: mustNativeEncrypt(t, 40, issuerPublic, amountBlind)},
+			}
+			if withAuditor {
+				participants = append(participants, mptcrypto.Participant{PublicKey: auditorPublic, Ciphertext: mustNativeEncrypt(t, 40, auditorPublic, amountBlind)})
+			}
+			amountCommitment, ok := mptcrypto.PedersenCommitment(40, amountBlind)
+			if !ok {
+				t.Fatal("amount commitment")
+			}
+			balanceCommitment, ok := mptcrypto.PedersenCommitment(100, balanceBlind)
+			if !ok {
+				t.Fatal("balance commitment")
+			}
+			sequence := uint32(7)
+			proofContext, ok := mptcrypto.SendContext(sender, id, sequence, destination, senderToken.ConfidentialBalanceVersion)
+			if !ok {
+				t.Fatal("send context")
+			}
+			proof, ok := mptcrypto.GenerateSendProof(senderPrivate, 40, participants, amountBlind, proofContext, amountCommitment, balanceCommitment, 100, senderToken.ConfidentialBalanceSpending, balanceBlind)
+			if !ok {
+				t.Fatal("send proof")
+			}
+			transaction := &ConfidentialMPTSend{
+				BaseTx:                     *tx.NewBaseTx(tx.TypeConfidentialMPTSend, state.EncodeAccountIDSafe(sender)),
+				MPTokenIssuanceID:          confidentialMPTIDString(id),
+				Destination:                state.EncodeAccountIDSafe(destination),
+				SenderEncryptedAmount:      hex.EncodeToString(participants[0].Ciphertext),
+				DestinationEncryptedAmount: hex.EncodeToString(participants[1].Ciphertext),
+				IssuerEncryptedAmount:      hex.EncodeToString(participants[2].Ciphertext),
+				ZKProof:                    hex.EncodeToString(proof),
+				AmountCommitment:           hex.EncodeToString(amountCommitment),
+				BalanceCommitment:          hex.EncodeToString(balanceCommitment),
+			}
+			transaction.Sequence = &sequence
+			if withAuditor {
+				encoded := hex.EncodeToString(participants[3].Ciphertext)
+				transaction.AuditorEncryptedAmount = &encoded
+			}
+			if err := transaction.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+			if got := transaction.Preclaim(view, tx.EngineConfig{ParentCloseTime: 100}); got != ter.TesSUCCESS {
+				t.Fatalf("Preclaim = %v", got)
+			}
+			if got := transaction.Preclaim(view, tx.EngineConfig{ParentCloseTime: 101}); got != ter.TecNO_AUTH {
+				t.Fatalf("Preclaim after domain credential expiration = %v, want %v", got, ter.TecNO_AUTH)
+			}
+			if got := transaction.Apply(nativeApplyContext(view, sender, senderRoot)); got != ter.TesSUCCESS {
+				t.Fatalf("Apply = %v", got)
+			}
+
+			updatedSender, err := state.ParseMPToken(view.entries[senderKey.Key])
+			if err != nil {
+				t.Fatal(err)
+			}
+			updatedDestination, err := state.ParseMPToken(view.entries[destinationKey.Key])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if updatedSender.ConfidentialBalanceVersion != 10 || updatedDestination.ConfidentialBalanceVersion != 5 {
+				t.Fatalf("versions = sender %d, destination %d", updatedSender.ConfidentialBalanceVersion, updatedDestination.ConfidentialBalanceVersion)
+			}
+			if updatedSender.MPTAmount != 7 || updatedDestination.MPTAmount != 11 {
+				t.Fatal("send changed public balances")
+			}
+			updatedIssuance, err := state.ParseMPTokenIssuance(view.entries[keylet.MPTIssuance(id).Key])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if updatedIssuance.OutstandingAmount != 100 || updatedIssuance.ConfidentialOutstandingAmount != 100 {
+				t.Fatal("send changed issuance amounts")
+			}
+			expectedSenderSpending, ok := mptcrypto.SubtractCiphertexts(senderToken.ConfidentialBalanceSpending, participants[0].Ciphertext)
+			if !ok || string(updatedSender.ConfidentialBalanceSpending) != string(expectedSenderSpending) {
+				t.Fatal("sender spending balance was not reduced")
+			}
+			expectedSenderIssuer, ok := mptcrypto.SubtractCiphertexts(senderToken.IssuerEncryptedBalance, participants[2].Ciphertext)
+			if !ok || string(updatedSender.IssuerEncryptedBalance) != string(expectedSenderIssuer) {
+				t.Fatal("sender issuer mirror was not reduced")
+			}
+			var challenge [32]byte
+			copy(challenge[:], proof[:32])
+			expectedReceive, ok := mptcrypto.RerandomizeCiphertext(participants[1].Ciphertext, destinationPublic, challenge)
+			if !ok {
+				t.Fatal("rerandomize expected destination amount")
+			}
+			expectedInbox, ok := mptcrypto.AddCiphertexts(destinationToken.ConfidentialBalanceInbox, expectedReceive)
+			if !ok || string(updatedDestination.ConfidentialBalanceInbox) != string(expectedInbox) {
+				t.Fatal("destination inbox was not rerandomized before addition")
+			}
+			expectedIssuerReceive, ok := mptcrypto.RerandomizeCiphertext(participants[2].Ciphertext, issuerPublic, challenge)
+			if !ok {
+				t.Fatal("rerandomize expected issuer amount")
+			}
+			expectedDestinationIssuer, ok := mptcrypto.AddCiphertexts(destinationToken.IssuerEncryptedBalance, expectedIssuerReceive)
+			if !ok || string(updatedDestination.IssuerEncryptedBalance) != string(expectedDestinationIssuer) {
+				t.Fatal("destination issuer mirror was not rerandomized before addition")
+			}
+			if withAuditor {
+				expectedSenderAuditor, ok := mptcrypto.SubtractCiphertexts(senderToken.AuditorEncryptedBalance, participants[3].Ciphertext)
+				if !ok || string(updatedSender.AuditorEncryptedBalance) != string(expectedSenderAuditor) {
+					t.Fatal("sender auditor mirror was not reduced")
+				}
+				expectedAuditorReceive, ok := mptcrypto.RerandomizeCiphertext(participants[3].Ciphertext, auditorPublic, challenge)
+				if !ok {
+					t.Fatal("rerandomize expected auditor amount")
+				}
+				expectedAuditor, ok := mptcrypto.AddCiphertexts(destinationToken.AuditorEncryptedBalance, expectedAuditorReceive)
+				if !ok || string(updatedDestination.AuditorEncryptedBalance) != string(expectedAuditor) {
+					t.Fatal("destination auditor balance was not rerandomized before addition")
+				}
+			}
+		})
+	}
+}
+
+func TestConfidentialMPTClawbackNativePreclaimAndApply(t *testing.T) {
+	issuer := [20]byte{1}
+	holder := [20]byte{2}
+	id := keylet.MakeMPTID(4, issuer)
+	issuerPrivate, issuerPublic := mustNativeKeyPair(t)
+	_, holderPublic := mustNativeKeyPair(t)
+	_, auditorPublic := mustNativeKeyPair(t)
+	blind := mustNativeBlind(t)
+	issuerBalance := mustNativeEncrypt(t, 75, issuerPublic, blind)
+	issuance := &state.MPTokenIssuanceData{
+		Issuer: issuer, Sequence: 4,
+		Flags:                         entry.LsfMPTCanClawback | entry.LsfMPTCanHoldConfidentialBalance | entry.LsfMPTLocked | entry.LsfMPTRequireAuth,
+		OutstandingAmount:             75,
+		ConfidentialOutstandingAmount: 75,
+		IssuerEncryptionKey:           issuerPublic,
+		AuditorEncryptionKey:          auditorPublic,
+	}
+	holding := &state.MPTokenData{
+		Account:                     holder,
+		MPTokenIssuanceID:           id,
+		Flags:                       entry.LsfMPTLocked,
+		MPTAmount:                   13,
+		HolderEncryptionKey:         holderPublic,
+		ConfidentialBalanceInbox:    mustNativeEncrypt(t, 50, holderPublic, blind),
+		ConfidentialBalanceSpending: mustNativeEncrypt(t, 25, holderPublic, blind),
+		IssuerEncryptedBalance:      issuerBalance,
+		AuditorEncryptedBalance:     mustNativeEncrypt(t, 75, auditorPublic, blind),
+		ConfidentialBalanceVersion:  6,
+	}
+	rules := amendment.NewRulesBuilder().Enable(amendment.FeatureConfidentialTransfer).Build()
+	view := &confidentialPreclaimView{entries: make(map[[32]byte][]byte), rules: rules}
+	issuerRoot := putConfidentialAccount(t, view, issuer)
+	putConfidentialAccount(t, view, holder)
+	issuanceKey := keylet.MPTIssuance(id)
+	holdingKey := keylet.MPToken(issuanceKey.Key, holder)
+	view.entries[issuanceKey.Key] = mustSerializeConfidentialIssuance(t, issuance)
+	view.entries[holdingKey.Key] = mustSerializeConfidentialHolding(t, holding)
+
+	sequence := uint32(9)
+	proofContext, ok := mptcrypto.ClawbackContext(issuer, id, sequence, holder)
+	if !ok {
+		t.Fatal("clawback context")
+	}
+	proof, ok := mptcrypto.GenerateClawbackProof(issuerPrivate, issuerPublic, proofContext, 75, issuerBalance)
+	if !ok {
+		t.Fatal("clawback proof")
+	}
+	holding.ConfidentialBalanceVersion = 99
+	view.entries[holdingKey.Key] = mustSerializeConfidentialHolding(t, holding)
+	transaction := &ConfidentialMPTClawback{
+		BaseTx:            *tx.NewBaseTx(tx.TypeConfidentialMPTClawback, state.EncodeAccountIDSafe(issuer)),
+		MPTokenIssuanceID: confidentialMPTIDString(id),
+		Holder:            state.EncodeAccountIDSafe(holder),
+		MPTAmount:         75,
+		ZKProof:           hex.EncodeToString(proof),
+	}
+	transaction.Sequence = &sequence
+	if err := transaction.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if got := transaction.Preclaim(view, tx.EngineConfig{}); got != ter.TesSUCCESS {
+		t.Fatalf("Preclaim with locks and auth = %v", got)
+	}
+	if got := transaction.Apply(nativeApplyContext(view, issuer, issuerRoot)); got != ter.TesSUCCESS {
+		t.Fatalf("Apply = %v", got)
+	}
+
+	updatedHolding, err := state.ParseMPToken(view.entries[holdingKey.Key])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updatedHolding.MPTAmount != 13 || updatedHolding.ConfidentialBalanceVersion != 100 {
+		t.Fatalf("holder public amount/version = %d/%d", updatedHolding.MPTAmount, updatedHolding.ConfidentialBalanceVersion)
+	}
+	for name, ciphertext := range map[string][]byte{
+		"inbox":    updatedHolding.ConfidentialBalanceInbox,
+		"spending": updatedHolding.ConfidentialBalanceSpending,
+	} {
+		want := mustNativeZero(t, holderPublic, holder, id)
+		if string(ciphertext) != string(want) {
+			t.Fatalf("%s is not the canonical holder zero", name)
+		}
+	}
+	if want := mustNativeZero(t, issuerPublic, holder, id); string(updatedHolding.IssuerEncryptedBalance) != string(want) {
+		t.Fatal("issuer mirror is not the canonical issuer zero")
+	}
+	if want := mustNativeZero(t, auditorPublic, holder, id); string(updatedHolding.AuditorEncryptedBalance) != string(want) {
+		t.Fatal("auditor mirror is not the canonical auditor zero")
+	}
+	updatedIssuance, err := state.ParseMPTokenIssuance(view.entries[issuanceKey.Key])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updatedIssuance.OutstandingAmount != 0 || updatedIssuance.ConfidentialOutstandingAmount != 0 {
+		t.Fatalf("issuance amounts = %d/%d", updatedIssuance.OutstandingAmount, updatedIssuance.ConfidentialOutstandingAmount)
+	}
+}
+
+type nativeClawbackFixture struct {
+	transaction *ConfidentialMPTClawback
+	view        *confidentialPreclaimView
+	issuer      [20]byte
+	holder      [20]byte
+	id          [24]byte
+	issuanceKey keylet.Keylet
+	holdingKey  keylet.Keylet
+	issuance    *state.MPTokenIssuanceData
+	holding     *state.MPTokenData
+}
+
+func newNativeClawbackFixture(t *testing.T) *nativeClawbackFixture {
+	t.Helper()
+	issuer := [20]byte{1}
+	holder := [20]byte{2}
+	id := keylet.MakeMPTID(4, issuer)
+	private, issuerPublic := mustNativeKeyPair(t)
+	_, holderPublic := mustNativeKeyPair(t)
+	blind := mustNativeBlind(t)
+	issuerBalance := mustNativeEncrypt(t, 75, issuerPublic, blind)
+	issuance := &state.MPTokenIssuanceData{
+		Issuer: issuer, Sequence: 4,
+		Flags:                         entry.LsfMPTCanClawback | entry.LsfMPTCanHoldConfidentialBalance,
+		OutstandingAmount:             75,
+		ConfidentialOutstandingAmount: 75,
+		IssuerEncryptionKey:           issuerPublic,
+	}
+	holding := &state.MPTokenData{
+		Account:                     holder,
+		MPTokenIssuanceID:           id,
+		HolderEncryptionKey:         holderPublic,
+		ConfidentialBalanceInbox:    mustNativeEncrypt(t, 50, holderPublic, blind),
+		ConfidentialBalanceSpending: mustNativeEncrypt(t, 25, holderPublic, blind),
+		IssuerEncryptedBalance:      issuerBalance,
+	}
+	view := &confidentialPreclaimView{entries: make(map[[32]byte][]byte), rules: amendment.NewRulesBuilder().Enable(amendment.FeatureConfidentialTransfer).Build()}
+	putConfidentialAccount(t, view, issuer)
+	putConfidentialAccount(t, view, holder)
+	issuanceKey := keylet.MPTIssuance(id)
+	holdingKey := keylet.MPToken(issuanceKey.Key, holder)
+	view.entries[issuanceKey.Key] = mustSerializeConfidentialIssuance(t, issuance)
+	view.entries[holdingKey.Key] = mustSerializeConfidentialHolding(t, holding)
+	sequence := uint32(9)
+	proofContext, ok := mptcrypto.ClawbackContext(issuer, id, sequence, holder)
+	if !ok {
+		t.Fatal("clawback context")
+	}
+	proof, ok := mptcrypto.GenerateClawbackProof(private, issuerPublic, proofContext, 75, issuerBalance)
+	if !ok {
+		t.Fatal("clawback proof")
+	}
+	transaction := &ConfidentialMPTClawback{
+		BaseTx:            *tx.NewBaseTx(tx.TypeConfidentialMPTClawback, state.EncodeAccountIDSafe(issuer)),
+		MPTokenIssuanceID: confidentialMPTIDString(id),
+		Holder:            state.EncodeAccountIDSafe(holder),
+		MPTAmount:         75,
+		ZKProof:           hex.EncodeToString(proof),
+	}
+	transaction.Sequence = &sequence
+	return &nativeClawbackFixture{transaction: transaction, view: view, issuer: issuer, holder: holder, id: id, issuanceKey: issuanceKey, holdingKey: holdingKey, issuance: issuance, holding: holding}
+}
+
+func TestConfidentialMPTClawbackNativePreclaimFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		want ter.Result
+		edit func(*testing.T, *nativeClawbackFixture)
+	}{
+		{name: "missing issuer account", want: ter.TerNO_ACCOUNT, edit: func(_ *testing.T, f *nativeClawbackFixture) { delete(f.view.entries, keylet.Account(f.issuer).Key) }},
+		{name: "missing holder account", want: ter.TecNO_TARGET, edit: func(_ *testing.T, f *nativeClawbackFixture) { delete(f.view.entries, keylet.Account(f.holder).Key) }},
+		{name: "missing issuance", want: ter.TecOBJECT_NOT_FOUND, edit: func(_ *testing.T, f *nativeClawbackFixture) { delete(f.view.entries, f.issuanceKey.Key) }},
+		{name: "missing clawback flag", want: ter.TecNO_PERMISSION, edit: func(t *testing.T, f *nativeClawbackFixture) {
+			f.issuance.Flags &^= entry.LsfMPTCanClawback
+			f.view.entries[f.issuanceKey.Key] = mustSerializeConfidentialIssuance(t, f.issuance)
+		}},
+		{name: "missing confidential flag", want: ter.TecNO_PERMISSION, edit: func(t *testing.T, f *nativeClawbackFixture) {
+			f.issuance.Flags &^= entry.LsfMPTCanHoldConfidentialBalance
+			f.view.entries[f.issuanceKey.Key] = mustSerializeConfidentialIssuance(t, f.issuance)
+		}},
+		{name: "missing issuer key", want: ter.TecNO_PERMISSION, edit: func(t *testing.T, f *nativeClawbackFixture) {
+			f.issuance.IssuerEncryptionKey = nil
+			f.view.entries[f.issuanceKey.Key] = mustSerializeConfidentialIssuance(t, f.issuance)
+		}},
+		{name: "malformed issuer key", want: ter.TecINTERNAL, edit: func(t *testing.T, f *nativeClawbackFixture) {
+			f.issuance.IssuerEncryptionKey = []byte{2}
+			f.view.entries[f.issuanceKey.Key] = mustSerializeConfidentialIssuance(t, f.issuance)
+		}},
+		{name: "missing holding", want: ter.TecOBJECT_NOT_FOUND, edit: func(_ *testing.T, f *nativeClawbackFixture) { delete(f.view.entries, f.holdingKey.Key) }},
+		{name: "missing confidential holding fields", want: ter.TecNO_PERMISSION, edit: func(t *testing.T, f *nativeClawbackFixture) {
+			f.holding.IssuerEncryptedBalance = nil
+			f.view.entries[f.holdingKey.Key] = mustSerializeConfidentialHolding(t, f.holding)
+		}},
+		{name: "malformed issuer ciphertext", want: ter.TecINTERNAL, edit: func(t *testing.T, f *nativeClawbackFixture) {
+			f.holding.IssuerEncryptedBalance = []byte{2}
+			f.view.entries[f.holdingKey.Key] = mustSerializeConfidentialHolding(t, f.holding)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newNativeClawbackFixture(t)
+			test.edit(t, fixture)
+			if got := fixture.transaction.Preclaim(fixture.view, tx.EngineConfig{}); got != test.want {
+				t.Fatalf("Preclaim = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestConfidentialMPTClawbackCommitFailureRollsBack(t *testing.T) {
+	fixture := newNativeClawbackFixture(t)
+	beforeIssuance := append([]byte(nil), fixture.view.entries[fixture.issuanceKey.Key]...)
+	beforeHolding := append([]byte(nil), fixture.view.entries[fixture.holdingKey.Key]...)
+	issuerRoot, err := state.ParseAccountRoot(fixture.view.entries[keylet.Account(fixture.issuer).Key])
+	if err != nil {
+		t.Fatal(err)
+	}
+	table := applystate.NewApplyStateTable(fixture.view, [32]byte{1}, 2, fixture.view.rules)
+	ctx := &tx.ApplyContext{
+		View: table, Account: issuerRoot, AccountID: fixture.issuer,
+		Config: tx.EngineConfig{Rules: fixture.view.rules}, Metadata: &tx.Metadata{}, Log: xrpllog.Discard(), Ctx: context.Background(),
+	}
+	if got := fixture.transaction.Apply(ctx); got != ter.TesSUCCESS {
+		t.Fatalf("Apply = %v", got)
+	}
+	fixture.view.failMutationAt = 2
+	if _, err := table.Apply(); !errors.Is(err, errConfidentialMutation) {
+		t.Fatalf("ApplyStateTable.Apply error = %v, want %v", err, errConfidentialMutation)
+	}
+	if string(fixture.view.entries[fixture.issuanceKey.Key]) != string(beforeIssuance) || string(fixture.view.entries[fixture.holdingKey.Key]) != string(beforeHolding) {
+		t.Fatal("failed commit retained a partial confidential clawback update")
+	}
+}
+
+func TestConfidentialMPTClawbackRequiresTheWholeEncryptedBalance(t *testing.T) {
+	issuer := [20]byte{1}
+	holder := [20]byte{2}
+	id := keylet.MakeMPTID(4, issuer)
+	private, public := mustNativeKeyPair(t)
+	_, holderPublic := mustNativeKeyPair(t)
+	ciphertext := mustNativeEncrypt(t, 75, public, mustNativeBlind(t))
+	issuance := &state.MPTokenIssuanceData{Issuer: issuer, Sequence: 4, Flags: entry.LsfMPTCanClawback | entry.LsfMPTCanHoldConfidentialBalance, OutstandingAmount: 100, ConfidentialOutstandingAmount: 100, IssuerEncryptionKey: public}
+	holding := &state.MPTokenData{Account: holder, MPTokenIssuanceID: id, HolderEncryptionKey: holderPublic, IssuerEncryptedBalance: ciphertext}
+	view := &confidentialPreclaimView{entries: make(map[[32]byte][]byte), rules: amendment.NewRulesBuilder().Enable(amendment.FeatureConfidentialTransfer).Build()}
+	putConfidentialAccount(t, view, issuer)
+	putConfidentialAccount(t, view, holder)
+	view.entries[keylet.MPTIssuance(id).Key] = mustSerializeConfidentialIssuance(t, issuance)
+	view.entries[keylet.MPToken(keylet.MPTIssuance(id).Key, holder).Key] = mustSerializeConfidentialHolding(t, holding)
+	sequence := uint32(9)
+	proofContext, _ := mptcrypto.ClawbackContext(issuer, id, sequence, holder)
+	proof, ok := mptcrypto.GenerateClawbackProof(private, public, proofContext, 75, ciphertext)
+	if !ok {
+		t.Fatal("generate full-balance proof")
+	}
+	transaction := &ConfidentialMPTClawback{BaseTx: *tx.NewBaseTx(tx.TypeConfidentialMPTClawback, state.EncodeAccountIDSafe(issuer)), MPTokenIssuanceID: confidentialMPTIDString(id), Holder: state.EncodeAccountIDSafe(holder), MPTAmount: 50, ZKProof: hex.EncodeToString(proof)}
+	transaction.Sequence = &sequence
+	if got := transaction.Preclaim(view, tx.EngineConfig{}); got != ter.TecBAD_PROOF {
+		t.Fatalf("Preclaim partial amount = %v, want %v", got, ter.TecBAD_PROOF)
+	}
+	issuance.ConfidentialOutstandingAmount = 49
+	view.entries[keylet.MPTIssuance(id).Key] = mustSerializeConfidentialIssuance(t, issuance)
+	if got := transaction.Preclaim(view, tx.EngineConfig{}); got != ter.TecINSUFFICIENT_FUNDS {
+		t.Fatalf("Preclaim insufficient global amount = %v, want %v", got, ter.TecINSUFFICIENT_FUNDS)
+	}
+}
+
+func TestConfidentialMPTClawbackAuditorMismatchDoesNotWrite(t *testing.T) {
+	issuer := [20]byte{1}
+	holder := [20]byte{2}
+	id := keylet.MakeMPTID(4, issuer)
+	_, issuerPublic := mustNativeKeyPair(t)
+	_, holderPublic := mustNativeKeyPair(t)
+	_, auditorPublic := mustNativeKeyPair(t)
+	issuance := &state.MPTokenIssuanceData{Issuer: issuer, Sequence: 4, Flags: entry.LsfMPTCanClawback | entry.LsfMPTCanHoldConfidentialBalance, OutstandingAmount: 1, ConfidentialOutstandingAmount: 1, IssuerEncryptionKey: issuerPublic}
+	holding := &state.MPTokenData{
+		Account:                     holder,
+		MPTokenIssuanceID:           id,
+		MPTAmount:                   7,
+		HolderEncryptionKey:         holderPublic,
+		ConfidentialBalanceInbox:    mustNativeZero(t, holderPublic, holder, id),
+		ConfidentialBalanceSpending: mustNativeZero(t, holderPublic, holder, id),
+		IssuerEncryptedBalance:      mustNativeZero(t, issuerPublic, holder, id),
+		AuditorEncryptedBalance:     mustNativeZero(t, auditorPublic, holder, id),
+	}
+	view := &confidentialPreclaimView{entries: make(map[[32]byte][]byte), rules: amendment.NewRulesBuilder().Enable(amendment.FeatureConfidentialTransfer).Build()}
+	issuerRoot := putConfidentialAccount(t, view, issuer)
+	issuanceKey := keylet.MPTIssuance(id)
+	holdingKey := keylet.MPToken(issuanceKey.Key, holder)
+	view.entries[issuanceKey.Key] = mustSerializeConfidentialIssuance(t, issuance)
+	view.entries[holdingKey.Key] = mustSerializeConfidentialHolding(t, holding)
+	beforeIssuance := append([]byte(nil), view.entries[issuanceKey.Key]...)
+	beforeHolding := append([]byte(nil), view.entries[holdingKey.Key]...)
+	transaction := &ConfidentialMPTClawback{BaseTx: *tx.NewBaseTx(tx.TypeConfidentialMPTClawback, state.EncodeAccountIDSafe(issuer)), MPTokenIssuanceID: confidentialMPTIDString(id), Holder: state.EncodeAccountIDSafe(holder), MPTAmount: 1, ZKProof: makeHex(mptcrypto.ClawbackProofSize, 1)}
+	if got := transaction.Apply(nativeApplyContext(view, issuer, issuerRoot)); got != ter.TecINTERNAL {
+		t.Fatalf("Apply auditor mismatch = %v, want %v", got, ter.TecINTERNAL)
+	}
+	if string(view.entries[issuanceKey.Key]) != string(beforeIssuance) || string(view.entries[holdingKey.Key]) != string(beforeHolding) {
+		t.Fatal("auditor mismatch wrote partial state")
+	}
+}

--- a/internal/tx/mpt/confidential_test.go
+++ b/internal/tx/mpt/confidential_test.go
@@ -2,10 +2,14 @@ package mpt
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/crypto/mptcrypto"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 func TestConfidentialMPTWireAmountAndOptionalPresence(t *testing.T) {
@@ -67,6 +71,18 @@ func TestConfidentialMPTUnmarshalClearsReusedReceiver(t *testing.T) {
 		convertBack.HolderEncryptedAmount != "" || convertBack.ZKProof != "" || convertBack.BalanceCommitment != "" {
 		t.Fatalf("reused ConvertBack retained stale fields: %+v", convertBack)
 	}
+
+	clawback := ConfidentialMPTClawback{MPTokenIssuanceID: "stale", Holder: "stale", MPTAmount: 9, ZKProof: "stale"}
+	if err := json.Unmarshal([]byte(`{"MPTAmount":"9223372036854775807"}`), &clawback); err != nil {
+		t.Fatal(err)
+	}
+	if clawback.MPTAmount != protocol.MaxMPTokenAmount || clawback.MPTokenIssuanceID != "" || clawback.Holder != "" || clawback.ZKProof != "" {
+		t.Fatalf("reused Clawback retained stale fields: %+v", clawback)
+	}
+	flat, err := clawback.Flatten()
+	if err != nil || flat["MPTAmount"] != "9223372036854775807" {
+		t.Fatalf("clawback flatten = %#v, %v", flat, err)
+	}
 }
 
 func TestConfidentialMPTProtocolShape(t *testing.T) {
@@ -82,6 +98,8 @@ func TestConfidentialMPTProtocolShape(t *testing.T) {
 		{&ConfidentialMPTConvert{}, tx.TypeConfidentialMPTConvert},
 		{&ConfidentialMPTMergeInbox{}, tx.TypeConfidentialMPTMergeInbox},
 		{&ConfidentialMPTConvertBack{}, tx.TypeConfidentialMPTConvertBack},
+		{&ConfidentialMPTSend{}, tx.TypeConfidentialMPTSend},
+		{&ConfidentialMPTClawback{}, tx.TypeConfidentialMPTClawback},
 	}
 	for _, test := range tests {
 		if got := test.transaction.TxType(); got != test.want {
@@ -95,4 +113,100 @@ func TestConfidentialMPTProtocolShape(t *testing.T) {
 			t.Fatalf("RequiredAmendments() = %x", features)
 		}
 	}
+}
+
+func TestConfidentialMPTRegisteredJSONRejectsMissingRequiredFields(t *testing.T) {
+	Register()
+	for _, test := range []struct {
+		name string
+		data string
+	}{
+		{
+			name: "send",
+			data: `{"TransactionType":"ConfidentialMPTSend","Account":"rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"}`,
+		},
+		{
+			name: "clawback",
+			data: `{"TransactionType":"ConfidentialMPTClawback","Account":"rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"}`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			transaction, err := tx.FromJSON([]byte(test.data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = transaction.Validate()
+			if err == nil || !strings.HasPrefix(err.Error(), "temMALFORMED: required confidential") {
+				t.Fatalf("Validate() = %v, want missing required-field temMALFORMED", err)
+			}
+		})
+	}
+}
+
+func TestConfidentialMPTSendCodecRoundTrip(t *testing.T) {
+	input := map[string]any{
+		"TransactionType":            "ConfidentialMPTSend",
+		"Account":                    "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+		"Sequence":                   uint32(1),
+		"Fee":                        "100",
+		"SigningPubKey":              "",
+		"MPTokenIssuanceID":          "00000001ABCDEF0123456789ABCDEF0123456789ABCDEF12",
+		"Destination":                "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"DestinationTag":             uint32(7),
+		"SenderEncryptedAmount":      makeHex(66, 0x11),
+		"DestinationEncryptedAmount": makeHex(66, 0x22),
+		"IssuerEncryptedAmount":      makeHex(66, 0x33),
+		"AuditorEncryptedAmount":     makeHex(66, 0x44),
+		"ZKProof":                    makeHex(mptcrypto.SendProofSize, 0x55),
+		"AmountCommitment":           makeHex(33, 0x66),
+		"BalanceCommitment":          makeHex(33, 0x77),
+		"CredentialIDs":              []any{makeHex(32, 0x88)},
+	}
+	encoded, err := binarycodec.EncodeBytes(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := binarycodec.DecodeBytes(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"SenderEncryptedAmount", "DestinationEncryptedAmount", "IssuerEncryptedAmount", "AuditorEncryptedAmount", "ZKProof", "AmountCommitment", "BalanceCommitment", "CredentialIDs"} {
+		if _, ok := decoded[field]; !ok {
+			t.Fatalf("decoded send omitted %s", field)
+		}
+	}
+}
+
+func TestConfidentialMPTClawbackCodecRoundTrip(t *testing.T) {
+	input := map[string]any{
+		"TransactionType":   "ConfidentialMPTClawback",
+		"Account":           "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+		"Sequence":          uint32(1),
+		"Fee":               "100",
+		"SigningPubKey":     "",
+		"MPTokenIssuanceID": "00000001ABCDEF0123456789ABCDEF0123456789ABCDEF12",
+		"Holder":            "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"MPTAmount":         "9223372036854775807",
+		"ZKProof":           makeHex(mptcrypto.ClawbackProofSize, 0x11),
+	}
+	encoded, err := binarycodec.EncodeBytes(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := binarycodec.DecodeBytes(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decoded["MPTAmount"] != "9223372036854775807" {
+		t.Fatalf("MPTAmount = %#v", decoded["MPTAmount"])
+	}
+}
+
+func makeHex(size int, value byte) string {
+	digits := "0123456789ABCDEF"
+	result := make([]byte, size*2)
+	for i := 0; i < size; i++ {
+		result[2*i], result[2*i+1] = digits[value>>4], digits[value&15]
+	}
+	return string(result)
 }

--- a/internal/tx/mpt/mptoken_test.go
+++ b/internal/tx/mpt/mptoken_test.go
@@ -427,7 +427,8 @@ func TestMPTokenIssuanceSetPreflightOrder(t *testing.T) {
 }
 
 // allRules mirrors rippled's testSetValidation(all - featureSingleAssetVault):
-// every supported amendment except SingleAssetVault and DynamicMPT, so their
+// every supported amendment except SingleAssetVault, DynamicMPT, and
+// ConfidentialTransfer, so their
 // "changes nothing" no-op rejection does not fire and the legacy Set-validation
 // shape checks are exercised in isolation. The SAV-on no-op behaviour has its
 // own coverage via a rules set that enables SingleAssetVault.
@@ -436,6 +437,7 @@ func allRules() *amendment.Rules {
 		FromPreset(amendment.PresetAllSupported).
 		DisableByName("SingleAssetVault").
 		DisableByName("DynamicMPT").
+		DisableByName("ConfidentialTransfer").
 		Build()
 }
 

--- a/internal/tx/mpt/register.go
+++ b/internal/tx/mpt/register.go
@@ -25,4 +25,10 @@ func Register() {
 	tx.Register(tx.TypeConfidentialMPTConvertBack, func() tx.Transaction {
 		return &ConfidentialMPTConvertBack{BaseTx: *tx.NewBaseTx(tx.TypeConfidentialMPTConvertBack, "")}
 	})
+	tx.Register(tx.TypeConfidentialMPTSend, func() tx.Transaction {
+		return &ConfidentialMPTSend{BaseTx: *tx.NewBaseTx(tx.TypeConfidentialMPTSend, "")}
+	})
+	tx.Register(tx.TypeConfidentialMPTClawback, func() tx.Transaction {
+		return &ConfidentialMPTClawback{BaseTx: *tx.NewBaseTx(tx.TypeConfidentialMPTClawback, "")}
+	})
 }

--- a/internal/tx/template_registry_test.go
+++ b/internal/tx/template_registry_test.go
@@ -20,17 +20,11 @@ func TestConfidentialTypeRegistration(t *testing.T) {
 		tx.TypeConfidentialMPTConvert,
 		tx.TypeConfidentialMPTMergeInbox,
 		tx.TypeConfidentialMPTConvertBack,
-	} {
-		if _, err := tx.NewFromType(txType); err != nil {
-			t.Fatalf("NewFromType(%s) error = %v", txType, err)
-		}
-	}
-	for _, txType := range []tx.Type{
 		tx.TypeConfidentialMPTSend,
 		tx.TypeConfidentialMPTClawback,
 	} {
-		if _, err := tx.NewFromType(txType); err != tx.ErrUnknownTransactionType {
-			t.Fatalf("NewFromType(%s) error = %v, want ErrUnknownTransactionType", txType, err)
+		if _, err := tx.NewFromType(txType); err != nil {
+			t.Fatalf("NewFromType(%s) error = %v", txType, err)
 		}
 	}
 }

--- a/justfile
+++ b/justfile
@@ -35,7 +35,7 @@ mpt-crypto-env:
     @./scripts/setup-mpt-crypto.sh env
 
 # Build mpt-crypto from its lockfile and run the native backend tests.
-test-mpt-crypto package="./crypto/mptcrypto/...":
+test-mpt-crypto package="./amendment/... ./crypto/mptcrypto/... ./internal/tx/mpt/... ./internal/testing/mpt/...":
     ./scripts/setup-mpt-crypto.sh test {{package}}
 
 # Run every test in the module.


### PR DESCRIPTION
## Summary

- implement `ConfidentialMPTSend` and `ConfidentialMPTClawback` against the final rippled v3.3.0 oracle
- match proof contexts, TER ordering, encrypted balance updates, versioning, credentials, DepositPreauth, and delegation behavior
- cover all four Batch modes, Ticket contexts, stale-proof rollback, corrupt ledger state, auditor paths, and credential expiry cleanup
- advertise `ConfidentialTransfer` only when the pinned native backend is available, while keeping untagged and no-CGO builds fail-closed
- update generated transaction documentation and native/no-CGO CI coverage

## Testing

- tagged native amendment, crypto, transaction, and MPT integration suites
- untagged default, untagged no-CGO, and tagged no-CGO suites
- full transaction and integration suites
- `just vet`
- `just build-all`
- `just build-nocgo`
- `just lint`
- `just docs-check`
- cumulative `git diff --check`

Depends on #1627.

Fixes #1372
