### PR TITLE
test: harden AccountDelete deletion coverage

### DIFF
--- a/codec/binarycodec/types/hash.go
+++ b/codec/binarycodec/types/hash.go
@@ -42,6 +42,9 @@ func hashFromJSON(json any, length int) ([]byte, error) {
 	if !ok {
 		return nil, &InvalidHashTypeError{}
 	}
+	if v == "0" {
+		return make([]byte, length), nil
+	}
 	decoded, err := hex.DecodeString(v)
 	if err != nil {
 		return nil, &InvalidHexStringError{Err: err}

--- a/codec/binarycodec/types/hash_test.go
+++ b/codec/binarycodec/types/hash_test.go
@@ -56,6 +56,8 @@ func TestHash_FromJson(t *testing.T) {
 			require.Equal(t, tc.expected, actual)
 			if tc.expectedErr != nil {
 				require.Equal(t, tc.expectedErr.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/codec/binarycodec/types/hash_test.go
+++ b/codec/binarycodec/types/hash_test.go
@@ -24,6 +24,12 @@ func TestHash_FromJson(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			name:     "Zero hash shorthand",
+			json:     "0",
+			length:   32,
+			expected: make([]byte, 32),
+		},
+		{
 			name:        "Invalid hex string",
 			json:        "031G020000000000000000000000000000000000000000000000000000000000",
 			length:      32,

--- a/internal/testing/accountdelete/accountdelete_test.go
+++ b/internal/testing/accountdelete/accountdelete_test.go
@@ -9,10 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/testing/credential"
 	"github.com/LeJamon/go-xrpl/internal/testing/depositpreauth"
 	"github.com/LeJamon/go-xrpl/internal/testing/escrow"
+	"github.com/LeJamon/go-xrpl/internal/testing/metadata"
 	offerbuild "github.com/LeJamon/go-xrpl/internal/testing/offer"
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
@@ -21,12 +23,66 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const acctDelFee = uint64(50_000_000) // 50 XRP — matches rippled's owner reserve
+type deleteBalances struct {
+	source      uint64
+	destination uint64
+	fee         uint64
+}
 
-func newAccountDelete(from, to *jtx.Account) *acctx.AccountDelete {
+func newAccountDelete(env *jtx.TestEnv, from, to *jtx.Account) *acctx.AccountDelete {
 	d := acctx.NewAccountDelete(from.Address, to.Address)
-	d.Fee = fmt.Sprintf("%d", acctDelFee)
+	d.Fee = fmt.Sprintf("%d", env.ReserveIncrement())
 	return d
+}
+
+func captureDeleteBalances(env *jtx.TestEnv, from, to *jtx.Account) deleteBalances {
+	return deleteBalances{
+		source:      env.Balance(from),
+		destination: env.Balance(to),
+		fee:         env.ReserveIncrement(),
+	}
+}
+
+func requireAccountDeleteSuccess(
+	t *testing.T,
+	env *jtx.TestEnv,
+	result jtx.TxResult,
+	from, to *jtx.Account,
+	before deleteBalances,
+	owned ...keylet.Keylet,
+) {
+	t.Helper()
+	jtx.RequireTxSuccess(t, result)
+	require.True(t, result.Applied)
+	require.Equal(t, before.fee, result.Fee)
+	require.GreaterOrEqual(t, before.source, before.fee)
+	delivered := before.source - before.fee
+	require.Equal(t, before.destination+delivered, env.Balance(to))
+
+	require.NotNil(t, result.Metadata)
+	require.NotNil(t, result.Metadata.DeliveredAmount)
+	require.True(t, result.Metadata.DeliveredAmount.IsNative())
+	require.Equal(t, fmt.Sprintf("%d", delivered), result.Metadata.DeliveredAmount.Value())
+	require.NotNil(t, metadata.FindNode(result.Metadata, "DeletedNode", "AccountRoot"))
+
+	jtx.RequireAccountNotExists(t, env, from)
+	jtx.RequireLedgerEntryNotExists(t, env, keylet.OwnerDir(from.ID))
+	for _, ownedKey := range owned {
+		jtx.RequireLedgerEntryNotExists(t, env, ownedKey)
+	}
+}
+
+func submitAccountDeleteSuccess(
+	t *testing.T,
+	env *jtx.TestEnv,
+	from, to *jtx.Account,
+	owned ...keylet.Keylet,
+) jtx.TxResult {
+	t.Helper()
+	before := captureDeleteBalances(env, from, to)
+	result := env.Submit(newAccountDelete(env, from, to))
+	requireAccountDeleteSuccess(t, env, result, from, to, before, owned...)
+	return result
 }
 
 // TestAccountDelete_Basics tests fundamental AccountDelete validation and success cases.
@@ -40,7 +96,7 @@ func TestAccountDelete_Basics(t *testing.T) {
 		env.Close()
 
 		d := acctx.NewAccountDelete(alice.Address, alice.Address)
-		d.Fee = fmt.Sprintf("%d", acctDelFee)
+		d.Fee = fmt.Sprintf("%d", env.ReserveIncrement())
 		jtx.RequireTxFail(t, env.Submit(d), jtx.TemDST_IS_SRC)
 	})
 
@@ -51,8 +107,7 @@ func TestAccountDelete_Basics(t *testing.T) {
 		env.Fund(alice, becky)
 		env.Close()
 
-		// Need ledger seq - account seq >= 256; right now it's too soon
-		result := env.Submit(newAccountDelete(alice, becky))
+		result := env.Submit(newAccountDelete(env, alice, becky))
 		jtx.RequireTxFail(t, result, "tecTOO_SOON")
 	})
 
@@ -65,43 +120,52 @@ func TestAccountDelete_Basics(t *testing.T) {
 
 		env.IncLedgerSeqForAccDel(alice)
 
-		beckyBefore := env.Balance(becky)
-		result := env.Submit(newAccountDelete(alice, becky))
-		jtx.RequireTxSuccess(t, result)
-
-		jtx.RequireAccountNotExists(t, env, alice)
-
-		beckyAfter := env.Balance(becky)
-		if beckyAfter <= beckyBefore {
-			t.Errorf("becky should receive alice's XRP: before=%d after=%d", beckyBefore, beckyAfter)
-		}
+		before := captureDeleteBalances(env, alice, becky)
+		result := env.Submit(newAccountDelete(env, alice, becky))
+		requireAccountDeleteSuccess(t, env, result, alice, becky, before)
 	})
 }
 
-// TestAccountDelete_TrustLineBlocks tests that trust lines with non-zero balance block deletion.
-// Reference: rippled AccountDelete_test.cpp testBasics (HasObligations)
+// TestAccountDelete_TrustLineBlocks tests that the RippleState object itself is
+// an obligation, regardless of whether its balance is zero.
 func TestAccountDelete_TrustLineBlocks(t *testing.T) {
-	env := jtx.NewTestEnv(t)
-	alice := jtx.NewAccount("alice")
-	becky := jtx.NewAccount("becky")
-	gw := jtx.NewAccount("gw")
-	env.Fund(alice, becky, gw)
-	env.Close()
+	for _, tc := range []struct {
+		name    string
+		balance float64
+	}{
+		{name: "zero balance"},
+		{name: "non-zero balance", balance: 100},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := jtx.NewTestEnv(t)
+			alice := jtx.NewAccount("alice")
+			becky := jtx.NewAccount("becky")
+			gw := jtx.NewAccount("gw")
+			env.Fund(alice, becky, gw)
+			env.Close()
 
-	// Becky sets up a trust line with balance
-	jtx.RequireTxSuccess(t, env.Submit(trustset.TrustLine(becky, "USD", gw, "1000").Build()))
-	env.Close()
-	env.PayIOU(gw, becky, gw, "USD", 100)
-	env.Close()
+			jtx.RequireTxSuccess(t, env.Submit(trustset.TrustLine(becky, "USD", gw, "1000").Build()))
+			env.Close()
+			if tc.balance != 0 {
+				env.PayIOU(gw, becky, gw, "USD", tc.balance)
+				env.Close()
+			}
+			lineKey := keylet.Line(becky.ID, gw.ID, "USD")
+			jtx.RequireLedgerEntryExists(t, env, lineKey)
 
-	env.IncLedgerSeqForAccDel(becky)
-
-	result := env.Submit(newAccountDelete(becky, alice))
-	jtx.RequireTxFail(t, result, jtx.TecHAS_OBLIGATIONS)
+			env.IncLedgerSeqForAccDel(becky)
+			before := captureDeleteBalances(env, becky, alice)
+			result := env.Submit(newAccountDelete(env, becky, alice))
+			jtx.RequireTxFail(t, result, jtx.TecHAS_OBLIGATIONS)
+			require.True(t, result.Applied)
+			require.Equal(t, before.fee, result.Fee)
+			jtx.RequireAccountExists(t, env, becky)
+			jtx.RequireLedgerEntryExists(t, env, lineKey)
+		})
+	}
 }
 
-// TestAccountDelete_OfferBlocks tests that open offers block deletion.
-func TestAccountDelete_OfferBlocks(t *testing.T) {
+func TestAccountDelete_CascadeDeletesOffer(t *testing.T) {
 	env := jtx.NewTestEnv(t)
 	alice := jtx.NewAccount("alice")
 	becky := jtx.NewAccount("becky")
@@ -109,19 +173,22 @@ func TestAccountDelete_OfferBlocks(t *testing.T) {
 	env.Fund(alice, becky, gw)
 	env.Close()
 
-	jtx.RequireTxSuccess(t, env.Submit(trustset.TrustLine(alice, "USD", gw, "10000").Build()))
-	env.Close()
-	env.PayIOU(gw, alice, gw, "USD", 1000)
-	env.Close()
-
-	// Alice creates an offer
+	offerSequence := env.Seq(alice)
 	jtx.RequireTxSuccess(t, env.Submit(offerbuild.OfferCreate(alice, gw.IOU("USD", 1), jtx.XRPTxAmount(jtx.XRP(1))).Build()))
 	env.Close()
+	offerKey := keylet.Offer(alice.ID, offerSequence)
+	offerData, err := env.LedgerEntry(offerKey)
+	require.NoError(t, err)
+	offer, err := state.ParseLedgerOffer(offerData)
+	require.NoError(t, err)
+	bookDirectory := keylet.Keylet{Key: offer.BookDirectory}
+	jtx.RequireLedgerEntryExists(t, env, offerKey)
+	jtx.RequireLedgerEntryExists(t, env, bookDirectory)
+	jtx.RequireOwnerDirectoryContains(t, env, alice, offerKey.Key, true)
 
 	env.IncLedgerSeqForAccDel(alice)
-
-	result := env.Submit(newAccountDelete(alice, becky))
-	jtx.RequireTxFail(t, result, jtx.TecHAS_OBLIGATIONS)
+	submitAccountDeleteSuccess(t, env, alice, becky, offerKey)
+	jtx.RequireLedgerEntryNotExists(t, env, bookDirectory)
 }
 
 // TestAccountDelete_EscrowBlocks tests that escrows block deletion.
@@ -134,21 +201,20 @@ func TestAccountDelete_EscrowBlocks(t *testing.T) {
 	env.Close()
 
 	finishTime := env.Now().Add(100 * time.Second)
+	escrowKey := keylet.Escrow(alice.ID, env.Seq(alice))
 
-	// Alice creates an escrow to becky
 	jtx.RequireTxSuccess(t, env.Submit(
 		escrow.EscrowCreate(alice, becky, jtx.XRP(100)).
 			FinishTime(finishTime).Build()))
 	env.Close()
+	jtx.RequireOwnerDirectoryContains(t, env, alice, escrowKey.Key, true)
+	jtx.RequireOwnerDirectoryContains(t, env, becky, escrowKey.Key, true)
 
 	env.IncLedgerSeqForAccDel(alice)
-	result := env.Submit(newAccountDelete(alice, becky))
-	jtx.RequireTxFail(t, result, jtx.TecHAS_OBLIGATIONS)
+	requireAccountDeleteObligation(t, env, alice, becky, escrowKey)
 
-	// Becky also has obligation (destination of escrow)
 	env.IncLedgerSeqForAccDel(becky)
-	result = env.Submit(newAccountDelete(becky, alice))
-	jtx.RequireTxFail(t, result, jtx.TecHAS_OBLIGATIONS)
+	requireAccountDeleteObligation(t, env, becky, alice, escrowKey)
 }
 
 // TestAccountDelete_DestinationConstraints tests destination requirements.
@@ -163,7 +229,7 @@ func TestAccountDelete_DestinationConstraints(t *testing.T) {
 
 		env.IncLedgerSeqForAccDel(alice)
 		d := acctx.NewAccountDelete(alice.Address, nonExistent.Address)
-		d.Fee = fmt.Sprintf("%d", acctDelFee)
+		d.Fee = fmt.Sprintf("%d", env.ReserveIncrement())
 		result := env.Submit(d)
 		jtx.RequireTxFail(t, result, jtx.TecNO_DST)
 	})
@@ -178,7 +244,7 @@ func TestAccountDelete_DestinationConstraints(t *testing.T) {
 
 		env.IncLedgerSeqForAccDel(alice)
 		d := acctx.NewAccountDelete(alice.Address, becky.Address)
-		d.Fee = fmt.Sprintf("%d", acctDelFee)
+		d.Fee = fmt.Sprintf("%d", env.ReserveIncrement())
 		result := env.Submit(d)
 		jtx.RequireTxFail(t, result, jtx.TecDST_TAG_NEEDED)
 	})
@@ -193,11 +259,12 @@ func TestAccountDelete_DestinationConstraints(t *testing.T) {
 
 		env.IncLedgerSeqForAccDel(alice)
 		d := acctx.NewAccountDelete(alice.Address, becky.Address)
-		d.Fee = fmt.Sprintf("%d", acctDelFee)
+		d.Fee = fmt.Sprintf("%d", env.ReserveIncrement())
 		tag := uint32(42)
 		d.DestinationTag = &tag
+		before := captureDeleteBalances(env, alice, becky)
 		result := env.Submit(d)
-		jtx.RequireTxSuccess(t, result)
+		requireAccountDeleteSuccess(t, env, result, alice, becky, before)
 	})
 }
 
