### PR TITLE
feat: add account_tx delegate filtering and tighten amm_info validation

### DIFF
--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -1001,6 +1001,16 @@ func (s *Service) UseTxTables() bool {
 // GetAccountTransactions retrieves transaction history for an account.
 // The supplied ctx is forwarded to the relational DB query.
 func (s *Service) GetAccountTransactions(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *relationaldb.AccountTxMarker, forward bool) (*AccountTxResult, error) {
+	return s.getAccountTransactions(ctx, account, ledgerMin, ledgerMax, limit, marker, forward, nil)
+}
+
+// GetAccountTransactionsWithDelegate retrieves delegated transaction history
+// for an account.
+func (s *Service) GetAccountTransactionsWithDelegate(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *relationaldb.AccountTxMarker, forward bool, delegate *relationaldb.AccountTxDelegateFilter) (*AccountTxResult, error) {
+	return s.getAccountTransactions(ctx, account, ledgerMin, ledgerMax, limit, marker, forward, delegate)
+}
+
+func (s *Service) getAccountTransactions(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *relationaldb.AccountTxMarker, forward bool, delegate *relationaldb.AccountTxDelegateFilter) (*AccountTxResult, error) {
 	// Snapshot the validated-seq bound under the lock, then release it before
 	// the DB pages: relationalDB is immutable and the query needs no other
 	// service state, so holding s.mu across the I/O would block consensus close
@@ -1059,6 +1069,7 @@ func (s *Service) GetAccountTransactions(ctx context.Context, account string, le
 		MaxLedger: maxLedger,
 		Marker:    marker,
 		Limit:     limit,
+		Delegate:  delegate,
 	}
 
 	var txResult *relationaldb.AccountTxResult

--- a/internal/rpc/account_tx_delegate_test.go
+++ b/internal/rpc/account_tx_delegate_test.go
@@ -1,0 +1,156 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountTxDelegateValidation(t *testing.T) {
+	const account = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	tests := []struct {
+		name     string
+		delegate any
+		code     int
+		message  string
+	}{
+		{name: "non-object", delegate: "actor", code: types.RpcINVALID_PARAMS, message: "Invalid field 'delegate'."},
+		{name: "null", delegate: nil, code: types.RpcINVALID_PARAMS, message: "Invalid field 'delegate'."},
+		{name: "missing filter", delegate: map[string]any{}, code: types.RpcINVALID_PARAMS, message: "Invalid field 'delegate_filter'."},
+		{name: "non-string filter", delegate: map[string]any{"delegate_filter": 1}, code: types.RpcINVALID_PARAMS, message: "Invalid field 'delegate_filter'."},
+		{name: "unknown filter", delegate: map[string]any{"delegate_filter": "other"}, code: types.RpcINVALID_PARAMS, message: "Invalid field 'delegate_filter'."},
+		{name: "non-string counterparty", delegate: map[string]any{"delegate_filter": "actor", "counter_party": 1}, code: types.RpcINVALID_PARAMS, message: "Invalid field 'counter_party'."},
+		{name: "malformed counterparty", delegate: map[string]any{"delegate_filter": "actor", "counter_party": "not-an-account"}, code: types.RpcACT_MALFORMED, message: "Account malformed."},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			params, err := json.Marshal(map[string]any{"account": account, "delegate": test.delegate})
+			require.NoError(t, err)
+			result, rpcErr := (&handlers.AccountTxMethod{}).Handle(&types.RpcContext{
+				Context:    context.Background(),
+				ApiVersion: types.ApiVersion3,
+				Services:   newTestServicesAccountTx(newAccountTxMock()),
+			}, params)
+			assert.Nil(t, result)
+			require.NotNil(t, rpcErr)
+			assert.Equal(t, test.code, rpcErr.Code)
+			assert.Equal(t, test.message, rpcErr.Message)
+		})
+	}
+}
+
+func TestAccountTxDelegateMarkerConvention(t *testing.T) {
+	const account = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	const mismatch = "Do not mix delegate and non-delegate pagination markers in account_tx; repeat the same `delegate` object when using a delegate marker."
+
+	for _, test := range []struct {
+		name   string
+		params map[string]any
+	}{
+		{
+			name: "delegate marker without filter",
+			params: map[string]any{
+				"account": account,
+				"marker":  map[string]any{"ledger": 2, "seq": 1, "delegate": true},
+			},
+		},
+		{
+			name: "ordinary marker with filter",
+			params: map[string]any{
+				"account":  account,
+				"marker":   map[string]any{"ledger": 2, "seq": 1},
+				"delegate": map[string]any{"delegate_filter": "actor"},
+			},
+		},
+		{
+			name: "false flag remains ordinary",
+			params: map[string]any{
+				"account":  account,
+				"marker":   map[string]any{"ledger": 2, "seq": 1, "delegate": false},
+				"delegate": map[string]any{"delegate_filter": "actor"},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			params, err := json.Marshal(test.params)
+			require.NoError(t, err)
+			result, rpcErr := (&handlers.AccountTxMethod{}).Handle(&types.RpcContext{
+				Context:    context.Background(),
+				ApiVersion: types.ApiVersion3,
+				Services:   newTestServicesAccountTx(newAccountTxMock()),
+			}, params)
+			assert.Nil(t, result)
+			require.NotNil(t, rpcErr)
+			assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+			assert.Equal(t, mismatch, rpcErr.Message)
+		})
+	}
+}
+
+func TestAccountTxDelegateForwardingAndMarker(t *testing.T) {
+	const (
+		account      = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+		counterparty = "rDsbeomae4FXwgQTJp9Rs64Qg9vDiTCdBv"
+	)
+	mock := newAccountTxMock()
+	mock.getAccountTransactionsWithDelegateFn = func(_ context.Context, gotAccount string, minLedger, maxLedger int64, limit uint32, marker *types.AccountTxMarker, forward bool, delegate *types.AccountTxDelegateFilter) (*types.AccountTxResult, error) {
+		assert.Equal(t, account, gotAccount)
+		assert.Equal(t, int64(1), minLedger)
+		assert.Equal(t, int64(2), maxLedger)
+		assert.Equal(t, uint32(10), limit)
+		assert.Nil(t, marker)
+		assert.True(t, forward)
+		require.NotNil(t, delegate)
+		assert.Equal(t, types.AccountTxDelegateActor, delegate.Role)
+		assert.Equal(t, counterparty, delegate.Counterparty)
+		return &types.AccountTxResult{
+			Account:   gotAccount,
+			LedgerMin: 1,
+			LedgerMax: 2,
+			Limit:     limit,
+			Marker:    &types.AccountTxMarker{LedgerSeq: 2, TxnSeq: 3},
+			Validated: true,
+		}, nil
+	}
+
+	params, err := json.Marshal(map[string]any{
+		"account": account,
+		"binary":  true,
+		"forward": true,
+		"limit":   10,
+		"delegate": map[string]any{
+			"delegate_filter": "actor",
+			"counter_party":   counterparty,
+		},
+	})
+	require.NoError(t, err)
+	result, rpcErr := (&handlers.AccountTxMethod{}).Handle(&types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion3,
+		Services:   newTestServicesAccountTx(mock),
+	}, params)
+	require.Nil(t, rpcErr)
+	response := result.(map[string]any)
+	marker := response["marker"].(map[string]any)
+	assert.Equal(t, uint32(2), marker["ledger"])
+	assert.Equal(t, uint32(3), marker["seq"])
+	assert.Equal(t, true, marker["delegate"])
+}
+
+func TestAccountTxMarkerShapePrecedesDelegateValidation(t *testing.T) {
+	const account = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	result, rpcErr := (&handlers.AccountTxMethod{}).Handle(&types.RpcContext{
+		Context:    context.Background(),
+		ApiVersion: types.ApiVersion3,
+		Services:   newTestServicesAccountTx(newAccountTxMock()),
+	}, json.RawMessage(`{"account":"`+account+`","marker":{},"delegate":"bad"}`))
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, "invalid marker. Provide ledger index via ledger field, and transaction sequence number via seq field", rpcErr.Message)
+}

