### PR TITLE
feat: stage VaultDelete MemoData

### DIFF
--- a/amendment/registry.go
+++ b/amendment/registry.go
@@ -30,6 +30,7 @@ var (
 var (
 	FeatureSponsor                       = registerFeature("Sponsor", SupportedYes, VoteDefaultNo)
 	FeatureBatchV1_1                     = registerFeature("BatchV1_1", SupportedYes, VoteDefaultNo)
+	FeatureLendingProtocolV1_1           = registerFeature("LendingProtocolV1_1", SupportedNo, VoteDefaultNo)
 	FeatureFixCleanup3_2_0               = registerFix("fixCleanup3_2_0", SupportedYes, VoteDefaultNo)
 	FeatureFixCleanup3_1_3               = registerFix("fixCleanup3_1_3", SupportedYes, VoteDefaultYes)
 	FeatureMPTokensV2                    = registerFeature("MPTokensV2", SupportedNo, VoteDefaultNo)

--- a/docs/amendments.md
+++ b/docs/amendments.md
@@ -7,7 +7,7 @@ XRPL amendments known to this node, generated from the amendment registry
 amendment's behavior; **Default vote** is whether the node votes for it by
 default (operators override via the `[amendments]` config section).
 
-Total: 108 amendments.
+Total: 109 amendments.
 
 | Amendment | Supported | Default vote |
 |-----------|-----------|--------------|
@@ -40,6 +40,7 @@ Total: 108 amendments.
 | `ImmediateOfferKilled` | yes | no |
 | `InvariantsV1_1` | no | no |
 | `LendingProtocol` | yes | no |
+| `LendingProtocolV1_1` | no | no |
 | `MPTokensV1` | yes | no |
 | `MPTokensV2` | no | no |
 | `MultiSign` | yes | no |

--- a/internal/testing/vault/vault_delete_memodata_test.go
+++ b/internal/testing/vault/vault_delete_memodata_test.go
@@ -1,0 +1,77 @@
+package vault_test
+
+import (
+	"strings"
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/vault"
+)
+
+func TestVaultDeleteMemoData(t *testing.T) {
+	env := newVaultEnv(t)
+	owner := jtx.NewAccount("owner")
+	env.Fund(owner)
+
+	missingID := strings.Repeat("01", 32)
+	maximumData := strings.Repeat("AA", vault.MaxVaultDataLength)
+
+	sequenceBefore := env.Seq(owner)
+	balanceBefore := env.Balance(owner)
+	disabled := vault.NewVaultDelete(owner.Address, missingID)
+	disabled.MemoData = maximumData
+	disabledResult := env.Submit(disabled)
+	jtx.RequireTxFail(t, disabledResult, jtx.TemDISABLED)
+	if disabledResult.Applied || disabledResult.Metadata != nil || disabledResult.Fee != 0 {
+		t.Fatalf("temDISABLED result committed effects: %+v", disabledResult)
+	}
+	if got := env.Seq(owner); got != sequenceBefore {
+		t.Fatalf("sequence after temDISABLED = %d, want %d", got, sequenceBefore)
+	}
+	if got := env.Balance(owner); got != balanceBefore {
+		t.Fatalf("balance after temDISABLED = %d, want %d", got, balanceBefore)
+	}
+
+	env.EnableFeature("LendingProtocolV1_1")
+	env.Close()
+
+	empty := vault.NewVaultDelete(owner.Address, missingID)
+	empty.Common.SetPresentFields(map[string]bool{"MemoData": true})
+	emptyResult := env.Submit(empty)
+	jtx.RequireTxFail(t, emptyResult, jtx.TemMALFORMED)
+	if emptyResult.Applied || emptyResult.Metadata != nil || emptyResult.Fee != 0 {
+		t.Fatalf("empty MemoData committed effects: %+v", emptyResult)
+	}
+	if got := env.Seq(owner); got != sequenceBefore {
+		t.Fatalf("sequence after empty MemoData = %d, want %d", got, sequenceBefore)
+	}
+
+	noEntry := vault.NewVaultDelete(owner.Address, missingID)
+	noEntry.MemoData = maximumData
+	noEntryResult := env.Submit(noEntry)
+	jtx.RequireTxClaimed(t, noEntryResult, jtx.TecNO_ENTRY)
+	if !noEntryResult.Applied || noEntryResult.Metadata == nil || noEntryResult.Fee == 0 {
+		t.Fatalf("tecNO_ENTRY did not claim normal fee/sequence effects: %+v", noEntryResult)
+	}
+	if got := env.Seq(owner); got != sequenceBefore+1 {
+		t.Fatalf("sequence after tecNO_ENTRY = %d, want %d", got, sequenceBefore+1)
+	}
+
+	createSequence := env.Seq(owner)
+	create := vault.NewVaultCreate(owner.Address, tx.Asset{Currency: "XRP"})
+	create.Common.Fee = createFee
+	jtx.RequireTxSuccess(t, env.Submit(create))
+	id := vaultID(owner, createSequence)
+
+	deleteTx := vault.NewVaultDelete(owner.Address, id)
+	deleteTx.MemoData = maximumData
+	deleteResult := env.Submit(deleteTx)
+	jtx.RequireTxSuccess(t, deleteResult)
+	if deleteResult.Metadata == nil {
+		t.Fatal("successful VaultDelete with MemoData returned no metadata")
+	}
+	if env.VaultExists(id) {
+		t.Fatal("vault still exists after VaultDelete with MemoData")
+	}
+}

--- a/internal/tx/engine/vault_delete_memodata_preflight_test.go
+++ b/internal/tx/engine/vault_delete_memodata_preflight_test.go
@@ -1,0 +1,76 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/internal/tx/vault"
+)
+
+func TestVaultDeleteMemoDataPreflightPrecedence(t *testing.T) {
+	off := amendment.NewRules([][32]byte{amendment.FeatureSingleAssetVault})
+	on := amendment.NewRules([][32]byte{
+		amendment.FeatureSingleAssetVault,
+		amendment.FeatureLendingProtocolV1_1,
+	})
+	validVaultID := strings.Repeat("01", 32)
+
+	newDelete := func(rules *amendment.Rules) (*Engine, *vault.VaultDelete) {
+		deleteTx := vault.NewVaultDelete(precedenceSourceAddr, validVaultID)
+		deleteTx.Fee = "10"
+		deleteTx.Sequence = u32(5)
+		deleteTx.MemoData = "AA"
+		return preflightEngine(rules), deleteTx
+	}
+
+	t.Run("bad fee precedes amendment gate", func(t *testing.T) {
+		engine, deleteTx := newDelete(off)
+		deleteTx.Fee = "-1"
+		if got := engine.preflight(deleteTx); got != ter.TemBAD_FEE {
+			t.Fatalf("preflight() = %v, want temBAD_FEE", got)
+		}
+	})
+
+	t.Run("invalid flags precede amendment gate", func(t *testing.T) {
+		engine, deleteTx := newDelete(off)
+		flags := uint32(0x00010000)
+		deleteTx.Flags = &flags
+		if got := engine.preflight(deleteTx); got != ter.TemINVALID_FLAG {
+			t.Fatalf("preflight() = %v, want temINVALID_FLAG", got)
+		}
+	})
+
+	t.Run("zero VaultID precedes amendment gate", func(t *testing.T) {
+		engine, deleteTx := newDelete(off)
+		deleteTx.VaultID = strings.Repeat("00", 32)
+		if got := engine.preflight(deleteTx); got != ter.TemMALFORMED {
+			t.Fatalf("preflight() = %v, want temMALFORMED", got)
+		}
+	})
+
+	t.Run("amendment gate precedes length", func(t *testing.T) {
+		engine, deleteTx := newDelete(off)
+		deleteTx.MemoData = strings.Repeat("AA", vault.MaxVaultDataLength+1)
+		if got := engine.preflight(deleteTx); got != ter.TemDISABLED {
+			t.Fatalf("preflight() = %v, want temDISABLED", got)
+		}
+	})
+
+	t.Run("enabled amendment reaches length check", func(t *testing.T) {
+		engine, deleteTx := newDelete(on)
+		deleteTx.MemoData = strings.Repeat("AA", vault.MaxVaultDataLength+1)
+		if got := engine.preflight(deleteTx); got != ter.TemMALFORMED {
+			t.Fatalf("preflight() = %v, want temMALFORMED", got)
+		}
+	})
+
+	t.Run("absent field does not require amendment", func(t *testing.T) {
+		engine, deleteTx := newDelete(off)
+		deleteTx.MemoData = ""
+		if got := engine.preflight(deleteTx); got != ter.TesSUCCESS {
+			t.Fatalf("preflight() = %v, want tesSUCCESS", got)
+		}
+	})
+}

--- a/internal/tx/template.go
+++ b/internal/tx/template.go
@@ -397,6 +397,7 @@ var txTemplates = map[Type][]templateField{
 	},
 	TypeVaultDelete: {
 		{name: "VaultID", style: soeREQUIRED},
+		{name: "MemoData", style: soeOPTIONAL},
 	},
 	TypeVaultDeposit: {
 		{name: "VaultID", style: soeREQUIRED},

--- a/internal/tx/vault/vault_create.go
+++ b/internal/tx/vault/vault_create.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	codecTypes "github.com/LeJamon/go-xrpl/codec/binarycodec/types"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
@@ -417,7 +418,7 @@ func (v *VaultCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 
 // decodeBlob decodes a hex-encoded Blob field to its raw bytes.
 func decodeBlob(s string) ([]byte, error) {
-	return hex.DecodeString(s)
+	return (&codecTypes.Blob{}).FromJSON(s)
 }
 
 // isZeroHash reports whether s is a valid 64-char hex string decoding to the

--- a/internal/tx/vault/vault_delete.go
+++ b/internal/tx/vault/vault_delete.go
@@ -16,6 +16,8 @@ type VaultDelete struct {
 
 	// VaultID is the ID of the vault to delete (required)
 	VaultID string `json:"VaultID" xrpl:"VaultID"`
+
+	MemoData string `json:"MemoData,omitempty" xrpl:"MemoData,omitempty"`
 }
 
 // NewVaultDelete creates a new VaultDelete transaction
@@ -38,6 +40,14 @@ func (v *VaultDelete) GetFlagsMask(rules *amendment.Rules) uint32 {
 }
 
 func (v *VaultDelete) Validate() error {
+	return v.validate(nil)
+}
+
+func (v *VaultDelete) PreflightWithRules(rules *amendment.Rules) error {
+	return v.validate(rules)
+}
+
+func (v *VaultDelete) validate(rules *amendment.Rules) error {
 	if err := v.BaseTx.Validate(); err != nil {
 		return err
 	}
@@ -51,6 +61,16 @@ func (v *VaultDelete) Validate() error {
 			return ErrVaultIDZero
 		}
 		return ter.Errorf(ter.TemMALFORMED, "VaultID must be a valid 256-bit hash")
+	}
+
+	if v.MemoData != "" || v.Common.HasField("MemoData") {
+		if rules != nil && !rules.Enabled(amendment.FeatureLendingProtocolV1_1) {
+			return ter.Errorf(ter.TemDISABLED, "LendingProtocolV1_1 amendment is disabled")
+		}
+		data, err := decodeBlob(v.MemoData)
+		if err != nil || len(data) == 0 || len(data) > MaxVaultDataLength {
+			return ter.Errorf(ter.TemMALFORMED, "MemoData must contain 1 to %d bytes", MaxVaultDataLength)
+		}
 	}
 
 	return nil

--- a/internal/tx/vault/vault_delete_memodata_test.go
+++ b/internal/tx/vault/vault_delete_memodata_test.go
@@ -50,6 +50,7 @@ func TestVaultDeleteMemoDataPreflight(t *testing.T) {
 		wantError bool
 	}{
 		{name: "absent amendment off", vaultID: validVaultID, rules: off},
+		{name: "odd length amendment on", vaultID: validVaultID, memoData: "A", rules: on},
 		{name: "one byte amendment on", vaultID: validVaultID, memoData: "AA", rules: on},
 		{name: "maximum amendment on", vaultID: validVaultID, memoData: strings.Repeat("AA", MaxVaultDataLength), rules: on},
 		{name: "empty amendment on", vaultID: validVaultID, present: true, rules: on, want: ter.TemMALFORMED, wantError: true},
@@ -86,10 +87,12 @@ func TestVaultDeleteMemoDataCodecRoundTrip(t *testing.T) {
 	tests := []struct {
 		name    string
 		value   string
+		decoded string
 		present bool
 	}{
 		{name: "absent"},
 		{name: "empty", present: true},
+		{name: "odd length", value: "A", decoded: "0A", present: true},
 		{name: "one byte", value: "AB", present: true},
 		{name: "maximum", value: strings.Repeat("AB", MaxVaultDataLength), present: true},
 		{name: "oversized", value: strings.Repeat("AB", MaxVaultDataLength+1), present: true},
@@ -125,8 +128,12 @@ func TestVaultDeleteMemoDataCodecRoundTrip(t *testing.T) {
 			if !ok {
 				t.Fatalf("parsed transaction = %T, want *VaultDelete", parsed)
 			}
-			if deleteTx.MemoData != test.value {
-				t.Fatalf("MemoData length = %d hex chars, want %d", len(deleteTx.MemoData), len(test.value))
+			wantValue := test.value
+			if test.decoded != "" {
+				wantValue = test.decoded
+			}
+			if deleteTx.MemoData != wantValue {
+				t.Fatalf("MemoData = %q, want %q", deleteTx.MemoData, wantValue)
 			}
 			if got := deleteTx.Common.HasField("MemoData"); got != test.present {
 				t.Fatalf("MemoData presence = %v, want %v", got, test.present)
@@ -137,8 +144,8 @@ func TestVaultDeleteMemoDataCodecRoundTrip(t *testing.T) {
 				t.Fatalf("flatten VaultDelete: %v", err)
 			}
 			flattened, flattenedPresent := flat["MemoData"]
-			if flattenedPresent != test.present || test.present && flattened != test.value {
-				t.Fatalf("flattened MemoData = %#v (present %v), want %q (present %v)", flattened, flattenedPresent, test.value, test.present)
+			if flattenedPresent != test.present || test.present && flattened != wantValue {
+				t.Fatalf("flattened MemoData = %#v (present %v), want %q (present %v)", flattened, flattenedPresent, wantValue, test.present)
 			}
 		})
 	}

--- a/internal/tx/vault/vault_delete_memodata_test.go
+++ b/internal/tx/vault/vault_delete_memodata_test.go
@@ -1,0 +1,145 @@
+package vault
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+func TestLendingProtocolV1_1Registration(t *testing.T) {
+	const wantID = "A360E2BFD775A5B0DCE1C36C16DF31B72735A57584FD163655D2F9564F8E7AC8"
+
+	feature := amendment.FeatureByName("LendingProtocolV1_1")
+	if feature == nil {
+		t.Fatal("LendingProtocolV1_1 is not registered")
+	}
+	if got := strings.ToUpper(hex.EncodeToString(feature.ID[:])); got != wantID {
+		t.Fatalf("LendingProtocolV1_1 ID = %s, want %s", got, wantID)
+	}
+	if feature.Supported != amendment.SupportedNo {
+		t.Fatalf("LendingProtocolV1_1 support = %v, want SupportedNo", feature.Supported)
+	}
+	if feature.Vote != amendment.VoteDefaultNo {
+		t.Fatalf("LendingProtocolV1_1 vote = %v, want VoteDefaultNo", feature.Vote)
+	}
+	if amendment.AllSupportedRules().Enabled(feature.ID) {
+		t.Fatal("unsupported LendingProtocolV1_1 must not be enabled by AllSupportedRules")
+	}
+}
+
+func TestVaultDeleteMemoDataPreflight(t *testing.T) {
+	off := amendment.NewRules([][32]byte{amendment.FeatureSingleAssetVault})
+	on := amendment.NewRules([][32]byte{
+		amendment.FeatureSingleAssetVault,
+		amendment.FeatureLendingProtocolV1_1,
+	})
+	validVaultID := strings.Repeat("01", 32)
+
+	tests := []struct {
+		name      string
+		vaultID   string
+		memoData  string
+		present   bool
+		rules     *amendment.Rules
+		want      ter.Result
+		wantError bool
+	}{
+		{name: "absent amendment off", vaultID: validVaultID, rules: off},
+		{name: "one byte amendment on", vaultID: validVaultID, memoData: "AA", rules: on},
+		{name: "maximum amendment on", vaultID: validVaultID, memoData: strings.Repeat("AA", MaxVaultDataLength), rules: on},
+		{name: "empty amendment on", vaultID: validVaultID, present: true, rules: on, want: ter.TemMALFORMED, wantError: true},
+		{name: "oversized amendment on", vaultID: validVaultID, memoData: strings.Repeat("AA", MaxVaultDataLength+1), rules: on, want: ter.TemMALFORMED, wantError: true},
+		{name: "malformed hex amendment on", vaultID: validVaultID, memoData: "GG", rules: on, want: ter.TemMALFORMED, wantError: true},
+		{name: "empty amendment off", vaultID: validVaultID, present: true, rules: off, want: ter.TemDISABLED, wantError: true},
+		{name: "oversized amendment off", vaultID: validVaultID, memoData: strings.Repeat("AA", MaxVaultDataLength+1), rules: off, want: ter.TemDISABLED, wantError: true},
+		{name: "zero VaultID precedes amendment gate", vaultID: strings.Repeat("00", 32), memoData: "AA", rules: off, want: ter.TemMALFORMED, wantError: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			deleteTx := NewVaultDelete("rOwner", test.vaultID)
+			deleteTx.MemoData = test.memoData
+			if test.present {
+				deleteTx.Common.SetPresentFields(map[string]bool{"MemoData": true})
+			}
+
+			err := deleteTx.PreflightWithRules(test.rules)
+			if !test.wantError {
+				if err != nil {
+					t.Fatalf("PreflightWithRules() = %v, want nil", err)
+				}
+				return
+			}
+			if got := vaultResultCode(t, err); got != test.want {
+				t.Fatalf("PreflightWithRules() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestVaultDeleteMemoDataCodecRoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		present bool
+	}{
+		{name: "absent"},
+		{name: "empty", present: true},
+		{name: "one byte", value: "AB", present: true},
+		{name: "maximum", value: strings.Repeat("AB", MaxVaultDataLength), present: true},
+		{name: "oversized", value: strings.Repeat("AB", MaxVaultDataLength+1), present: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fields := map[string]any{
+				"TransactionType": "VaultDelete",
+				"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"Sequence":        uint32(1),
+				"Fee":             "10",
+				"SigningPubKey":   "",
+				"VaultID":         strings.Repeat("01", 32),
+			}
+			if test.present {
+				fields["MemoData"] = test.value
+			}
+
+			encoded, err := binarycodec.Encode(fields)
+			if err != nil {
+				t.Fatalf("encode VaultDelete: %v", err)
+			}
+			blob, err := hex.DecodeString(encoded)
+			if err != nil {
+				t.Fatalf("decode encoded transaction: %v", err)
+			}
+			parsed, err := tx.ParseFromBinary(blob)
+			if err != nil {
+				t.Fatalf("parse VaultDelete: %v", err)
+			}
+			deleteTx, ok := parsed.(*VaultDelete)
+			if !ok {
+				t.Fatalf("parsed transaction = %T, want *VaultDelete", parsed)
+			}
+			if deleteTx.MemoData != test.value {
+				t.Fatalf("MemoData length = %d hex chars, want %d", len(deleteTx.MemoData), len(test.value))
+			}
+			if got := deleteTx.Common.HasField("MemoData"); got != test.present {
+				t.Fatalf("MemoData presence = %v, want %v", got, test.present)
+			}
+
+			flat, err := deleteTx.Flatten()
+			if err != nil {
+				t.Fatalf("flatten VaultDelete: %v", err)
+			}
+			flattened, flattenedPresent := flat["MemoData"]
+			if flattenedPresent != test.present || test.present && flattened != test.value {
+				t.Fatalf("flattened MemoData = %#v (present %v), want %q (present %v)", flattened, flattenedPresent, test.value, test.present)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- register LendingProtocolV1_1 with the exact v3.3.0 amendment ID as unsupported and DefaultNo
- add optional VaultDelete MemoData serialization with rippled-matching amendment gating, decoded-byte bounds, and validation precedence
- cover codec boundaries, forced amendment states, metadata, fee/sequence effects, and rollback behavior

## Test plan
- [x] go test ./amendment ./internal/tx/vault ./internal/tx/engine
- [x] go test ./internal/testing/vault
- [x] go test ./internal/tx/...
- [x] go test ./internal/testing/...
- [x] go test ./amendment ./codec/binarycodec/...
- [x] just build
- [x] just vet
- [x] just lint
- [x] just docs-check

Fixes #1377