@@ -215,7 +282,7 @@ func TestAccountDelete_DepositAuth(t *testing.T) {
 		env.Close()
 
 		env.IncLedgerSeqForAccDel(alice)
-		result := env.Submit(newAccountDelete(alice, carol))
+		result := env.Submit(newAccountDelete(env, alice, carol))
 		jtx.RequireTxFail(t, result, jtx.TecNO_PERMISSION)
 	})
 
@@ -231,8 +298,11 @@ func TestAccountDelete_DepositAuth(t *testing.T) {
 		env.Close()
 
 		env.IncLedgerSeqForAccDel(alice)
-		result := env.Submit(newAccountDelete(alice, carol))
-		jtx.RequireTxSuccess(t, result)
+		preauthKey := keylet.DepositPreauth(carol.ID, alice.ID)
+		before := captureDeleteBalances(env, alice, carol)
+		result := env.Submit(newAccountDelete(env, alice, carol))
+		requireAccountDeleteSuccess(t, env, result, alice, carol, before)
+		jtx.RequireLedgerEntryExists(t, env, preauthKey)
 	})
 }
 
@@ -245,15 +315,26 @@ func TestAccountDelete_SequenceDistanceEnforced(t *testing.T) {
 	env.Fund(alice, becky)
 	env.Close()
 
-	// Use IncLedgerSeqForAccDel which advances enough ledgers.
-	// First verify it's too soon at current state.
-	result := env.Submit(newAccountDelete(alice, becky))
+	sequence := env.Seq(alice)
+	for env.LedgerSeq() < sequence+254 {
+		env.Close()
+	}
+	require.Equal(t, sequence+254, env.LedgerSeq())
+	beforeFailure := captureDeleteBalances(env, alice, becky)
+	result := env.Submit(newAccountDelete(env, alice, becky))
 	jtx.RequireTxFail(t, result, "tecTOO_SOON")
+	require.True(t, result.Applied)
+	require.Equal(t, beforeFailure.fee, result.Fee)
+	require.Equal(t, sequence+1, env.Seq(alice))
+	require.Equal(t, beforeFailure.source-beforeFailure.fee, env.Balance(alice))
+	require.Equal(t, beforeFailure.destination, env.Balance(becky))
 
-	// Now advance enough for deletion
-	env.IncLedgerSeqForAccDel(alice)
-	result = env.Submit(newAccountDelete(alice, becky))
-	jtx.RequireTxSuccess(t, result)
+	env.Close()
+	env.Close()
+	require.Equal(t, env.Seq(alice)+255, env.LedgerSeq())
+	beforeSuccess := captureDeleteBalances(env, alice, becky)
+	result = env.Submit(newAccountDelete(env, alice, becky))
+	requireAccountDeleteSuccess(t, env, result, alice, becky, beforeSuccess)
 }
 
 // TestAccountDelete_MultiSign tests that account deletion works with multisig.
@@ -271,16 +352,10 @@ func TestAccountDelete_MultiSign(t *testing.T) {
 
 	env.IncLedgerSeqForAccDel(carol)
 
-	// carol is deleted using alice's multisig.
-	// Note: signer list itself counts as an owned object, so AccountDelete
-	// cascade must remove it. If the engine supports cascade deletion of
-	// signer lists, this succeeds.
-	// Multi-sign fee: baseFee * (1 + numSigners) = 50_000_000 * 2 = 100_000_000
-	d := newAccountDelete(carol, becky)
-	d.Fee = fmt.Sprintf("%d", acctDelFee*2)
+	d := newAccountDelete(env, carol, becky)
+	before := captureDeleteBalances(env, carol, becky)
 	result := env.SubmitMultiSigned(d, []*jtx.Account{alice})
-	jtx.RequireTxSuccess(t, result)
-	jtx.RequireAccountNotExists(t, env, carol)
+	requireAccountDeleteSuccess(t, env, result, carol, becky, before, keylet.SignerList(carol.ID))
 }
 
 // TestAccountDelete_Resurrection tests that a deleted account address can be reused.
@@ -292,26 +367,22 @@ func TestAccountDelete_Resurrection(t *testing.T) {
 	env.Fund(alice, becky)
 	env.Close()
 
-	aliceAddr := alice.Address
-
 	env.IncLedgerSeqForAccDel(alice)
-	jtx.RequireTxSuccess(t, env.Submit(newAccountDelete(alice, becky)))
-	jtx.RequireAccountNotExists(t, env, alice)
+	submitAccountDeleteSuccess(t, env, alice, becky)
 
-	// Resurrect alice by sending enough XRP to cover reserve.
-	// Payment to non-existent account requires at least reserve base (10 XRP).
 	reserveBase := env.ReserveBase()
 	expectedSequence := env.LedgerSeq()
 	jtx.RequireTxSuccess(t, env.Submit(payment.Pay(becky, alice, reserveBase).Build()))
 	env.Close()
 
-	jtx.RequireAccountExists(t, env, alice)
-
-	require.Equal(t, expectedSequence, env.Seq(alice))
-
-	if alice.Address != aliceAddr {
-		t.Errorf("resurrected alice should have same address")
-	}
+	accountData, err := env.LedgerEntry(keylet.Account(alice.ID))
+	require.NoError(t, err)
+	account, err := state.ParseAccountRoot(accountData)
+	require.NoError(t, err)
+	require.Equal(t, alice.Address, account.Account)
+	require.Equal(t, expectedSequence, account.Sequence)
+	require.Equal(t, reserveBase, account.Balance)
+	require.Zero(t, account.OwnerCount)
 }
 
 // TestAccountDelete_RegularKey tests deletion when regular key is set.