--- a/internal/rpc/account_tx_test.go
+++ b/internal/rpc/account_tx_test.go
@@ -20,9 +20,17 @@ import (
 // accountTxMock wraps mockLedgerService and overrides GetAccountTransactions
 type accountTxMock struct {
 	*mockLedgerService
-	getAccountTransactionsFn func(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error)
-	getLedgerBySequenceFn    func(uint32) (types.LedgerReader, error)
-	getLedgerByHashFn        func([32]byte) (types.LedgerReader, error)
+	getAccountTransactionsFn             func(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error)
+	getAccountTransactionsWithDelegateFn func(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool, delegate *types.AccountTxDelegateFilter) (*types.AccountTxResult, error)
+	getLedgerBySequenceFn                func(uint32) (types.LedgerReader, error)
+	getLedgerByHashFn                    func([32]byte) (types.LedgerReader, error)
+}
+
+func (m *accountTxMock) GetAccountTransactionsWithDelegate(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool, delegate *types.AccountTxDelegateFilter) (*types.AccountTxResult, error) {
+	if m.getAccountTransactionsWithDelegateFn != nil {
+		return m.getAccountTransactionsWithDelegateFn(ctx, account, ledgerMin, ledgerMax, limit, marker, forward, delegate)
+	}
+	return nil, errors.New("not implemented")
 }
 
 func newAccountTxMock() *accountTxMock {

--- a/internal/rpc/adapter/accounts.go
+++ b/internal/rpc/adapter/accounts.go
@@ -2,8 +2,10 @@ package adapter
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
+	"github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
@@ -114,6 +116,41 @@ func (a *LedgerServiceAdapter) GetAccountOffers(ctx context.Context, account str
 }
 
 func (a *LedgerServiceAdapter) GetAccountTransactions(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {
+	return a.getAccountTransactions(ctx, account, ledgerMin, ledgerMax, limit, marker, forward, nil)
+}
+
+// GetAccountTransactionsWithDelegate retrieves account transaction history
+// using a delegation filter.
+func (a *LedgerServiceAdapter) GetAccountTransactionsWithDelegate(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool, delegate *types.AccountTxDelegateFilter) (*types.AccountTxResult, error) {
+	var relationalDelegate *relationaldb.AccountTxDelegateFilter
+	if delegate != nil {
+		var role relationaldb.AccountTxDelegateRole
+		switch delegate.Role {
+		case types.AccountTxDelegateActor:
+			role = relationaldb.AccountTxDelegateActor
+		case types.AccountTxDelegateAuthorizer:
+			role = relationaldb.AccountTxDelegateAuthorizer
+		default:
+			return nil, fmt.Errorf("invalid account_tx delegate role %d", delegate.Role)
+		}
+		relationalDelegate = &relationaldb.AccountTxDelegateFilter{Role: role}
+		if delegate.Counterparty != "" {
+			_, raw, err := addresscodec.DecodeClassicAddressToAccountID(delegate.Counterparty)
+			if err != nil {
+				return nil, err
+			}
+			if len(raw) != len(relationaldb.AccountID{}) {
+				return nil, fmt.Errorf("counterparty account ID has length %d", len(raw))
+			}
+			var counterparty relationaldb.AccountID
+			copy(counterparty[:], raw)
+			relationalDelegate.Counterparty = &counterparty
+		}
+	}
+	return a.getAccountTransactions(ctx, account, ledgerMin, ledgerMax, limit, marker, forward, relationalDelegate)
+}
+
+func (a *LedgerServiceAdapter) getAccountTransactions(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool, delegate *relationaldb.AccountTxDelegateFilter) (*types.AccountTxResult, error) {
 	// Convert RPC marker to service marker
 	var svcMarker *relationaldb.AccountTxMarker
 	if marker != nil {
@@ -123,7 +160,7 @@ func (a *LedgerServiceAdapter) GetAccountTransactions(ctx context.Context, accou
 		}
 	}
 
-	result, err := a.svc.GetAccountTransactions(ctx, account, ledgerMin, ledgerMax, limit, svcMarker, forward)
+	result, err := a.svc.GetAccountTransactionsWithDelegate(ctx, account, ledgerMin, ledgerMax, limit, svcMarker, forward, delegate)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rpc/handlers/account_tx.go
+++ b/internal/rpc/handlers/account_tx.go
@@ -79,12 +79,25 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 	}
 
 	var marker *types.AccountTxMarker
+	markerFromDelegate := false
 	if raw, ok := fields["marker"]; ok {
 		var markerErr *types.RpcError
-		marker, markerErr = parseAccountTxMarker(raw)
+		marker, markerFromDelegate, markerErr = parseAccountTxMarker(raw)
 		if markerErr != nil {
 			return nil, markerErr
 		}
+	}
+
+	var delegate *types.AccountTxDelegateFilter
+	if raw, ok := fields["delegate"]; ok {
+		var delegateErr *types.RpcError
+		delegate, delegateErr = parseAccountTxDelegate(raw)
+		if delegateErr != nil {
+			return nil, delegateErr
+		}
+	}
+	if marker != nil && markerFromDelegate != (delegate != nil) {
+		return nil, types.RpcErrorInvalidParams("Do not mix delegate and non-delegate pagination markers in account_tx; repeat the same `delegate` object when using a delegate marker.")
 	}
 
 	ledgerIndexMin, ledgerIndexMax, ledgerErr := resolveAccountTxLedgerSelection(ctx, ledgerSelection)
@@ -93,15 +106,34 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 	}
 
 	setLoadMedium(ctx)
-	result, err := ctx.Services.Ledger.GetAccountTransactions(
-		ctx.Context,
-		account,
-		ledgerIndexMin,
-		ledgerIndexMax,
-		limit,
-		marker,
-		forward,
-	)
+	var result *types.AccountTxResult
+	var err error
+	if delegate == nil {
+		result, err = ctx.Services.Ledger.GetAccountTransactions(
+			ctx.Context,
+			account,
+			ledgerIndexMin,
+			ledgerIndexMax,
+			limit,
+			marker,
+			forward,
+		)
+	} else {
+		querier, ok := ctx.Services.Ledger.(types.AccountTxDelegateQuerier)
+		if !ok {
+			return nil, types.RpcErrorInternal()
+		}
+		result, err = querier.GetAccountTransactionsWithDelegate(
+			ctx.Context,
+			account,
+			ledgerIndexMin,
+			ledgerIndexMax,
+			limit,
+			marker,
+			forward,
+			delegate,
+		)
+	}
 	if err != nil {
 		if errors.Is(err, svcerr.ErrTxHistoryUnavailable) {
 			return nil, types.RpcErrorNotEnabled("")
@@ -253,10 +285,14 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 	}
 
 	if result.Marker != nil {
-		response["marker"] = map[string]any{
+		responseMarker := map[string]any{
 			"ledger": result.Marker.LedgerSeq,
 			"seq":    result.Marker.TxnSeq,
 		}
+		if delegate != nil {
+			responseMarker["delegate"] = true
+		}
+		response["marker"] = responseMarker
 	}
 
 	return response, nil
@@ -491,32 +527,70 @@ func accountTxLedgerIndex(raw json.RawMessage) (types.LedgerIndex, *types.RpcErr
 	}
 }
 
-func parseAccountTxMarker(raw json.RawMessage) (*types.AccountTxMarker, *types.RpcError) {
+func parseAccountTxMarker(raw json.RawMessage) (*types.AccountTxMarker, bool, *types.RpcError) {
 	invalid := func() *types.RpcError {
 		return types.RpcErrorInvalidParams("invalid marker. Provide ledger index via ledger field, and transaction sequence number via seq field")
 	}
 	value, err := decodeAccountTxValue(raw)
 	if err != nil {
-		return nil, invalid()
+		return nil, false, invalid()
 	}
 	markerMap, ok := value.(map[string]any)
 	if !ok {
-		return nil, invalid()
+		return nil, false, invalid()
 	}
 	ledgerValue, hasLedger := markerMap["ledger"]
 	seqValue, hasSeq := markerMap["seq"]
 	if !hasLedger || !hasSeq {
-		return nil, invalid()
+		return nil, false, invalid()
 	}
 	ledger, ok := accountTxUint32(ledgerValue)
 	if !ok {
-		return nil, invalid()
+		return nil, false, invalid()
 	}
 	seq, ok := accountTxUint32(seqValue)
 	if !ok {
-		return nil, invalid()
+		return nil, false, invalid()
 	}
-	return &types.AccountTxMarker{LedgerSeq: ledger, TxnSeq: seq}, nil
+	fromDelegate, _ := markerMap["delegate"].(bool)
+	return &types.AccountTxMarker{LedgerSeq: ledger, TxnSeq: seq}, fromDelegate, nil
+}
+
+func parseAccountTxDelegate(raw json.RawMessage) (*types.AccountTxDelegateFilter, *types.RpcError) {
+	value, err := decodeAccountTxValue(raw)
+	if err != nil {
+		return nil, types.RpcErrorInvalidField("delegate")
+	}
+	delegate, ok := value.(map[string]any)
+	if !ok {
+		return nil, types.RpcErrorInvalidField("delegate")
+	}
+	filterValue, ok := delegate["delegate_filter"].(string)
+	if !ok {
+		return nil, types.RpcErrorInvalidField("delegate_filter")
+	}
+
+	result := &types.AccountTxDelegateFilter{}
+	switch filterValue {
+	case "actor":
+		result.Role = types.AccountTxDelegateActor
+	case "authorizer":
+		result.Role = types.AccountTxDelegateAuthorizer
+	default:
+		return nil, types.RpcErrorInvalidField("delegate_filter")
+	}
+
+	if counterpartyValue, present := delegate["counter_party"]; present {
+		counterparty, ok := counterpartyValue.(string)
+		if !ok {
+			return nil, types.RpcErrorInvalidField("counter_party")
+		}
+		if !types.IsValidClassicAddress(counterparty) {
+			return nil, types.RpcErrorActMalformed("Account malformed.")
+		}
+		result.Counterparty = counterparty
+	}
+	return result, nil
 }
 
 func accountTxUint32(value any) (uint32, bool) {

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -12,7 +12,6 @@ import (
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
-	"github.com/LeJamon/go-xrpl/crypto/secp256k1"
 	ledgerselector "github.com/LeJamon/go-xrpl/internal/ledger/selector"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
@@ -86,10 +85,14 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 
 	var ammKey [32]byte
 	if hasAMMAccount {
+		ammAccount, ok := accountIdent(request.AMMAccount)
+		if !ok {
+			return nil, types.RpcErrorActMalformed("Account malformed.")
+		}
 		// rippled AMMInfo returns actMalformed (not invalidParams or
 		// actNotFound) both when the amm_account does not parse and when it
 		// does not exist in the ledger.
-		_, accountEntry, rpcErr := readAccountRoot(ctx, ledgerIndex, accountIdent(request.AMMAccount))
+		_, accountEntry, rpcErr := readAccountRoot(ctx, ledgerIndex, ammAccount)
 		if rpcErr != nil {
 			return nil, rpcErr
 		}
@@ -120,8 +123,12 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 
 	var lpAccountID [20]byte
 	if hasLPAccount {
+		account, ok := accountIdent(request.Account)
+		if !ok {
+			return nil, types.RpcErrorActMalformed("Account malformed.")
+		}
 		var rpcErr *types.RpcError
-		lpAccountID, _, rpcErr = readAccountRoot(ctx, ledgerIndex, accountIdent(request.Account))
+		lpAccountID, _, rpcErr = readAccountRoot(ctx, ledgerIndex, account)
 		if rpcErr != nil {
 			return nil, rpcErr
 		}
@@ -473,45 +480,21 @@ func extractIssue(raw any) (ammIssue, bool) {
 	return issue, true
 }
 
-// accountIdent extracts the string form of an account parameter; any
-// non-string value yields "", which never resolves to an account.
-func accountIdent(raw json.RawMessage) string {
+func accountIdent(raw json.RawMessage) (string, bool) {
 	var ident string
 	if err := json.Unmarshal(raw, &ident); err != nil {
-		return ""
+		return "", false
 	}
-	return ident
+	return ident, true
 }
 
-// accountFromString resolves an account identifier the way rippled's
-// RPC::accountFromString does in non-strict mode (RPCHelpers.cpp:43-85): a
-// base58 account public key, a classic address, or — as a debugging
-// convenience — anything that parses as a generic seed, whose secp256k1
-// keypair identifies the account.
 func accountFromString(ident string) ([20]byte, bool) {
 	var accountID [20]byte
-	if pubKey, err := addresscodec.DecodeAccountPublicKey(ident); err == nil {
-		copy(accountID[:], addresscodec.SHA256RIPEMD160(pubKey))
-		return accountID, true
-	}
-	if _, raw, err := addresscodec.DecodeClassicAddressToAccountID(ident); err == nil {
-		copy(accountID[:], raw)
-		return accountID, true
-	}
-
-	seed, ok := parseGenericSeed(ident)
-	if !ok {
+	_, raw, err := addresscodec.DecodeClassicAddressToAccountID(ident)
+	if err != nil || len(raw) != len(accountID) {
 		return accountID, false
 	}
-	_, pubKeyHex, err := secp256k1.Algorithm{}.DeriveKeypair(seed, false)
-	if err != nil {
-		return accountID, false
-	}
-	pubKey, err := hex.DecodeString(pubKeyHex)
-	if err != nil {
-		return accountID, false
-	}
-	copy(accountID[:], addresscodec.SHA256RIPEMD160(pubKey))
+	copy(accountID[:], raw)
 	return accountID, true
 }
 

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -993,6 +993,27 @@ type AccountQuerier interface {
 	GetAccountNFTs(ctx context.Context, account string, ledgerIndex string, limit uint32, marker string) (*AccountNFTsResult, error)
 }
 
+// AccountTxDelegateRole identifies the queried account's role in a delegated
+// transaction.
+type AccountTxDelegateRole uint8
+
+const (
+	AccountTxDelegateActor AccountTxDelegateRole = iota
+	AccountTxDelegateAuthorizer
+)
+
+// AccountTxDelegateFilter selects delegated account transactions and an
+// optional counterparty.
+type AccountTxDelegateFilter struct {
+	Role         AccountTxDelegateRole
+	Counterparty string
+}
+
+// AccountTxDelegateQuerier extends account_tx with delegation filtering.
+type AccountTxDelegateQuerier interface {
+	GetAccountTransactionsWithDelegate(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *AccountTxMarker, forward bool, delegate *AccountTxDelegateFilter) (*AccountTxResult, error)
+}
+
 // LedgerService is the full interface for ledger operations.
 // It composes the sub-interfaces and includes remaining methods.
 type LedgerService interface {

--- a/internal/testing/rpcenv/account_tx_delegate_test.go
+++ b/internal/testing/rpcenv/account_tx_delegate_test.go
@@ -1,0 +1,90 @@
+package rpcenv
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	delegatetx "github.com/LeJamon/go-xrpl/internal/tx/delegate"
+	paymenttx "github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountTxDelegateFiltering(t *testing.T) {
+	env := New(t)
+	env.EnableFeature("PermissionDelegationV1_1")
+	owner := jtx.NewAccount("owner")
+	authorizer := jtx.NewAccount("authorizer")
+	destination := jtx.NewAccount("destination")
+	env.Fund(owner, authorizer, destination)
+	env.Close()
+	ledgerMin := env.LedgerSeq()
+
+	set := delegatetx.NewDelegateSet(owner.Address)
+	set.Authorize = authorizer.Address
+	set.Permissions = []delegatetx.Permission{delegatetx.NewPermission("Payment")}
+	jtx.RequireTxSuccess(t, env.SubmitSignedWith(set, owner))
+	env.Close()
+
+	for range 2 {
+		payment := paymenttx.NewPayment(owner.Address, destination.Address, txcore.NewXRPAmount(1_000_000))
+		payment.Delegate = authorizer.Address
+		jtx.RequireTxSuccess(t, env.SubmitSignedWith(payment, authorizer))
+		env.Close()
+	}
+
+	for _, query := range []struct {
+		name         string
+		account      string
+		filter       string
+		counterparty string
+	}{
+		{name: "actor", account: owner.Address, filter: "actor", counterparty: authorizer.Address},
+		{name: "authorizer", account: authorizer.Address, filter: "authorizer", counterparty: owner.Address},
+	} {
+		t.Run(query.name, func(t *testing.T) {
+			result, rpcErr := env.RPCAs("account_tx", map[string]any{
+				"account":          query.account,
+				"forward":          true,
+				"ledger_index_min": ledgerMin,
+				"delegate": map[string]any{
+					"delegate_filter": query.filter,
+					"counter_party":   query.counterparty,
+				},
+			}, types.RoleAdmin, types.ApiVersion3)
+			require.Nil(t, rpcErr)
+			transactions := didJSONMap(t, result)["transactions"].([]any)
+			require.Len(t, transactions, 2)
+			for _, transaction := range transactions {
+				fields := transaction.(map[string]any)["tx_json"].(map[string]any)
+				require.Equal(t, owner.Address, fields["Account"])
+				require.Equal(t, authorizer.Address, fields["Delegate"])
+			}
+		})
+	}
+
+	pageOneResult, pageOneErr := env.RPCAs("account_tx", map[string]any{
+		"account":          owner.Address,
+		"forward":          true,
+		"ledger_index_min": ledgerMin,
+		"limit":            1,
+		"delegate":         map[string]any{"delegate_filter": "actor"},
+	}, types.RoleAdmin, types.ApiVersion3)
+	require.Nil(t, pageOneErr)
+	pageOne := didJSONMap(t, pageOneResult)
+	require.Len(t, pageOne["transactions"].([]any), 1)
+	marker := pageOne["marker"].(map[string]any)
+	require.Equal(t, true, marker["delegate"])
+
+	pageTwoResult, pageTwoErr := env.RPCAs("account_tx", map[string]any{
+		"account":          owner.Address,
+		"forward":          true,
+		"ledger_index_min": ledgerMin,
+		"limit":            1,
+		"marker":           marker,
+		"delegate":         map[string]any{"delegate_filter": "actor"},
+	}, types.RoleAdmin, types.ApiVersion3)
+	require.Nil(t, pageTwoErr)
+	require.Len(t, didJSONMap(t, pageTwoResult)["transactions"].([]any), 1)
+}

--- a/internal/testing/rpcenv/adapter.go
+++ b/internal/testing/rpcenv/adapter.go
@@ -19,6 +19,7 @@ import (
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/protocol"
+	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 )
 
 var errNotImplemented = errors.New("rpcenv: LedgerService method not implemented — extend the adapter when adding a consumer test")
@@ -33,6 +34,7 @@ type ledgerAdapter struct {
 }
 
 var _ types.LedgerService = (*ledgerAdapter)(nil)
+var _ types.AccountTxDelegateQuerier = (*ledgerAdapter)(nil)
 
 func newLedgerAdapter(env *jtx.TestEnv) *ledgerAdapter {
 	a := &ledgerAdapter{env: env, closedLedgers: make(map[uint32]*ledger.Ledger)}
@@ -418,6 +420,14 @@ func (a *ledgerAdapter) GetAccountOffers(_ context.Context, _ string, _ string, 
 }
 
 func (a *ledgerAdapter) GetAccountTransactions(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {
+	return a.getAccountTransactions(ctx, account, ledgerMin, ledgerMax, limit, marker, forward, nil)
+}
+
+func (a *ledgerAdapter) GetAccountTransactionsWithDelegate(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool, delegate *types.AccountTxDelegateFilter) (*types.AccountTxResult, error) {
+	return a.getAccountTransactions(ctx, account, ledgerMin, ledgerMax, limit, marker, forward, delegate)
+}
+
+func (a *ledgerAdapter) getAccountTransactions(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool, delegate *types.AccountTxDelegateFilter) (*types.AccountTxResult, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -425,9 +435,12 @@ func (a *ledgerAdapter) GetAccountTransactions(ctx context.Context, account stri
 	if closed == nil {
 		return nil, errors.New("rpcenv: no closed ledger available")
 	}
-	if _, _, err := addresscodec.DecodeClassicAddressToAccountID(account); err != nil {
+	_, rawAccount, err := addresscodec.DecodeClassicAddressToAccountID(account)
+	if err != nil || len(rawAccount) != len(relationaldb.AccountID{}) {
 		return nil, fmt.Errorf("%w: %v", svcerr.ErrAccountMalformed, err)
 	}
+	var accountID relationaldb.AccountID
+	copy(accountID[:], rawAccount)
 	if limit == 0 {
 		limit = 200
 	}
@@ -508,7 +521,10 @@ func (a *ledgerAdapter) GetAccountTransactions(ctx context.Context, account stri
 		found := false
 		for i := range transactions {
 			if transactions[i].LedgerIndex == marker.LedgerSeq && transactions[i].TxnSeq == marker.TxnSeq {
-				start = i + 1
+				start = i
+				if delegate == nil {
+					start++
+				}
 				found = true
 				break
 			}
@@ -517,12 +533,78 @@ func (a *ledgerAdapter) GetAccountTransactions(ctx context.Context, account stri
 			return nil, errors.New("rpcenv: account_tx marker not found")
 		}
 	}
+	if delegate != nil {
+		return filterRPCEnvAccountTransactions(account, accountID, result, transactions[start:], limit, marker, delegate)
+	}
+
 	end := min(start+int(limit), len(transactions))
 	result.Transactions = transactions[start:end]
 	if end < len(transactions) && end > start {
 		last := transactions[end-1]
 		result.Marker = &types.AccountTxMarker{LedgerSeq: last.LedgerIndex, TxnSeq: last.TxnSeq}
 	}
+	return result, nil
+}
+
+func filterRPCEnvAccountTransactions(account string, accountID relationaldb.AccountID, result *types.AccountTxResult, transactions []types.AccountTransaction, limit uint32, marker *types.AccountTxMarker, delegate *types.AccountTxDelegateFilter) (*types.AccountTxResult, error) {
+	filter := &relationaldb.AccountTxDelegateFilter{Role: relationaldb.AccountTxDelegateActor}
+	if delegate.Role == types.AccountTxDelegateAuthorizer {
+		filter.Role = relationaldb.AccountTxDelegateAuthorizer
+	}
+	if delegate.Counterparty != "" {
+		_, rawCounterparty, err := addresscodec.DecodeClassicAddressToAccountID(delegate.Counterparty)
+		if err != nil || len(rawCounterparty) != len(relationaldb.AccountID{}) {
+			return nil, fmt.Errorf("%w: %v", svcerr.ErrAccountMalformed, err)
+		}
+		var counterparty relationaldb.AccountID
+		copy(counterparty[:], rawCounterparty)
+		filter.Counterparty = &counterparty
+	}
+
+	scanEnd := min(int(limit)+1, len(transactions))
+	scanned := make([]relationaldb.TransactionInfo, scanEnd)
+	for index, transaction := range transactions[:scanEnd] {
+		scanned[index] = relationaldb.TransactionInfo{
+			Hash:      relationaldb.Hash(transaction.Hash),
+			LedgerSeq: relationaldb.LedgerIndex(transaction.LedgerIndex),
+			TxnSeq:    transaction.TxnSeq,
+			RawTxn:    transaction.TxBlob,
+			TxnMeta:   transaction.Meta,
+		}
+	}
+	var relationalMarker *relationaldb.AccountTxMarker
+	if marker != nil {
+		relationalMarker = &relationaldb.AccountTxMarker{
+			LedgerSeq: relationaldb.LedgerIndex(marker.LedgerSeq),
+			TxnSeq:    marker.TxnSeq,
+		}
+	}
+	page, err := relationaldb.BuildAccountTxPage("rpcenv_account_tx", relationaldb.AccountTxPageOptions{
+		Account:  accountID,
+		Marker:   relationalMarker,
+		Limit:    limit,
+		Delegate: filter,
+	}, scanned)
+	if err != nil {
+		return nil, err
+	}
+	result.Transactions = make([]types.AccountTransaction, len(page.Transactions))
+	for index, transaction := range page.Transactions {
+		result.Transactions[index] = types.AccountTransaction{
+			Hash:        [32]byte(transaction.Hash),
+			LedgerIndex: uint32(transaction.LedgerSeq),
+			TxnSeq:      transaction.TxnSeq,
+			TxBlob:      transaction.RawTxn,
+			Meta:        transaction.TxnMeta,
+		}
+	}
+	if page.Marker != nil {
+		result.Marker = &types.AccountTxMarker{
+			LedgerSeq: uint32(page.Marker.LedgerSeq),
+			TxnSeq:    page.Marker.TxnSeq,
+		}
+	}
+	result.Account = account
 	return result, nil
 }
 

--- a/internal/testing/rpcenv/amm_info_test.go
+++ b/internal/testing/rpcenv/amm_info_test.go
@@ -339,44 +339,42 @@ func TestAMMInfo_PresenceSemantics(t *testing.T) {
 	})
 }
 
-// TestAMMInfo_AccountIdentForms verifies the account param accepts the
-// identifier forms rippled's non-strict accountFromString does: a base58
-// account public key and a seed/passphrase (RPCHelpers.cpp:43-85).
-func TestAMMInfo_AccountIdentForms(t *testing.T) {
+func TestAMMInfo_AccountFieldsRequireClassicAddresses(t *testing.T) {
 	amm.TestAMM(t, nil, 0, func(ammEnv *amm.AMMTestEnv, ammAcc *jtx.Account) {
 		env := rpcenv.Wrap(t, ammEnv.TestEnv)
 
-		lpToken := func(ident string) map[string]any {
+		expectMalformed := func(params map[string]any) {
 			t.Helper()
-			result, rpcErr := env.RPC("amm_info", map[string]any{
-				"asset":   map[string]any{"currency": "XRP"},
-				"asset2":  map[string]any{"currency": "USD", "issuer": ammEnv.GW.Address},
-				"account": ident,
-			})
-			if rpcErr != nil {
-				t.Fatalf("amm_info(account=%q): %s (code=%d)", ident, rpcErr.Message, rpcErr.Code)
+			_, rpcErr := env.RPCAs("amm_info", params, types.RoleAdmin, types.ApiVersion3)
+			if rpcErr == nil {
+				t.Fatalf("amm_info(%#v): expected error, got nil", params)
 			}
-			tok, ok := result.(map[string]any)["amm"].(map[string]any)["lp_token"].(map[string]any)
-			if !ok {
-				t.Fatalf("amm_info(account=%q): missing lp_token", ident)
+			if rpcErr.Code != types.RpcACT_MALFORMED || rpcErr.Message != "Account malformed." {
+				t.Errorf("amm_info(%#v) = %q (code=%d), want actMalformed",
+					params, rpcErr.Message, rpcErr.Code)
 			}
-			return tok
 		}
-
-		byAddress := lpToken(ammEnv.Alice.Address)
 
 		alicePubKey, err := addresscodec.EncodeAccountPublicKey(ammEnv.Alice.PublicKey)
 		if err != nil {
 			t.Fatalf("encode alice public key: %v", err)
 		}
-		if got := lpToken(alicePubKey); got["value"] != byAddress["value"] {
-			t.Errorf("lp_token via public key = %#v, want %#v", got, byAddress)
+		pair := map[string]any{
+			"asset":  map[string]any{"currency": "XRP"},
+			"asset2": map[string]any{"currency": "USD", "issuer": ammEnv.GW.Address},
+		}
+		for _, ident := range []string{alicePubKey, ammEnv.Alice.Name} {
+			params := maps.Clone(pair)
+			params["account"] = ident
+			expectMalformed(params)
+			expectMalformed(map[string]any{"amm_account": ident})
 		}
 
-		// Test accounts derive from sha512half(name), the same derivation
-		// rippled applies to a passphrase identifier.
-		if got := lpToken(ammEnv.Alice.Name); got["value"] != byAddress["value"] {
-			t.Errorf("lp_token via passphrase = %#v, want %#v", got, byAddress)
+		for _, value := range []any{nil, true, 42, []any{}, map[string]any{}} {
+			params := maps.Clone(pair)
+			params["account"] = value
+			expectMalformed(params)
+			expectMalformed(map[string]any{"amm_account": value})
 		}
 	})
 }

--- a/storage/relationaldb/account_tx.go
+++ b/storage/relationaldb/account_tx.go
@@ -1,0 +1,129 @@
+package relationaldb
+
+import (
+	"fmt"
+
+	"github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+)
+
+// BuildAccountTxPage applies account_tx pagination semantics to the bounded
+// rows returned by a relational backend.
+func BuildAccountTxPage(opName string, options AccountTxPageOptions, scanned []TransactionInfo) (*AccountTxResult, error) {
+	result := &AccountTxResult{
+		LedgerRange: LedgerRange{Min: options.MinLedger, Max: options.MaxLedger},
+		Limit:       options.Limit,
+	}
+
+	if options.Delegate == nil {
+		result.Transactions = scanned
+		if uint64(len(scanned)) > uint64(options.Limit) {
+			result.Transactions = scanned[:options.Limit]
+			if len(result.Transactions) > 0 {
+				last := result.Transactions[len(result.Transactions)-1]
+				result.Marker = accountTxMarker(last)
+			}
+		}
+		return result, nil
+	}
+
+	fetchedRows := len(scanned)
+	lastScanned := accountTxMarkerFromRows(scanned)
+	if options.Marker != nil {
+		markerIndex := -1
+		for index, transaction := range scanned {
+			if transaction.LedgerSeq == options.Marker.LedgerSeq && transaction.TxnSeq == options.Marker.TxnSeq {
+				markerIndex = index
+				break
+			}
+		}
+		if markerIndex < 0 {
+			return result, nil
+		}
+		scanned = scanned[markerIndex+1:]
+	}
+
+	result.Transactions = make([]TransactionInfo, 0, min(len(scanned), int(options.Limit)))
+	var lastEmitted *AccountTxMarker
+	for _, transaction := range scanned {
+		matches, err := matchesAccountTxDelegate(transaction.RawTxn, options.Account, *options.Delegate)
+		if err != nil {
+			return nil, NewDataError(opName, fmt.Sprintf("malformed transaction while applying delegate filter: %v", err), ErrInvalidData)
+		}
+		if !matches {
+			continue
+		}
+		if uint64(len(result.Transactions)) == uint64(options.Limit) {
+			result.Marker = lastEmitted
+			break
+		}
+		result.Transactions = append(result.Transactions, transaction)
+		lastEmitted = accountTxMarker(transaction)
+	}
+
+	if result.Marker == nil && uint64(fetchedRows) == uint64(options.Limit)+1 {
+		result.Marker = lastScanned
+	}
+	return result, nil
+}
+
+func accountTxMarker(transaction TransactionInfo) *AccountTxMarker {
+	return &AccountTxMarker{LedgerSeq: transaction.LedgerSeq, TxnSeq: transaction.TxnSeq}
+}
+
+func accountTxMarkerFromRows(transactions []TransactionInfo) *AccountTxMarker {
+	if len(transactions) == 0 {
+		return nil
+	}
+	return accountTxMarker(transactions[len(transactions)-1])
+}
+
+func matchesAccountTxDelegate(rawTransaction []byte, account AccountID, filter AccountTxDelegateFilter) (bool, error) {
+	if len(rawTransaction) == 0 {
+		return false, nil
+	}
+	transaction, err := binarycodec.DecodeBytes(rawTransaction)
+	if err != nil {
+		return false, err
+	}
+	owner, err := accountTxAccountID(transaction["Account"], "Account")
+	if err != nil {
+		return false, err
+	}
+	delegateValue, present := transaction["Delegate"]
+	if !present {
+		return false, nil
+	}
+	delegate, err := accountTxAccountID(delegateValue, "Delegate")
+	if err != nil {
+		return false, err
+	}
+
+	switch filter.Role {
+	case AccountTxDelegateActor:
+		return owner == account && delegate != account &&
+			(filter.Counterparty == nil || delegate == *filter.Counterparty), nil
+	case AccountTxDelegateAuthorizer:
+		return delegate == account && owner != account &&
+			(filter.Counterparty == nil || owner == *filter.Counterparty), nil
+	default:
+		return false, fmt.Errorf("invalid delegate role %d", filter.Role)
+	}
+}
+
+func accountTxAccountID(value any, field string) (AccountID, error) {
+	address, ok := value.(string)
+	if !ok {
+		return AccountID{}, fmt.Errorf("%s is not an account", field)
+	}
+	_, raw, err := addresscodec.DecodeClassicAddressToAccountID(address)
+	if err != nil {
+		return AccountID{}, fmt.Errorf("decode %s: %w", field, err)
+	}
+	if len(raw) != len(AccountID{}) {
+		return AccountID{}, fmt.Errorf("decode %s: account ID has length %d", field, len(raw))
+	}
+	var account AccountID
+	copy(account[:], raw)
+	return account, nil
+}

--- a/storage/relationaldb/interface.go
+++ b/storage/relationaldb/interface.go
@@ -65,6 +65,7 @@ type AccountTxMarker struct {
 // queried account occupies.
 type AccountTxDelegateRole uint8
 
+// Account transaction delegate roles.
 const (
 	AccountTxDelegateActor AccountTxDelegateRole = iota
 	AccountTxDelegateAuthorizer

--- a/storage/relationaldb/interface.go
+++ b/storage/relationaldb/interface.go
@@ -61,13 +61,30 @@ type AccountTxMarker struct {
 	TxnSeq    uint32      `json:"txn_seq"`
 }
 
+// AccountTxDelegateRole identifies which side of a delegated transaction the
+// queried account occupies.
+type AccountTxDelegateRole uint8
+
+const (
+	AccountTxDelegateActor AccountTxDelegateRole = iota
+	AccountTxDelegateAuthorizer
+)
+
+// AccountTxDelegateFilter limits account transaction results to delegated
+// transactions, optionally involving one counterparty.
+type AccountTxDelegateFilter struct {
+	Role         AccountTxDelegateRole `json:"role"`
+	Counterparty *AccountID            `json:"counterparty,omitempty"`
+}
+
 // AccountTxPageOptions contains criteria for paginated account transaction queries
 type AccountTxPageOptions struct {
-	Account   AccountID        `json:"account"`
-	MinLedger LedgerIndex      `json:"min_ledger"`
-	MaxLedger LedgerIndex      `json:"max_ledger"`
-	Marker    *AccountTxMarker `json:"marker,omitempty"`
-	Limit     uint32           `json:"limit"`
+	Account   AccountID                `json:"account"`
+	MinLedger LedgerIndex              `json:"min_ledger"`
+	MaxLedger LedgerIndex              `json:"max_ledger"`
+	Marker    *AccountTxMarker         `json:"marker,omitempty"`
+	Limit     uint32                   `json:"limit"`
+	Delegate  *AccountTxDelegateFilter `json:"delegate,omitempty"`
 }
 
 // AccountTxResult contains the result of an account transaction query

--- a/storage/relationaldb/internal/contracttest/contract.go
+++ b/storage/relationaldb/internal/contracttest/contract.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 )
 
@@ -258,6 +260,9 @@ func Run(t *testing.T, factory Factory) {
 	})
 	t.Run("account transaction repository", func(t *testing.T) {
 		runAccountTransactionRepository(t, factory)
+	})
+	t.Run("delegate account transaction repository", func(t *testing.T) {
+		runDelegateAccountTransactionRepository(t, factory)
 	})
 	t.Run("validation repository", func(t *testing.T) {
 		runValidationRepository(t, factory)
@@ -581,6 +586,148 @@ func runAccountTransactionRepository(t *testing.T, factory Factory) {
 	}
 }
 
+func runDelegateAccountTransactionRepository(t *testing.T, factory Factory) {
+	t.Helper()
+	ctx := context.Background()
+	manager := factory(t)
+	repository := manager.AccountTransaction()
+	transactionRepository := manager.Transaction()
+
+	ownerAddress, owner := encodedAccount(t, 1)
+	delegateAddress, delegate := encodedAccount(t, 2)
+	otherDelegateAddress, otherDelegate := encodedAccount(t, 3)
+	transactions := []relationaldb.TransactionInfo{
+		accountTransaction(t, 60, 20, 1, ownerAddress, ""),
+		accountTransaction(t, 61, 21, 1, ownerAddress, delegateAddress),
+		accountTransaction(t, 62, 22, 1, ownerAddress, ""),
+		accountTransaction(t, 63, 23, 1, ownerAddress, delegateAddress),
+		accountTransaction(t, 64, 24, 1, ownerAddress, otherDelegateAddress),
+	}
+	for index, transaction := range transactions {
+		if err := transactionRepository.SaveTransaction(ctx, transaction); err != nil {
+			t.Fatal(err)
+		}
+		if err := repository.SaveAccountTransaction(ctx, owner, transaction); err != nil {
+			t.Fatal(err)
+		}
+		if index == 1 || index == 3 {
+			if err := repository.SaveAccountTransaction(ctx, delegate, transaction); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if index == 4 {
+			if err := repository.SaveAccountTransaction(ctx, otherDelegate, transaction); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	actorOptions := relationaldb.AccountTxPageOptions{
+		Account: owner,
+		Limit:   2,
+		Delegate: &relationaldb.AccountTxDelegateFilter{
+			Role:         relationaldb.AccountTxDelegateActor,
+			Counterparty: &delegate,
+		},
+	}
+	first, err := repository.GetOldestAccountTxsPage(ctx, actorOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAccountPage(t, first, actorOptions, transactions[1])
+	assertMarker(t, first.Marker, 22, 1)
+	actorOptions.Marker = first.Marker
+	second, err := repository.GetOldestAccountTxsPage(ctx, actorOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAccountPage(t, second, actorOptions, transactions[3])
+	assertMarker(t, second.Marker, 24, 1)
+	actorOptions.Marker = second.Marker
+	third, err := repository.GetOldestAccountTxsPage(ctx, actorOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAccountPage(t, third, actorOptions)
+	if third.Marker != nil {
+		t.Fatalf("last filtered page marker = %+v, want nil", third.Marker)
+	}
+
+	authorizerOptions := relationaldb.AccountTxPageOptions{
+		Account:  delegate,
+		Limit:    1,
+		Delegate: &relationaldb.AccountTxDelegateFilter{Role: relationaldb.AccountTxDelegateAuthorizer},
+	}
+	first, err = repository.GetOldestAccountTxsPage(ctx, authorizerOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAccountPage(t, first, authorizerOptions, transactions[1])
+	assertMarker(t, first.Marker, 21, 1)
+	authorizerOptions.Marker = first.Marker
+	second, err = repository.GetOldestAccountTxsPage(ctx, authorizerOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAccountPage(t, second, authorizerOptions, transactions[3])
+	assertMarker(t, second.Marker, 23, 1)
+	authorizerOptions.Marker = second.Marker
+	third, err = repository.GetOldestAccountTxsPage(ctx, authorizerOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAccountPage(t, third, authorizerOptions)
+	if third.Marker != nil {
+		t.Fatalf("last authorizer page marker = %+v, want nil", third.Marker)
+	}
+
+	reverseOptions := relationaldb.AccountTxPageOptions{
+		Account:  owner,
+		Limit:    2,
+		Delegate: &relationaldb.AccountTxDelegateFilter{Role: relationaldb.AccountTxDelegateActor},
+	}
+	reverse, err := repository.GetNewestAccountTxsPage(ctx, reverseOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAccountPage(t, reverse, reverseOptions, transactions[4], transactions[3])
+	assertMarker(t, reverse.Marker, 22, 1)
+	reverseOptions.Marker = reverse.Marker
+	reverse, err = repository.GetNewestAccountTxsPage(ctx, reverseOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAccountPage(t, reverse, reverseOptions, transactions[1])
+	assertMarker(t, reverse.Marker, 20, 1)
+	reverseOptions.Marker = reverse.Marker
+	reverse, err = repository.GetNewestAccountTxsPage(ctx, reverseOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAccountPage(t, reverse, reverseOptions)
+	if reverse.Marker != nil {
+		t.Fatalf("last reverse page marker = %+v, want nil", reverse.Marker)
+	}
+
+	corrupt := transactionAt(65, 25, 1)
+	if err := transactionRepository.SaveTransaction(ctx, corrupt); err != nil {
+		t.Fatal(err)
+	}
+	if err := repository.SaveAccountTransaction(ctx, owner, corrupt); err != nil {
+		t.Fatal(err)
+	}
+	_, err = repository.GetOldestAccountTxsPage(ctx, relationaldb.AccountTxPageOptions{
+		Account:   owner,
+		MinLedger: 25,
+		MaxLedger: 25,
+		Limit:     1,
+		Delegate:  &relationaldb.AccountTxDelegateFilter{Role: relationaldb.AccountTxDelegateActor},
+	})
+	if !errors.Is(err, relationaldb.ErrInvalidData) {
+		t.Fatalf("corrupt delegated transaction error = %v, want ErrInvalidData", err)
+	}
+}
+
 func runValidationRepository(t *testing.T, factory Factory) {
 	t.Helper()
 	ctx := context.Background()
@@ -835,6 +982,37 @@ func accountID(value byte) relationaldb.AccountID {
 	var result relationaldb.AccountID
 	result[0] = value
 	result[len(result)-1] = value
+	return result
+}
+
+func encodedAccount(t *testing.T, value byte) (string, relationaldb.AccountID) {
+	t.Helper()
+	account := accountID(value)
+	address, err := addresscodec.EncodeAccountIDToClassicAddress(account[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	return address, account
+}
+
+func accountTransaction(t *testing.T, hashByte byte, ledgerSeq relationaldb.LedgerIndex, txnSeq uint32, account, delegate string) relationaldb.TransactionInfo {
+	t.Helper()
+	transaction := map[string]any{
+		"TransactionType": "AccountSet",
+		"Account":         account,
+		"Fee":             "10",
+		"Sequence":        uint32(hashByte),
+		"SigningPubKey":   "",
+	}
+	if delegate != "" {
+		transaction["Delegate"] = delegate
+	}
+	raw, err := binarycodec.EncodeBytes(transaction)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := transactionAt(hashByte, ledgerSeq, txnSeq)
+	result.RawTxn = raw
 	return result
 }
 

--- a/storage/relationaldb/postgres/account_repository.go
+++ b/storage/relationaldb/postgres/account_repository.go
@@ -95,8 +95,12 @@ func (r *accountTransactionRepository) queryAccountTxsPage(ctx context.Context, 
 	if options.Marker != nil {
 		args = append(args, options.Marker.LedgerSeq, options.Marker.TxnSeq)
 		seqArg, txnArg := len(args)-1, len(args)
+		sequenceCmp := markerCmp
+		if options.Delegate != nil {
+			sequenceCmp += "="
+		}
 		query += fmt.Sprintf(" AND (at.ledger_seq %s $%d OR (at.ledger_seq = $%d AND at.txn_seq %s $%d))",
-			markerCmp, seqArg, seqArg, markerCmp, txnArg)
+			markerCmp, seqArg, seqArg, sequenceCmp, txnArg)
 	}
 
 	query += " ORDER BY at.ledger_seq " + orderDir + ", at.txn_seq " + orderDir
@@ -116,28 +120,7 @@ func (r *accountTransactionRepository) queryAccountTxsPage(ctx context.Context, 
 		return nil, err
 	}
 
-	result := &relationaldb.AccountTxResult{
-		LedgerRange: relationaldb.LedgerRange{
-			Min: options.MinLedger,
-			Max: options.MaxLedger,
-		},
-		Limit: options.Limit,
-	}
-
-	// Check if there are more results
-	if uint64(len(transactions)) > uint64(options.Limit) {
-		transactions = transactions[:len(transactions)-1]
-		if len(transactions) > 0 {
-			lastTx := transactions[len(transactions)-1]
-			result.Marker = &relationaldb.AccountTxMarker{
-				LedgerSeq: lastTx.LedgerSeq,
-				TxnSeq:    lastTx.TxnSeq,
-			}
-		}
-	}
-
-	result.Transactions = transactions
-	return result, nil
+	return relationaldb.BuildAccountTxPage(opName, options, transactions)
 }
 
 // GetOldestAccountTxsPage returns a marker-paginated page of an account's

--- a/storage/relationaldb/sqlite/account_repository.go
+++ b/storage/relationaldb/sqlite/account_repository.go
@@ -55,8 +55,11 @@ func (r *accountTransactionRepository) queryAccountTxsPage(ctx context.Context, 
 	}
 
 	if options.Marker != nil {
-		// For ASC: > marker; for DESC: < marker
-		query += " AND (at.ledger_seq " + markerCmp + " ? OR (at.ledger_seq = ? AND at.txn_seq " + markerCmp + " ?))"
+		sequenceCmp := markerCmp
+		if options.Delegate != nil {
+			sequenceCmp += "="
+		}
+		query += " AND (at.ledger_seq " + markerCmp + " ? OR (at.ledger_seq = ? AND at.txn_seq " + sequenceCmp + " ?))"
 		args = append(args, options.Marker.LedgerSeq, options.Marker.LedgerSeq, options.Marker.TxnSeq)
 	}
 
@@ -92,27 +95,7 @@ func (r *accountTransactionRepository) queryAccountTxsPage(ctx context.Context, 
 		return nil, relationaldb.NewQueryError(opName, "error iterating rows", err)
 	}
 
-	result := &relationaldb.AccountTxResult{
-		LedgerRange: relationaldb.LedgerRange{
-			Min: options.MinLedger,
-			Max: options.MaxLedger,
-		},
-		Limit: options.Limit,
-	}
-
-	if uint64(len(transactions)) > uint64(options.Limit) {
-		transactions = transactions[:len(transactions)-1]
-		if len(transactions) > 0 {
-			lastTx := transactions[len(transactions)-1]
-			result.Marker = &relationaldb.AccountTxMarker{
-				LedgerSeq: lastTx.LedgerSeq,
-				TxnSeq:    lastTx.TxnSeq,
-			}
-		}
-	}
-
-	result.Transactions = transactions
-	return result, nil
+	return relationaldb.BuildAccountTxPage(opName, options, transactions)
 }
 
 // GetOldestAccountTxsPage returns a marker-paginated page of an account's


### PR DESCRIPTION
## Summary

- add `account_tx` delegate filtering for actor and authorizer roles, including optional counterparties
- preserve rippled's bounded relational scan and delegate-marker continuation semantics in both directions
- require classic account addresses for `amm_info` `account` and `amm_account`
- cover handler validation, repository paging, and end-to-end delegated transactions

## Test plan

- [x] `just test`
- [x] `just test-core`
- [x] `just test-libs`
- [x] `just test-integration`
- [x] `just vet`
- [x] `just lint`
- [x] `just build-all`
- [x] `just docs-check`
- [x] `git diff --check`
- [ ] `just conformance AccountTx` / `just conformance AMMInfo` (no matching runnable fixtures; each filter skipped one test and ran zero)

Fixes #1596