@@ -330,10 +401,119 @@ func TestAccountDelete_RegularKey(t *testing.T) {
 	env.IncLedgerSeqForAccDel(becky)
 
 	// Becky deletes her account signed by regular key
-	d := newAccountDelete(becky, alice)
+	d := newAccountDelete(env, becky, alice)
+	before := captureDeleteBalances(env, becky, alice)
 	result := env.SubmitSignedWith(d, rk)
-	jtx.RequireTxSuccess(t, result)
-	jtx.RequireAccountNotExists(t, env, becky)
+	requireAccountDeleteSuccess(t, env, result, becky, alice, before)
+}
+
+func TestAccountDelete_ClearsDestinationPasswordSpent(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	carol := jtx.NewAccount("carol")
+	becky := jtx.NewAccount("becky")
+	firstKey := jtx.NewAccount("first-key")
+	secondKey := jtx.NewAccount("second-key")
+	env.Fund(carol, becky, firstKey, secondKey)
+	env.Close()
+
+	setFirst := jtx.NewSetRegularKeyTx(becky, firstKey)
+	setFirst.GetCommon().Fee = "0"
+	jtx.RequireTxSuccess(t, env.Submit(setFirst))
+	env.Close()
+	require.NotZero(t, env.AccountInfo(becky).Flags&state.LsfPasswordSpent)
+
+	env.IncLedgerSeqForAccDel(carol)
+	submitAccountDeleteSuccess(t, env, carol, becky)
+	require.Zero(t, env.AccountInfo(becky).Flags&state.LsfPasswordSpent)
+
+	setSecond := jtx.NewSetRegularKeyTx(becky, secondKey)
+	setSecond.GetCommon().Fee = "0"
+	jtx.RequireTxSuccess(t, env.Submit(setSecond))
+}
+
+func TestAccountDelete_FeeAndFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		code jtx.TxResultCode
+		edit func(*acctx.AccountDelete, *jtx.TestEnv)
+	}{
+		{
+			name: "negative fee",
+			code: jtx.TemBAD_FEE,
+			edit: func(d *acctx.AccountDelete, _ *jtx.TestEnv) { d.Fee = "-1" },
+		},
+		{
+			name: "invalid flags",
+			code: jtx.TemINVALID_FLAG,
+			edit: func(d *acctx.AccountDelete, _ *jtx.TestEnv) { d.SetFlags(0x00020000) },
+		},
+		{
+			name: "default fee",
+			code: "telINSUF_FEE_P",
+		},
+		{
+			name: "one drop below reserve increment",
+			code: "telINSUF_FEE_P",
+			edit: func(d *acctx.AccountDelete, env *jtx.TestEnv) {
+				d.Fee = fmt.Sprintf("%d", env.ReserveIncrement()-1)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := jtx.NewTestEnv(t)
+			alice := jtx.NewAccount("alice")
+			becky := jtx.NewAccount("becky")
+			env.Fund(alice, becky)
+			env.Close()
+
+			d := acctx.NewAccountDelete(alice.Address, becky.Address)
+			if tc.edit != nil {
+				tc.edit(d, env)
+			}
+			before := captureDeleteBalances(env, alice, becky)
+			sequence := env.Seq(alice)
+			result := env.Submit(d)
+			jtx.RequireTxFail(t, result, tc.code)
+			require.False(t, result.Applied)
+			require.Zero(t, result.Fee)
+			require.Equal(t, before.source, env.Balance(alice))
+			require.Equal(t, before.destination, env.Balance(becky))
+			require.Equal(t, sequence, env.Seq(alice))
+		})
+	}
+}
+
+func TestAccountDelete_BalanceBelowFee(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	destination := env.MasterAccount()
+	env.FundAmount(alice, env.ReserveBase())
+	env.Close()
+
+	remaining := uint64(jtx.XRP(1))
+	env.NoopWithFee(alice, env.Balance(alice)-remaining)
+	env.Close()
+	require.Equal(t, remaining, env.Balance(alice))
+	require.Greater(t, env.ReserveIncrement(), remaining)
+
+	before := captureDeleteBalances(env, alice, destination)
+	result := env.Submit(newAccountDelete(env, alice, destination))
+	jtx.RequireTxFail(t, result, jtx.TerINSUF_FEE_B)
+	require.False(t, result.Applied)
+	require.Zero(t, result.Fee)
+	require.Equal(t, before.source, env.Balance(alice))
+	require.Equal(t, before.destination, env.Balance(destination))
+
+	d := acctx.NewAccountDelete(alice.Address, destination.Address)
+	d.Fee = fmt.Sprintf("%d", remaining)
+	result = env.Submit(d)
+	jtx.RequireTxFail(t, result, "telINSUF_FEE_P")
+	require.False(t, result.Applied)
+	require.Zero(t, result.Fee)
+	require.Equal(t, before.source, env.Balance(alice))
+	require.Equal(t, before.destination, env.Balance(destination))
 }
 
 // TestAccountDelete_CredentialExpiry verifies rippled's credential expiry
@@ -371,7 +551,7 @@ func TestAccountDelete_CredentialExpiry(t *testing.T) {
 		// Advancing 256 ledgers also moves time far past the expiration.
 		env.IncLedgerSeqForAccDel(john)
 
-		d := newAccountDelete(john, alice)
+		d := newAccountDelete(env, john, alice)
 		d.CredentialIDs = []string{credIdx}
 		jtx.RequireTxFail(t, env.Submit(d), "tecEXPIRED")
 		env.Close()
@@ -414,20 +594,14 @@ func TestAccountDelete_CredentialExpiry(t *testing.T) {
 		env.IncLedgerSeqForAccDel(john)
 		env.CloseToParentCloseTime(expiration)
 
-		d := newAccountDelete(john, alice)
+		d := newAccountDelete(env, john, alice)
 		d.CredentialIDs = []string{credIdx}
-		jtx.RequireTxSuccess(t, env.Submit(d))
+		before := captureDeleteBalances(env, john, alice)
+		result := env.Submit(d)
+		requireAccountDeleteSuccess(t, env, result, john, alice, before, credK)
 		env.Close()
 
-		jtx.RequireAccountNotExists(t, env, john)
 		require.False(t, env.LedgerEntryExists(credK),
 			"credential must be cascade-deleted with the account")
 	})
 }
-
-// Suppress unused import warnings
-var (
-	_ = offerbuild.OfferCreate
-	_ = escrow.EscrowCreate
-	_ = trustset.TrustLine
-)

--- a/internal/testing/accountdelete/credential_matrix_test.go
+++ b/internal/testing/accountdelete/credential_matrix_test.go
@@ -124,4 +124,17 @@ func TestAccountDelete_CredentialAuthorization(t *testing.T) {
 		d.CredentialIDs = []string{credID}
 		jtx.RequireTxFail(t, env.Submit(d), "tecBAD_CREDENTIALS")
 	})
+
+	t.Run("zero credential id reaches ledger validation", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		destination := jtx.NewAccount("destination")
+		env.Fund(alice, destination)
+		env.Close()
+		env.IncLedgerSeqForAccDel(alice)
+
+		d := newAccountDelete(env, alice, destination)
+		d.CredentialIDs = []string{"0"}
+		jtx.RequireTxFail(t, env.Submit(d), "tecBAD_CREDENTIALS")
+	})
 }

--- a/internal/testing/accountdelete/credential_matrix_test.go
+++ b/internal/testing/accountdelete/credential_matrix_test.go
@@ -1,0 +1,127 @@
+package accountdelete_test
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	credentialtest "github.com/LeJamon/go-xrpl/internal/testing/credential"
+	"github.com/LeJamon/go-xrpl/internal/testing/depositpreauth"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+func TestAccountDelete_CredentialAuthorization(t *testing.T) {
+	const credentialType = "account-delete"
+
+	t.Run("credential preauthorization", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		destination := jtx.NewAccount("destination")
+		subject := jtx.NewAccount("subject")
+		issuer := jtx.NewAccount("issuer")
+		env.Fund(destination, subject, issuer)
+		env.Close()
+		env.EnableDepositAuth(destination)
+		env.Close()
+
+		credentialKey := keylet.Credential(subject.ID, issuer.ID, []byte(credentialType))
+		credentialID := depositpreauth.CredentialIndexHex(subject, issuer, credentialType)
+		jtx.RequireTxSuccess(t, env.Submit(
+			credentialtest.CredentialCreateText(issuer, subject, credentialType).Build()))
+		env.Close()
+
+		env.IncLedgerSeqForAccDel(subject)
+		unaccepted := newAccountDelete(env, subject, destination)
+		unaccepted.CredentialIDs = []string{credentialID}
+		jtx.RequireTxFail(t, env.Submit(unaccepted), "tecBAD_CREDENTIALS")
+		env.Close()
+
+		jtx.RequireTxSuccess(t, env.Submit(
+			credentialtest.CredentialAcceptText(subject, issuer, credentialType).Build()))
+		env.Close()
+		env.IncLedgerSeqForAccDel(issuer)
+		wrongSubject := newAccountDelete(env, issuer, destination)
+		wrongSubject.CredentialIDs = []string{credentialID}
+		jtx.RequireTxFail(t, env.Submit(wrongSubject), "tecBAD_CREDENTIALS")
+
+		env.IncLedgerSeqForAccDel(subject)
+		unauthorized := newAccountDelete(env, subject, destination)
+		unauthorized.CredentialIDs = []string{credentialID}
+		jtx.RequireTxFail(t, env.Submit(unauthorized), jtx.TecNO_PERMISSION)
+		env.Close()
+
+		jtx.RequireTxSuccess(t, env.Submit(depositpreauth.AuthCredentials(destination,
+			[]depositpreauth.AuthorizeCredentials{{Issuer: issuer, CredTypeText: credentialType}}).Build()))
+		env.Close()
+		env.IncLedgerSeqForAccDel(subject)
+		before := captureDeleteBalances(env, subject, destination)
+		d := newAccountDelete(env, subject, destination)
+		d.CredentialIDs = []string{credentialID}
+		result := env.Submit(d)
+		requireAccountDeleteSuccess(t, env, result, subject, destination, before, credentialKey)
+	})
+
+	t.Run("direct account preauthorization", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		destination := jtx.NewAccount("destination")
+		subject := jtx.NewAccount("subject")
+		issuer := jtx.NewAccount("issuer")
+		env.Fund(destination, subject, issuer)
+		env.Close()
+		env.EnableDepositAuth(destination)
+		env.Preauthorize(destination, subject)
+		env.Close()
+
+		credentialKey := keylet.Credential(subject.ID, issuer.ID, []byte(credentialType))
+		credentialID := depositpreauth.CredentialIndexHex(subject, issuer, credentialType)
+		jtx.RequireTxSuccess(t, env.Submit(
+			credentialtest.CredentialCreateText(issuer, subject, credentialType).Build()))
+		env.Close()
+		jtx.RequireTxSuccess(t, env.Submit(
+			credentialtest.CredentialAcceptText(subject, issuer, credentialType).Build()))
+		env.Close()
+
+		env.IncLedgerSeqForAccDel(subject)
+		before := captureDeleteBalances(env, subject, destination)
+		d := newAccountDelete(env, subject, destination)
+		d.CredentialIDs = []string{credentialID}
+		result := env.Submit(d)
+		requireAccountDeleteSuccess(t, env, result, subject, destination, before, credentialKey)
+	})
+
+	t.Run("credentials not required", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		destination := jtx.NewAccount("destination")
+		subject := jtx.NewAccount("subject")
+		issuer := jtx.NewAccount("issuer")
+		env.Fund(destination, subject, issuer)
+		env.Close()
+
+		credentialKey := keylet.Credential(subject.ID, issuer.ID, []byte(credentialType))
+		credentialID := depositpreauth.CredentialIndexHex(subject, issuer, credentialType)
+		jtx.RequireTxSuccess(t, env.Submit(
+			credentialtest.CredentialCreateText(issuer, subject, credentialType).Build()))
+		env.Close()
+		jtx.RequireTxSuccess(t, env.Submit(
+			credentialtest.CredentialAcceptText(subject, issuer, credentialType).Build()))
+		env.Close()
+
+		env.IncLedgerSeqForAccDel(subject)
+		before := captureDeleteBalances(env, subject, destination)
+		d := newAccountDelete(env, subject, destination)
+		d.CredentialIDs = []string{credentialID}
+		result := env.Submit(d)
+		requireAccountDeleteSuccess(t, env, result, subject, destination, before, credentialKey)
+	})
+
+	t.Run("unknown credential", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		destination := jtx.NewAccount("destination")
+		env.Fund(alice, destination)
+		env.Close()
+		env.IncLedgerSeqForAccDel(alice)
+
+		d := newAccountDelete(env, alice, destination)
+		d.CredentialIDs = []string{credID}
+		jtx.RequireTxFail(t, env.Submit(d), "tecBAD_CREDENTIALS")
+	})
+}

--- a/internal/testing/accountdelete/delegate_cleanup_test.go
+++ b/internal/testing/accountdelete/delegate_cleanup_test.go
@@ -19,18 +19,6 @@ func setDelegate(t *testing.T, env *jtx.TestEnv, owner, authorized *jtx.Account)
 	jtx.RequireTxSuccess(t, env.Submit(ds))
 }
 
-func directoryContains(t *testing.T, env *jtx.TestEnv, owner [20]byte, item [32]byte) bool {
-	t.Helper()
-	found := false
-	require.NoError(t, state.DirForEach(env.Ledger(), keylet.OwnerDir(owner), func(key [32]byte) error {
-		if key == item {
-			found = true
-		}
-		return nil
-	}))
-	return found
-}
-
 func TestAccountDelete_CleansDelegateWhenDeletingDelegator(t *testing.T) {
 	env := jtx.NewTestEnv(t)
 	env.EnableFeature("PermissionDelegationV1_1")
@@ -43,15 +31,13 @@ func TestAccountDelete_CleansDelegateWhenDeletingDelegator(t *testing.T) {
 	setDelegate(t, env, alice, bob)
 	env.Close()
 	delegateKey := keylet.Delegate(alice.ID, bob.ID)
-	require.True(t, directoryContains(t, env, bob.ID, delegateKey.Key))
+	jtx.RequireOwnerDirectoryContains(t, env, bob, delegateKey.Key, true)
 
 	env.IncLedgerSeqForAccDel(alice)
-	jtx.RequireTxSuccess(t, env.Submit(newAccountDelete(alice, carol)))
+	submitAccountDeleteSuccess(t, env, alice, carol, delegateKey)
 	env.Close()
 
-	jtx.RequireAccountNotExists(t, env, alice)
-	require.False(t, env.LedgerEntryExists(delegateKey))
-	require.False(t, directoryContains(t, env, bob.ID, delegateKey.Key))
+	jtx.RequireOwnerDirectoryContains(t, env, bob, delegateKey.Key, false)
 }
 
 func TestAccountDelete_CleansDelegateWhenDeletingDelegatee(t *testing.T) {
@@ -76,12 +62,10 @@ func TestAccountDelete_CleansDelegateWhenDeletingDelegatee(t *testing.T) {
 	require.Zero(t, entry.DestinationNode)
 
 	env.IncLedgerSeqForAccDel(bob)
-	jtx.RequireTxSuccess(t, env.Submit(newAccountDelete(bob, carol)))
+	submitAccountDeleteSuccess(t, env, bob, carol, delegateKey)
 	env.Close()
 
-	jtx.RequireAccountNotExists(t, env, bob)
-	require.False(t, env.LedgerEntryExists(delegateKey))
-	require.False(t, directoryContains(t, env, alice.ID, delegateKey.Key))
+	jtx.RequireOwnerDirectoryContains(t, env, alice, delegateKey.Key, false)
 	require.Equal(t, uint32(32), env.OwnerCount(alice))
 }
 
@@ -98,15 +82,16 @@ func TestAccountDelete_CleansMultipleInboundDelegates(t *testing.T) {
 	setDelegate(t, env, alice, bob)
 	setDelegate(t, env, carol, bob)
 	env.Close()
+	aliceDelegate := keylet.Delegate(alice.ID, bob.ID)
+	carolDelegate := keylet.Delegate(carol.ID, bob.ID)
 
 	env.IncLedgerSeqForAccDel(bob)
-	jtx.RequireTxSuccess(t, env.Submit(newAccountDelete(bob, destination)))
+	submitAccountDeleteSuccess(t, env, bob, destination, aliceDelegate, carolDelegate)
 	env.Close()
 
 	for _, owner := range []*jtx.Account{alice, carol} {
 		delegateKey := keylet.Delegate(owner.ID, bob.ID)
-		require.False(t, env.LedgerEntryExists(delegateKey))
-		require.False(t, directoryContains(t, env, owner.ID, delegateKey.Key))
+		jtx.RequireOwnerDirectoryContains(t, env, owner, delegateKey.Key, false)
 		require.Zero(t, env.OwnerCount(owner))
 	}
 }
@@ -143,7 +128,7 @@ func TestAccountDelete_DelegateCleanupFailureIsAtomic(t *testing.T) {
 	balanceBefore := env.Balance(alice)
 	sequenceBefore := env.Seq(alice)
 
-	result := env.Submit(newAccountDelete(alice, carol))
+	result := env.Submit(newAccountDelete(env, alice, carol))
 	jtx.RequireTxFail(t, result, jtx.TefBAD_LEDGER)
 	require.Nil(t, result.Metadata)
 

--- a/internal/testing/accountdelete/did_cascade_test.go
+++ b/internal/testing/accountdelete/did_cascade_test.go
@@ -40,10 +40,10 @@ func TestAccountDeleteCascadesDIDFromNonRootOwnerPage(t *testing.T) {
 	env.IncLedgerSeqForAccDel(alice)
 	aliceBefore := env.Balance(alice)
 	beckyBefore := env.Balance(becky)
-	result := env.Submit(newAccountDelete(alice, becky))
+	result := env.Submit(newAccountDelete(env, alice, becky))
 	jtx.RequireTxSuccess(t, result)
 
-	delivered := aliceBefore - acctDelFee
+	delivered := aliceBefore - env.ReserveIncrement()
 	require.Equal(t, beckyBefore+delivered, env.Balance(becky))
 	require.NotNil(t, result.Metadata)
 	require.NotNil(t, result.Metadata.DeliveredAmount)

--- a/internal/testing/accountdelete/limits_test.go
+++ b/internal/testing/accountdelete/limits_test.go
@@ -1,0 +1,61 @@
+package accountdelete_test
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	offerbuild "github.com/LeJamon/go-xrpl/internal/testing/offer"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountDelete_DeletableEntryLimitAndDirectoryPages(t *testing.T) {
+	env := jtx.NewTestEnvBacked(t)
+	alice := jtx.NewAccount("alice")
+	gw := jtx.NewAccount("gw")
+	env.FundAmount(alice, uint64(jtx.XRP(10_000_000)))
+	env.Fund(gw)
+	env.Close()
+
+	const offerCount = 1001
+	offerKeys := make([]keylet.Keylet, 0, offerCount)
+	firstOfferSequence := env.Seq(alice)
+	for range offerCount {
+		offerKey := keylet.Offer(alice.ID, env.Seq(alice))
+		jtx.RequireTxSuccess(t, env.Submit(
+			offerbuild.OfferCreate(alice, gw.IOU("USD", 1), jtx.XRPTxAmount(jtx.XRP(1))).Build()))
+		offerKeys = append(offerKeys, offerKey)
+	}
+	env.Close()
+	require.Equal(t, uint32(offerCount), env.OwnerCount(alice))
+	for page := uint64(0); page <= offerCount/32; page++ {
+		jtx.RequireLedgerEntryExists(t, env, keylet.OwnerDirPage(alice.ID, page))
+	}
+
+	env.IncLedgerSeqForAccDel(alice)
+	stateBefore, err := env.Ledger().StateMapHash()
+	require.NoError(t, err)
+	sequenceBefore := env.Seq(alice)
+	balanceBefore := env.Balance(alice)
+	result := env.Submit(newAccountDelete(env, alice, gw))
+	jtx.RequireTxFail(t, result, jtx.TefTOO_BIG)
+	require.False(t, result.Applied)
+	require.Zero(t, result.Fee)
+	require.Nil(t, result.Metadata)
+	stateAfter, err := env.Ledger().StateMapHash()
+	require.NoError(t, err)
+	require.Equal(t, stateBefore, stateAfter)
+	require.Equal(t, sequenceBefore, env.Seq(alice))
+	require.Equal(t, balanceBefore, env.Balance(alice))
+
+	jtx.RequireTxSuccess(t, env.Submit(offerbuild.OfferCancel(alice, firstOfferSequence).Build()))
+	env.Close()
+	require.Equal(t, uint32(offerCount-1), env.OwnerCount(alice))
+	env.IncLedgerSeqForAccDel(alice)
+	before := captureDeleteBalances(env, alice, gw)
+	result = env.Submit(newAccountDelete(env, alice, gw))
+	requireAccountDeleteSuccess(t, env, result, alice, gw, before, offerKeys...)
+	for page := uint64(0); page <= offerCount/32; page++ {
+		jtx.RequireLedgerEntryNotExists(t, env, keylet.OwnerDirPage(alice.ID, page))
+	}
+}

--- a/internal/testing/accountdelete/obligations_test.go
+++ b/internal/testing/accountdelete/obligations_test.go
@@ -49,7 +49,7 @@ func TestAccountDelete_BlockingBacklinks(t *testing.T) {
 
 		checkKey := keylet.Check(alice.ID, env.Seq(alice))
 		jtx.RequireTxSuccess(t, env.Submit(
-			check.CheckCreate(alice, bob, tx.NewXRPAmount(int64(jtx.XRP(1)))).Build()))
+			check.CheckCreate(alice, bob, tx.NewXRPAmount(jtx.XRP(1))).Build()))
 		env.Close()
 		jtx.RequireOwnerDirectoryContains(t, env, alice, checkKey.Key, true)
 		jtx.RequireOwnerDirectoryContains(t, env, bob, checkKey.Key, true)
@@ -70,7 +70,7 @@ func TestAccountDelete_BlockingBacklinks(t *testing.T) {
 
 		channelKey := keylet.PayChannel(alice.ID, bob.ID, env.Seq(alice))
 		jtx.RequireTxSuccess(t, env.Submit(
-			paychan.ChannelCreate(alice, bob, int64(jtx.XRP(1)), 100, alice.PublicKeyHex()).Build()))
+			paychan.ChannelCreate(alice, bob, jtx.XRP(1), 100, alice.PublicKeyHex()).Build()))
 		env.Close()
 		jtx.RequireOwnerDirectoryContains(t, env, alice, channelKey.Key, true)
 		jtx.RequireOwnerDirectoryContains(t, env, bob, channelKey.Key, true)

--- a/internal/testing/accountdelete/obligations_test.go
+++ b/internal/testing/accountdelete/obligations_test.go
@@ -1,0 +1,180 @@
+package accountdelete_test
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/accountset"
+	"github.com/LeJamon/go-xrpl/internal/testing/check"
+	"github.com/LeJamon/go-xrpl/internal/testing/nft"
+	offerbuild "github.com/LeJamon/go-xrpl/internal/testing/offer"
+	"github.com/LeJamon/go-xrpl/internal/testing/paychan"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func requireAccountDeleteObligation(
+	t *testing.T,
+	env *jtx.TestEnv,
+	from, to *jtx.Account,
+	entries ...keylet.Keylet,
+) {
+	t.Helper()
+	before := captureDeleteBalances(env, from, to)
+	sequence := env.Seq(from)
+	result := env.Submit(newAccountDelete(env, from, to))
+	jtx.RequireTxFail(t, result, jtx.TecHAS_OBLIGATIONS)
+	require.True(t, result.Applied)
+	require.Equal(t, before.fee, result.Fee)
+	require.Equal(t, before.source-before.fee, env.Balance(from))
+	require.Equal(t, before.destination, env.Balance(to))
+	require.Equal(t, sequence+1, env.Seq(from))
+	jtx.RequireAccountExists(t, env, from)
+	for _, entryKey := range entries {
+		jtx.RequireLedgerEntryExists(t, env, entryKey)
+	}
+}
+
+func TestAccountDelete_BlockingBacklinks(t *testing.T) {
+	t.Run("Check", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		destination := jtx.NewAccount("destination")
+		env.Fund(alice, bob, destination)
+		env.Close()
+
+		checkKey := keylet.Check(alice.ID, env.Seq(alice))
+		jtx.RequireTxSuccess(t, env.Submit(
+			check.CheckCreate(alice, bob, tx.NewXRPAmount(int64(jtx.XRP(1)))).Build()))
+		env.Close()
+		jtx.RequireOwnerDirectoryContains(t, env, alice, checkKey.Key, true)
+		jtx.RequireOwnerDirectoryContains(t, env, bob, checkKey.Key, true)
+
+		env.IncLedgerSeqForAccDel(alice)
+		env.IncLedgerSeqForAccDel(bob)
+		requireAccountDeleteObligation(t, env, alice, destination, checkKey)
+		requireAccountDeleteObligation(t, env, bob, destination, checkKey)
+	})
+
+	t.Run("PayChannel", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		destination := jtx.NewAccount("destination")
+		env.Fund(alice, bob, destination)
+		env.Close()
+
+		channelKey := keylet.PayChannel(alice.ID, bob.ID, env.Seq(alice))
+		jtx.RequireTxSuccess(t, env.Submit(
+			paychan.ChannelCreate(alice, bob, int64(jtx.XRP(1)), 100, alice.PublicKeyHex()).Build()))
+		env.Close()
+		jtx.RequireOwnerDirectoryContains(t, env, alice, channelKey.Key, true)
+		jtx.RequireOwnerDirectoryContains(t, env, bob, channelKey.Key, true)
+
+		env.IncLedgerSeqForAccDel(alice)
+		env.IncLedgerSeqForAccDel(bob)
+		requireAccountDeleteObligation(t, env, alice, destination, channelKey)
+		requireAccountDeleteObligation(t, env, bob, destination, channelKey)
+	})
+}
+
+func TestAccountDelete_ImplicitTrustLineBlocks(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	gw := jtx.NewAccount("gw")
+	destination := jtx.NewAccount("destination")
+	env.Fund(alice, gw, destination)
+	env.Close()
+
+	jtx.RequireTxSuccess(t, env.Submit(
+		offerbuild.OfferCreate(alice, gw.IOU("BUX", 30), jtx.XRPTxAmount(jtx.XRP(30))).Build()))
+	env.Close()
+	jtx.RequireTxSuccess(t, env.Submit(
+		offerbuild.OfferCreate(gw, jtx.XRPTxAmount(jtx.XRP(30)), gw.IOU("BUX", 30)).Build()))
+	env.Close()
+	lineKey := keylet.Line(alice.ID, gw.ID, "BUX")
+	jtx.RequireLedgerEntryExists(t, env, lineKey)
+
+	env.IncLedgerSeqForAccDel(alice)
+	env.IncLedgerSeqForAccDel(gw)
+	requireAccountDeleteObligation(t, env, alice, destination, lineKey)
+	requireAccountDeleteObligation(t, env, gw, destination, lineKey)
+}
+
+func TestAccountDelete_NFTokenObligations(t *testing.T) {
+	t.Run("issuer without token page", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		issuer := jtx.NewAccount("issuer")
+		minter := jtx.NewAccount("minter")
+		destination := jtx.NewAccount("destination")
+		env.Fund(issuer, minter, destination)
+		env.Close()
+
+		jtx.RequireTxSuccess(t, env.Submit(accountset.AccountSet(issuer).AuthorizedMinter(minter).Build()))
+		env.Close()
+		jtx.RequireTxSuccess(t, env.Submit(nft.NFTokenMint(minter, 0).Issuer(issuer).Transferable().Build()))
+		env.Close()
+		require.Equal(t, uint32(1), env.MintedCount(issuer))
+		require.Zero(t, env.BurnedCount(issuer))
+
+		env.IncLedgerSeqForAccDel(issuer)
+		requireAccountDeleteObligation(t, env, issuer, destination)
+	})
+
+	t.Run("owned token page without issuer count", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		issuer := jtx.NewAccount("issuer")
+		destination := jtx.NewAccount("destination")
+		env.Fund(alice, issuer, destination)
+		env.Close()
+
+		nftID := nft.GetNextNFTokenID(env, issuer, 0, 8, 0)
+		jtx.RequireTxSuccess(t, env.Submit(nft.NFTokenMint(issuer, 0).Transferable().Build()))
+		env.Close()
+		sellOffer := keylet.NFTokenOffer(issuer.ID, env.Seq(issuer))
+		jtx.RequireTxSuccess(t, env.Submit(
+			nft.NFTokenCreateSellOffer(issuer, nftID, tx.NewXRPAmount(0)).Destination(alice).Build()))
+		env.Close()
+		jtx.RequireTxSuccess(t, env.Submit(
+			nft.NFTokenAcceptSellOffer(alice, strings.ToUpper(hex.EncodeToString(sellOffer.Key[:]))).Build()))
+		env.Close()
+		require.Zero(t, env.MintedCount(alice))
+		require.Zero(t, env.BurnedCount(alice))
+
+		env.IncLedgerSeqForAccDel(alice)
+		requireAccountDeleteObligation(t, env, alice, destination)
+	})
+
+	t.Run("burned issuer token at remint boundary", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		issuer := jtx.NewAccount("issuer")
+		minter := jtx.NewAccount("minter")
+		destination := jtx.NewAccount("destination")
+		env.Fund(issuer, minter, destination)
+		env.Close()
+
+		jtx.RequireTxSuccess(t, env.Submit(accountset.AccountSet(issuer).AuthorizedMinter(minter).Build()))
+		env.Close()
+		nftID := nft.GetNextNFTokenID(env, issuer, 0, 8, 0)
+		jtx.RequireTxSuccess(t, env.Submit(nft.NFTokenMint(minter, 0).Issuer(issuer).Transferable().Build()))
+		env.Close()
+		jtx.RequireTxSuccess(t, env.Submit(nft.NFTokenBurn(minter, nftID).Build()))
+		env.Close()
+		require.Equal(t, uint32(1), env.MintedCount(issuer))
+		require.Equal(t, uint32(1), env.BurnedCount(issuer))
+
+		info := env.AccountInfo(issuer)
+		require.NotNil(t, info.FirstNFTokenSequence)
+		nftBoundary := *info.FirstNFTokenSequence + info.MintedNFTokens + 255
+		for env.LedgerSeq() < nftBoundary {
+			env.Close()
+		}
+		env.IncLedgerSeqForAccDel(issuer)
+		submitAccountDeleteSuccess(t, env, issuer, destination)
+	})
+}

--- a/internal/testing/accountdelete/owned_cleanup_test.go
+++ b/internal/testing/accountdelete/owned_cleanup_test.go
@@ -1,0 +1,207 @@
+package accountdelete_test
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	credentialtest "github.com/LeJamon/go-xrpl/internal/testing/credential"
+	"github.com/LeJamon/go-xrpl/internal/testing/depositpreauth"
+	"github.com/LeJamon/go-xrpl/internal/testing/nft"
+	oracletest "github.com/LeJamon/go-xrpl/internal/testing/oracle"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountDelete_CascadeDeletesOwnedEntries(t *testing.T) {
+	t.Run("DepositPreauth", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		destination := jtx.NewAccount("destination")
+		env.Fund(alice, bob, destination)
+		env.Close()
+
+		preauthKey := keylet.DepositPreauth(alice.ID, bob.ID)
+		jtx.RequireTxSuccess(t, env.Submit(depositpreauth.Auth(alice, bob).Build()))
+		env.Close()
+		jtx.RequireLedgerEntryExists(t, env, preauthKey)
+		jtx.RequireOwnerDirectoryContains(t, env, alice, preauthKey.Key, true)
+
+		env.IncLedgerSeqForAccDel(alice)
+		submitAccountDeleteSuccess(t, env, alice, destination, preauthKey)
+	})
+
+	t.Run("NFTokenOffer", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		destination := jtx.NewAccount("destination")
+		env.Fund(alice, bob, destination)
+		env.Close()
+
+		nftID := nft.GetNextNFTokenID(env, bob, 0, 8, 0)
+		jtx.RequireTxSuccess(t, env.Submit(nft.NFTokenMint(bob, 0).Transferable().Build()))
+		env.Close()
+		offerKey := keylet.NFTokenOffer(alice.ID, env.Seq(alice))
+		jtx.RequireTxSuccess(t, env.Submit(
+			nft.NFTokenCreateBuyOffer(alice, nftID, tx.NewXRPAmount(1), bob).Build()))
+		env.Close()
+
+		offerData, err := env.LedgerEntry(offerKey)
+		require.NoError(t, err)
+		offer, err := state.ParseNFTokenOffer(offerData)
+		require.NoError(t, err)
+		tokenDirectory := keylet.NFTBuys(offer.NFTokenID)
+		jtx.RequireLedgerEntryExists(t, env, offerKey)
+		jtx.RequireLedgerEntryExists(t, env, tokenDirectory)
+		jtx.RequireOwnerDirectoryContains(t, env, alice, offerKey.Key, true)
+
+		env.IncLedgerSeqForAccDel(alice)
+		submitAccountDeleteSuccess(t, env, alice, destination, offerKey)
+		jtx.RequireLedgerEntryNotExists(t, env, tokenDirectory)
+	})
+
+	t.Run("Oracle", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		destination := jtx.NewAccount("destination")
+		env.Fund(alice, destination)
+		env.Close()
+
+		const documentID = uint32(7)
+		oracleKey := keylet.Oracle(alice.ID, documentID)
+		jtx.RequireTxSuccess(t, env.Submit(
+			oracletest.OracleSet(alice, documentID, oracletest.DefaultLastUpdateTime(env)).
+				ProviderHex(32).
+				AssetClassHex(8).
+				AddPrice("XRP", "USD", 740, 1).
+				Build()))
+		env.Close()
+		jtx.RequireLedgerEntryExists(t, env, oracleKey)
+		jtx.RequireOwnerDirectoryContains(t, env, alice, oracleKey.Key, true)
+
+		env.IncLedgerSeqForAccDel(alice)
+		submitAccountDeleteSuccess(t, env, alice, destination, oracleKey)
+	})
+
+	t.Run("Oracle corrupt owner node", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		destination := jtx.NewAccount("destination")
+		env.Fund(alice, destination)
+		env.Close()
+
+		const documentID = uint32(7)
+		oracleKey := keylet.Oracle(alice.ID, documentID)
+		jtx.RequireTxSuccess(t, env.Submit(
+			oracletest.OracleSet(alice, documentID, oracletest.DefaultLastUpdateTime(env)).
+				ProviderHex(32).
+				AssetClassHex(8).
+				AddPrice("XRP", "USD", 740, 1).
+				Build()))
+		env.Close()
+		oracleData, err := env.LedgerEntry(oracleKey)
+		require.NoError(t, err)
+		oracle, err := state.ParseOracle(oracleData)
+		require.NoError(t, err)
+		oracle.OwnerNode++
+		oracleData, err = state.SerializeOracle(oracle)
+		require.NoError(t, err)
+		require.NoError(t, env.Ledger().Update(oracleKey, oracleData))
+
+		env.IncLedgerSeqForAccDel(alice)
+		stateBefore, err := env.Ledger().StateMapHash()
+		require.NoError(t, err)
+		balanceBefore := env.Balance(alice)
+		sequenceBefore := env.Seq(alice)
+		result := env.Submit(newAccountDelete(env, alice, destination))
+		jtx.RequireTxFail(t, result, jtx.TefBAD_LEDGER)
+		require.False(t, result.Applied)
+		require.Zero(t, result.Fee)
+		require.Nil(t, result.Metadata)
+		stateAfter, err := env.Ledger().StateMapHash()
+		require.NoError(t, err)
+		require.Equal(t, stateBefore, stateAfter)
+		require.Equal(t, balanceBefore, env.Balance(alice))
+		require.Equal(t, sequenceBefore, env.Seq(alice))
+		jtx.RequireLedgerEntryExists(t, env, oracleKey)
+	})
+
+	t.Run("CredentialIssuer", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		issuer := jtx.NewAccount("issuer")
+		subject := jtx.NewAccount("subject")
+		destination := jtx.NewAccount("destination")
+		env.Fund(issuer, subject, destination)
+		env.Close()
+
+		const credentialType = "account-delete"
+		credentialKey := keylet.Credential(subject.ID, issuer.ID, []byte(credentialType))
+		jtx.RequireTxSuccess(t, env.Submit(
+			credentialtest.CredentialCreateText(issuer, subject, credentialType).Build()))
+		env.Close()
+		jtx.RequireTxSuccess(t, env.Submit(
+			credentialtest.CredentialAcceptText(subject, issuer, credentialType).Build()))
+		env.Close()
+		jtx.RequireOwnerDirectoryContains(t, env, issuer, credentialKey.Key, true)
+		jtx.RequireOwnerDirectoryContains(t, env, subject, credentialKey.Key, true)
+
+		env.IncLedgerSeqForAccDel(issuer)
+		submitAccountDeleteSuccess(t, env, issuer, destination, credentialKey)
+		jtx.RequireOwnerDirectoryContains(t, env, subject, credentialKey.Key, false)
+		require.Zero(t, env.OwnerCount(subject))
+	})
+
+	t.Run("CredentialSubject", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		issuer := jtx.NewAccount("issuer")
+		subject := jtx.NewAccount("subject")
+		destination := jtx.NewAccount("destination")
+		env.Fund(issuer, subject, destination)
+		env.Close()
+
+		const credentialType = "account-delete"
+		credentialKey := keylet.Credential(subject.ID, issuer.ID, []byte(credentialType))
+		jtx.RequireTxSuccess(t, env.Submit(
+			credentialtest.CredentialCreateText(issuer, subject, credentialType).Build()))
+		env.Close()
+		jtx.RequireTxSuccess(t, env.Submit(
+			credentialtest.CredentialAcceptText(subject, issuer, credentialType).Build()))
+		env.Close()
+		jtx.RequireOwnerDirectoryContains(t, env, issuer, credentialKey.Key, true)
+		jtx.RequireOwnerDirectoryContains(t, env, subject, credentialKey.Key, true)
+
+		env.IncLedgerSeqForAccDel(subject)
+		submitAccountDeleteSuccess(t, env, subject, destination, credentialKey)
+		jtx.RequireOwnerDirectoryContains(t, env, issuer, credentialKey.Key, false)
+		require.Zero(t, env.OwnerCount(issuer))
+	})
+}
+
+func TestAccountDelete_WithTicketCleansAllTickets(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	destination := jtx.NewAccount("destination")
+	env.FundAmount(alice, uint64(jtx.XRP(100_000)))
+	env.Fund(destination)
+	env.Close()
+
+	const ticketCount = uint32(250)
+	firstTicket := env.CreateTickets(alice, ticketCount)
+	env.Close()
+	jtx.RequireTicketCount(t, env, alice, ticketCount)
+	ticketKeys := make([]keylet.Keylet, 0, ticketCount)
+	for offset := uint32(0); offset < ticketCount; offset++ {
+		ticketKey := keylet.Ticket(alice.ID, firstTicket+offset)
+		ticketKeys = append(ticketKeys, ticketKey)
+		jtx.RequireLedgerEntryExists(t, env, ticketKey)
+	}
+
+	env.IncLedgerSeqForAccDel(alice)
+	before := captureDeleteBalances(env, alice, destination)
+	d := jtx.WithTicketSeq(newAccountDelete(env, alice, destination), firstTicket)
+	result := env.Submit(d)
+	requireAccountDeleteSuccess(t, env, result, alice, destination, before, ticketKeys...)
+}

--- a/internal/testing/accountdelete/preflight_precedence_test.go
+++ b/internal/testing/accountdelete/preflight_precedence_test.go
@@ -1,25 +1,20 @@
-// Preflight TER-precedence pins for AccountDelete: the CredentialIDs amendment
-// gate is a checkExtraFeatures rejection that runs before preflight1 and the
-// AccountDelete preflight body, so temDISABLED wins over the shape check
-// (temMALFORMED), the self-delete check (temDST_IS_SRC), and every ledger-state
-// TER (terPRE_SEQ).
-//
-// Reference: rippled DeleteAccount.cpp checkExtraFeatures().
 package accountdelete_test
 
 import (
+	"encoding/hex"
+	"strings"
 	"testing"
 
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	acctx "github.com/LeJamon/go-xrpl/internal/tx/account"
+	"github.com/stretchr/testify/require"
 )
 
-// credID is a well-formed 256-bit credential id (64 hex chars).
-const credID = "ABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABAB0"
+const credID = "ABABABABABABABAB" +
+	"ABABABABABABABAB" +
+	"ABABABABABABABAB" +
+	"ABABABABABABABAB"
 
-// newCredEnv builds an environment with featureCredentials disabled and one
-// funded account, so a CredentialIDs-bearing AccountDelete hits the
-// checkExtraFeatures temDISABLED gate.
 func newCredEnv(t *testing.T) (*jtx.TestEnv, *jtx.Account, *jtx.Account) {
 	env := jtx.NewTestEnv(t)
 	env.DisableFeature("Credentials")
@@ -31,24 +26,33 @@ func newCredEnv(t *testing.T) (*jtx.TestEnv, *jtx.Account, *jtx.Account) {
 	return env, alice, becky
 }
 
-// TestAccountDelete_CredentialsDisabledPrecedence pins finding AccountDelete-order
-// across its three illustrations: the temDISABLED gate beats the duplicate-id
-// shape check, the self-delete check, and a sequence gap.
 func TestAccountDelete_CredentialsDisabledPrecedence(t *testing.T) {
+	decoded, err := hex.DecodeString(credID)
+	require.NoError(t, err)
+	require.Len(t, decoded, 32)
+
+	t.Run("beats empty-present shape check", func(t *testing.T) {
+		env, alice, becky := newCredEnv(t)
+		d := acctx.NewAccountDelete(alice.Address, becky.Address)
+		d.Fee = "10"
+		d.CredentialIDs = []string{}
+		jtx.RequireTxFail(t, env.Submit(d), jtx.TemDISABLED)
+	})
+
 	t.Run("beats duplicate-id shape check", func(t *testing.T) {
 		env, alice, becky := newCredEnv(t)
 		d := acctx.NewAccountDelete(alice.Address, becky.Address)
 		d.Fee = "10"
-		d.CredentialIDs = []string{credID, credID} // duplicate → temMALFORMED if reached
-		jtx.RequireTxFail(t, env.Submit(d), "temDISABLED")
+		d.CredentialIDs = []string{credID, credID}
+		jtx.RequireTxFail(t, env.Submit(d), jtx.TemDISABLED)
 	})
 
 	t.Run("beats self-delete check", func(t *testing.T) {
 		env, alice, _ := newCredEnv(t)
-		d := acctx.NewAccountDelete(alice.Address, alice.Address) // dest==src → temDST_IS_SRC if reached
+		d := acctx.NewAccountDelete(alice.Address, alice.Address)
 		d.Fee = "10"
 		d.CredentialIDs = []string{credID}
-		jtx.RequireTxFail(t, env.Submit(d), "temDISABLED")
+		jtx.RequireTxFail(t, env.Submit(d), jtx.TemDISABLED)
 	})
 
 	t.Run("beats sequence gap", func(t *testing.T) {
@@ -56,7 +60,47 @@ func TestAccountDelete_CredentialsDisabledPrecedence(t *testing.T) {
 		d := acctx.NewAccountDelete(alice.Address, becky.Address)
 		d.Fee = "10"
 		d.CredentialIDs = []string{credID}
-		d.SetSequence(env.Seq(alice) + 10) // future sequence → terPRE_SEQ if reached
-		jtx.RequireTxFail(t, env.Submit(d), "temDISABLED")
+		d.SetSequence(env.Seq(alice) + 10)
+		jtx.RequireTxFail(t, env.Submit(d), jtx.TemDISABLED)
 	})
+}
+
+func TestAccountDelete_ValidCredentialFixtureReachesSequenceCheck(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	becky := jtx.NewAccount("becky")
+	env.Fund(alice, becky)
+	env.Close()
+
+	d := acctx.NewAccountDelete(alice.Address, becky.Address)
+	d.Fee = "10"
+	d.CredentialIDs = []string{credID}
+	d.SetSequence(env.Seq(alice) + 10)
+	jtx.RequireTxFail(t, env.Submit(d), jtx.TerPRE_SEQ)
+}
+
+func TestAccountDelete_EmptyCredentialIDsMalformedWhenEnabled(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	becky := jtx.NewAccount("becky")
+	env.Fund(alice, becky)
+	env.Close()
+
+	d := acctx.NewAccountDelete(alice.Address, becky.Address)
+	d.Fee = "10"
+	d.CredentialIDs = []string{}
+	jtx.RequireTxFail(t, env.Submit(d), jtx.TemMALFORMED)
+}
+
+func TestAccountDelete_MixedCaseCredentialIDsAreDuplicates(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	becky := jtx.NewAccount("becky")
+	env.Fund(alice, becky)
+	env.Close()
+
+	d := acctx.NewAccountDelete(alice.Address, becky.Address)
+	d.Fee = "10"
+	d.CredentialIDs = []string{credID, strings.ToLower(credID)}
+	jtx.RequireTxFail(t, env.Submit(d), jtx.TemMALFORMED)
 }

--- a/internal/tx/account/account_delete.go
+++ b/internal/tx/account/account_delete.go
@@ -36,13 +36,17 @@ func (a *AccountDelete) GetFlagsMask(rules *amendment.Rules) uint32 {
 	return tx.TfUniversalMask
 }
 
+func (a *AccountDelete) credentialIDsPresent() bool {
+	return a.CredentialIDs != nil || a.GetCommon().HasField("CredentialIDs")
+}
+
 // CheckExtraFeatures gates CredentialIDs behind featureCredentials. rippled runs
 // this in checkExtraFeatures — before preflight1 and DeleteAccount::preflight —
 // so the temDISABLED wins over temDST_IS_SRC, the credential shape check, and
 // every ledger-state TER.
 // Reference: rippled DeleteAccount.cpp checkExtraFeatures().
 func (a *AccountDelete) CheckExtraFeatures(rules *amendment.Rules) error {
-	if len(a.CredentialIDs) > 0 && !rules.Enabled(amendment.FeatureCredentials) {
+	if a.credentialIDsPresent() && !rules.Enabled(amendment.FeatureCredentials) {
 		return ter.Errorf(ter.TemDISABLED, "CredentialIDs requires the Credentials amendment")
 	}
 	return nil
@@ -58,8 +62,7 @@ func (a *AccountDelete) Validate() error {
 	if a.Account == a.Destination {
 		return ter.Errorf(ter.TemDST_IS_SRC, "cannot delete account to self")
 	}
-	present := a.CredentialIDs != nil || a.GetCommon().HasField("CredentialIDs")
-	if err := credential.CheckFields(a.CredentialIDs, present, "Duplicate credential ID"); err != nil {
+	if err := credential.CheckFields(a.CredentialIDs, a.credentialIDsPresent(), "Duplicate credential ID"); err != nil {
 		return err
 	}
 	return nil
@@ -94,12 +97,12 @@ func (a *AccountDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 	if (destAccount.Flags&state.LsfRequireDestTag) != 0 && a.DestinationTag == nil {
 		return ter.TecDST_TAG_NEEDED
 	}
-	if len(a.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
+	if a.credentialIDsPresent() && rules.Enabled(amendment.FeatureCredentials) {
 		if result := credential.ValidateCredentialIDs(ctx, a.CredentialIDs); result != ter.TesSUCCESS {
 			return result
 		}
 	}
-	if len(a.CredentialIDs) == 0 {
+	if !a.credentialIDsPresent() {
 		if (destAccount.Flags & state.LsfDepositAuth) != 0 {
 			preauthKey := keylet.DepositPreauth(destID, ctx.AccountID)
 			if exists, _ := ctx.View.Exists(preauthKey); !exists {
@@ -151,7 +154,7 @@ func (a *AccountDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 	// check must happen first.
 	// Reference: rippled DeleteAccount.cpp doApply() — verifyDepositPreauth
 	// is called before cleanupOnAccountDelete.
-	if len(a.CredentialIDs) > 0 {
+	if a.credentialIDsPresent() {
 		if r := credential.VerifyDepositPreauth(ctx, a.CredentialIDs, ctx.AccountID, destID, destAccount); r != ter.TesSUCCESS {
 			return r
 		}

--- a/internal/tx/credential/credential_helpers.go
+++ b/internal/tx/credential/credential_helpers.go
@@ -206,18 +206,29 @@ func CheckFields(ids []string, present bool, dupDetail string) error {
 	}
 	seen := make(map[[32]byte]struct{}, len(ids))
 	for _, id := range ids {
-		decoded, err := hex.DecodeString(id)
-		if err != nil || len(decoded) != 32 {
+		credentialID, ok := parseCredentialID(id)
+		if !ok {
 			return ter.Errorf(ter.TemMALFORMED, "CredentialID is invalid")
 		}
-		var credentialID [32]byte
-		copy(credentialID[:], decoded)
 		if _, exists := seen[credentialID]; exists {
 			return ter.Errorf(ter.TemMALFORMED, "%s", dupDetail)
 		}
 		seen[credentialID] = struct{}{}
 	}
 	return nil
+}
+
+func parseCredentialID(value string) ([32]byte, bool) {
+	var id [32]byte
+	if value == "0" {
+		return id, true
+	}
+	decoded, err := hex.DecodeString(value)
+	if err != nil || len(decoded) != len(id) {
+		return id, false
+	}
+	copy(id[:], decoded)
+	return id, true
 }
 
 // ValidateCredentialIDs validates a transaction's CredentialIDs: each
@@ -233,12 +244,10 @@ func ValidateCredentialIDs(ctx *tx.ApplyContext, credentialIDs []string) ter.Res
 // Preclaim where only a LedgerView (not an ApplyContext) is available.
 func ValidCredentials(view tx.LedgerView, subject [20]byte, credentialIDs []string) ter.Result {
 	for _, idHex := range credentialIDs {
-		credIDBytes, err := hex.DecodeString(idHex)
-		if err != nil || len(credIDBytes) != 32 {
+		credID, ok := parseCredentialID(idHex)
+		if !ok {
 			return ter.TecBAD_CREDENTIALS
 		}
-		var credID [32]byte
-		copy(credID[:], credIDBytes)
 
 		credData, err := view.Read(keylet.CredentialByID(credID))
 		if err != nil || credData == nil {
@@ -350,12 +359,10 @@ func VerifyValidDomain(ctx *tx.ApplyContext, subject [20]byte, domainID [32]byte
 	}
 
 	for _, idHex := range ids {
-		idBytes, err := hex.DecodeString(idHex)
-		if err != nil || len(idBytes) != 32 {
+		id, ok := parseCredentialID(idHex)
+		if !ok {
 			return ter.TefINTERNAL
 		}
-		var id [32]byte
-		copy(id[:], idBytes)
 		raw, err := ctx.View.Read(keylet.CredentialByID(id))
 		if err != nil {
 			return ter.TefINTERNAL
@@ -389,12 +396,10 @@ func removeExpired(ctx *tx.ApplyContext, credentialIDs []string, stopOnFailure b
 	failTER = ter.TesSUCCESS
 
 	for _, idHex := range credentialIDs {
-		credIDBytes, err := hex.DecodeString(idHex)
-		if err != nil || len(credIDBytes) != 32 {
+		credID, ok := parseCredentialID(idHex)
+		if !ok {
 			continue
 		}
-		var credID [32]byte
-		copy(credID[:], credIDBytes)
 
 		credKey := keylet.CredentialByID(credID)
 		credData, err := ctx.View.Read(credKey)
@@ -482,12 +487,10 @@ func authorizedDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, dst 
 	seen := make(map[string]bool, len(credentialIDs))
 
 	for _, idHex := range credentialIDs {
-		credIDBytes, err := hex.DecodeString(idHex)
-		if err != nil || len(credIDBytes) != 32 {
+		credID, ok := parseCredentialID(idHex)
+		if !ok {
 			return ter.TefINTERNAL
 		}
-		var credID [32]byte
-		copy(credID[:], credIDBytes)
 
 		// Credential existence was already checked in preclaim.
 		credData, err := ctx.View.Read(keylet.CredentialByID(credID))

--- a/internal/tx/credential/credential_helpers.go
+++ b/internal/tx/credential/credential_helpers.go
@@ -190,12 +190,12 @@ func CheckCredentialExpired(cred *CredentialEntry, closeTime uint32) bool {
 
 // CheckFields validates a transaction's CredentialIDs field shape, matching
 // rippled's credentials::checkFields(): when the field is present it must hold
-// between 1 and maxCredentialsArraySize (8) entries with no duplicates. present
-// must reflect whether the field was supplied (callers compute it from the
-// slice plus HasField, since an empty array parses back to a nil slice under
-// omitempty). dupDetail is the detail string used for the duplicate error so
-// each call site keeps its existing message. A malformed field returns
-// temMALFORMED.
+// between 1 and maxCredentialsArraySize (8) valid 256-bit entries with no
+// duplicates. present must reflect whether the field was supplied (callers
+// compute it from the slice plus HasField, since an empty array parses back to
+// a nil slice under omitempty). dupDetail is the detail string used for the
+// duplicate error so each call site keeps its existing message. A malformed
+// field returns temMALFORMED.
 // Reference: rippled CredentialHelpers.cpp credentials::checkFields().
 func CheckFields(ids []string, present bool, dupDetail string) error {
 	if !present {
@@ -204,12 +204,18 @@ func CheckFields(ids []string, present bool, dupDetail string) error {
 	if len(ids) == 0 || len(ids) > 8 {
 		return ter.Errorf(ter.TemMALFORMED, "CredentialIDs array size is invalid")
 	}
-	seen := make(map[string]bool, len(ids))
+	seen := make(map[[32]byte]struct{}, len(ids))
 	for _, id := range ids {
-		if seen[id] {
+		decoded, err := hex.DecodeString(id)
+		if err != nil || len(decoded) != 32 {
+			return ter.Errorf(ter.TemMALFORMED, "CredentialID is invalid")
+		}
+		var credentialID [32]byte
+		copy(credentialID[:], decoded)
+		if _, exists := seen[credentialID]; exists {
 			return ter.Errorf(ter.TemMALFORMED, "%s", dupDetail)
 		}
-		seen[id] = true
+		seen[credentialID] = struct{}{}
 	}
 	return nil
 }

--- a/internal/tx/oracle/oracle_delete.go
+++ b/internal/tx/oracle/oracle_delete.go
@@ -105,8 +105,8 @@ func (o *OracleDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 func DeleteOracleFromView(view tx.LedgerView, oracleKey keylet.Keylet, oracle *state.OracleData, accountID [20]byte, ownerCount *uint32) ter.Result {
 	// DirRemove from owner directory
 	ownerDirKey := keylet.OwnerDir(accountID)
-	_, err := state.DirRemove(view, ownerDirKey, oracle.OwnerNode, oracleKey.Key, true)
-	if err != nil {
+	removed, err := state.DirRemove(view, ownerDirKey, oracle.OwnerNode, oracleKey.Key, true)
+	if err != nil || !removed.Success {
 		return ter.TefBAD_LEDGER
 	}
 


### PR DESCRIPTION
## Summary

- match AccountDelete credential field-presence and decoded duplicate validation to rippled v3.2.0
- make Oracle cascade cleanup fail closed when its owner-directory link cannot be removed
- replace false-green AccountDelete cases with exact result, balance, metadata, obligation, owner-type, credential, NFT, ticket, and 1,000/1,001-entry coverage

## Test plan

- [x] `go test -count=1 ./internal/testing/accountdelete ./internal/tx/oracle/... ./internal/testing/oracle/...`
- [x] `go test -race -count=3 ./internal/testing/accountdelete`
- [x] `go test -count=20 ./internal/testing/accountdelete`
- [x] affected credential, AccountDelete, Payment, PayChannel, Escrow, and Oracle packages
- [x] `just test-tx`
- [x] `just test-integration`
- [x] `just build`
- [x] `just vet`
- [x] `just lint`

Fixes #1495
