### PR TITLE
test: harden Batch conformance coverage

### DIFF
--- a/internal/ledger/service/tx_query_submit_test.go
+++ b/internal/ledger/service/tx_query_submit_test.go
@@ -10,7 +10,6 @@ import (
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
-	batchtesting "github.com/LeJamon/go-xrpl/internal/testing/batch"
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	batchtx "github.com/LeJamon/go-xrpl/internal/tx/batch"
@@ -42,6 +41,36 @@ func signedPaymentWithFee(t *testing.T, env *jtx.TestEnv, sender, receiver *jtx.
 		t.Fatalf("hex.DecodeString: %v", err)
 	}
 	hash, err := tx.ComputeTransactionHash(txn)
+	if err != nil {
+		t.Fatalf("ComputeTransactionHash: %v", err)
+	}
+	return blob, hash
+}
+
+func innerBatchPaymentBlob(t *testing.T, sender, receiver *jtx.Account) ([]byte, [32]byte) {
+	t.Helper()
+	txn := payment.Pay(sender, receiver, 1).Fee(10).Sequence(1).Build()
+	txn.GetCommon().SetFlags(tx.TfInnerBatchTxn)
+	txn.GetCommon().SigningPubKey = ""
+
+	txMap, err := txn.Flatten()
+	if err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+	txMap["SigningPubKey"] = ""
+	hexStr, err := binarycodec.Encode(txMap)
+	if err != nil {
+		t.Fatalf("binarycodec.Encode: %v", err)
+	}
+	blob, err := hex.DecodeString(hexStr)
+	if err != nil {
+		t.Fatalf("hex.DecodeString: %v", err)
+	}
+	parsed, err := tx.ParseFromBinary(blob)
+	if err != nil {
+		t.Fatalf("ParseFromBinary: %v", err)
+	}
+	hash, err := tx.ComputeTransactionHash(parsed)
 	if err != nil {
 		t.Fatalf("ComputeTransactionHash: %v", err)
 	}
@@ -100,6 +129,58 @@ func TestService_SubmitTransaction_RejectsOversizedMemo(t *testing.T) {
 	}
 	if res.CurrentLedgerState != nil {
 		t.Errorf("local rejection must omit current-ledger state, got %+v", res.CurrentLedgerState)
+	}
+}
+
+func TestService_SubmitTransaction_RejectsInnerBatchTransaction(t *testing.T) {
+	tests := []struct {
+		name       string
+		amendments [][32]byte
+		want       ter.Result
+	}{
+		{
+			name:       "Batch enabled",
+			amendments: [][32]byte{amendment.FeatureBatch},
+			want:       ter.TemINVALID_FLAG,
+		},
+		{
+			name:       "fixBatchInnerSigs enabled",
+			amendments: [][32]byte{amendment.FeatureBatch, amendment.FeatureFixBatchInnerSigs},
+			want:       ter.TemINVALID,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := defaultServiceConfig()
+			cfg.Startup.Mode = service.StartupFresh
+			cfg.GenesisConfig.Amendments = append(cfg.GenesisConfig.Amendments, test.amendments...)
+			svc, err := service.New(cfg)
+			if err != nil {
+				t.Fatalf("service.New: %v", err)
+			}
+			if err := svc.Start(); err != nil {
+				t.Fatalf("service.Start: %v", err)
+			}
+			t.Cleanup(svc.Stop)
+			for _, feature := range test.amendments {
+				if !svc.TransactionRules().Enabled(feature) {
+					t.Fatalf("configured amendment %X is not enabled", feature)
+				}
+			}
+
+			blob, hash := innerBatchPaymentBlob(t, jtx.MasterAccount(), jtx.NewAccount("alice"))
+			result := submitBlob(t, svc, blob, false)
+			if result.Result != test.want {
+				t.Fatalf("Result = %s, want %s", result.Result, test.want)
+			}
+			if result.Applied {
+				t.Fatal("directly submitted inner Batch transaction applied")
+			}
+			if openLedgerHasTx(t, svc, hash) {
+				t.Fatal("directly submitted inner Batch transaction entered the open ledger")
+			}
+		})
 	}
 }
 
@@ -227,16 +308,25 @@ func TestService_SubmitTransaction_BatchSignerFailureRemainsQueryable(t *testing
 	env.SetVerifySignatures(true)
 	outer := jtx.MasterAccount()
 	innerSigner := jtx.NewAccount("batch-signer")
-	batch := batchtesting.NewBatchBuilder(
-		outer,
-		1,
-		batchtesting.CalcBatchFeeFromEnv(env, 1, 2),
-		batchtx.BatchFlagAllOrNothing,
-	).
-		AddInnerTx(batchtesting.MakeInnerPaymentXRP(outer, innerSigner, 1, 2)).
-		AddInnerTx(batchtesting.MakeInnerPaymentXRP(innerSigner, outer, 1, 1)).
-		AddGarbageSigner(innerSigner).
-		Build()
+	batch := batchtx.NewBatch(outer.Address)
+	batch.Fee = "50"
+	batch.SetSequence(1)
+	batch.SetFlags(batchtx.BatchFlagAllOrNothing)
+	for _, inner := range []tx.Transaction{
+		payment.Pay(outer, innerSigner, uint64(jtx.XRP(1))).Fee(0).Sequence(2).Build(),
+		payment.Pay(innerSigner, outer, uint64(jtx.XRP(1))).Fee(0).Sequence(1).Build(),
+	} {
+		inner.GetCommon().SigningPubKey = ""
+		inner.GetCommon().SetFlags(tx.TfInnerBatchTxn)
+		batch.AddInnerTransaction(inner)
+	}
+	batch.BatchSigners = []batchtx.BatchSigner{{
+		BatchSigner: batchtx.BatchSignerData{
+			Account:           innerSigner.Address,
+			SigningPubKey:     innerSigner.PublicKeyHex(),
+			BatchTxnSignature: "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
+		},
+	}}
 	env.SignWith(batch, outer)
 
 	txMap, err := batch.Flatten()

--- a/internal/ledger/service/tx_query_submit_test.go
+++ b/internal/ledger/service/tx_query_submit_test.go
@@ -209,8 +209,6 @@ func TestService_SubmitTransaction_AppliesAtOrAboveFeeLevel(t *testing.T) {
 	master := jtx.MasterAccount()
 	alice := jtx.NewAccount("alice")
 
-	// Fee 10 == base fee → fee level == base level == required level at an
-	// empty open ledger, so the tx applies directly.
 	blob, hash := signedPaymentWithFee(t, env, master, alice, 100_000_000, 10, 1)
 
 	res := submitBlob(t, svc, blob, false)
@@ -388,8 +386,6 @@ func TestService_SubmitTransaction_QueuesBelowFeeLevel(t *testing.T) {
 	master := jtx.MasterAccount()
 	alice := jtx.NewAccount("alice")
 
-	// Fee 1 < base fee 10 → fee level 25 < required base level 256 at an
-	// empty open ledger, so TxQ holds the tx rather than applying it.
 	blob, hash := signedPaymentWithFee(t, env, master, alice, 100_000_000, 1, 1)
 
 	res := submitBlob(t, svc, blob, false)

--- a/internal/testing/batch/batch_test.go
+++ b/internal/testing/batch/batch_test.go
@@ -46,9 +46,19 @@ func requireBatchLedgerData(
 	require.NoError(t, err)
 	closed := env.LastClosedLedger()
 	require.Equal(t, uint32(1+len(expectedResults)), closed.TxCount())
-	outerExists, err := closed.TxExists(batchID)
+	outerStored, outerExists, err := closed.GetTransaction(batchID)
 	require.NoError(t, err)
 	require.True(t, outerExists)
+	outerTxn, outerMeta, err := tx.SplitTxWithMetaBlobStrict(outerStored)
+	require.NoError(t, err)
+	decodedOuterTxn, err := binarycodec.DecodeBytes(outerTxn)
+	require.NoError(t, err)
+	require.Equal(t, tx.TypeBatch.String(), decodedOuterTxn["TransactionType"])
+	decodedOuterMeta, err := binarycodec.DecodeBytes(outerMeta)
+	require.NoError(t, err)
+	require.Equal(t, ter.TesSUCCESS.String(), decodedOuterMeta["TransactionResult"])
+	outerIndex, ok := decodedOuterMeta["TransactionIndex"].(uint32)
+	require.True(t, ok)
 
 	for i, expectedResult := range expectedResults {
 		expectedTxn := batch.RawTransactions[i].RawTransaction.InnerTx
@@ -66,7 +76,7 @@ func requireBatchLedgerData(
 		decodedMeta, decodeErr := binarycodec.DecodeBytes(storedMeta)
 		require.NoError(t, decodeErr)
 		require.Equal(t, expectedResult.String(), decodedMeta["TransactionResult"])
-		require.EqualValues(t, result.Metadata.TransactionIndex+uint32(i)+1, decodedMeta["TransactionIndex"])
+		require.EqualValues(t, outerIndex+uint32(i)+1, decodedMeta["TransactionIndex"])
 		require.Equal(t, fmt.Sprintf("%X", batchID), decodedMeta["ParentBatchID"])
 	}
 

--- a/internal/testing/batch/batch_test.go
+++ b/internal/testing/batch/batch_test.go
@@ -1,5 +1,4 @@
 // Package batch provides integration tests for Batch transactions.
-// Test structure mirrors rippled's Batch_test.cpp 1:1.
 // Reference: rippled/src/test/app/Batch_test.cpp
 package batch
 
@@ -128,7 +127,6 @@ func TestEnabled(t *testing.T) {
 		env.Fund(alice, bob)
 		env.Close()
 
-		// Submit a valid batch with feature enabled - should succeed
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
@@ -149,7 +147,6 @@ func TestEnabled(t *testing.T) {
 		env.Fund(alice, bob)
 		env.Close()
 
-		// Submit a batch with feature disabled - should fail with temDISABLED
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
@@ -209,7 +206,6 @@ func TestEnabled(t *testing.T) {
 		env.Fund(alice, bob)
 		env.Close()
 
-		// A regular payment with tfInnerBatchTxn should fail with temINVALID_FLAG
 		p := MakeInnerPayment(alice, bob, jtx.XRP(1), env.Seq(alice))
 		p.Fee = fmt.Sprintf("%d", env.BaseFee())
 		p.SigningPubKey = ""
@@ -227,7 +223,6 @@ func TestPreflight(t *testing.T) {
 		env.Fund(alice, bob)
 		env.Close()
 
-		// Negative fee should fail
 		batch := batchtx.NewBatch(alice.Address)
 		batch.Fee = "-10"
 		seq := env.Seq(alice)
@@ -269,7 +264,6 @@ func TestPreflight(t *testing.T) {
 
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		// Two mode flags set simultaneously
 		batch := NewBatchBuilder(alice, seq, batchFee,
 			batchtx.BatchFlagAllOrNothing|batchtx.BatchFlagOnlyOne).
 			AddInnerTx(MakeFakeInnerTx(1)).
@@ -347,7 +341,7 @@ func TestPreflight(t *testing.T) {
 			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 1, env.Seq(bob))).
 			AddInnerTx(MakeFakeInnerTx(2)).
 			AddSigner(bob).
-			AddSigner(bob). // duplicate
+			AddSigner(bob).
 			MustBuild()
 
 		result := env.Submit(batch)
@@ -367,7 +361,7 @@ func TestPreflight(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeFakeInnerTx(1)).
 			AddInnerTx(MakeFakeInnerTx(2)).
-			AddSigner(alice). // signer is outer account
+			AddSigner(alice).
 			MustBuild()
 
 		result := env.Submit(batch)
@@ -704,7 +698,6 @@ func TestPreflight(t *testing.T) {
 
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		// Two identical inner txns → identical hashes → temREDUNDANT.
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
@@ -723,7 +716,6 @@ func TestPreflight(t *testing.T) {
 
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		// Two distinct inner txns with the SAME Sequence for alice → temREDUNDANT.
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+1)).
@@ -762,25 +754,19 @@ func TestPreflight(t *testing.T) {
 
 func TestCalculateBaseFee(t *testing.T) {
 	t.Run("fee formula correct", func(t *testing.T) {
-		// (numSigners + 2) * baseFee + baseFee * txns
 		baseFee := uint64(10)
 
-		// 0 signers, 2 txns -> (0+2)*10 + 10*2 = 40
 		require.Equal(t, uint64(40), CalcBatchFee(baseFee, 0, 2))
 
-		// 1 signer, 2 txns -> (1+2)*10 + 10*2 = 50
 		require.Equal(t, uint64(50), CalcBatchFee(baseFee, 1, 2))
 
-		// 2 signers, 3 txns -> (2+2)*10 + 10*3 = 70
 		require.Equal(t, uint64(70), CalcBatchFee(baseFee, 2, 3))
 
-		// 0 signers, 8 txns -> (0+2)*10 + 10*8 = 100
 		require.Equal(t, uint64(100), CalcBatchFee(baseFee, 0, 8))
 	})
 
 	t.Run("calculateBaseFee from env", func(t *testing.T) {
 		env := newBatchEnv(t)
-		// Default base fee is 10
 		require.Equal(t, uint64(40), CalcBatchFeeFromEnv(env, 0, 2))
 		require.Equal(t, uint64(50), CalcBatchFeeFromEnv(env, 1, 2))
 	})

--- a/internal/testing/batch/batch_test.go
+++ b/internal/testing/batch/batch_test.go
@@ -9,14 +9,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/tx"
-	accounttx "github.com/LeJamon/go-xrpl/internal/tx/account"
 	batchtx "github.com/LeJamon/go-xrpl/internal/tx/batch"
-	"github.com/LeJamon/go-xrpl/internal/tx/check"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
-	"github.com/LeJamon/go-xrpl/internal/txq"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -30,6 +29,55 @@ func newBatchEnv(t *testing.T) *jtx.TestEnv {
 	env := jtx.NewTestEnv(t)
 	env.EnableFeatureNow("Batch")
 	return env
+}
+
+func requireBatchLedgerData(
+	t *testing.T,
+	env *jtx.TestEnv,
+	batch *batchtx.Batch,
+	result jtx.TxResult,
+	expectedResults ...ter.Result,
+) {
+	t.Helper()
+	require.NotNil(t, result.Metadata)
+	require.Empty(t, result.AppliedInnerTransactions)
+
+	batchID, err := tx.ComputeTransactionHash(batch)
+	require.NoError(t, err)
+	closed := env.LastClosedLedger()
+	require.Equal(t, uint32(1+len(expectedResults)), closed.TxCount())
+	outerExists, err := closed.TxExists(batchID)
+	require.NoError(t, err)
+	require.True(t, outerExists)
+
+	for i, expectedResult := range expectedResults {
+		expectedTxn := batch.RawTransactions[i].RawTransaction.InnerTx
+		expectedID, hashErr := tx.ComputeTransactionHash(expectedTxn)
+		require.NoError(t, hashErr)
+
+		stored, found, getErr := closed.GetTransaction(expectedID)
+		require.NoError(t, getErr)
+		require.True(t, found)
+		storedTxn, storedMeta, splitErr := tx.SplitTxWithMetaBlobStrict(stored)
+		require.NoError(t, splitErr)
+		decodedTxn, decodeErr := binarycodec.DecodeBytes(storedTxn)
+		require.NoError(t, decodeErr)
+		require.Equal(t, expectedTxn.TxType().String(), decodedTxn["TransactionType"])
+		decodedMeta, decodeErr := binarycodec.DecodeBytes(storedMeta)
+		require.NoError(t, decodeErr)
+		require.Equal(t, expectedResult.String(), decodedMeta["TransactionResult"])
+		require.EqualValues(t, result.Metadata.TransactionIndex+uint32(i)+1, decodedMeta["TransactionIndex"])
+		require.Equal(t, fmt.Sprintf("%X", batchID), decodedMeta["ParentBatchID"])
+	}
+
+	for i := len(expectedResults); i < len(batch.RawTransactions); i++ {
+		inner := batch.RawTransactions[i].RawTransaction.InnerTx
+		innerID, hashErr := tx.ComputeTransactionHash(inner)
+		require.NoError(t, hashErr)
+		exists, existsErr := closed.TxExists(innerID)
+		require.NoError(t, existsErr)
+		require.False(t, exists, "uncommitted inner transaction %d persisted", i)
+	}
 }
 
 func TestInnerSetRegularKeyDoesNotReceiveFreePasswordChange(t *testing.T) {
@@ -49,8 +97,9 @@ func TestInnerSetRegularKeyDoesNotReceiveFreePasswordChange(t *testing.T) {
 	batch := NewBatchBuilder(alice, seq, CalcBatchFeeFromEnv(env, 0, 2), batchtx.BatchFlagAllOrNothing).
 		AddInnerTx(setRegularKey).
 		AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2)).
-		Build()
+		MustBuild()
 	jtx.RequireTxSuccess(t, env.Submit(batch))
+	env.Close()
 
 	data, err := env.Ledger().Read(keylet.Account(alice.ID))
 	require.NoError(t, err)
@@ -59,11 +108,6 @@ func TestInnerSetRegularKeyDoesNotReceiveFreePasswordChange(t *testing.T) {
 	require.Equal(t, regularKey.Address, account.RegularKey)
 	require.Zero(t, account.Flags&state.LsfPasswordSpent)
 }
-
-// =============================================================================
-// Test 1: testEnable
-// Reference: rippled Batch_test.cpp testEnable()
-// =============================================================================
 
 func TestEnabled(t *testing.T) {
 	t.Run("batch enabled", func(t *testing.T) {
@@ -80,7 +124,7 @@ func TestEnabled(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2)).
-			Build()
+			MustBuild()
 
 		result := env.Submit(batch)
 		jtx.RequireTxSuccess(t, result)
@@ -101,7 +145,7 @@ func TestEnabled(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2)).
-			Build()
+			MustBuild()
 
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "temDISABLED")
@@ -165,11 +209,6 @@ func TestEnabled(t *testing.T) {
 	})
 }
 
-// =============================================================================
-// Test 2: testPreflight
-// Reference: rippled Batch_test.cpp testPreflight()
-// =============================================================================
-
 func TestPreflight(t *testing.T) {
 	t.Run("temBAD_FEE - negative fee", func(t *testing.T) {
 		env := newBatchEnv(t)
@@ -184,8 +223,8 @@ func TestPreflight(t *testing.T) {
 		seq := env.Seq(alice)
 		batch.SetSequence(seq)
 		batch.SetFlags(batchtx.BatchFlagAllOrNothing)
-		batch.AddInnerTransaction(MakeFakeInnerTx())
-		batch.AddInnerTransaction(MakeFakeInnerTx())
+		batch.AddInnerTransaction(MakeFakeInnerTx(1))
+		batch.AddInnerTransaction(MakeFakeInnerTx(2))
 
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "temBAD_FEE")
@@ -203,9 +242,9 @@ func TestPreflight(t *testing.T) {
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 		batch := NewBatchBuilder(alice, seq, batchFee, 0x00100000). // invalid flag
-										AddInnerTx(MakeFakeInnerTx()).
-										AddInnerTx(MakeFakeInnerTx()).
-										Build()
+										AddInnerTx(MakeFakeInnerTx(1)).
+										AddInnerTx(MakeFakeInnerTx(2)).
+										MustBuild()
 
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "temINVALID_FLAG")
@@ -223,9 +262,9 @@ func TestPreflight(t *testing.T) {
 		// Two mode flags set simultaneously
 		batch := NewBatchBuilder(alice, seq, batchFee,
 			batchtx.BatchFlagAllOrNothing|batchtx.BatchFlagOnlyOne).
-			AddInnerTx(MakeFakeInnerTx()).
-			AddInnerTx(MakeFakeInnerTx()).
-			Build()
+			AddInnerTx(MakeFakeInnerTx(1)).
+			AddInnerTx(MakeFakeInnerTx(2)).
+			MustBuild()
 
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "temINVALID_FLAG")
@@ -240,11 +279,11 @@ func TestPreflight(t *testing.T) {
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 0, 0)
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			Build()
+			MustBuild()
 
 		result := env.Submit(batch)
-		require.False(t, result.Success)
-		require.Contains(t, result.Code, "tem")
+		jtx.RequireTxFail(t, result, "temARRAY_EMPTY")
+		jtx.RequireSequence(t, env, alice, seq)
 	})
 
 	t.Run("temARRAY_EMPTY - only 1 transaction", func(t *testing.T) {
@@ -258,11 +297,11 @@ func TestPreflight(t *testing.T) {
 		batchFee := CalcBatchFeeFromEnv(env, 0, 1)
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			Build()
+			MustBuild()
 
 		result := env.Submit(batch)
-		require.False(t, result.Success)
-		require.Contains(t, result.Code, "tem")
+		jtx.RequireTxFail(t, result, "temARRAY_EMPTY")
+		jtx.RequireSequence(t, env, alice, seq)
 	})
 
 	t.Run("temARRAY_TOO_LARGE - more than 8 transactions", func(t *testing.T) {
@@ -275,13 +314,14 @@ func TestPreflight(t *testing.T) {
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 0, 9)
 		builder := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing)
-		for range 9 {
-			builder.AddInnerTx(MakeFakeInnerTx())
+		for i := range 9 {
+			builder.AddInnerTx(MakeFakeInnerTx(uint32(i + 1)))
 		}
-		batch := builder.Build()
+		batch := builder.MustBuild()
 
 		result := env.Submit(batch)
-		require.False(t, result.Success)
+		jtx.RequireTxFail(t, result, "temARRAY_TOO_LARGE")
+		jtx.RequireSequence(t, env, alice, seq)
 	})
 
 	t.Run("temREDUNDANT - duplicate batch signer", func(t *testing.T) {
@@ -294,14 +334,15 @@ func TestPreflight(t *testing.T) {
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 2, 2)
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeFakeInnerTx()).
-			AddInnerTx(MakeFakeInnerTx()).
-			AddSigner(bob, "DEADBEEF").
-			AddSigner(bob, "DEADBEEF"). // duplicate
-			Build()
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 1, env.Seq(bob))).
+			AddInnerTx(MakeFakeInnerTx(2)).
+			AddSigner(bob).
+			AddSigner(bob). // duplicate
+			MustBuild()
 
 		result := env.Submit(batch)
-		require.False(t, result.Success)
+		jtx.RequireTxFail(t, result, "temREDUNDANT")
+		jtx.RequireSequence(t, env, alice, seq)
 	})
 
 	t.Run("temBAD_SIGNER - signer is outer account", func(t *testing.T) {
@@ -314,13 +355,14 @@ func TestPreflight(t *testing.T) {
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeFakeInnerTx()).
-			AddInnerTx(MakeFakeInnerTx()).
-			AddSigner(alice, "DEADBEEF"). // signer is outer account
-			Build()
+			AddInnerTx(MakeFakeInnerTx(1)).
+			AddInnerTx(MakeFakeInnerTx(2)).
+			AddSigner(alice). // signer is outer account
+			MustBuild()
 
 		result := env.Submit(batch)
-		require.False(t, result.Success)
+		jtx.RequireTxFail(t, result, "temBAD_SIGNER")
+		jtx.RequireSequence(t, env, alice, seq)
 	})
 
 	t.Run("temARRAY_TOO_LARGE - too many signers", func(t *testing.T) {
@@ -332,16 +374,17 @@ func TestPreflight(t *testing.T) {
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 9, 2)
 		builder := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeFakeInnerTx()).
-			AddInnerTx(MakeFakeInnerTx())
+			AddInnerTx(MakeFakeInnerTx(1)).
+			AddInnerTx(MakeFakeInnerTx(2))
 		for i := range 9 {
 			signer := jtx.NewAccount(fmt.Sprintf("signer%d", i))
-			builder.AddSigner(signer, "DEADBEEF")
+			builder.AddSigner(signer)
 		}
-		batch := builder.Build()
+		batch := builder.MustBuild()
 
 		result := env.Submit(batch)
-		require.False(t, result.Success)
+		jtx.RequireTxFail(t, result, "temARRAY_TOO_LARGE")
+		jtx.RequireSequence(t, env, alice, seq)
 	})
 
 	// Reference: rippled Batch_test.cpp:398-406.
@@ -364,7 +407,7 @@ func TestPreflight(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(badInner).
-			Build()
+			MustBuild()
 
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "temINVALID_INNER_BATCH")
@@ -387,7 +430,7 @@ func TestPreflight(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(MakeInnerVaultCreate(alice, seq+2)).
-			Build()
+			MustBuild()
 
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "temINVALID_INNER_BATCH")
@@ -412,7 +455,7 @@ func TestPreflight(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(badVault).
-			Build()
+			MustBuild()
 
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "temINVALID_INNER_BATCH")
@@ -436,7 +479,7 @@ func TestPreflight(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(badVault).
-			Build()
+			MustBuild()
 
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "temINVALID_INNER_BATCH")
@@ -459,7 +502,7 @@ func TestPreflight(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(badInner).
-			Build()
+			MustBuild()
 
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "temBAD_FEE")
@@ -481,7 +524,7 @@ func TestPreflight(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(bothInner).
-			Build()
+			MustBuild()
 
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "temSEQ_AND_TICKET")
@@ -501,7 +544,7 @@ func TestPreflight(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(neitherInner).
-			Build()
+			MustBuild()
 
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "temSEQ_AND_TICKET")
@@ -522,7 +565,7 @@ func TestPreflight(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(signedInner).
-			Build()
+			MustBuild()
 
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "temBAD_SIGNATURE")
@@ -545,7 +588,7 @@ func TestPreflight(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(multiInner).
-			Build()
+			MustBuild()
 
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "temBAD_SIGNER")
@@ -566,7 +609,7 @@ func TestPreflight(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(pkInner).
-			Build()
+			MustBuild()
 
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "temBAD_REGKEY")
@@ -590,7 +633,7 @@ func TestPreflight(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(innerBatch).
-			Build()
+			MustBuild()
 
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "temINVALID")
@@ -614,7 +657,7 @@ func TestPreflight(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(badInner).
-			Build()
+			MustBuild()
 
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "temINVALID_INNER_BATCH")
@@ -636,7 +679,7 @@ func TestPreflight(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(noFlagInner).
-			Build()
+			MustBuild()
 
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "temINVALID_FLAG")
@@ -655,7 +698,7 @@ func TestPreflight(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			Build()
+			MustBuild()
 
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "temREDUNDANT")
@@ -674,7 +717,7 @@ func TestPreflight(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+1)).
-			Build()
+			MustBuild()
 
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "temREDUNDANT")
@@ -698,7 +741,7 @@ func TestPreflight(t *testing.T) {
 			batch := NewBatchBuilder(alice, seq, batchFee, flag).
 				AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 				AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2)).
-				Build()
+				MustBuild()
 
 			result := env.Submit(batch)
 			jtx.RequireTxSuccess(t, result)
@@ -706,11 +749,6 @@ func TestPreflight(t *testing.T) {
 		}
 	})
 }
-
-// =============================================================================
-// Test 3: testCalculateBaseFee
-// Reference: rippled Batch_test.cpp testCalculateBaseFee()
-// =============================================================================
 
 func TestCalculateBaseFee(t *testing.T) {
 	t.Run("fee formula correct", func(t *testing.T) {
@@ -735,2797 +773,5 @@ func TestCalculateBaseFee(t *testing.T) {
 		// Default base fee is 10
 		require.Equal(t, uint64(40), CalcBatchFeeFromEnv(env, 0, 2))
 		require.Equal(t, uint64(50), CalcBatchFeeFromEnv(env, 1, 2))
-	})
-}
-
-// =============================================================================
-// Test 4: testAllOrNothing
-// Reference: rippled Batch_test.cpp testAllOrNothing()
-// =============================================================================
-
-func TestAllOrNothing(t *testing.T) {
-	t.Run("all succeed", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		seq := env.Seq(alice)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+2)).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// Alice consumes sequences (outer + 2 inner)
-		jtx.RequireSequence(t, env, alice, seq+3)
-
-		// Alice pays XRP(3) + fee; Bob receives XRP(3)
-		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
-	})
-
-	t.Run("tec failure - all rolled back", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		seq := env.Seq(alice)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			// tecUNFUNDED_PAYMENT: alice does not have enough XRP
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+2)).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result) // Batch itself succeeds
-		env.Close()
-
-		// Only outer sequence consumed (inner txns rolled back)
-		jtx.RequireSequence(t, env, alice, seq+1)
-
-		// Alice pays fee only; Bob unaffected
-		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob)
-	})
-
-	t.Run("tef failure - all rolled back", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		seq := env.Seq(alice)
-
-		// Create a second inner tx that will cause a tef error.
-		// AccountSet with SetFlag that requires authorization when not set up
-		// triggers tefNO_AUTH_REQUIRED equivalent.
-		// Use a past sequence for the second tx to trigger tefPAST_SEQ
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			AddInnerTx(MakeInnerPayment(alice, bob, jtx.XRP(1), 1)). // past seq -> tef
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result) // Batch itself succeeds
-		env.Close()
-
-		// Only outer sequence consumed
-		jtx.RequireSequence(t, env, alice, seq+1)
-
-		// Alice pays fee only; Bob unaffected
-		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob)
-	})
-}
-
-// =============================================================================
-// Test 5: testOnlyOne
-// Reference: rippled Batch_test.cpp testOnlyOne()
-// =============================================================================
-
-func TestOnlyOne(t *testing.T) {
-	t.Run("all transactions fail", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		batchFee := CalcBatchFeeFromEnv(env, 0, 3)
-		seq := env.Seq(alice)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagOnlyOne).
-			// All underfunded
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+2)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+3)).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// All inner txns executed (all failed) -> seq advances by 4 (outer + 3 inner)
-		jtx.RequireSequence(t, env, alice, seq+4)
-
-		// Alice pays fee only; Bob unaffected
-		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob)
-	})
-
-	t.Run("first fails then succeeds - stops after success", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		batchFee := CalcBatchFeeFromEnv(env, 0, 3)
-		seq := env.Seq(alice)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagOnlyOne).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+1)). // fails
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2)).    // succeeds -> stop
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).    // not executed
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// Only 2 inner txns processed (fail + success) -> seq advances by 3
-		jtx.RequireSequence(t, env, alice, seq+3)
-
-		// Alice pays XRP(1) + fee
-		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(1))-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(1)))
-	})
-
-	t.Run("succeeds first - stops immediately", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		batchFee := CalcBatchFeeFromEnv(env, 0, 3)
-		seq := env.Seq(alice)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagOnlyOne).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).    // succeeds -> stop
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+2)). // not executed
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).    // not executed
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// Only 1 inner txn processed -> seq advances by 2
-		jtx.RequireSequence(t, env, alice, seq+2)
-
-		// Alice pays XRP(1) + fee
-		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(1))-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(1)))
-	})
-}
-
-// =============================================================================
-// Test 6: testUntilFailure
-// Reference: rippled Batch_test.cpp testUntilFailure()
-// =============================================================================
-
-func TestUntilFailure(t *testing.T) {
-	t.Run("first transaction fails - stops immediately", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		batchFee := CalcBatchFeeFromEnv(env, 0, 4)
-		seq := env.Seq(alice)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagUntilFailure).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+1)). // fails -> stop
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 3, seq+4)).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// 1 inner txn processed (the failure) -> seq advances by 2
-		jtx.RequireSequence(t, env, alice, seq+2)
-
-		// Alice pays fee only; Bob unaffected
-		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob)
-	})
-
-	t.Run("all transactions succeed", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		batchFee := CalcBatchFeeFromEnv(env, 0, 4)
-		seq := env.Seq(alice)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagUntilFailure).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+2)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 3, seq+3)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 4, seq+4)).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// All 4 inner txns succeed -> seq advances by 5
-		jtx.RequireSequence(t, env, alice, seq+5)
-
-		// Alice pays XRP(10) + fee
-		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(10))-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(10)))
-	})
-
-	t.Run("tec error in middle - stops at failure", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		batchFee := CalcBatchFeeFromEnv(env, 0, 4)
-		seq := env.Seq(alice)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagUntilFailure).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+2)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+3)). // fails -> stop
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 3, seq+4)).    // not executed
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// 3 inner txns processed (2 success + 1 failure) -> seq advances by 4
-		jtx.RequireSequence(t, env, alice, seq+4)
-
-		// Alice pays XRP(3) + fee (the 2 successful payments)
-		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
-	})
-}
-
-// =============================================================================
-// Test 7: testIndependent
-// Reference: rippled Batch_test.cpp testIndependent()
-// =============================================================================
-
-func TestIndependent(t *testing.T) {
-	t.Run("multiple transactions fail - all execute", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		batchFee := CalcBatchFeeFromEnv(env, 0, 4)
-		seq := env.Seq(alice)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagIndependent).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).    // succeeds
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+2)). // fails
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+3)). // fails
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 3, seq+4)).    // succeeds
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// All 4 inner txns processed -> seq advances by 5
-		jtx.RequireSequence(t, env, alice, seq+5)
-
-		// Alice pays XRP(4) + fee (only successful payments)
-		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(4))-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(4)))
-	})
-
-	t.Run("tec error in middle - continues executing", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		batchFee := CalcBatchFeeFromEnv(env, 0, 4)
-		seq := env.Seq(alice)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagIndependent).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+2)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+3)). // fails
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 3, seq+4)).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// All 4 inner txns processed -> seq advances by 5
-		jtx.RequireSequence(t, env, alice, seq+5)
-
-		// Alice pays XRP(6) + fee (3 successful payments)
-		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(6))-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(6)))
-	})
-}
-
-// =============================================================================
-// Test 8: testAccountActivation
-// Reference: rippled Batch_test.cpp testAccountActivation()
-// =============================================================================
-
-func TestAccountActivation(t *testing.T) {
-	env := newBatchEnv(t)
-	alice := jtx.NewAccount("alice")
-	bob := jtx.NewAccount("bob")
-	env.FundAmount(alice, uint64(jtx.XRP(10000))) // rippled funds with XRP(10000)
-	env.Close()
-
-	// Bob does not exist yet
-	jtx.RequireAccountNotExists(t, env, bob)
-
-	preAlice := env.Balance(alice)
-
-	seq := env.Seq(alice)
-	batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-
-	// Create bob by funding and then do an AccountSet on bob within the batch
-	batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-		AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1000, seq+1)).
-		AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2)). // second payment to newly created bob
-		Build()
-
-	result := env.Submit(batch)
-	jtx.RequireTxSuccess(t, result)
-	env.Close()
-
-	// Bob now exists
-	jtx.RequireAccountExists(t, env, bob)
-
-	// Alice consumes sequences (outer + 2 inner)
-	jtx.RequireSequence(t, env, alice, seq+3)
-
-	// Alice pays XRP(1001) + fee; Bob receives XRP(1001)
-	jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(1001))-batchFee)
-	jtx.RequireBalance(t, env, bob, uint64(jtx.XRP(1001)))
-}
-
-// TestActivateTwoAccounts is the issue #846 regression: a Batch whose inner txs
-// fund TWO distinct new accounts must succeed. rippled runs each inner Payment
-// through its own invariant pass, so each pass sees exactly one account
-// creation; the outer ttBATCH pass never sees the combined two-creation delta.
-// goXRPL previously ran the shared ValidNewAccountRoot checker on the combined
-// outer delta (createdCount=2) and wrongly returned tecINVARIANT_FAILED.
-// Reference: rippled apply.cpp:189-207, InvariantCheck.cpp:964-967.
-func TestActivateTwoAccounts(t *testing.T) {
-	env := newBatchEnv(t)
-	alice := jtx.NewAccount("alice")
-	bob := jtx.NewAccount("bob")
-	carol := jtx.NewAccount("carol")
-	env.FundAmount(alice, uint64(jtx.XRP(10000)))
-	env.Close()
-
-	jtx.RequireAccountNotExists(t, env, bob)
-	jtx.RequireAccountNotExists(t, env, carol)
-
-	preAlice := env.Balance(alice)
-	seq := env.Seq(alice)
-	batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-
-	// Two funding Payments to two brand-new accounts in a single batch.
-	batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-		AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1000, seq+1)).
-		AddInnerTx(MakeInnerPaymentXRP(alice, carol, 1000, seq+2)).
-		Build()
-
-	result := env.Submit(batch)
-	jtx.RequireTxSuccess(t, result)
-	env.Close()
-
-	// Both new accounts now exist and are funded.
-	jtx.RequireAccountExists(t, env, bob)
-	jtx.RequireAccountExists(t, env, carol)
-
-	// Alice consumes sequences (outer + 2 inner).
-	jtx.RequireSequence(t, env, alice, seq+3)
-
-	// Alice pays XRP(2000) + fee; bob and carol each receive XRP(1000).
-	jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(2000))-batchFee)
-	jtx.RequireBalance(t, env, bob, uint64(jtx.XRP(1000)))
-	jtx.RequireBalance(t, env, carol, uint64(jtx.XRP(1000)))
-}
-
-// =============================================================================
-// Test 9: testAccountSet
-// Reference: rippled Batch_test.cpp testAccountSet()
-// =============================================================================
-
-func TestAccountSet(t *testing.T) {
-	env := newBatchEnv(t)
-	alice := jtx.NewAccount("alice")
-	bob := jtx.NewAccount("bob")
-	env.Fund(alice, bob)
-	env.Close()
-
-	preAlice := env.Balance(alice)
-	preBob := env.Balance(bob)
-
-	seq := env.Seq(alice)
-	batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-
-	// Create an AccountSet (require dest tag) as inner tx
-	as := accounttx.NewAccountSet(alice.Address)
-	as.Fee = "0"
-	as.SigningPubKey = ""
-	as.SetSequence(seq + 1)
-	as.SetFlags(tx.TfInnerBatchTxn)
-	flag := accounttx.AccountSetFlagRequireDest
-	as.SetFlag = &flag
-
-	batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-		AddInnerTx(as).
-		AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2)).
-		Build()
-
-	result := env.Submit(batch)
-	jtx.RequireTxSuccess(t, result)
-	env.Close()
-
-	// Alice consumes sequences (outer + 2 inner)
-	jtx.RequireSequence(t, env, alice, seq+3)
-
-	// Alice pays XRP(1) + fee; Bob receives XRP(1)
-	jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(1))-batchFee)
-	jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(1)))
-}
-
-// =============================================================================
-// Test 10: testBadSequence
-// Reference: rippled Batch_test.cpp testBadSequence()
-// =============================================================================
-
-func TestBadSequence(t *testing.T) {
-	t.Run("past sequence - inner tx with past seq", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-		preAliceSeq := env.Seq(alice)
-
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		batch := NewBatchBuilder(alice, preAliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			// Past sequence (before current)
-			AddInnerTx(MakeInnerPayment(alice, bob, jtx.XRP(10), 1)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 5, preAliceSeq+1)).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result) // Batch itself succeeds
-		env.Close()
-
-		// Alice pays fee only, sequence advances by 1 (outer only)
-		jtx.RequireSequence(t, env, alice, preAliceSeq+1)
-		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob)
-	})
-
-	t.Run("future sequence - inner tx with far future seq", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-		preAliceSeq := env.Seq(alice)
-
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		batch := NewBatchBuilder(alice, preAliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			// Future sequence (well ahead of current)
-			AddInnerTx(MakeInnerPayment(alice, bob, jtx.XRP(10), preAliceSeq+10)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 5, preAliceSeq+1)).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result) // Batch itself succeeds
-		env.Close()
-
-		// Alice pays fee only, sequence advances by 1 (outer only)
-		jtx.RequireSequence(t, env, alice, preAliceSeq+1)
-		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob)
-	})
-
-	t.Run("same sequence as outer - inner tx uses outer's seq", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-		preAliceSeq := env.Seq(alice)
-
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		batch := NewBatchBuilder(alice, preAliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			// Same sequence as outer
-			AddInnerTx(MakeInnerPayment(alice, bob, jtx.XRP(10), preAliceSeq)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 5, preAliceSeq+1)).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result) // Batch itself succeeds
-		env.Close()
-
-		// Alice pays fee only
-		jtx.RequireSequence(t, env, alice, preAliceSeq+1)
-		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob)
-	})
-}
-
-// =============================================================================
-// Test 11: testBadOuterFee
-// Reference: rippled Batch_test.cpp testBadOuterFee()
-// =============================================================================
-
-func TestBadOuterFee(t *testing.T) {
-	t.Run("insufficient fee without signers", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		// Bad fee: should be calcBatchFee(env, 0, 2) = 40, but we use 30
-		badFee := CalcBatchFeeFromEnv(env, 0, 1) // 30 instead of 40
-		seq := env.Seq(alice)
-		batch := NewBatchBuilder(alice, seq, badFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 15, seq+2)).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxFail(t, result, "telINSUF_FEE_P")
-	})
-
-	t.Run("insufficient fee with batch signers", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		// Bad fee: should be calcBatchFee(env, 1, 2) = 50, but we use 40.
-		// The second inner is from bob so bob is a genuinely required signer,
-		// letting preflight pass and the fee floor fire in preclaim.
-		badFee := CalcBatchFeeFromEnv(env, 0, 2) // 40 instead of 50
-		seq := env.Seq(alice)
-		batch := NewBatchBuilder(alice, seq, badFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
-			AddSigner(bob, "DEADBEEF").
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxFail(t, result, "telINSUF_FEE_P")
-	})
-}
-
-// =============================================================================
-// Test 12: testBatchDelegate
-// Reference: rippled Batch_test.cpp testBatchDelegate()
-// =============================================================================
-
-func TestBatchDelegate(t *testing.T) {
-	t.Run("delegated non atomic inner", func(t *testing.T) {
-		// Alice delegates "Payment" permission to bob.
-		// Inner tx[0] is a payment from alice to bob with Delegate=bob.
-		// Inner tx[1] is a regular payment from alice to bob.
-		// Reference: rippled Batch_test.cpp testBatchDelegate() - "delegated non atomic inner"
-		env := newBatchEnv(t)
-		env.EnableFeature("PermissionDelegationV1_1")
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.FundAmount(alice, uint64(jtx.XRP(10000)))
-		env.FundAmount(bob, uint64(jtx.XRP(10000)))
-		env.Close()
-
-		// Alice delegates Payment permission to bob
-		env.SetDelegate(alice, bob, []string{"Payment"})
-		env.Close()
-
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		seq := env.Seq(alice)
-
-		// Inner tx[0]: payment from alice to bob, delegated to bob
-		innerTx0 := MakeInnerPaymentXRPWithDelegate(alice, bob, 1, seq+1, bob)
-		// Inner tx[1]: regular payment from alice to bob
-		innerTx1 := MakeInnerPaymentXRP(alice, bob, 2, seq+2)
-
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(innerTx0).
-			AddInnerTx(innerTx1).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// Alice consumes sequences: outer + 2 inner = seq + 3
-		jtx.RequireSequence(t, env, alice, seq+3)
-
-		// Alice pays XRP(3) + fee; Bob receives XRP(3)
-		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
-	})
-
-	t.Run("delegated atomic inner", func(t *testing.T) {
-		// Bob delegates "Payment" permission to carol.
-		// Carol submits batch: inner tx[0] is payment bob->alice with Delegate=carol, inner tx[1] is payment alice->bob.
-		// Reference: rippled Batch_test.cpp testBatchDelegate() - "delegated atomic inner"
-		env := newBatchEnv(t)
-		env.EnableFeature("PermissionDelegationV1_1")
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		carol := jtx.NewAccount("carol")
-		env.FundAmount(alice, uint64(jtx.XRP(10000)))
-		env.FundAmount(bob, uint64(jtx.XRP(10000)))
-		env.FundAmount(carol, uint64(jtx.XRP(10000)))
-		env.Close()
-
-		// Bob delegates Payment permission to carol
-		env.SetDelegate(bob, carol, []string{"Payment"})
-		env.Close()
-
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-		preCarol := env.Balance(carol)
-
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-		aliceSeq := env.Seq(alice)
-		bobSeq := env.Seq(bob)
-
-		// Inner tx[0]: payment bob->alice, delegated to carol
-		innerTx0 := MakeInnerPaymentXRPWithDelegate(bob, alice, 1, bobSeq, carol)
-		// Inner tx[1]: payment alice->bob
-		innerTx1 := MakeInnerPaymentXRP(alice, bob, 2, aliceSeq+1)
-
-		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(innerTx0).
-			AddInnerTx(innerTx1).
-			AddSigner(bob, "DEADBEEF").
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// Alice: outer seq + 1 inner = aliceSeq + 2
-		jtx.RequireSequence(t, env, alice, aliceSeq+2)
-		// Bob: 1 inner = bobSeq + 1
-		jtx.RequireSequence(t, env, bob, bobSeq+1)
-
-		// Alice: -XRP(1) (net: pay 2 to bob, receive 1 from bob) - batchFee
-		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(1))-batchFee)
-		// Bob: +XRP(1) (net: receive 2 from alice, pay 1 to alice)
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(1)))
-		// Carol: unchanged (batch is atomic, fee is paid by batch outer account)
-		jtx.RequireBalance(t, env, carol, preCarol)
-	})
-}
-
-// =============================================================================
-// Tests 13-15: testTickets, testTicketsOpenLedger
-// Reference: rippled Batch_test.cpp testTickets(), testTicketsOpenLedger()
-// =============================================================================
-
-func TestTickets(t *testing.T) {
-	t.Run("tickets outer", func(t *testing.T) {
-		// Outer batch uses a ticket; inner transactions use regular sequences.
-		// Reference: rippled Batch_test.cpp testTickets() - "tickets outer"
-		env := newBatchEnv(t)
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.FundAmount(alice, uint64(jtx.XRP(10000)))
-		env.FundAmount(bob, uint64(jtx.XRP(10000)))
-		env.Close()
-
-		// Create 10 tickets for alice
-		aliceTicketSeq := env.CreateTickets(alice, 10)
-		env.Close()
-
-		aliceSeq := env.Seq(alice)
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		// Submit batch with outer using ticket, inner using sequences
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, aliceSeq+0)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, aliceSeq+1)).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// Verify owner count: started with 10 tickets, consumed 1 (outer ticket) = 9
-		require.Equal(t, uint32(9), env.OwnerCount(alice), "alice should have 9 owner objects")
-		require.Equal(t, uint32(9), env.TicketCount(alice), "alice should have 9 tickets remaining")
-
-		// Alice's sequence advances by 2 (inner txns use sequences)
-		jtx.RequireSequence(t, env, alice, aliceSeq+2)
-
-		// Alice pays XRP(3) + batchFee; Bob receives XRP(3)
-		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
-	})
-
-	t.Run("tickets inner", func(t *testing.T) {
-		// Outer batch uses regular sequence; inner transactions use tickets.
-		// Reference: rippled Batch_test.cpp testTickets() - "tickets inner"
-		env := newBatchEnv(t)
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.FundAmount(alice, uint64(jtx.XRP(10000)))
-		env.FundAmount(bob, uint64(jtx.XRP(10000)))
-		env.Close()
-
-		// Create 10 tickets for alice
-		aliceTicketSeq := env.CreateTickets(alice, 10)
-		env.Close()
-
-		aliceSeq := env.Seq(alice)
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		// Submit batch with outer using sequence, inner using tickets
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq)).
-			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 2, aliceTicketSeq+1)).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// Verify owner count: started with 10 tickets, consumed 2 (inner tickets) = 8
-		require.Equal(t, uint32(8), env.OwnerCount(alice), "alice should have 8 owner objects")
-		require.Equal(t, uint32(8), env.TicketCount(alice), "alice should have 8 tickets remaining")
-
-		// Alice's sequence advances by 1 (only outer seq increment, inner use tickets)
-		jtx.RequireSequence(t, env, alice, aliceSeq+1)
-
-		// Alice pays XRP(3) + batchFee; Bob receives XRP(3)
-		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
-	})
-
-	t.Run("tickets outer inner", func(t *testing.T) {
-		// Outer batch uses a ticket; one inner tx uses a ticket, the other uses a sequence.
-		// Reference: rippled Batch_test.cpp testTickets() - "tickets outer inner"
-		env := newBatchEnv(t)
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.FundAmount(alice, uint64(jtx.XRP(10000)))
-		env.FundAmount(bob, uint64(jtx.XRP(10000)))
-		env.Close()
-
-		// Create 10 tickets for alice
-		aliceTicketSeq := env.CreateTickets(alice, 10)
-		env.Close()
-
-		aliceSeq := env.Seq(alice)
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		// Submit batch:
-		// - outer uses ticket aliceTicketSeq
-		// - inner[0] uses ticket aliceTicketSeq+1
-		// - inner[1] uses sequence aliceSeq
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, aliceSeq)).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// Verify owner count: started with 10 tickets, consumed 2 (outer + inner[0]) = 8
-		require.Equal(t, uint32(8), env.OwnerCount(alice), "alice should have 8 owner objects")
-		require.Equal(t, uint32(8), env.TicketCount(alice), "alice should have 8 tickets remaining")
-
-		// Alice's sequence advances by 1 (only inner[1] uses a sequence)
-		jtx.RequireSequence(t, env, alice, aliceSeq+1)
-
-		// Alice pays XRP(3) + batchFee; Bob receives XRP(3)
-		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
-	})
-}
-
-func TestTicketsOpenLedger(t *testing.T) {
-	// Reference: rippled Batch_test.cpp testTicketsOpenLedger()
-	// Tests that batch transactions using tickets interact correctly with
-	// standalone transactions using tickets from the same set.
-
-	t.Run("before batch txn with same ticket", func(t *testing.T) {
-		// Reference: rippled testTicketsOpenLedger() "Before Batch Txn w/ same ticket"
-		// The batch is applied first (canonical order), consuming the ticket
-		// used by the inner tx. The noop that also uses that ticket is
-		// overwritten.
-		env := newBatchEnv(t)
-		env.EnableOpenLedgerReplay()
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		aliceTicketSeq := env.CreateTickets(alice, 10)
-		env.Close()
-
-		aliceSeq := env.Seq(alice)
-
-		// AccountSet Txn using ticket+1
-		noopTxn := accounttx.NewAccountSet(alice.Address)
-		noopTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
-		noopTxn.SigningPubKey = alice.PublicKeyHex()
-		zero := uint32(0)
-		noopTxn.Sequence = &zero
-		ticketSeq1 := aliceTicketSeq + 1
-		noopTxn.TicketSequence = &ticketSeq1
-		result := env.Submit(noopTxn)
-		jtx.RequireTxSuccess(t, result)
-
-		// Batch Txn using ticket for outer, ticket+1 for inner payment
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, aliceSeq)).
-			Build()
-		result = env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// After close: batch succeeds. The inner tx consumed ticket+1, so
-		// the standalone noop that used ticket+1 fails during replay
-		// (ticket already consumed). alice seq should advance.
-		env.Close()
-
-		// Verify final state: alice consumed aliceSeq (inner payment #2),
-		// ticket (batch outer), ticket+1 (inner payment #1)
-		require.Equal(t, aliceSeq+1, env.Seq(alice))
-	})
-
-	t.Run("after batch txn with same ticket", func(t *testing.T) {
-		// Reference: rippled testTicketsOpenLedger() "After Batch Txn w/ same ticket"
-		env := newBatchEnv(t)
-		env.EnableOpenLedgerReplay()
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		aliceTicketSeq := env.CreateTickets(alice, 10)
-		env.Close()
-
-		aliceSeq := env.Seq(alice)
-
-		// Batch Txn first
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, aliceSeq)).
-			Build()
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-
-		// AccountSet Txn using ticket+1 (already consumed by batch inner)
-		noopTxn := accounttx.NewAccountSet(alice.Address)
-		noopTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
-		noopTxn.SigningPubKey = alice.PublicKeyHex()
-		zero := uint32(0)
-		noopTxn.Sequence = &zero
-		ticketSeq1 := aliceTicketSeq + 1
-		noopTxn.TicketSequence = &ticketSeq1
-		// In rippled this succeeds in the open view (noop applies because
-		// ticket+1 was consumed by batch's inner tx, but the noop itself
-		// is an AccountSet that just bumps the account state).
-		// The exact behavior depends on replay ordering.
-		// After close: batch wins in replay, noop fails.
-		env.Submit(noopTxn)
-		env.Close()
-
-		env.Close()
-
-		// Verify final state
-		require.Equal(t, aliceSeq+1, env.Seq(alice))
-	})
-}
-
-// =============================================================================
-// Test 18: testBatchTxQueue
-// Reference: rippled Batch_test.cpp testBatchTxQueue()
-// =============================================================================
-
-func TestBatchTxQueue(t *testing.T) {
-	t.Run("outer batch txns count towards queue size", func(t *testing.T) {
-		// Reference: rippled Batch_test.cpp testBatchTxQueue() first sub-test
-		// "only outer batch transactions are counter towards the queue size"
-		cfg := makeSmallQueueConfig(2)
-		env := jtx.NewTestEnvWithTxQ(t, cfg)
-		env.EnableFeatureNow("Batch")
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		carol := jtx.NewAccount("carol")
-
-		// Fund across several ledgers so the TxQ metrics stay restricted.
-		// noripple funds do not enable DefaultRipple (1 tx per account instead of 2).
-		env.FundAmountNoRipple(alice, uint64(jtx.XRP(10000)))
-		env.FundAmountNoRipple(bob, uint64(jtx.XRP(10000)))
-		env.Close()
-		env.FundAmountNoRipple(carol, uint64(jtx.XRP(10000)))
-		env.Close()
-
-		// Fill the ledger: 3 noops above the threshold of 2.
-		env.Noop(alice)
-		env.Noop(alice)
-		env.Noop(alice)
-		checkMetrics(t, env, 0, nil, 3, 2)
-
-		// Carol's noop gets queued because fee escalation requires more than base fee.
-		result := env.Submit(makeNoopWithFee(carol, env.BaseFee()))
-		jtx.RequireTxFail(t, result, "terQUEUED")
-		checkMetrics(t, env, 1, nil, 3, 2)
-
-		aliceSeq := env.Seq(alice)
-		bobSeq := env.Seq(bob)
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-
-		// Queue Batch: regular batch fee is too low to bypass escalation.
-		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, aliceSeq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, bobSeq)).
-			AddSigner(bob, "").
-			Build()
-		result = env.Submit(batch)
-		jtx.RequireTxFail(t, result, "terQUEUED")
-		checkMetrics(t, env, 2, nil, 3, 2)
-
-		// Replace Queued Batch with open ledger fee.
-		olFee := env.OpenLedgerFee(batchFee)
-		batch2 := NewBatchBuilder(alice, aliceSeq, olFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, aliceSeq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, bobSeq)).
-			AddSigner(bob, "").
-			Build()
-		result = env.Submit(batch2)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// After close: queue drained (carol's noop applied in new ledger),
-		// maxSize = txnsExpected * ledgersInQueue.
-		// Closed ledger had: 3 noops + 1 batch outer + 2 inner = 6 txns.
-		// With NormalConsensusIncreasePercent=0, txnsExpected = 6.
-		// maxSize = 6 * 2 = 12. txInLedger = 1 (carol's noop from queue).
-		maxSize := uint64(12)
-		checkMetrics(t, env, 0, &maxSize, 1, 6)
-		closed := env.LastClosedLedger()
-		require.Equal(t, uint32(6), closed.TxCount())
-		root, err := closed.TxMapHash()
-		require.NoError(t, err)
-		require.NotEqual(t, [32]byte{}, root)
-		require.Equal(t, root, closed.Header().TxHash)
-	})
-
-	t.Run("inner batch txns count towards ledger tx count", func(t *testing.T) {
-		// Reference: rippled Batch_test.cpp testBatchTxQueue() second sub-test
-		// "inner batch transactions are counter towards the ledger tx count"
-		cfg := makeSmallQueueConfig(2)
-		env := jtx.NewTestEnvWithTxQ(t, cfg)
-		env.EnableFeatureNow("Batch")
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		carol := jtx.NewAccount("carol")
-
-		// Fund across several ledgers so the TxQ metrics stay restricted.
-		env.FundAmountNoRipple(alice, uint64(jtx.XRP(10000)))
-		env.FundAmountNoRipple(bob, uint64(jtx.XRP(10000)))
-		env.Close()
-		env.FundAmountNoRipple(carol, uint64(jtx.XRP(10000)))
-		env.Close()
-
-		// Fill the ledger leaving room for 1 more transaction at base fee.
-		env.Noop(alice)
-		env.Noop(alice)
-		checkMetrics(t, env, 0, nil, 2, 2)
-
-		aliceSeq := env.Seq(alice)
-		bobSeq := env.Seq(bob)
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-
-		// Batch Successful: at txInLedger=2 (equal to threshold), batch gets in.
-		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, aliceSeq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, bobSeq)).
-			AddSigner(bob, "").
-			Build()
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		// txInLedger = 3 (2 noops + 1 batch outer).
-		// The batch counts as 1 for open ledger txInLedger.
-		checkMetrics(t, env, 0, nil, 3, 2)
-
-		// Carol's noop gets queued because txInLedger=3 > txnsExpected=2.
-		result = env.Submit(makeNoopWithFee(carol, env.BaseFee()))
-		jtx.RequireTxFail(t, result, "terQUEUED")
-		checkMetrics(t, env, 1, nil, 3, 2)
-	})
-}
-
-// makeSmallQueueConfig creates a TxQ config matching rippled's Batch_test
-// makeSmallQueueConfig({{"minimum_txn_in_ledger_standalone", minTxn}}).
-// Reference: rippled Batch_test.cpp makeSmallQueueConfig()
-func makeSmallQueueConfig(minTxnStandalone uint32) txq.Config {
-	return txq.Config{
-		LedgersInQueue:                 2,
-		QueueSizeMin:                   2,
-		RetrySequencePercent:           25,
-		MinimumEscalationMultiplier:    txq.BaseLevel * 500, // 128000
-		MinimumTxnInLedger:             32,
-		MinimumTxnInLedgerStandalone:   minTxnStandalone,
-		TargetTxnInLedger:              256,
-		MaximumTxnInLedger:             0,
-		NormalConsensusIncreasePercent: 0,
-		SlowConsensusDecreasePercent:   50,
-		MaximumTxnPerAccount:           10,
-		MinimumLastLedgerBuffer:        2,
-		Standalone:                     true,
-	}
-}
-
-// makeNoopWithFee creates an AccountSet noop with a specific fee.
-// Unlike env.Noop() which auto-fills and submits, this returns the raw tx.
-func makeNoopWithFee(acc *jtx.Account, fee uint64) *accounttx.AccountSet {
-	as := accounttx.NewAccountSet(acc.Address)
-	as.Fee = fmt.Sprintf("%d", fee)
-	return as
-}
-
-// checkMetrics asserts TxQ metrics match expected values.
-// maxSize nil means skip that assertion (matches rippled's std::nullopt).
-// Reference: rippled test/jtx/TestHelpers.h checkMetrics()
-func checkMetrics(t *testing.T, env *jtx.TestEnv, expectedQueueSize uint64, expectedMaxSize *uint64, expectedTxInLedger uint64, expectedTxPerLedger uint64) {
-	t.Helper()
-	metrics := env.TxQMetrics()
-
-	require.Equal(t, expectedQueueSize, metrics.TxCount,
-		"checkMetrics: txCount (queue size) mismatch")
-
-	if expectedMaxSize != nil {
-		require.NotNil(t, metrics.TxQMaxSize, "checkMetrics: maxSize should not be nil")
-		require.Equal(t, *expectedMaxSize, *metrics.TxQMaxSize,
-			"checkMetrics: txQMaxSize mismatch")
-	}
-
-	require.Equal(t, expectedTxInLedger, metrics.TxInLedger,
-		"checkMetrics: txInLedger mismatch")
-
-	require.Equal(t, expectedTxPerLedger, metrics.TxPerLedger,
-		"checkMetrics: txPerLedger mismatch")
-}
-
-// =============================================================================
-// Test 19: testBatchNetworkOps
-// Reference: rippled Batch_test.cpp testBatchNetworkOps()
-// =============================================================================
-
-func TestBatchNetworkOps(t *testing.T) {
-	t.Skip("Skipped: Network operations not available in go-xrpl test environment")
-}
-
-// =============================================================================
-// Test 20: testSequenceOpenLedger
-// Reference: rippled Batch_test.cpp testSequenceOpenLedger()
-// =============================================================================
-
-func TestSequenceOpenLedger(t *testing.T) {
-	// Reference: rippled Batch_test.cpp testSequenceOpenLedger()
-	// Tests interactions between batch inner transactions advancing sequences
-	// and standalone transactions with future sequences or the same sequences.
-	//
-	// Key difference from rippled: In our Go implementation, batch inner
-	// transactions are applied immediately to the open view (unlike rippled
-	// which defers them to consensus). The replay-on-close mechanism ensures
-	// the final closed ledger state matches rippled. We verify final state
-	// (sequences, balances) rather than per-ledger transaction inclusion.
-
-	t.Run("before batch txn with retry following ledger", func(t *testing.T) {
-		// Reference: rippled testSequenceOpenLedger() "Before Batch Txn w/ retry following ledger"
-		// A noop at aliceSeq+2 gets terPRE_SEQ. Then a batch with carol as
-		// outer submitter and alice as inner signer advances alice's seq.
-		// After close: batch succeeds, noop retried in next ledger.
-		env := newBatchEnv(t)
-		env.EnableOpenLedgerReplay()
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		carol := jtx.NewAccount("carol")
-		env.Fund(alice, bob, carol)
-		env.Close()
-
-		aliceSeq := env.Seq(alice)
-		carolSeq := env.Seq(carol)
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		// AccountSet Txn at aliceSeq+2 -> terPRE_SEQ (future sequence)
-		noopTxn := accounttx.NewAccountSet(alice.Address)
-		noopTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
-		noopTxn.SigningPubKey = alice.PublicKeyHex()
-		futureSeq := aliceSeq + 2
-		noopTxn.Sequence = &futureSeq
-		result := env.Submit(noopTxn)
-		jtx.RequireTxFail(t, result, "terPRE_SEQ")
-
-		// Batch Txn: carol outer, alice inner signer
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-		batch := NewBatchBuilder(carol, carolSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, aliceSeq)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, aliceSeq+1)).
-			AddSigner(alice, "").
-			Build()
-		result = env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// After first close: batch applied (alice seq -> aliceSeq+2).
-		// Noop at aliceSeq+2 may or may not be in first closed ledger
-		// (depends on canonical ordering and replay behavior).
-		// Close again to ensure the noop is retried if held.
-		env.Close()
-
-		// Final state verification:
-		// - alice's seq should be aliceSeq+3 (aliceSeq consumed by inner pay#1,
-		//   aliceSeq+1 by inner pay#2, aliceSeq+2 by noop)
-		require.Equal(t, aliceSeq+3, env.Seq(alice),
-			"alice seq should have advanced by 3 (2 inner payments + 1 noop)")
-
-		// Carol consumed carolSeq for the batch outer
-		require.Equal(t, carolSeq+1, env.Seq(carol),
-			"carol seq should have advanced by 1 (batch outer)")
-
-		// alice paid XRP(1) + XRP(2) = XRP(3) to bob, plus baseFee for noop
-		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-env.BaseFee())
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
-	})
-
-	t.Run("before batch txn with same sequence", func(t *testing.T) {
-		// Reference: rippled testSequenceOpenLedger() "Before Batch Txn w/ same sequence"
-		// A noop at aliceSeq+1 gets terPRE_SEQ. Then a batch with alice as
-		// outer submitter has inner payments consuming aliceSeq+1 and aliceSeq+2.
-		// After close: batch wins (canonical order), noop overwritten.
-		env := newBatchEnv(t)
-		env.EnableOpenLedgerReplay()
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		aliceSeq := env.Seq(alice)
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		// AccountSet Txn at aliceSeq+1 -> terPRE_SEQ
-		noopTxn := accounttx.NewAccountSet(alice.Address)
-		noopTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
-		noopTxn.SigningPubKey = alice.PublicKeyHex()
-		futureSeq := aliceSeq + 1
-		noopTxn.Sequence = &futureSeq
-		result := env.Submit(noopTxn)
-		jtx.RequireTxFail(t, result, "terPRE_SEQ")
-
-		// Batch Txn: alice outer
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, aliceSeq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, aliceSeq+2)).
-			Build()
-		result = env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// After first close: batch applied. The noop at aliceSeq+1 is
-		// overwritten by the batch's inner payment at the same sequence.
-		// Close again to flush held transactions.
-		env.Close()
-
-		// Final state: batch consumed aliceSeq (outer), aliceSeq+1 (inner#1),
-		// aliceSeq+2 (inner#2). The noop at aliceSeq+1 failed (sequence
-		// already consumed by inner payment). alice seq = aliceSeq+3.
-		require.Equal(t, aliceSeq+3, env.Seq(alice),
-			"alice seq should have advanced by 3 (outer + 2 inner payments)")
-
-		// alice paid XRP(1) + XRP(2) + batchFee to bob
-		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
-	})
-
-	t.Run("after batch txn with same sequence", func(t *testing.T) {
-		// Reference: rippled testSequenceOpenLedger() "After Batch Txn w/ same sequence"
-		// Batch submitted first, then noop at aliceSeq+1.
-		// After close: batch wins (applied first), noop at same seq overwritten.
-		env := newBatchEnv(t)
-		env.EnableOpenLedgerReplay()
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		aliceSeq := env.Seq(alice)
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		// Batch Txn: alice outer
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, aliceSeq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, aliceSeq+2)).
-			Build()
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-
-		// AccountSet Txn at aliceSeq+1 (same as inner payment #1's seq)
-		// In our Go code, this may succeed since inner txns already applied
-		// and alice's seq is already aliceSeq+3.
-		// In rippled, this gets tesSUCCESS in open view (but at a different
-		// seq since inner txns weren't applied).
-		// After close (replay): batch applied first, noop overwritten.
-		noopTxn := accounttx.NewAccountSet(alice.Address)
-		noopTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
-		noopTxn.SigningPubKey = alice.PublicKeyHex()
-		sameSeq := aliceSeq + 1
-		noopTxn.Sequence = &sameSeq
-		env.Submit(noopTxn)
-		env.Close()
-
-		// After close: batch consumed aliceSeq (outer), aliceSeq+1 (inner#1),
-		// aliceSeq+2 (inner#2). The noop at aliceSeq+1 was overwritten.
-		env.Close()
-
-		// Final state: alice seq = aliceSeq+3
-		require.Equal(t, aliceSeq+3, env.Seq(alice),
-			"alice seq should have advanced by 3 (outer + 2 inner payments)")
-
-		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
-	})
-
-	t.Run("outer batch terPRE_SEQ", func(t *testing.T) {
-		// Reference: rippled testSequenceOpenLedger() "Outer Batch terPRE_SEQ"
-		// Batch outer has a future sequence (carolSeq+1) -> terPRE_SEQ.
-		// A noop advances carol's seq. After close: batch succeeds.
-		env := newBatchEnv(t)
-		env.EnableOpenLedgerReplay()
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		carol := jtx.NewAccount("carol")
-		env.Fund(alice, bob, carol)
-		env.Close()
-
-		aliceSeq := env.Seq(alice)
-		carolSeq := env.Seq(carol)
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		// Batch Txn with future carolSeq -> terPRE_SEQ
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-		batch := NewBatchBuilder(carol, carolSeq+1, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, aliceSeq)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, aliceSeq+1)).
-			AddSigner(alice, "").
-			Build()
-		result := env.Submit(batch)
-		jtx.RequireTxFail(t, result, "terPRE_SEQ")
-
-		// AccountSet noop at carolSeq -> tesSUCCESS (advances carol's seq)
-		noopTxn := accounttx.NewAccountSet(carol.Address)
-		noopTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
-		noopTxn.SigningPubKey = carol.PublicKeyHex()
-		noopTxn.Sequence = &carolSeq
-		result = env.Submit(noopTxn)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// After close: noop advances carol's seq, then batch succeeds.
-		// Close again to flush held transactions.
-		env.Close()
-
-		// Final state:
-		// - alice consumed aliceSeq and aliceSeq+1 (inner payments)
-		require.Equal(t, aliceSeq+2, env.Seq(alice),
-			"alice seq should advance by 2 (inner payments)")
-
-		// - carol consumed carolSeq (noop) and carolSeq+1 (batch outer)
-		require.Equal(t, carolSeq+2, env.Seq(carol),
-			"carol seq should advance by 2 (noop + batch outer)")
-
-		// alice paid XRP(3) total to bob
-		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3)))
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
-	})
-}
-
-// =============================================================================
-// Test 21: testObjectsOpenLedger
-// Reference: rippled Batch_test.cpp testObjectsOpenLedger()
-// =============================================================================
-
-func TestObjectsOpenLedger(t *testing.T) {
-	// Reference: rippled Batch_test.cpp testObjectsOpenLedger()
-	// Tests interactions between batch inner transactions creating/consuming
-	// ledger objects and standalone transactions that depend on those objects.
-
-	t.Run("consume object before batch txn", func(t *testing.T) {
-		// Reference: rippled testObjectsOpenLedger() "Consume Object Before Batch Txn"
-		// CheckCash submitted before the batch that creates the check.
-		// In rippled, CheckCash gets tecNO_ENTRY initially (inner txns deferred).
-		// During consensus replay, batch (alice) is applied first in canonical
-		// order, creating the check. Then CheckCash (bob) succeeds.
-		//
-		// In our Go code, the batch inner txns are applied immediately, so
-		// the CheckCash may succeed or fail depending on submission order.
-		// After replay-on-close, the final state is the same.
-		env := newBatchEnv(t)
-		env.EnableOpenLedgerReplay()
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		aliceTicketSeq := env.CreateTickets(alice, 10)
-		env.Close()
-
-		aliceSeq := env.Seq(alice)
-		bobSeq := env.Seq(bob)
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		// CheckCash Txn for a check that doesn't exist yet
-		chkID := GetCheckIndex(alice, aliceSeq)
-		cashTxn := check.NewCheckCash(bob.Address, chkID)
-		cashTxn.SetExactAmount(tx.NewXRPAmount(jtx.XRP(10)))
-		cashTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
-		cashTxn.SigningPubKey = bob.PublicKeyHex()
-		cashTxn.Sequence = &bobSeq
-		// In rippled this gets tecNO_ENTRY. In our Go code, it may get
-		// tecNO_ENTRY too since the batch hasn't been submitted yet.
-		env.Submit(cashTxn)
-
-		// Batch Txn: creates the check and pays XRP(1)
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerCheckCreate(alice, bob, tx.NewXRPAmount(jtx.XRP(10)), aliceSeq)).
-			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq+1)).
-			Build()
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// After close (replay): batch creates check, then CheckCash succeeds.
-		env.Close()
-
-		// Final state verification:
-		// bob should have cashed XRP(10) check + received XRP(1) payment
-		// alice should have lost XRP(10) (check) + XRP(1) (payment) + batchFee + baseFee (for CheckCash on bob)
-		// bob consumes bobSeq for CheckCash
-		require.Equal(t, bobSeq+1, env.Seq(bob),
-			"bob seq should advance by 1 (CheckCash)")
-		// alice consumes aliceSeq (inner CheckCreate), aliceTicketSeq (outer), aliceTicketSeq+1 (inner payment)
-		require.Equal(t, aliceSeq+1, env.Seq(alice),
-			"alice seq should advance by 1 (inner CheckCreate)")
-
-		// Balance check: alice paid XRP(10) check + XRP(1) + batchFee
-		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(11))-batchFee)
-		// bob gained XRP(10) check + XRP(1), paid baseFee for CheckCash
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(11))-env.BaseFee())
-	})
-
-	t.Run("create object before batch txn", func(t *testing.T) {
-		// Reference: rippled testObjectsOpenLedger() "Create Object Before Batch Txn"
-		// CheckCreate submitted before the batch. The batch's inner CheckCash
-		// consumes the check. The standalone CheckCreate runs first in the
-		// open view.
-		env := newBatchEnv(t)
-		env.EnableOpenLedgerReplay()
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		aliceTicketSeq := env.CreateTickets(alice, 10)
-		env.Close()
-
-		aliceSeq := env.Seq(alice)
-		bobSeq := env.Seq(bob)
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		// CheckCreate Txn (standalone) — alice creates a check payable to bob
-		chkID := GetCheckIndex(alice, aliceSeq)
-		createTxn := check.NewCheckCreate(alice.Address, bob.Address, tx.NewXRPAmount(jtx.XRP(10)))
-		createTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
-		createTxn.SigningPubKey = alice.PublicKeyHex()
-		createTxn.Sequence = &aliceSeq
-		result := env.Submit(createTxn)
-		jtx.RequireTxSuccess(t, result)
-
-		// Batch Txn: inner CheckCash (bob cashes the check) + inner Payment
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerCheckCash(bob, chkID, tx.NewXRPAmount(jtx.XRP(10)), bobSeq)).
-			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq+1)).
-			AddSigner(bob, "").
-			Build()
-		result = env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// Final state verification:
-		// bob cashed check XRP(10) + received XRP(1) payment
-		require.Equal(t, bobSeq+1, env.Seq(bob),
-			"bob seq should advance by 1 (inner CheckCash)")
-		require.Equal(t, aliceSeq+1, env.Seq(alice),
-			"alice seq should advance by 1 (standalone CheckCreate)")
-
-		// alice paid: XRP(10) check + XRP(1) payment + batchFee + baseFee for CheckCreate
-		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(11))-batchFee-env.BaseFee())
-		// bob gained: XRP(10) check + XRP(1) payment
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(11)))
-	})
-
-	t.Run("after batch txn", func(t *testing.T) {
-		// Reference: rippled testObjectsOpenLedger() "After Batch Txn"
-		// Batch creates a check (inner), then standalone CheckCash tries to cash it.
-		// In rippled, the CheckCash gets tecNO_ENTRY because batch inner txns
-		// are deferred. During replay, batch applies first, then CheckCash succeeds.
-		env := newBatchEnv(t)
-		env.EnableOpenLedgerReplay()
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		aliceTicketSeq := env.CreateTickets(alice, 10)
-		env.Close()
-
-		aliceSeq := env.Seq(alice)
-		bobSeq := env.Seq(bob)
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		// Batch Txn: creates check + payment
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		chkID := GetCheckIndex(alice, aliceSeq)
-		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerCheckCreate(alice, bob, tx.NewXRPAmount(jtx.XRP(10)), aliceSeq)).
-			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq+1)).
-			Build()
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-
-		// CheckCash Txn (standalone) — bob cashes the check
-		cashTxn := check.NewCheckCash(bob.Address, chkID)
-		cashTxn.SetExactAmount(tx.NewXRPAmount(jtx.XRP(10)))
-		cashTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
-		cashTxn.SigningPubKey = bob.PublicKeyHex()
-		cashTxn.Sequence = &bobSeq
-		// In our Go code, the check exists (inner txns applied), so this
-		// may succeed directly. In rippled, it gets tecNO_ENTRY.
-		env.Submit(cashTxn)
-		env.Close()
-
-		// After close (replay): batch creates check, then CheckCash succeeds.
-		env.Close()
-
-		// Final state verification:
-		require.Equal(t, bobSeq+1, env.Seq(bob),
-			"bob seq should advance by 1 (CheckCash)")
-		require.Equal(t, aliceSeq+1, env.Seq(alice),
-			"alice seq should advance by 1 (inner CheckCreate)")
-
-		// alice lost XRP(10) check + XRP(1) payment + batchFee
-		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(11))-batchFee)
-		// bob gained XRP(10) check + XRP(1) payment, paid baseFee for CheckCash
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(11))-env.BaseFee())
-	})
-}
-
-// =============================================================================
-// Test 22: testOpenLedger
-// Reference: rippled Batch_test.cpp testOpenLedger()
-// =============================================================================
-
-func TestOpenLedger(t *testing.T) {
-	// Reference: rippled Batch_test.cpp testOpenLedger()
-	// Tests a mixed scenario: alice pays bob, then an atomic batch with
-	// alice+bob, then bob pays alice with a future sequence (terPRE_SEQ).
-	// The canonical ordering during consensus determines transaction placement.
-	//
-	// In rippled's canonical ordering (salted), alice's payment comes first,
-	// then the batch, then bob's payment is retried next ledger.
-	//
-	// In our implementation, since inner batch txns are applied immediately,
-	// bob's payment at bobSeq+1 may or may not get terPRE_SEQ depending on
-	// whether the batch has already been applied. We verify final state.
-	env := newBatchEnv(t)
-	env.EnableOpenLedgerReplay()
-
-	alice := jtx.NewAccount("alice")
-	bob := jtx.NewAccount("bob")
-	env.Fund(alice, bob)
-	env.Close()
-
-	// Extra noop to advance bob's seq (matching rippled: env(noop(bob)))
-	noopBob := accounttx.NewAccountSet(bob.Address)
-	noopBob.Fee = fmt.Sprintf("%d", env.BaseFee())
-	noopBob.SigningPubKey = bob.PublicKeyHex()
-	bobNoopSeq := env.Seq(bob)
-	noopBob.Sequence = &bobNoopSeq
-	result := env.Submit(noopBob)
-	jtx.RequireTxSuccess(t, result)
-	env.Close()
-
-	aliceSeq := env.Seq(alice)
-	preAlice := env.Balance(alice)
-	preBob := env.Balance(bob)
-	bobSeq := env.Seq(bob)
-
-	// Alice Pays Bob (Open Ledger)
-	payTxn1 := payment.NewPayment(alice.Address, bob.Address, tx.NewXRPAmount(jtx.XRP(10)))
-	payTxn1.Fee = fmt.Sprintf("%d", env.BaseFee())
-	payTxn1.SigningPubKey = alice.PublicKeyHex()
-	payTxn1.Sequence = &aliceSeq
-	result = env.Submit(payTxn1)
-	jtx.RequireTxSuccess(t, result)
-
-	// Alice & Bob Atomic Batch
-	batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-	batch := NewBatchBuilder(alice, aliceSeq+1, batchFee, batchtx.BatchFlagAllOrNothing).
-		AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, aliceSeq+2)).
-		AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, bobSeq)).
-		AddSigner(bob, "").
-		Build()
-	result = env.Submit(batch)
-	jtx.RequireTxSuccess(t, result)
-
-	// Bob pays Alice (Open Ledger) at bobSeq+1
-	// In rippled this gets terPRE_SEQ because bob's seq hasn't advanced in
-	// the open view (inner txns deferred). In our code, bob's seq may have
-	// already advanced due to immediate inner txn application.
-	bobPaySeq := bobSeq + 1
-	payTxn2 := payment.NewPayment(bob.Address, alice.Address, tx.NewXRPAmount(jtx.XRP(5)))
-	payTxn2.Fee = fmt.Sprintf("%d", env.BaseFee())
-	payTxn2.SigningPubKey = bob.PublicKeyHex()
-	payTxn2.Sequence = &bobPaySeq
-	env.Submit(payTxn2)
-	env.Close()
-
-	// Close again to ensure any held transactions are retried
-	env.Close()
-
-	// Final state verification (matches rippled):
-	// alice: aliceSeq (pay#1) + aliceSeq+1 (batch outer) + aliceSeq+2 (inner pay) = 3 txns
-	require.Equal(t, aliceSeq+3, env.Seq(alice),
-		"alice seq should have advanced by 3")
-
-	// bob: bobSeq (inner pay to alice) + bobSeq+1 (standalone pay to alice) = 2 txns
-	require.Equal(t, bobSeq+2, env.Seq(bob),
-		"bob seq should have advanced by 2")
-
-	// Balance verification:
-	// alice: -XRP(10) pay1 - baseFee pay1 - XRP(10) inner pay - batchFee + XRP(5) inner bob->alice
-	// but also bob pays alice XRP(5) standalone
-	// Net alice: preAlice - XRP(10) - XRP(10) + XRP(5) + XRP(5) - baseFee - batchFee
-	//          = preAlice - XRP(10) - baseFee - batchFee
-	jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(10))-batchFee-env.BaseFee())
-
-	// bob: +XRP(10) pay1 + XRP(10) inner alice->bob - XRP(5) inner bob->alice
-	//      - XRP(5) standalone - baseFee for standalone
-	// Net bob: preBob + XRP(10) - baseFee
-	jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(10))-env.BaseFee())
-}
-
-// =============================================================================
-// Test 24: testBadRawTxn
-// Reference: rippled Batch_test.cpp testBadRawTxn()
-// =============================================================================
-
-func TestBadRawTxn(t *testing.T) {
-	t.Run("nil inner transaction", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-
-		// Manually build a batch with a nil inner tx
-		batch := batchtx.NewBatch(alice.Address)
-		batch.Fee = fmt.Sprintf("%d", batchFee)
-		batch.SetSequence(seq)
-		batch.SetFlags(batchtx.BatchFlagAllOrNothing)
-		batch.RawTransactions = []batchtx.RawTransaction{
-			{RawTransaction: batchtx.RawTransactionData{InnerTx: nil}}, // nil
-			{RawTransaction: batchtx.RawTransactionData{InnerTx: MakeInnerPaymentXRP(alice, bob, 1, seq+2)}},
-		}
-
-		result := env.Submit(batch)
-		// Should fail validation - nil inner transaction
-		require.False(t, result.Success)
-	})
-}
-
-// =============================================================================
-// Test 25: testPreclaim
-// Reference: rippled Batch_test.cpp testPreclaim()
-// Skipped in part: Multi-signing, SignersList, RegularKey require infra not yet available
-// =============================================================================
-
-func TestPreclaim(t *testing.T) {
-	// Reference: rippled Batch_test.cpp testPreclaim()
-	// Tests checkSign.checkSingleSign, checkBatchSign.checkMultiSign, and checkBatchSign.checkSingleSign.
-	// Uses a shared environment because state accumulates (signer lists, regular keys, disabled masters).
-
-	env := newBatchEnv(t)
-
-	alice := jtx.NewAccount("alice")
-	bob := jtx.NewAccount("bob")
-	carol := jtx.NewAccount("carol")
-	dave := jtx.NewAccount("dave")
-	elsa := jtx.NewAccount("elsa")
-	frank := jtx.NewAccount("frank")
-	phantom := jtx.NewAccount("phantom") // not funded — phantom account
-
-	env.FundAmount(alice, uint64(jtx.XRP(10000)))
-	env.FundAmount(bob, uint64(jtx.XRP(10000)))
-	env.FundAmount(carol, uint64(jtx.XRP(10000)))
-	env.FundAmount(dave, uint64(jtx.XRP(10000)))
-	env.FundAmount(elsa, uint64(jtx.XRP(10000)))
-	env.FundAmount(frank, uint64(jtx.XRP(10000)))
-	env.Close()
-
-	// ------------------------------------------------------------------
-	// checkSign.checkSingleSign
-	// tefBAD_AUTH: Bob is not authorized to sign for Alice
-	// SKIPPED: Go test env uses SkipSignatureVerification=true, so the outer
-	// signature check (checkSign.checkSingleSign) is skipped entirely.
-	// This test verifies outer tx signature, not batch signer authorization.
-
-	// ------------------------------------------------------------------
-	// checkBatchSign.checkMultiSign
-
-	// tefNOT_MULTI_SIGNING: SignersList not enabled for bob
-	t.Run("checkBatchSign.checkMultiSign/tefNOT_MULTI_SIGNING", func(t *testing.T) {
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
-			AddMultiSignBatchSigner(bob, []*jtx.Account{dave, carol}).
-			Build()
-		result := env.Submit(batch)
-		require.Equal(t, "tefNOT_MULTI_SIGNING", result.Code)
-		env.Close()
-	})
-
-	// Set up signer lists for alice and bob
-	// alice: quorum=2, signers={bob:1, carol:1}
-	env.SetSignerList(alice, 2, []jtx.TestSigner{
-		{Account: bob, Weight: 1},
-		{Account: carol, Weight: 1},
-	})
-	env.Close()
-
-	// bob: quorum=2, signers={carol:1, dave:1, elsa:1}
-	env.SetSignerList(bob, 2, []jtx.TestSigner{
-		{Account: carol, Weight: 1},
-		{Account: dave, Weight: 1},
-		{Account: elsa, Weight: 1},
-	})
-	env.Close()
-
-	// tefBAD_SIGNATURE: Account not in SignersList (frank not in bob's list)
-	t.Run("checkBatchSign.checkMultiSign/tefBAD_SIGNATURE_not_in_list", func(t *testing.T) {
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
-			AddMultiSignBatchSigner(bob, []*jtx.Account{carol, frank}).
-			Build()
-		result := env.Submit(batch)
-		require.Equal(t, "tefBAD_SIGNATURE", result.Code)
-		env.Close()
-	})
-
-	// tefBAD_SIGNATURE: Wrong publicKey type (ed25519 dave not in signer list)
-	t.Run("checkBatchSign.checkMultiSign/tefBAD_SIGNATURE_wrong_key_type", func(t *testing.T) {
-		daveEd := jtx.NewAccountWithKeyType("dave", jtx.KeyTypeEd25519)
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
-			AddMultiSignBatchSigner(bob, []*jtx.Account{carol, daveEd}).
-			Build()
-		result := env.Submit(batch)
-		require.Equal(t, "tefBAD_SIGNATURE", result.Code)
-		env.Close()
-	})
-
-	// tefMASTER_DISABLED: elsa has master disabled
-	env.SetRegularKey(elsa, frank)
-	env.DisableMasterKey(elsa)
-	t.Run("checkBatchSign.checkMultiSign/tefMASTER_DISABLED", func(t *testing.T) {
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
-			AddMultiSignBatchSigner(bob, []*jtx.Account{carol, elsa}).
-			Build()
-		result := env.Submit(batch)
-		require.Equal(t, "tefMASTER_DISABLED", result.Code)
-		env.Close()
-	})
-
-	// tefBAD_SIGNATURE: Signer does not exist (phantom not in ledger, not in signer list)
-	t.Run("checkBatchSign.checkMultiSign/tefBAD_SIGNATURE_phantom", func(t *testing.T) {
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
-			AddMultiSignBatchSigner(bob, []*jtx.Account{carol, phantom}).
-			Build()
-		result := env.Submit(batch)
-		require.Equal(t, "tefBAD_SIGNATURE", result.Code)
-		env.Close()
-	})
-
-	// tefBAD_SIGNATURE: Signer has not enabled RegularKey
-	// dave signs with davo (ed25519) key, but dave has no regular key set
-	t.Run("checkBatchSign.checkMultiSign/tefBAD_SIGNATURE_no_regkey", func(t *testing.T) {
-		davo := jtx.NewAccountWithKeyType("davo", jtx.KeyTypeEd25519)
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
-			AddMultiSignBatchSignerWithRegKeys(bob, []RegKeySigner{
-				{Account: carol, SigningKey: carol}, // carol signs with own key
-				{Account: dave, SigningKey: davo},   // dave signs with davo's key (no regkey set)
-			}).
-			Build()
-		result := env.Submit(batch)
-		require.Equal(t, "tefBAD_SIGNATURE", result.Code)
-		env.Close()
-	})
-
-	// tefBAD_SIGNATURE: Wrong RegularKey Set
-	// dave's regular key is frank, but trying to sign with davo
-	env.SetRegularKey(dave, frank)
-	t.Run("checkBatchSign.checkMultiSign/tefBAD_SIGNATURE_wrong_regkey", func(t *testing.T) {
-		davo := jtx.NewAccountWithKeyType("davo", jtx.KeyTypeEd25519)
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
-			AddMultiSignBatchSignerWithRegKeys(bob, []RegKeySigner{
-				{Account: carol, SigningKey: carol},
-				{Account: dave, SigningKey: davo}, // davo != frank (dave's regular key)
-			}).
-			Build()
-		result := env.Submit(batch)
-		require.Equal(t, "tefBAD_SIGNATURE", result.Code)
-		env.Close()
-	})
-
-	// tefBAD_QUORUM: Only carol signs (weight 1), quorum is 2
-	t.Run("checkBatchSign.checkMultiSign/tefBAD_QUORUM", func(t *testing.T) {
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 2, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
-			AddMultiSignBatchSigner(bob, []*jtx.Account{carol}).
-			Build()
-		result := env.Submit(batch)
-		require.Equal(t, "tefBAD_QUORUM", result.Code)
-		env.Close()
-	})
-
-	// tesSUCCESS: BatchSigners.Signers with carol + dave (weight 2, quorum 2)
-	t.Run("checkBatchSign.checkMultiSign/tesSUCCESS", func(t *testing.T) {
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
-			AddMultiSignBatchSigner(bob, []*jtx.Account{carol, dave}).
-			Build()
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-	})
-
-	// tesSUCCESS: Multisign outer + BatchSigners.Signers
-	// SKIPPED: Outer multi-signing (msig(bob, carol)) is a signature verification feature,
-	// which is skipped in Go test env (SkipSignatureVerification=true). The previous
-	// test already verifies BatchSigners.Signers succeeds.
-
-	// ------------------------------------------------------------------
-	// checkBatchSign.checkSingleSign
-
-	// tefBAD_AUTH: Inner Account (phantom) is not a signer — phantom doesn't exist and
-	// carol's pubkey doesn't derive to phantom's address
-	t.Run("checkBatchSign.checkSingleSign/tefBAD_AUTH_phantom", func(t *testing.T) {
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, phantom, 1000, seq+1)).
-			AddInnerTx(MakeInnerAccountSet(phantom, env.LedgerSeq())).
-			AddSignerWithRegKey(phantom, carol, "DEADBEEF").
-			Build()
-		result := env.Submit(batch)
-		require.Equal(t, "tefBAD_AUTH", result.Code)
-		env.Close()
-	})
-
-	// tefBAD_AUTH: Account (bob) signed with carol's key, but bob doesn't have carol as regular key
-	// Note: at this point bob does NOT yet have carol as his regular key (that's set at line 801 in rippled)
-	// Wait — actually, by this point in our test, bob HAS a regular key? Let me check...
-	// Actually, in the shared env, we haven't set bob's regular key yet.
-	// But bob has a signer list. A signer list is NOT the same as regular key.
-	t.Run("checkBatchSign.checkSingleSign/tefBAD_AUTH_not_signer", func(t *testing.T) {
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1000, seq+1)).
-			AddInnerTx(MakeInnerAccountSet(bob, env.LedgerSeq())).
-			AddSignerWithRegKey(bob, carol, "DEADBEEF").
-			Build()
-		result := env.Submit(batch)
-		require.Equal(t, "tefBAD_AUTH", result.Code)
-		env.Close()
-	})
-
-	// tesSUCCESS: Signed With Regular Key
-	env.SetRegularKey(bob, carol)
-	t.Run("checkBatchSign.checkSingleSign/tesSUCCESS_regular_key", func(t *testing.T) {
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 2, env.Seq(bob))).
-			AddSignerWithRegKey(bob, carol, "DEADBEEF").
-			Build()
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-	})
-
-	// tesSUCCESS: Signed With Master Key
-	t.Run("checkBatchSign.checkSingleSign/tesSUCCESS_master_key", func(t *testing.T) {
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 2, env.Seq(bob))).
-			AddSigner(bob, "DEADBEEF").
-			Build()
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-	})
-
-	// tefMASTER_DISABLED: Signed With Master Key Disabled
-	env.SetRegularKey(bob, carol) // regkey(bob, carol) — already set but matches rippled
-	env.DisableMasterKey(bob)
-	t.Run("checkBatchSign.checkSingleSign/tefMASTER_DISABLED", func(t *testing.T) {
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 2, env.Seq(bob))).
-			AddSigner(bob, "DEADBEEF").
-			Build()
-		result := env.Submit(batch)
-		require.Equal(t, "tefMASTER_DISABLED", result.Code)
-		env.Close()
-	})
-}
-
-// =============================================================================
-// Test 26: testAccountDelete
-// Reference: rippled Batch_test.cpp testAccountDelete()
-// =============================================================================
-
-func TestAccountDelete(t *testing.T) {
-	t.Run("tfIndependent - account delete success", func(t *testing.T) {
-		// Reference: rippled Batch_test.cpp testAccountDelete() - tfIndependent success
-		env := newBatchEnv(t)
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.FundAmount(alice, uint64(jtx.XRP(10000)))
-		env.FundAmount(bob, uint64(jtx.XRP(10000)))
-		env.Close()
-
-		env.IncLedgerSeqForAccDel(alice)
-		for range 5 {
-			env.Close()
-		}
-
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-
-		seq := env.Seq(alice)
-		// batchFee = calcBatchFee(env, 0, 2) + increment
-		// The 2 payments cost baseFee each; the AccountDelete costs increment.
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2) + env.ReserveIncrement()
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagIndependent).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			AddInnerTx(MakeInnerAccountDelete(alice, bob, seq+2)).
-			// terNO_ACCOUNT: alice does not exist after deletion
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// Alice does not exist; Bob receives Alice's XRP
-		jtx.RequireAccountNotExists(t, env, alice)
-		jtx.RequireBalance(t, env, bob, preBob+(preAlice-batchFee))
-	})
-
-	t.Run("tfIndependent - account delete fails", func(t *testing.T) {
-		// Reference: rippled Batch_test.cpp testAccountDelete() - tfIndependent fails
-		env := newBatchEnv(t)
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.FundAmount(alice, uint64(jtx.XRP(10000)))
-		env.FundAmount(bob, uint64(jtx.XRP(10000)))
-		env.Close()
-
-		env.IncLedgerSeqForAccDel(alice)
-		for range 5 {
-			env.Close()
-		}
-
-		preBob := env.Balance(bob)
-
-		// Alice creates a trust line which counts as an obligation
-		env.Trust(alice, bob.IOU("USD", 1000))
-		env.Close()
-
-		seq := env.Seq(alice)
-		// batchFee = calcBatchFee(env, 0, 2) + increment
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2) + env.ReserveIncrement()
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagIndependent).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			// tecHAS_OBLIGATIONS: alice has obligations (trust line)
-			AddInnerTx(MakeInnerAccountDelete(alice, bob, seq+2)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// Alice still exists; Bob receives XRP(3) from the two successful payments
-		jtx.RequireAccountExists(t, env, alice)
-		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
-	})
-
-	t.Run("tfAllOrNothing - account delete fails", func(t *testing.T) {
-		// Reference: rippled Batch_test.cpp testAccountDelete() - tfAllOrNothing fails
-		env := newBatchEnv(t)
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.FundAmount(alice, uint64(jtx.XRP(10000)))
-		env.FundAmount(bob, uint64(jtx.XRP(10000)))
-		env.Close()
-
-		env.IncLedgerSeqForAccDel(alice)
-		for range 5 {
-			env.Close()
-		}
-
-		preBob := env.Balance(bob)
-
-		seq := env.Seq(alice)
-		// batchFee = calcBatchFee(env, 0, 2) + increment
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2) + env.ReserveIncrement()
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			AddInnerTx(MakeInnerAccountDelete(alice, bob, seq+2)).
-			// terNO_ACCOUNT: alice does not exist after deletion, causing rollback
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// Alice still exists (all rolled back); Bob is unchanged
-		jtx.RequireAccountExists(t, env, alice)
-		jtx.RequireBalance(t, env, bob, preBob)
-	})
-}
-
-// =============================================================================
-// Test 27: testObjectCreateSequence
-// Reference: rippled Batch_test.cpp testObjectCreateSequence()
-// =============================================================================
-
-func TestObjectCreateSequence(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
-		// Create a CheckCreate from bob to alice, then CheckCash from alice, all in a batch.
-		// Reference: rippled Batch_test.cpp testObjectCreateSequence() - success
-		env := newBatchEnv(t)
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		gw := jtx.NewAccount("gw")
-		env.FundAmount(alice, uint64(jtx.XRP(10000)))
-		env.FundAmount(bob, uint64(jtx.XRP(10000)))
-		env.FundAmount(gw, uint64(jtx.XRP(10000)))
-		env.Close()
-
-		// Set up trust lines and issue USD
-		usd10 := tx.NewIssuedAmountFromFloat64(10, "USD", gw.Address)
-		usd1000 := tx.NewIssuedAmountFromFloat64(1000, "USD", gw.Address)
-
-		env.Trust(alice, usd1000)
-		env.Trust(bob, usd1000)
-		env.PayIOU(gw, alice, gw, "USD", 100)
-		env.PayIOU(gw, bob, gw, "USD", 100)
-		env.Close()
-
-		aliceSeq := env.Seq(alice)
-		bobSeq := env.Seq(bob)
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-		preAliceUSD := env.BalanceIOU(alice, "USD", gw)
-		preBobUSD := env.BalanceIOU(bob, "USD", gw)
-
-		// CheckCreate from bob to alice for USD(10), then CheckCash from alice
-		// chkID is derived from bob's account and bob's current seq
-		chkID := GetCheckIndex(bob, bobSeq)
-
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerCheckCreate(bob, alice, usd10, bobSeq)).
-			AddInnerTx(MakeInnerCheckCash(alice, chkID, usd10, aliceSeq+1)).
-			AddSigner(bob, "DEADBEEF").
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// Alice consumes sequences (outer + 1 inner)
-		jtx.RequireSequence(t, env, alice, aliceSeq+2)
-
-		// Bob consumes sequences (1 inner)
-		jtx.RequireSequence(t, env, bob, bobSeq+1)
-
-		// Alice pays fee; Bob XRP unchanged
-		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob)
-
-		// Alice gains USD(10); Bob loses USD(10)
-		require.InDelta(t, preAliceUSD+10.0, env.BalanceIOU(alice, "USD", gw), 0.001,
-			"alice should have gained USD 10")
-		require.InDelta(t, preBobUSD-10.0, env.BalanceIOU(bob, "USD", gw), 0.001,
-			"bob should have lost USD 10")
-	})
-
-	t.Run("failure - tecDST_TAG_NEEDED", func(t *testing.T) {
-		// Alice enables asfRequireDest, so CheckCreate to alice fails with tecDST_TAG_NEEDED.
-		// In Independent mode, CheckCash then fails with tecNO_ENTRY.
-		// Reference: rippled Batch_test.cpp testObjectCreateSequence() - failure
-		env := newBatchEnv(t)
-
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		gw := jtx.NewAccount("gw")
-		env.FundAmount(alice, uint64(jtx.XRP(10000)))
-		env.FundAmount(bob, uint64(jtx.XRP(10000)))
-		env.FundAmount(gw, uint64(jtx.XRP(10000)))
-		env.Close()
-
-		usd10 := tx.NewIssuedAmountFromFloat64(10, "USD", gw.Address)
-		usd1000 := tx.NewIssuedAmountFromFloat64(1000, "USD", gw.Address)
-
-		env.Trust(alice, usd1000)
-		env.Trust(bob, usd1000)
-		env.PayIOU(gw, alice, gw, "USD", 100)
-		env.PayIOU(gw, bob, gw, "USD", 100)
-		env.Close()
-
-		// Enable RequireDest on alice
-		env.EnableRequireDest(alice)
-		env.Close()
-
-		aliceSeq := env.Seq(alice)
-		bobSeq := env.Seq(bob)
-		preAlice := env.Balance(alice)
-		preBob := env.Balance(bob)
-		preAliceUSD := env.BalanceIOU(alice, "USD", gw)
-		preBobUSD := env.BalanceIOU(bob, "USD", gw)
-
-		chkID := GetCheckIndex(bob, bobSeq)
-
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagIndependent).
-			AddInnerTx(MakeInnerCheckCreate(bob, alice, usd10, bobSeq)).
-			AddInnerTx(MakeInnerCheckCash(alice, chkID, usd10, aliceSeq+1)).
-			AddSigner(bob, "DEADBEEF").
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result) // Batch itself succeeds
-		env.Close()
-
-		// Alice consumes sequences (outer + 1 inner)
-		jtx.RequireSequence(t, env, alice, aliceSeq+2)
-
-		// Bob consumes sequences (1 inner)
-		jtx.RequireSequence(t, env, bob, bobSeq+1)
-
-		// Alice pays fee only; Bob XRP unchanged
-		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
-		jtx.RequireBalance(t, env, bob, preBob)
-
-		// USD balances unchanged (both inner txns failed)
-		require.InDelta(t, preAliceUSD, env.BalanceIOU(alice, "USD", gw), 0.001,
-			"alice USD should be unchanged")
-		require.InDelta(t, preBobUSD, env.BalanceIOU(bob, "USD", gw), 0.001,
-			"bob USD should be unchanged")
-	})
-}
-
-// =============================================================================
-// Test 28: testObjectCreateTicket
-// Reference: rippled Batch_test.cpp testObjectCreateTicket()
-// =============================================================================
-
-func TestObjectCreateTicket(t *testing.T) {
-	// Create tickets inside a batch, then use a ticket for CheckCreate, then CheckCash.
-	// Reference: rippled Batch_test.cpp testObjectCreateTicket()
-	env := newBatchEnv(t)
-
-	alice := jtx.NewAccount("alice")
-	bob := jtx.NewAccount("bob")
-	gw := jtx.NewAccount("gw")
-	env.FundAmount(alice, uint64(jtx.XRP(10000)))
-	env.FundAmount(bob, uint64(jtx.XRP(10000)))
-	env.FundAmount(gw, uint64(jtx.XRP(10000)))
-	env.Close()
-
-	// Set up trust lines and issue USD
-	usd10 := tx.NewIssuedAmountFromFloat64(10, "USD", gw.Address)
-	usd1000 := tx.NewIssuedAmountFromFloat64(1000, "USD", gw.Address)
-
-	env.Trust(alice, usd1000)
-	env.Trust(bob, usd1000)
-	env.PayIOU(gw, alice, gw, "USD", 100)
-	env.PayIOU(gw, bob, gw, "USD", 100)
-	env.Close()
-
-	aliceSeq := env.Seq(alice)
-	bobSeq := env.Seq(bob)
-	preAlice := env.Balance(alice)
-	preBob := env.Balance(bob)
-	preAliceUSD := env.BalanceIOU(alice, "USD", gw)
-	preBobUSD := env.BalanceIOU(bob, "USD", gw)
-
-	// Batch with 3 inner txns:
-	// 1. TicketCreate(bob, 10) using bobSeq
-	// 2. CheckCreate(bob->alice, USD(10)) using ticket bobSeq+1
-	// 3. CheckCash(alice, chkID, USD(10)) using aliceSeq+1
-	//
-	// After TicketCreate, bob's sequence advances by 10 (tickets) + 1 (for the TicketCreate).
-	// The first ticket is at bobSeq+1. CheckCreate uses ticket bobSeq+1.
-	// The check ID is derived from bob's account and the ticket sequence.
-	chkID := GetCheckIndex(bob, bobSeq+1)
-
-	batchFee := CalcBatchFeeFromEnv(env, 1, 3)
-	batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-		AddInnerTx(MakeInnerTicketCreate(bob, 10, bobSeq)).
-		AddInnerTx(MakeInnerCheckCreateWithTicket(bob, alice, usd10, bobSeq+1)).
-		AddInnerTx(MakeInnerCheckCash(alice, chkID, usd10, aliceSeq+1)).
-		AddSigner(bob, "DEADBEEF").
-		Build()
-
-	result := env.Submit(batch)
-	jtx.RequireTxSuccess(t, result)
-	env.Close()
-
-	// Alice consumes sequences: outer + 1 inner = aliceSeq + 2
-	jtx.RequireSequence(t, env, alice, aliceSeq+2)
-
-	// Bob: TicketCreate uses seq bobSeq (sequence advances by 1 + 10 tickets = 11).
-	// CheckCreate uses ticket (no sequence advancement).
-	// So bob's sequence = bobSeq + 10 + 1 = bobSeq + 11
-	jtx.RequireSequence(t, env, bob, bobSeq+10+1)
-
-	// Alice pays fee; Bob XRP unchanged
-	jtx.RequireBalance(t, env, alice, preAlice-batchFee)
-	jtx.RequireBalance(t, env, bob, preBob)
-
-	// Alice gains USD(10); Bob loses USD(10)
-	require.InDelta(t, preAliceUSD+10.0, env.BalanceIOU(alice, "USD", gw), 0.001,
-		"alice should have gained USD 10")
-	require.InDelta(t, preBobUSD-10.0, env.BalanceIOU(bob, "USD", gw), 0.001,
-		"bob should have lost USD 10")
-}
-
-// =============================================================================
-// Test 29: testObjectCreate3rdParty
-// Reference: rippled Batch_test.cpp testObjectCreate3rdParty()
-// =============================================================================
-
-func TestObjectCreate3rdParty(t *testing.T) {
-	// Reference: rippled Batch_test.cpp testObjectCreate3rdParty()
-	// Carol submits a batch containing inner transactions from alice and bob.
-	// bob creates a check for alice, alice cashes it.
-	// batch::sig(alice, bob) provides authorization.
-
-	env := newBatchEnv(t)
-
-	alice := jtx.NewAccount("alice")
-	bob := jtx.NewAccount("bob")
-	carol := jtx.NewAccount("carol")
-	gw := jtx.NewAccount("gw")
-
-	env.FundAmount(alice, uint64(jtx.XRP(10000)))
-	env.FundAmount(bob, uint64(jtx.XRP(10000)))
-	env.FundAmount(carol, uint64(jtx.XRP(10000)))
-	env.FundAmount(gw, uint64(jtx.XRP(10000)))
-	env.Close()
-
-	// Set up trust lines and fund IOU
-	env.Trust(alice, tx.NewIssuedAmountFromFloat64(1000, "USD", gw.Address))
-	env.Trust(bob, tx.NewIssuedAmountFromFloat64(1000, "USD", gw.Address))
-	env.PayIOU(gw, alice, gw, "USD", 100)
-	env.PayIOU(gw, bob, gw, "USD", 100)
-	env.Close()
-
-	aliceSeq := env.Seq(alice)
-	bobSeq := env.Seq(bob)
-	carolSeq := env.Seq(carol)
-	preAlice := env.Balance(alice)
-	preBob := env.Balance(bob)
-	preCarol := env.Balance(carol)
-	preAliceUSD := env.BalanceIOU(alice, "USD", gw)
-	preBobUSD := env.BalanceIOU(bob, "USD", gw)
-
-	// Build the check ID from bob's current sequence
-	chkID := GetCheckIndex(bob, bobSeq)
-
-	batchFee := CalcBatchFeeFromEnv(env, 2, 2)
-	batch := NewBatchBuilder(carol, carolSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-		AddInnerTx(MakeInnerCheckCreate(bob, alice, tx.NewIssuedAmountFromFloat64(10.0, "USD", gw.Address), bobSeq)).
-		AddInnerTx(MakeInnerCheckCash(alice, chkID, tx.NewIssuedAmountFromFloat64(10.0, "USD", gw.Address), aliceSeq)).
-		AddSigner(alice, "DEADBEEF").
-		AddSigner(bob, "DEADBEEF").
-		Build()
-
-	result := env.Submit(batch)
-	jtx.RequireTxSuccess(t, result)
-	env.Close()
-
-	// Verify sequences advanced
-	jtx.RequireSequence(t, env, alice, aliceSeq+1)
-	jtx.RequireSequence(t, env, bob, bobSeq+1)
-	jtx.RequireSequence(t, env, carol, carolSeq+1)
-
-	// Verify XRP balances: alice and bob unchanged, carol pays fee
-	jtx.RequireBalance(t, env, alice, preAlice)
-	jtx.RequireBalance(t, env, bob, preBob)
-	jtx.RequireBalance(t, env, carol, preCarol-batchFee)
-
-	// Verify IOU balances: alice gains USD(10), bob loses USD(10)
-	require.InDelta(t, preAliceUSD+10.0, env.BalanceIOU(alice, "USD", gw), 0.001,
-		"alice should have gained USD 10")
-	require.InDelta(t, preBobUSD-10.0, env.BalanceIOU(bob, "USD", gw), 0.001,
-		"bob should have lost USD 10")
-}
-
-// =============================================================================
-// Test 30: testBatchCalculateBaseFee
-// Reference: rippled Batch_test.cpp testBatchCalculateBaseFee()
-// =============================================================================
-
-func TestBatchCalculateBaseFee(t *testing.T) {
-	t.Run("too many txns returns error fee", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		// 9 inner txns should exceed max (8)
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 0, 9)
-		builder := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing)
-		for range 9 {
-			builder.AddInnerTx(MakeFakeInnerTx())
-		}
-		batch := builder.Build()
-
-		// Should fail validation
-		err := batch.Validate()
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "exceeds 8")
-	})
-
-	t.Run("too many signers returns error fee", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		env.Fund(alice)
-		env.Close()
-
-		bob := jtx.NewAccount("bob")
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 9, 2)
-		builder := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2))
-		for i := range 9 {
-			signer := jtx.NewAccount(fmt.Sprintf("signer%d", i))
-			builder.AddSigner(signer, "DEADBEEF")
-		}
-		batch := builder.Build()
-
-		err := batch.Validate()
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "exceeds 8")
-	})
-
-	t.Run("valid batch fee calculation", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2) // = 40 with base fee 10
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+2)).
-			Build()
-
-		err := batch.Validate()
-		require.NoError(t, err)
-
-		// Verify fee is correct
-		require.Equal(t, fmt.Sprintf("%d", batchFee), batch.Fee)
-	})
-}
-
-// =============================================================================
-// Batch signature verification vectors
-// Reference: rippled Batch_test.cpp testBadSign() signature cases (:530-592).
-// These exercise serializeBatch digest verification and the requiredSigners
-// coverage rule, which run in preflight (Batch.Validate).
-// =============================================================================
-
-func TestBatchSigningVectors(t *testing.T) {
-	// temBAD_SIGNER: bob's inner makes bob a required signer, but no BatchSigners
-	// are provided at all, so the required set is never emptied (Batch.cpp:448-453).
-	t.Run("temBAD_SIGNER - foreign inner with no batch signers", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxFail(t, result, "temBAD_SIGNER")
-	})
-
-	// temBAD_SIGNER: a presented signer is not required because both inner txns
-	// belong to the outer account, so requiredSigners is empty (Batch.cpp:530-541).
-	t.Run("temBAD_SIGNER - stray signer, no inner requires it", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 5, seq+2)).
-			AddSigner(bob, "DEADBEEF").
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxFail(t, result, "temBAD_SIGNER")
-	})
-
-	// temBAD_SIGNER: bob's inner requires bob, but the presented signer is carol
-	// (Batch.cpp:543-552).
-	t.Run("temBAD_SIGNER - wrong signer for required inner account", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		carol := jtx.NewAccount("carol")
-		env.Fund(alice, bob, carol)
-		env.Close()
-
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
-			AddSigner(carol, "DEADBEEF").
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxFail(t, result, "temBAD_SIGNER")
-	})
-
-	// temBAD_SIGNER: a required inner account (carol) is left uncovered after all
-	// presented signers are consumed (Batch.cpp:581-592).
-	t.Run("temBAD_SIGNER - required inner account uncovered", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		carol := jtx.NewAccount("carol")
-		env.Fund(alice, bob, carol)
-		env.Close()
-
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 2, 3)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
-			AddInnerTx(MakeInnerPaymentXRP(carol, alice, 5, env.Seq(carol))).
-			AddSigner(bob, "DEADBEEF").
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxFail(t, result, "temBAD_SIGNER")
-	})
-
-	// temBAD_SIGNATURE: signer Account is bob (required) and the signature is made
-	// with bob's key, but the presented SigningPubKey is alice's, so the signature
-	// fails to verify against it (Batch_test.cpp:555-579).
-	// The cryptographic BatchSigner check runs in the engine's signature stage, so
-	// it is exercised with VerifySignatures enabled (the outer batch is signed by
-	// alice). This mirrors rippled, where checkBatchSign rejects in preflight before
-	// the preclaim authorization check is reached.
-	t.Run("temBAD_SIGNATURE - signature key mismatched to signing pubkey", func(t *testing.T) {
-		env := newBatchEnv(t)
-		env.VerifySignatures = true
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
-			AddMismatchedSigner(bob, alice, bob).
-			Build()
-
-		result := env.SubmitSigned(batch)
-		jtx.RequireTxFail(t, result, "temBAD_SIGNATURE")
-	})
-
-	// temBAD_SIGNATURE: bob is the required signer with his own public key but a
-	// corrupted signature that does not verify over the batch digest.
-	t.Run("temBAD_SIGNATURE - garbage signature", func(t *testing.T) {
-		env := newBatchEnv(t)
-		env.VerifySignatures = true
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
-			AddGarbageSigner(bob).
-			Build()
-
-		result := env.SubmitSigned(batch)
-		jtx.RequireTxFail(t, result, "temBAD_SIGNATURE")
-	})
-
-	// tesSUCCESS: a single required signer (bob) signs the batch digest with his
-	// master key — a valid single-signed BatchSigner.
-	t.Run("tesSUCCESS - valid single-signed batch signer", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 2, env.Seq(bob))).
-			AddSigner(bob, "DEADBEEF").
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-	})
-
-	// tesSUCCESS: same valid single-signed BatchSigner, with full signature
-	// verification enabled so bob's BatchTxnSignature is checked cryptographically
-	// over the batch digest, exercising the engine's batch single-sign crypto path.
-	t.Run("tesSUCCESS - valid single-signed batch signer (verified)", func(t *testing.T) {
-		env := newBatchEnv(t)
-		env.VerifySignatures = true
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 2, env.Seq(bob))).
-			AddSigner(bob, "DEADBEEF").
-			Build()
-
-		result := env.SubmitSigned(batch)
-		jtx.RequireTxSuccess(t, result)
-	})
-
-	// tesSUCCESS: bob's required signature is satisfied by a nested multi-sign
-	// BatchSigner (carol + dave on bob's signer list) — a valid multi-signed
-	// BatchSigner.
-	t.Run("tesSUCCESS - valid multi-signed batch signer", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		carol := jtx.NewAccount("carol")
-		dave := jtx.NewAccount("dave")
-		env.Fund(alice, bob, carol, dave)
-		env.Close()
-
-		env.SetSignerList(bob, 2, []jtx.TestSigner{
-			{Account: carol, Weight: 1},
-			{Account: dave, Weight: 1},
-		})
-		env.Close()
-
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
-			AddMultiSignBatchSigner(bob, []*jtx.Account{carol, dave}).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-	})
-
-	// tesSUCCESS: same valid multi-signed BatchSigner, but with full signature
-	// verification enabled so the nested BatchSigner signatures are checked
-	// cryptographically over the digest-plus-accountID message, exercising the
-	// engine's batch multi-sign crypto path end-to-end.
-	t.Run("tesSUCCESS - valid multi-signed batch signer (verified)", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		carol := jtx.NewAccount("carol")
-		dave := jtx.NewAccount("dave")
-		env.Fund(alice, bob, carol, dave)
-		env.Close()
-
-		// Establish bob's signer list before enabling signature verification, since
-		// the SetSignerList helper submits an unsigned SignerListSet.
-		env.SetSignerList(bob, 2, []jtx.TestSigner{
-			{Account: carol, Weight: 1},
-			{Account: dave, Weight: 1},
-		})
-		env.Close()
-		env.VerifySignatures = true
-
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
-			AddMultiSignBatchSigner(bob, []*jtx.Account{carol, dave}).
-			Build()
-
-		result := env.SubmitSigned(batch)
-		jtx.RequireTxSuccess(t, result)
-	})
-
-	// tesSUCCESS: a single-account batch (both inners from the outer account)
-	// needs no BatchSigners at all.
-	t.Run("tesSUCCESS - single-account batch needs no signers", func(t *testing.T) {
-		env := newBatchEnv(t)
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.Fund(alice, bob)
-		env.Close()
-
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+2)).
-			Build()
-
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
-	})
-}
-
-// TestBatchSignerArrayBound exercises the rules-gated upper bound on a
-// multi-signed BatchSigner's nested Signers array. rippled enforces it in
-// multiSignHelper (called from Batch::preflight with ctx.rules): 32 with
-// featureExpandedSignerList, 8 without. An over-bound array there surfaces as
-// temBAD_SIGNATURE at the checkBatchSign call site (Batch.cpp:439-444).
-// Reference: rippled STTx::maxMultiSigners + Batch_test.cpp multi-sign vectors.
-func TestBatchSignerArrayBound(t *testing.T) {
-	// makeNestedSigners builds n distinct, funded signer accounts.
-	makeNestedSigners := func(env *jtx.TestEnv, n int) []*jtx.Account {
-		signers := make([]*jtx.Account, n)
-		for i := range n {
-			s := jtx.NewAccount(fmt.Sprintf("nsigner%d", i))
-			env.FundAmount(s, uint64(jtx.XRP(1000)))
-			signers[i] = s
-		}
-		return signers
-	}
-
-	// buildBatch produces a two-inner batch whose bob account is multi-signed by
-	// the supplied nested signers. bob's inner makes it a required signer.
-	buildBatch := func(env *jtx.TestEnv, alice, bob *jtx.Account, signers []*jtx.Account) *batchtx.Batch {
-		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, uint32(len(signers)+1), 2)
-		return NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
-			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
-			AddMultiSignBatchSigner(bob, signers).
-			Build()
-	}
-
-	// Amendment enabled (mainnet): the bound is 32. 33 nested signers is rejected
-	// in preflight before any SignerList lookup.
-	t.Run("ExpandedSignerList enabled - 33 nested signers rejected", func(t *testing.T) {
-		env := newBatchEnv(t)
-		require.True(t, env.FeatureEnabled("ExpandedSignerList"))
-		alice := jtx.NewAccount("alice")
-		bob := jtx.NewAccount("bob")
-		env.FundAmount(alice, uint64(jtx.XRP(10000)))
-		env.FundAmount(bob, uint64(jtx.XRP(10000)))
-		env.Close()
-
-		batch := buildBatch(env, alice, bob, makeNestedSigners(env, 33))
-		env.Close()
-
-		result := env.Submit(batch)
-		require.Equal(t, "temBAD_SIGNATURE", result.Code)
 	})
 }

--- a/internal/testing/batch/builder_test.go
+++ b/internal/testing/batch/builder_test.go
@@ -34,10 +34,10 @@ func TestBuilderSortsNestedSignersByBinaryAccountID(t *testing.T) {
 	}
 
 	batch := NewBatchBuilder(master, 1, 100, 0x00010000). // tfAllOrNothing
-								AddInnerTx(MakeFakeInnerTx()).
-								AddInnerTx(MakeFakeInnerTx()).
+								AddInnerTx(MakeFakeInnerTx(1)).
+								AddInnerTx(MakeFakeInnerTx(2)).
 								AddMultiSignBatchSigner(master, signers).
-								Build()
+								MustBuild()
 
 	require.Len(t, batch.BatchSigners, 1)
 	nested := batch.BatchSigners[0].BatchSigner.Signers
@@ -54,4 +54,18 @@ func TestBuilderSortsNestedSignersByBinaryAccountID(t *testing.T) {
 		}
 		last = id
 	}
+}
+
+func TestBuilderReturnsSigningMessageErrors(t *testing.T) {
+	outer := jtx.NewAccount("outer")
+	signer := jtx.NewAccount("signer")
+
+	batch, err := NewBatchBuilder(outer, 1, 50, 0x00010000).
+		AddInnerTx(nil).
+		AddInnerTx(MakeFakeInnerTx(2)).
+		AddSigner(signer).
+		Build()
+
+	require.Nil(t, batch)
+	require.ErrorContains(t, err, "build Batch signing message")
 }

--- a/internal/testing/batch/execution_test.go
+++ b/internal/testing/batch/execution_test.go
@@ -33,10 +33,8 @@ func TestAllOrNothing(t *testing.T) {
 		env.Close()
 		requireBatchLedgerData(t, env, batch, result, ter.TesSUCCESS, ter.TesSUCCESS)
 
-		// Alice consumes sequences (outer + 2 inner)
 		jtx.RequireSequence(t, env, alice, seq+3)
 
-		// Alice pays XRP(3) + fee; Bob receives XRP(3)
 		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
 	})
@@ -55,19 +53,16 @@ func TestAllOrNothing(t *testing.T) {
 		seq := env.Seq(alice)
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			// tecUNFUNDED_PAYMENT: alice does not have enough XRP
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+2)).
 			MustBuild()
 
 		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result) // Batch itself succeeds
+		jtx.RequireTxSuccess(t, result)
 		env.Close()
 		requireBatchLedgerData(t, env, batch, result)
 
-		// Only outer sequence consumed (inner txns rolled back)
 		jtx.RequireSequence(t, env, alice, seq+1)
 
-		// Alice pays fee only; Bob unaffected
 		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob)
 	})
@@ -85,24 +80,18 @@ func TestAllOrNothing(t *testing.T) {
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 		seq := env.Seq(alice)
 
-		// Create a second inner tx that will cause a tef error.
-		// AccountSet with SetFlag that requires authorization when not set up
-		// triggers tefNO_AUTH_REQUIRED equivalent.
-		// Use a past sequence for the second tx to trigger tefPAST_SEQ
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			AddInnerTx(MakeInnerPayment(alice, bob, jtx.XRP(1), 1)). // past seq -> tef
+			AddInnerTx(MakeInnerPayment(alice, bob, jtx.XRP(1), 1)).
 			MustBuild()
 
 		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result) // Batch itself succeeds
+		jtx.RequireTxSuccess(t, result)
 		env.Close()
 		requireBatchLedgerData(t, env, batch, result)
 
-		// Only outer sequence consumed
 		jtx.RequireSequence(t, env, alice, seq+1)
 
-		// Alice pays fee only; Bob unaffected
 		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob)
 	})
@@ -122,7 +111,6 @@ func TestOnlyOne(t *testing.T) {
 		batchFee := CalcBatchFeeFromEnv(env, 0, 3)
 		seq := env.Seq(alice)
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagOnlyOne).
-			// All underfunded
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+1)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+2)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+3)).
@@ -134,10 +122,8 @@ func TestOnlyOne(t *testing.T) {
 		requireBatchLedgerData(t, env, batch, result,
 			ter.TecUNFUNDED_PAYMENT, ter.TecUNFUNDED_PAYMENT, ter.TecUNFUNDED_PAYMENT)
 
-		// All inner txns executed (all failed) -> seq advances by 4 (outer + 3 inner)
 		jtx.RequireSequence(t, env, alice, seq+4)
 
-		// Alice pays fee only; Bob unaffected
 		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob)
 	})
@@ -155,9 +141,9 @@ func TestOnlyOne(t *testing.T) {
 		batchFee := CalcBatchFeeFromEnv(env, 0, 3)
 		seq := env.Seq(alice)
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagOnlyOne).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+1)). // fails
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2)).    // succeeds -> stop
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).    // not executed
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).
 			MustBuild()
 
 		result := env.Submit(batch)
@@ -165,10 +151,8 @@ func TestOnlyOne(t *testing.T) {
 		env.Close()
 		requireBatchLedgerData(t, env, batch, result, ter.TecUNFUNDED_PAYMENT, ter.TesSUCCESS)
 
-		// Only 2 inner txns processed (fail + success) -> seq advances by 3
 		jtx.RequireSequence(t, env, alice, seq+3)
 
-		// Alice pays XRP(1) + fee
 		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(1))-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(1)))
 	})
@@ -186,9 +170,9 @@ func TestOnlyOne(t *testing.T) {
 		batchFee := CalcBatchFeeFromEnv(env, 0, 3)
 		seq := env.Seq(alice)
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagOnlyOne).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).    // succeeds -> stop
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+2)). // not executed
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).    // not executed
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+2)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).
 			MustBuild()
 
 		result := env.Submit(batch)
@@ -196,10 +180,8 @@ func TestOnlyOne(t *testing.T) {
 		env.Close()
 		requireBatchLedgerData(t, env, batch, result, ter.TesSUCCESS)
 
-		// Only 1 inner txn processed -> seq advances by 2
 		jtx.RequireSequence(t, env, alice, seq+2)
 
-		// Alice pays XRP(1) + fee
 		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(1))-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(1)))
 	})
@@ -219,7 +201,7 @@ func TestUntilFailure(t *testing.T) {
 		batchFee := CalcBatchFeeFromEnv(env, 0, 4)
 		seq := env.Seq(alice)
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagUntilFailure).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+1)). // fails -> stop
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+1)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 3, seq+4)).
@@ -230,10 +212,8 @@ func TestUntilFailure(t *testing.T) {
 		env.Close()
 		requireBatchLedgerData(t, env, batch, result, ter.TecUNFUNDED_PAYMENT)
 
-		// 1 inner txn processed (the failure) -> seq advances by 2
 		jtx.RequireSequence(t, env, alice, seq+2)
 
-		// Alice pays fee only; Bob unaffected
 		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob)
 	})
@@ -263,10 +243,8 @@ func TestUntilFailure(t *testing.T) {
 		requireBatchLedgerData(t, env, batch, result,
 			ter.TesSUCCESS, ter.TesSUCCESS, ter.TesSUCCESS, ter.TesSUCCESS)
 
-		// All 4 inner txns succeed -> seq advances by 5
 		jtx.RequireSequence(t, env, alice, seq+5)
 
-		// Alice pays XRP(10) + fee
 		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(10))-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(10)))
 	})
@@ -286,8 +264,8 @@ func TestUntilFailure(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagUntilFailure).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+2)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+3)). // fails -> stop
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 3, seq+4)).    // not executed
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+3)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 3, seq+4)).
 			MustBuild()
 
 		result := env.Submit(batch)
@@ -296,10 +274,8 @@ func TestUntilFailure(t *testing.T) {
 		requireBatchLedgerData(t, env, batch, result,
 			ter.TesSUCCESS, ter.TesSUCCESS, ter.TecUNFUNDED_PAYMENT)
 
-		// 3 inner txns processed (2 success + 1 failure) -> seq advances by 4
 		jtx.RequireSequence(t, env, alice, seq+4)
 
-		// Alice pays XRP(3) + fee (the 2 successful payments)
 		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
 	})
@@ -319,10 +295,10 @@ func TestIndependent(t *testing.T) {
 		batchFee := CalcBatchFeeFromEnv(env, 0, 4)
 		seq := env.Seq(alice)
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagIndependent).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).    // succeeds
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+2)). // fails
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+3)). // fails
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 3, seq+4)).    // succeeds
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+2)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+3)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 3, seq+4)).
 			MustBuild()
 
 		result := env.Submit(batch)
@@ -331,10 +307,8 @@ func TestIndependent(t *testing.T) {
 		requireBatchLedgerData(t, env, batch, result,
 			ter.TesSUCCESS, ter.TecUNFUNDED_PAYMENT, ter.TecUNFUNDED_PAYMENT, ter.TesSUCCESS)
 
-		// All 4 inner txns processed -> seq advances by 5
 		jtx.RequireSequence(t, env, alice, seq+5)
 
-		// Alice pays XRP(4) + fee (only successful payments)
 		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(4))-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(4)))
 	})
@@ -354,7 +328,7 @@ func TestIndependent(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagIndependent).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+2)).
-			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+3)). // fails
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+3)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 3, seq+4)).
 			MustBuild()
 
@@ -364,10 +338,8 @@ func TestIndependent(t *testing.T) {
 		requireBatchLedgerData(t, env, batch, result,
 			ter.TesSUCCESS, ter.TesSUCCESS, ter.TecUNFUNDED_PAYMENT, ter.TesSUCCESS)
 
-		// All 4 inner txns processed -> seq advances by 5
 		jtx.RequireSequence(t, env, alice, seq+5)
 
-		// Alice pays XRP(6) + fee (3 successful payments)
 		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(6))-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(6)))
 	})
@@ -377,10 +349,9 @@ func TestAccountActivation(t *testing.T) {
 	env := newBatchEnv(t)
 	alice := jtx.NewAccount("alice")
 	bob := jtx.NewAccount("bob")
-	env.FundAmount(alice, uint64(jtx.XRP(10000))) // rippled funds with XRP(10000)
+	env.FundAmount(alice, uint64(jtx.XRP(10000)))
 	env.Close()
 
-	// Bob does not exist yet
 	jtx.RequireAccountNotExists(t, env, bob)
 
 	preAlice := env.Balance(alice)
@@ -388,23 +359,19 @@ func TestAccountActivation(t *testing.T) {
 	seq := env.Seq(alice)
 	batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 
-	// Create bob by funding and then do an AccountSet on bob within the batch
 	batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 		AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1000, seq+1)).
-		AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2)). // second payment to newly created bob
+		AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2)).
 		MustBuild()
 
 	result := env.Submit(batch)
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
 
-	// Bob now exists
 	jtx.RequireAccountExists(t, env, bob)
 
-	// Alice consumes sequences (outer + 2 inner)
 	jtx.RequireSequence(t, env, alice, seq+3)
 
-	// Alice pays XRP(1001) + fee; Bob receives XRP(1001)
 	jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(1001))-batchFee)
 	jtx.RequireBalance(t, env, bob, uint64(jtx.XRP(1001)))
 }
@@ -431,7 +398,6 @@ func TestActivateTwoAccounts(t *testing.T) {
 	seq := env.Seq(alice)
 	batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 
-	// Two funding Payments to two brand-new accounts in a single batch.
 	batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 		AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1000, seq+1)).
 		AddInnerTx(MakeInnerPaymentXRP(alice, carol, 1000, seq+2)).
@@ -441,14 +407,11 @@ func TestActivateTwoAccounts(t *testing.T) {
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
 
-	// Both new accounts now exist and are funded.
 	jtx.RequireAccountExists(t, env, bob)
 	jtx.RequireAccountExists(t, env, carol)
 
-	// Alice consumes sequences (outer + 2 inner).
 	jtx.RequireSequence(t, env, alice, seq+3)
 
-	// Alice pays XRP(2000) + fee; bob and carol each receive XRP(1000).
 	jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(2000))-batchFee)
 	jtx.RequireBalance(t, env, bob, uint64(jtx.XRP(1000)))
 	jtx.RequireBalance(t, env, carol, uint64(jtx.XRP(1000)))
@@ -467,7 +430,6 @@ func TestAccountSet(t *testing.T) {
 	seq := env.Seq(alice)
 	batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 
-	// Create an AccountSet (require dest tag) as inner tx
 	as := accounttx.NewAccountSet(alice.Address)
 	as.Fee = "0"
 	as.SigningPubKey = ""
@@ -485,10 +447,8 @@ func TestAccountSet(t *testing.T) {
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
 
-	// Alice consumes sequences (outer + 2 inner)
 	jtx.RequireSequence(t, env, alice, seq+3)
 
-	// Alice pays XRP(1) + fee; Bob receives XRP(1)
 	jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(1))-batchFee)
 	jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(1)))
 }
@@ -507,16 +467,14 @@ func TestBadSequence(t *testing.T) {
 
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 		batch := NewBatchBuilder(alice, preAliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			// Past sequence (before current)
 			AddInnerTx(MakeInnerPayment(alice, bob, jtx.XRP(10), 1)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 5, preAliceSeq+1)).
 			MustBuild()
 
 		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result) // Batch itself succeeds
+		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// Alice pays fee only, sequence advances by 1 (outer only)
 		jtx.RequireSequence(t, env, alice, preAliceSeq+1)
 		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob)
@@ -535,16 +493,14 @@ func TestBadSequence(t *testing.T) {
 
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 		batch := NewBatchBuilder(alice, preAliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			// Future sequence (well ahead of current)
 			AddInnerTx(MakeInnerPayment(alice, bob, jtx.XRP(10), preAliceSeq+10)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 5, preAliceSeq+1)).
 			MustBuild()
 
 		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result) // Batch itself succeeds
+		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// Alice pays fee only, sequence advances by 1 (outer only)
 		jtx.RequireSequence(t, env, alice, preAliceSeq+1)
 		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob)
@@ -563,16 +519,14 @@ func TestBadSequence(t *testing.T) {
 
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 		batch := NewBatchBuilder(alice, preAliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
-			// Same sequence as outer
 			AddInnerTx(MakeInnerPayment(alice, bob, jtx.XRP(10), preAliceSeq)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 5, preAliceSeq+1)).
 			MustBuild()
 
 		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result) // Batch itself succeeds
+		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// Alice pays fee only
 		jtx.RequireSequence(t, env, alice, preAliceSeq+1)
 		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob)
@@ -587,8 +541,7 @@ func TestBadOuterFee(t *testing.T) {
 		env.Fund(alice, bob)
 		env.Close()
 
-		// Bad fee: should be calcBatchFee(env, 0, 2) = 40, but we use 30
-		badFee := CalcBatchFeeFromEnv(env, 0, 1) // 30 instead of 40
+		badFee := CalcBatchFeeFromEnv(env, 0, 1)
 		seq := env.Seq(alice)
 		batch := NewBatchBuilder(alice, seq, badFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
@@ -609,7 +562,7 @@ func TestBadOuterFee(t *testing.T) {
 		// Bad fee: should be calcBatchFee(env, 1, 2) = 50, but we use 40.
 		// The second inner is from bob so bob is a genuinely required signer,
 		// letting preflight pass and the fee floor fire in preclaim.
-		badFee := CalcBatchFeeFromEnv(env, 0, 2) // 40 instead of 50
+		badFee := CalcBatchFeeFromEnv(env, 0, 2)
 		seq := env.Seq(alice)
 		batch := NewBatchBuilder(alice, seq, badFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
@@ -624,9 +577,6 @@ func TestBadOuterFee(t *testing.T) {
 
 func TestBatchDelegate(t *testing.T) {
 	t.Run("delegated non atomic inner", func(t *testing.T) {
-		// Alice delegates "Payment" permission to bob.
-		// Inner tx[0] is a payment from alice to bob with Delegate=bob.
-		// Inner tx[1] is a regular payment from alice to bob.
 		// Reference: rippled Batch_test.cpp testBatchDelegate() - "delegated non atomic inner"
 		env := newBatchEnv(t)
 		env.EnableFeature("PermissionDelegationV1_1")
@@ -637,7 +587,6 @@ func TestBatchDelegate(t *testing.T) {
 		env.FundAmount(bob, uint64(jtx.XRP(10000)))
 		env.Close()
 
-		// Alice delegates Payment permission to bob
 		env.SetDelegate(alice, bob, []string{"Payment"})
 		env.Close()
 
@@ -647,9 +596,7 @@ func TestBatchDelegate(t *testing.T) {
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 		seq := env.Seq(alice)
 
-		// Inner tx[0]: payment from alice to bob, delegated to bob
 		innerTx0 := MakeInnerPaymentXRPWithDelegate(alice, bob, 1, seq+1, bob)
-		// Inner tx[1]: regular payment from alice to bob
 		innerTx1 := MakeInnerPaymentXRP(alice, bob, 2, seq+2)
 
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
@@ -661,17 +608,13 @@ func TestBatchDelegate(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// Alice consumes sequences: outer + 2 inner = seq + 3
 		jtx.RequireSequence(t, env, alice, seq+3)
 
-		// Alice pays XRP(3) + fee; Bob receives XRP(3)
 		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
 	})
 
 	t.Run("delegated atomic inner", func(t *testing.T) {
-		// Bob delegates "Payment" permission to carol.
-		// Carol submits batch: inner tx[0] is payment bob->alice with Delegate=carol, inner tx[1] is payment alice->bob.
 		// Reference: rippled Batch_test.cpp testBatchDelegate() - "delegated atomic inner"
 		env := newBatchEnv(t)
 		env.EnableFeature("PermissionDelegationV1_1")
@@ -684,7 +627,6 @@ func TestBatchDelegate(t *testing.T) {
 		env.FundAmount(carol, uint64(jtx.XRP(10000)))
 		env.Close()
 
-		// Bob delegates Payment permission to carol
 		env.SetDelegate(bob, carol, []string{"Payment"})
 		env.Close()
 
@@ -696,9 +638,7 @@ func TestBatchDelegate(t *testing.T) {
 		aliceSeq := env.Seq(alice)
 		bobSeq := env.Seq(bob)
 
-		// Inner tx[0]: payment bob->alice, delegated to carol
 		innerTx0 := MakeInnerPaymentXRPWithDelegate(bob, alice, 1, bobSeq, carol)
-		// Inner tx[1]: payment alice->bob
 		innerTx1 := MakeInnerPaymentXRP(alice, bob, 2, aliceSeq+1)
 
 		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
@@ -711,18 +651,11 @@ func TestBatchDelegate(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// Alice: outer seq + 1 inner = aliceSeq + 2
 		jtx.RequireSequence(t, env, alice, aliceSeq+2)
-		// Bob: 1 inner = bobSeq + 1
 		jtx.RequireSequence(t, env, bob, bobSeq+1)
 
-		// Alice: -XRP(1) (net: pay 2 to bob, receive 1 from bob) - batchFee
 		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(1))-batchFee)
-		// Bob: +XRP(1) (net: receive 2 from alice, pay 1 to alice)
 		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(1)))
-		// Carol: unchanged (batch is atomic, fee is paid by batch outer account)
 		jtx.RequireBalance(t, env, carol, preCarol)
 	})
 }
-
-// Tests 13-15: testTickets, testTicketsOpenLedger

--- a/internal/testing/batch/execution_test.go
+++ b/internal/testing/batch/execution_test.go
@@ -1,0 +1,728 @@
+package batch
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	accounttx "github.com/LeJamon/go-xrpl/internal/tx/account"
+	batchtx "github.com/LeJamon/go-xrpl/internal/tx/batch"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+func TestAllOrNothing(t *testing.T) {
+	t.Run("all succeed", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		seq := env.Seq(alice)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+2)).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		requireBatchLedgerData(t, env, batch, result, ter.TesSUCCESS, ter.TesSUCCESS)
+
+		// Alice consumes sequences (outer + 2 inner)
+		jtx.RequireSequence(t, env, alice, seq+3)
+
+		// Alice pays XRP(3) + fee; Bob receives XRP(3)
+		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
+	})
+
+	t.Run("tec failure - all rolled back", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		seq := env.Seq(alice)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			// tecUNFUNDED_PAYMENT: alice does not have enough XRP
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+2)).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result) // Batch itself succeeds
+		env.Close()
+		requireBatchLedgerData(t, env, batch, result)
+
+		// Only outer sequence consumed (inner txns rolled back)
+		jtx.RequireSequence(t, env, alice, seq+1)
+
+		// Alice pays fee only; Bob unaffected
+		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob)
+	})
+
+	t.Run("tef failure - all rolled back", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		seq := env.Seq(alice)
+
+		// Create a second inner tx that will cause a tef error.
+		// AccountSet with SetFlag that requires authorization when not set up
+		// triggers tefNO_AUTH_REQUIRED equivalent.
+		// Use a past sequence for the second tx to trigger tefPAST_SEQ
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPayment(alice, bob, jtx.XRP(1), 1)). // past seq -> tef
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result) // Batch itself succeeds
+		env.Close()
+		requireBatchLedgerData(t, env, batch, result)
+
+		// Only outer sequence consumed
+		jtx.RequireSequence(t, env, alice, seq+1)
+
+		// Alice pays fee only; Bob unaffected
+		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob)
+	})
+}
+
+func TestOnlyOne(t *testing.T) {
+	t.Run("all transactions fail", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		batchFee := CalcBatchFeeFromEnv(env, 0, 3)
+		seq := env.Seq(alice)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagOnlyOne).
+			// All underfunded
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+2)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+3)).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		requireBatchLedgerData(t, env, batch, result,
+			ter.TecUNFUNDED_PAYMENT, ter.TecUNFUNDED_PAYMENT, ter.TecUNFUNDED_PAYMENT)
+
+		// All inner txns executed (all failed) -> seq advances by 4 (outer + 3 inner)
+		jtx.RequireSequence(t, env, alice, seq+4)
+
+		// Alice pays fee only; Bob unaffected
+		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob)
+	})
+
+	t.Run("first fails then succeeds - stops after success", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		batchFee := CalcBatchFeeFromEnv(env, 0, 3)
+		seq := env.Seq(alice)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagOnlyOne).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+1)). // fails
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2)).    // succeeds -> stop
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).    // not executed
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		requireBatchLedgerData(t, env, batch, result, ter.TecUNFUNDED_PAYMENT, ter.TesSUCCESS)
+
+		// Only 2 inner txns processed (fail + success) -> seq advances by 3
+		jtx.RequireSequence(t, env, alice, seq+3)
+
+		// Alice pays XRP(1) + fee
+		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(1))-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(1)))
+	})
+
+	t.Run("succeeds first - stops immediately", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		batchFee := CalcBatchFeeFromEnv(env, 0, 3)
+		seq := env.Seq(alice)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagOnlyOne).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).    // succeeds -> stop
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+2)). // not executed
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).    // not executed
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		requireBatchLedgerData(t, env, batch, result, ter.TesSUCCESS)
+
+		// Only 1 inner txn processed -> seq advances by 2
+		jtx.RequireSequence(t, env, alice, seq+2)
+
+		// Alice pays XRP(1) + fee
+		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(1))-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(1)))
+	})
+}
+
+func TestUntilFailure(t *testing.T) {
+	t.Run("first transaction fails - stops immediately", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		batchFee := CalcBatchFeeFromEnv(env, 0, 4)
+		seq := env.Seq(alice)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagUntilFailure).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+1)). // fails -> stop
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 3, seq+4)).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		requireBatchLedgerData(t, env, batch, result, ter.TecUNFUNDED_PAYMENT)
+
+		// 1 inner txn processed (the failure) -> seq advances by 2
+		jtx.RequireSequence(t, env, alice, seq+2)
+
+		// Alice pays fee only; Bob unaffected
+		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob)
+	})
+
+	t.Run("all transactions succeed", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		batchFee := CalcBatchFeeFromEnv(env, 0, 4)
+		seq := env.Seq(alice)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagUntilFailure).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+2)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 3, seq+3)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 4, seq+4)).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		requireBatchLedgerData(t, env, batch, result,
+			ter.TesSUCCESS, ter.TesSUCCESS, ter.TesSUCCESS, ter.TesSUCCESS)
+
+		// All 4 inner txns succeed -> seq advances by 5
+		jtx.RequireSequence(t, env, alice, seq+5)
+
+		// Alice pays XRP(10) + fee
+		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(10))-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(10)))
+	})
+
+	t.Run("tec error in middle - stops at failure", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		batchFee := CalcBatchFeeFromEnv(env, 0, 4)
+		seq := env.Seq(alice)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagUntilFailure).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+2)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+3)). // fails -> stop
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 3, seq+4)).    // not executed
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		requireBatchLedgerData(t, env, batch, result,
+			ter.TesSUCCESS, ter.TesSUCCESS, ter.TecUNFUNDED_PAYMENT)
+
+		// 3 inner txns processed (2 success + 1 failure) -> seq advances by 4
+		jtx.RequireSequence(t, env, alice, seq+4)
+
+		// Alice pays XRP(3) + fee (the 2 successful payments)
+		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
+	})
+}
+
+func TestIndependent(t *testing.T) {
+	t.Run("multiple transactions fail - all execute", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		batchFee := CalcBatchFeeFromEnv(env, 0, 4)
+		seq := env.Seq(alice)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagIndependent).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).    // succeeds
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+2)). // fails
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+3)). // fails
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 3, seq+4)).    // succeeds
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		requireBatchLedgerData(t, env, batch, result,
+			ter.TesSUCCESS, ter.TecUNFUNDED_PAYMENT, ter.TecUNFUNDED_PAYMENT, ter.TesSUCCESS)
+
+		// All 4 inner txns processed -> seq advances by 5
+		jtx.RequireSequence(t, env, alice, seq+5)
+
+		// Alice pays XRP(4) + fee (only successful payments)
+		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(4))-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(4)))
+	})
+
+	t.Run("tec error in middle - continues executing", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		batchFee := CalcBatchFeeFromEnv(env, 0, 4)
+		seq := env.Seq(alice)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagIndependent).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+2)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 9999, seq+3)). // fails
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 3, seq+4)).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		requireBatchLedgerData(t, env, batch, result,
+			ter.TesSUCCESS, ter.TesSUCCESS, ter.TecUNFUNDED_PAYMENT, ter.TesSUCCESS)
+
+		// All 4 inner txns processed -> seq advances by 5
+		jtx.RequireSequence(t, env, alice, seq+5)
+
+		// Alice pays XRP(6) + fee (3 successful payments)
+		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(6))-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(6)))
+	})
+}
+
+func TestAccountActivation(t *testing.T) {
+	env := newBatchEnv(t)
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	env.FundAmount(alice, uint64(jtx.XRP(10000))) // rippled funds with XRP(10000)
+	env.Close()
+
+	// Bob does not exist yet
+	jtx.RequireAccountNotExists(t, env, bob)
+
+	preAlice := env.Balance(alice)
+
+	seq := env.Seq(alice)
+	batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+
+	// Create bob by funding and then do an AccountSet on bob within the batch
+	batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+		AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1000, seq+1)).
+		AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2)). // second payment to newly created bob
+		MustBuild()
+
+	result := env.Submit(batch)
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	// Bob now exists
+	jtx.RequireAccountExists(t, env, bob)
+
+	// Alice consumes sequences (outer + 2 inner)
+	jtx.RequireSequence(t, env, alice, seq+3)
+
+	// Alice pays XRP(1001) + fee; Bob receives XRP(1001)
+	jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(1001))-batchFee)
+	jtx.RequireBalance(t, env, bob, uint64(jtx.XRP(1001)))
+}
+
+// TestActivateTwoAccounts is the issue #846 regression: a Batch whose inner txs
+// fund TWO distinct new accounts must succeed. rippled runs each inner Payment
+// through its own invariant pass, so each pass sees exactly one account
+// creation; the outer ttBATCH pass never sees the combined two-creation delta.
+// goXRPL previously ran the shared ValidNewAccountRoot checker on the combined
+// outer delta (createdCount=2) and wrongly returned tecINVARIANT_FAILED.
+// Reference: rippled apply.cpp:189-207, InvariantCheck.cpp:964-967.
+func TestActivateTwoAccounts(t *testing.T) {
+	env := newBatchEnv(t)
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	carol := jtx.NewAccount("carol")
+	env.FundAmount(alice, uint64(jtx.XRP(10000)))
+	env.Close()
+
+	jtx.RequireAccountNotExists(t, env, bob)
+	jtx.RequireAccountNotExists(t, env, carol)
+
+	preAlice := env.Balance(alice)
+	seq := env.Seq(alice)
+	batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+
+	// Two funding Payments to two brand-new accounts in a single batch.
+	batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+		AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1000, seq+1)).
+		AddInnerTx(MakeInnerPaymentXRP(alice, carol, 1000, seq+2)).
+		MustBuild()
+
+	result := env.Submit(batch)
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	// Both new accounts now exist and are funded.
+	jtx.RequireAccountExists(t, env, bob)
+	jtx.RequireAccountExists(t, env, carol)
+
+	// Alice consumes sequences (outer + 2 inner).
+	jtx.RequireSequence(t, env, alice, seq+3)
+
+	// Alice pays XRP(2000) + fee; bob and carol each receive XRP(1000).
+	jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(2000))-batchFee)
+	jtx.RequireBalance(t, env, bob, uint64(jtx.XRP(1000)))
+	jtx.RequireBalance(t, env, carol, uint64(jtx.XRP(1000)))
+}
+
+func TestAccountSet(t *testing.T) {
+	env := newBatchEnv(t)
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	env.Fund(alice, bob)
+	env.Close()
+
+	preAlice := env.Balance(alice)
+	preBob := env.Balance(bob)
+
+	seq := env.Seq(alice)
+	batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+
+	// Create an AccountSet (require dest tag) as inner tx
+	as := accounttx.NewAccountSet(alice.Address)
+	as.Fee = "0"
+	as.SigningPubKey = ""
+	as.SetSequence(seq + 1)
+	as.SetFlags(tx.TfInnerBatchTxn)
+	flag := accounttx.AccountSetFlagRequireDest
+	as.SetFlag = &flag
+
+	batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+		AddInnerTx(as).
+		AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2)).
+		MustBuild()
+
+	result := env.Submit(batch)
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	// Alice consumes sequences (outer + 2 inner)
+	jtx.RequireSequence(t, env, alice, seq+3)
+
+	// Alice pays XRP(1) + fee; Bob receives XRP(1)
+	jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(1))-batchFee)
+	jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(1)))
+}
+
+func TestBadSequence(t *testing.T) {
+	t.Run("past sequence - inner tx with past seq", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+		preAliceSeq := env.Seq(alice)
+
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		batch := NewBatchBuilder(alice, preAliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+			// Past sequence (before current)
+			AddInnerTx(MakeInnerPayment(alice, bob, jtx.XRP(10), 1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 5, preAliceSeq+1)).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result) // Batch itself succeeds
+		env.Close()
+
+		// Alice pays fee only, sequence advances by 1 (outer only)
+		jtx.RequireSequence(t, env, alice, preAliceSeq+1)
+		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob)
+	})
+
+	t.Run("future sequence - inner tx with far future seq", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+		preAliceSeq := env.Seq(alice)
+
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		batch := NewBatchBuilder(alice, preAliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+			// Future sequence (well ahead of current)
+			AddInnerTx(MakeInnerPayment(alice, bob, jtx.XRP(10), preAliceSeq+10)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 5, preAliceSeq+1)).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result) // Batch itself succeeds
+		env.Close()
+
+		// Alice pays fee only, sequence advances by 1 (outer only)
+		jtx.RequireSequence(t, env, alice, preAliceSeq+1)
+		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob)
+	})
+
+	t.Run("same sequence as outer - inner tx uses outer's seq", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+		preAliceSeq := env.Seq(alice)
+
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		batch := NewBatchBuilder(alice, preAliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+			// Same sequence as outer
+			AddInnerTx(MakeInnerPayment(alice, bob, jtx.XRP(10), preAliceSeq)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 5, preAliceSeq+1)).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result) // Batch itself succeeds
+		env.Close()
+
+		// Alice pays fee only
+		jtx.RequireSequence(t, env, alice, preAliceSeq+1)
+		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob)
+	})
+}
+
+func TestBadOuterFee(t *testing.T) {
+	t.Run("insufficient fee without signers", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		// Bad fee: should be calcBatchFee(env, 0, 2) = 40, but we use 30
+		badFee := CalcBatchFeeFromEnv(env, 0, 1) // 30 instead of 40
+		seq := env.Seq(alice)
+		batch := NewBatchBuilder(alice, seq, badFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 15, seq+2)).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "telINSUF_FEE_P")
+	})
+
+	t.Run("insufficient fee with batch signers", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		// Bad fee: should be calcBatchFee(env, 1, 2) = 50, but we use 40.
+		// The second inner is from bob so bob is a genuinely required signer,
+		// letting preflight pass and the fee floor fire in preclaim.
+		badFee := CalcBatchFeeFromEnv(env, 0, 2) // 40 instead of 50
+		seq := env.Seq(alice)
+		batch := NewBatchBuilder(alice, seq, badFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddSigner(bob).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "telINSUF_FEE_P")
+	})
+}
+
+func TestBatchDelegate(t *testing.T) {
+	t.Run("delegated non atomic inner", func(t *testing.T) {
+		// Alice delegates "Payment" permission to bob.
+		// Inner tx[0] is a payment from alice to bob with Delegate=bob.
+		// Inner tx[1] is a regular payment from alice to bob.
+		// Reference: rippled Batch_test.cpp testBatchDelegate() - "delegated non atomic inner"
+		env := newBatchEnv(t)
+		env.EnableFeature("PermissionDelegationV1_1")
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.FundAmount(alice, uint64(jtx.XRP(10000)))
+		env.FundAmount(bob, uint64(jtx.XRP(10000)))
+		env.Close()
+
+		// Alice delegates Payment permission to bob
+		env.SetDelegate(alice, bob, []string{"Payment"})
+		env.Close()
+
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		seq := env.Seq(alice)
+
+		// Inner tx[0]: payment from alice to bob, delegated to bob
+		innerTx0 := MakeInnerPaymentXRPWithDelegate(alice, bob, 1, seq+1, bob)
+		// Inner tx[1]: regular payment from alice to bob
+		innerTx1 := MakeInnerPaymentXRP(alice, bob, 2, seq+2)
+
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(innerTx0).
+			AddInnerTx(innerTx1).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		// Alice consumes sequences: outer + 2 inner = seq + 3
+		jtx.RequireSequence(t, env, alice, seq+3)
+
+		// Alice pays XRP(3) + fee; Bob receives XRP(3)
+		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
+	})
+
+	t.Run("delegated atomic inner", func(t *testing.T) {
+		// Bob delegates "Payment" permission to carol.
+		// Carol submits batch: inner tx[0] is payment bob->alice with Delegate=carol, inner tx[1] is payment alice->bob.
+		// Reference: rippled Batch_test.cpp testBatchDelegate() - "delegated atomic inner"
+		env := newBatchEnv(t)
+		env.EnableFeature("PermissionDelegationV1_1")
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		carol := jtx.NewAccount("carol")
+		env.FundAmount(alice, uint64(jtx.XRP(10000)))
+		env.FundAmount(bob, uint64(jtx.XRP(10000)))
+		env.FundAmount(carol, uint64(jtx.XRP(10000)))
+		env.Close()
+
+		// Bob delegates Payment permission to carol
+		env.SetDelegate(bob, carol, []string{"Payment"})
+		env.Close()
+
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+		preCarol := env.Balance(carol)
+
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		aliceSeq := env.Seq(alice)
+		bobSeq := env.Seq(bob)
+
+		// Inner tx[0]: payment bob->alice, delegated to carol
+		innerTx0 := MakeInnerPaymentXRPWithDelegate(bob, alice, 1, bobSeq, carol)
+		// Inner tx[1]: payment alice->bob
+		innerTx1 := MakeInnerPaymentXRP(alice, bob, 2, aliceSeq+1)
+
+		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(innerTx0).
+			AddInnerTx(innerTx1).
+			AddSigner(bob).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		// Alice: outer seq + 1 inner = aliceSeq + 2
+		jtx.RequireSequence(t, env, alice, aliceSeq+2)
+		// Bob: 1 inner = bobSeq + 1
+		jtx.RequireSequence(t, env, bob, bobSeq+1)
+
+		// Alice: -XRP(1) (net: pay 2 to bob, receive 1 from bob) - batchFee
+		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(1))-batchFee)
+		// Bob: +XRP(1) (net: receive 2 from alice, pay 1 to alice)
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(1)))
+		// Carol: unchanged (batch is atomic, fee is paid by batch outer account)
+		jtx.RequireBalance(t, env, carol, preCarol)
+	})
+}
+
+// Tests 13-15: testTickets, testTicketsOpenLedger

--- a/internal/testing/batch/fixture_test.go
+++ b/internal/testing/batch/fixture_test.go
@@ -33,6 +33,16 @@ func CalcBatchFeeFromEnv(env *jtx.TestEnv, numSigners uint32, numInnerTxns uint3
 	return CalcBatchFee(env.BaseFee(), numSigners, numInnerTxns)
 }
 
+func SetMinimumBatchFeeFromEnv(env *jtx.TestEnv, batch *batchtx.Batch) uint64 {
+	fee := batch.CalculateMinimumFee(env.Ledger(), tx.EngineConfig{
+		BaseFee:          env.BaseFee(),
+		ReserveIncrement: env.ReserveIncrement(),
+		Rules:            env.Ledger().Rules(),
+	})
+	batch.Fee = fmt.Sprintf("%d", fee)
+	return fee
+}
+
 // BatchBuilder provides a fluent interface for building Batch transactions in tests.
 // Reference: rippled test/jtx/batch.h outer() + inner() classes
 type BatchBuilder struct {
@@ -44,7 +54,6 @@ type BatchBuilder struct {
 	innerTxns []batchtx.RawTransaction
 	signers   []batchtx.BatchSigner
 	signSpecs []signSpec
-	baseFee   uint64
 }
 
 // signSpec records how to produce a real BatchSigner signature once the batch
@@ -67,7 +76,6 @@ func NewBatchBuilder(account *jtx.Account, seq uint32, fee uint64, flag uint32) 
 		seq:     &seq,
 		fee:     fee,
 		flag:    flag,
-		baseFee: 10, // default
 	}
 }
 
@@ -84,10 +92,8 @@ func (b *BatchBuilder) AddInnerTx(txn tx.Transaction) *BatchBuilder {
 }
 
 // AddSigner adds a single-sign batch signer whose master key signs the digest.
-// The signature passed here is a placeholder; the real signature over the batch
-// digest is computed in Build().
 // Reference: rippled test/jtx/batch.h sig class
-func (b *BatchBuilder) AddSigner(account *jtx.Account, signature string) *BatchBuilder {
+func (b *BatchBuilder) AddSigner(account *jtx.Account) *BatchBuilder {
 	b.signSpecs = append(b.signSpecs, signSpec{
 		index:       len(b.signers),
 		signingKeys: []*jtx.Account{account},
@@ -96,7 +102,7 @@ func (b *BatchBuilder) AddSigner(account *jtx.Account, signature string) *BatchB
 		BatchSigner: batchtx.BatchSignerData{
 			Account:           account.Address,
 			SigningPubKey:     account.PublicKeyHex(),
-			BatchTxnSignature: signature,
+			BatchTxnSignature: "DEADBEEF",
 		},
 	})
 	return b
@@ -106,7 +112,7 @@ func (b *BatchBuilder) AddSigner(account *jtx.Account, signature string) *BatchB
 // The 'account' is the BatchSigner.Account, and 'regKey' provides the signing key.
 // The real signature is computed in Build().
 // Reference: rippled test/jtx/batch.h sig(Reg{account, regKey})
-func (b *BatchBuilder) AddSignerWithRegKey(account, regKey *jtx.Account, signature string) *BatchBuilder {
+func (b *BatchBuilder) AddSignerWithRegKey(account, regKey *jtx.Account) *BatchBuilder {
 	b.signSpecs = append(b.signSpecs, signSpec{
 		index:       len(b.signers),
 		signingKeys: []*jtx.Account{regKey},
@@ -115,7 +121,7 @@ func (b *BatchBuilder) AddSignerWithRegKey(account, regKey *jtx.Account, signatu
 		BatchSigner: batchtx.BatchSignerData{
 			Account:           account.Address,
 			SigningPubKey:     regKey.PublicKeyHex(),
-			BatchTxnSignature: signature,
+			BatchTxnSignature: "DEADBEEF",
 		},
 	})
 	return b
@@ -245,8 +251,9 @@ type RegKeySigner struct {
 	SigningKey *jtx.Account
 }
 
-// Build constructs the Batch transaction.
-func (b *BatchBuilder) Build() *batchtx.Batch {
+// Build constructs the Batch transaction and signs every intended-valid
+// BatchSigner.
+func (b *BatchBuilder) Build() (*batchtx.Batch, error) {
 	batch := batchtx.NewBatch(b.account.Address)
 	batch.Fee = fmt.Sprintf("%d", b.fee)
 	if b.seq != nil {
@@ -259,19 +266,29 @@ func (b *BatchBuilder) Build() *batchtx.Batch {
 	batch.RawTransactions = b.innerTxns
 	if len(b.signers) > 0 {
 		batch.BatchSigners = b.signers
-		b.signBatchSigners(batch)
+		if err := b.signBatchSigners(batch); err != nil {
+			return nil, err
+		}
+	}
+	return batch, nil
+}
+
+// MustBuild constructs an intended-valid fixture and panics if signing fails.
+// Negative signature fixtures must use the explicit malformed signer methods.
+func (b *BatchBuilder) MustBuild() *batchtx.Batch {
+	batch, err := b.Build()
+	if err != nil {
+		panic(err)
 	}
 	return batch
 }
 
 // signBatchSigners replaces the placeholder BatchSigner signatures with real
-// signatures over the batch digest, mirroring rippled's batch::sig / batch::msig
-// test helpers. Specs whose digest cannot be computed (e.g. a deliberately
-// malformed batch) are left with their placeholder signatures.
-func (b *BatchBuilder) signBatchSigners(batch *batchtx.Batch) {
+// signatures over the batch digest.
+func (b *BatchBuilder) signBatchSigners(batch *batchtx.Batch) error {
 	digest, err := batch.BatchSigningMessage()
 	if err != nil {
-		return
+		return fmt.Errorf("build Batch signing message: %w", err)
 	}
 	for _, spec := range b.signSpecs {
 		signer := &batch.BatchSigners[spec.index].BatchSigner
@@ -279,31 +296,40 @@ func (b *BatchBuilder) signBatchSigners(batch *batchtx.Batch) {
 			for j, key := range spec.signingKeys {
 				nestedID := spec.signerAccounts[j].ID
 				msg := append(append([]byte{}, digest...), nestedID[:]...)
-				signer.Signers[j].Signer.TxnSignature = signBatchMessage(key, msg)
+				signature, err := signBatchMessage(key, msg)
+				if err != nil {
+					return fmt.Errorf("sign nested Batch signer %s: %w", key.Address, err)
+				}
+				signer.Signers[j].Signer.TxnSignature = signature
 			}
 			continue
 		}
-		signer.BatchTxnSignature = signBatchMessage(spec.signingKeys[0], digest)
+		signature, err := signBatchMessage(spec.signingKeys[0], digest)
+		if err != nil {
+			return fmt.Errorf("sign Batch signer %s: %w", spec.signingKeys[0].Address, err)
+		}
+		signer.BatchTxnSignature = signature
 	}
+	return nil
 }
 
 // signBatchMessage signs raw message bytes with the account's key, mirroring
 // rippled's ripple::sign over the serializeBatch slice. The crypto scheme hashes
 // the message internally.
-func signBatchMessage(acc *jtx.Account, msg []byte) string {
+func signBatchMessage(acc *jtx.Account, msg []byte) (string, error) {
 	priv := prefixedPrivateKeyHex(acc)
 	if acc.IsEd25519() {
 		sig, err := ed25519.Algorithm{}.Sign(string(msg), priv)
 		if err != nil {
-			return ""
+			return "", err
 		}
-		return sig
+		return sig, nil
 	}
 	sig, err := secp256k1.Algorithm{}.Sign(string(msg), priv)
 	if err != nil {
-		return ""
+		return "", err
 	}
-	return sig
+	return sig, nil
 }
 
 // prefixedPrivateKeyHex returns the key-type-prefixed private key hex expected by
@@ -317,7 +343,7 @@ func prefixedPrivateKeyHex(acc *jtx.Account) string {
 
 // MakeFakeInnerTx creates a minimal valid inner transaction for validation-only tests.
 // Returns a Payment that satisfies Batch.Validate() requirements.
-func MakeFakeInnerTx() tx.Transaction {
+func MakeFakeInnerTx(sequence uint32) tx.Transaction {
 	p := payment.NewPayment(
 		"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh", // genesis account
 		"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
@@ -325,8 +351,7 @@ func MakeFakeInnerTx() tx.Transaction {
 	)
 	p.Fee = "0"
 	p.SigningPubKey = ""
-	seq := uint32(1)
-	p.Sequence = &seq
+	p.Sequence = &sequence
 	flags := tx.TfInnerBatchTxn
 	p.Flags = &flags
 	return p
@@ -379,7 +404,6 @@ func NewBatchBuilderWithTicket(account *jtx.Account, ticketSeq uint32, fee uint6
 		seq:       &zero,
 		fee:       fee,
 		flag:      flag,
-		baseFee:   10,
 		ticketSeq: &ticketSeq,
 	}
 }

--- a/internal/testing/batch/fixture_test.go
+++ b/internal/testing/batch/fixture_test.go
@@ -28,7 +28,6 @@ func CalcBatchFee(baseFee uint64, numSigners uint32, numInnerTxns uint32) uint64
 	return (uint64(numSigners)+2)*baseFee + baseFee*uint64(numInnerTxns)
 }
 
-// CalcBatchFeeFromEnv calculates the expected batch fee using the env's base fee.
 func CalcBatchFeeFromEnv(env *jtx.TestEnv, numSigners uint32, numInnerTxns uint32) uint64 {
 	return CalcBatchFee(env.BaseFee(), numSigners, numInnerTxns)
 }
@@ -377,7 +376,6 @@ func MakeInnerPaymentXRPWithDelegate(from, to *jtx.Account, xrp int64, seq uint3
 	return p
 }
 
-// MakeInnerPaymentXRP creates an inner Payment for an XRP amount in whole XRP units.
 func MakeInnerPaymentXRP(from, to *jtx.Account, xrp int64, seq uint32) *payment.Payment {
 	return MakeInnerPayment(from, to, jtx.XRP(xrp), seq)
 }

--- a/internal/testing/batch/objects_test.go
+++ b/internal/testing/batch/objects_test.go
@@ -33,7 +33,6 @@ func TestAccountDelete(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, 0, batchtx.BatchFlagIndependent).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(MakeInnerAccountDelete(alice, bob, seq+2)).
-			// terNO_ACCOUNT: alice does not exist after deletion
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).
 			MustBuild()
 		batchFee := SetMinimumBatchFeeFromEnv(env, batch)
@@ -42,7 +41,6 @@ func TestAccountDelete(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// Alice does not exist; Bob receives Alice's XRP
 		jtx.RequireAccountNotExists(t, env, alice)
 		jtx.RequireBalance(t, env, bob, preBob+(preAlice-batchFee))
 	})
@@ -64,14 +62,12 @@ func TestAccountDelete(t *testing.T) {
 
 		preBob := env.Balance(bob)
 
-		// Alice creates a trust line which counts as an obligation
 		env.Trust(alice, bob.IOU("USD", 1000))
 		env.Close()
 
 		seq := env.Seq(alice)
 		batch := NewBatchBuilder(alice, seq, 0, batchtx.BatchFlagIndependent).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
-			// tecHAS_OBLIGATIONS: alice has obligations (trust line)
 			AddInnerTx(MakeInnerAccountDelete(alice, bob, seq+2)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).
 			MustBuild()
@@ -81,7 +77,6 @@ func TestAccountDelete(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// Alice still exists; Bob receives XRP(3) from the two successful payments
 		jtx.RequireAccountExists(t, env, alice)
 		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
 	})
@@ -107,7 +102,6 @@ func TestAccountDelete(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, 0, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(MakeInnerAccountDelete(alice, bob, seq+2)).
-			// terNO_ACCOUNT: alice does not exist after deletion, causing rollback
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).
 			MustBuild()
 		SetMinimumBatchFeeFromEnv(env, batch)
@@ -116,7 +110,6 @@ func TestAccountDelete(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// Alice still exists (all rolled back); Bob is unchanged
 		jtx.RequireAccountExists(t, env, alice)
 		jtx.RequireBalance(t, env, bob, preBob)
 	})
@@ -124,7 +117,6 @@ func TestAccountDelete(t *testing.T) {
 
 func TestObjectCreateSequence(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		// Create a CheckCreate from bob to alice, then CheckCash from alice, all in a batch.
 		// Reference: rippled Batch_test.cpp testObjectCreateSequence() - success
 		env := newBatchEnv(t)
 
@@ -136,7 +128,6 @@ func TestObjectCreateSequence(t *testing.T) {
 		env.FundAmount(gw, uint64(jtx.XRP(10000)))
 		env.Close()
 
-		// Set up trust lines and issue USD
 		usd10 := tx.NewIssuedAmountFromFloat64(10, "USD", gw.Address)
 		usd1000 := tx.NewIssuedAmountFromFloat64(1000, "USD", gw.Address)
 
@@ -153,8 +144,6 @@ func TestObjectCreateSequence(t *testing.T) {
 		preAliceUSD := env.BalanceIOU(alice, "USD", gw)
 		preBobUSD := env.BalanceIOU(bob, "USD", gw)
 
-		// CheckCreate from bob to alice for USD(10), then CheckCash from alice
-		// chkID is derived from bob's account and bob's current seq
 		chkID := GetCheckIndex(bob, bobSeq)
 
 		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
@@ -168,17 +157,13 @@ func TestObjectCreateSequence(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// Alice consumes sequences (outer + 1 inner)
 		jtx.RequireSequence(t, env, alice, aliceSeq+2)
 
-		// Bob consumes sequences (1 inner)
 		jtx.RequireSequence(t, env, bob, bobSeq+1)
 
-		// Alice pays fee; Bob XRP unchanged
 		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob)
 
-		// Alice gains USD(10); Bob loses USD(10)
 		require.InDelta(t, preAliceUSD+10.0, env.BalanceIOU(alice, "USD", gw), 0.001,
 			"alice should have gained USD 10")
 		require.InDelta(t, preBobUSD-10.0, env.BalanceIOU(bob, "USD", gw), 0.001,
@@ -186,8 +171,6 @@ func TestObjectCreateSequence(t *testing.T) {
 	})
 
 	t.Run("failure - tecDST_TAG_NEEDED", func(t *testing.T) {
-		// Alice enables asfRequireDest, so CheckCreate to alice fails with tecDST_TAG_NEEDED.
-		// In Independent mode, CheckCash then fails with tecNO_ENTRY.
 		// Reference: rippled Batch_test.cpp testObjectCreateSequence() - failure
 		env := newBatchEnv(t)
 
@@ -208,7 +191,6 @@ func TestObjectCreateSequence(t *testing.T) {
 		env.PayIOU(gw, bob, gw, "USD", 100)
 		env.Close()
 
-		// Enable RequireDest on alice
 		env.EnableRequireDest(alice)
 		env.Close()
 
@@ -229,20 +211,16 @@ func TestObjectCreateSequence(t *testing.T) {
 			MustBuild()
 
 		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result) // Batch itself succeeds
+		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// Alice consumes sequences (outer + 1 inner)
 		jtx.RequireSequence(t, env, alice, aliceSeq+2)
 
-		// Bob consumes sequences (1 inner)
 		jtx.RequireSequence(t, env, bob, bobSeq+1)
 
-		// Alice pays fee only; Bob XRP unchanged
 		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob)
 
-		// USD balances unchanged (both inner txns failed)
 		require.InDelta(t, preAliceUSD, env.BalanceIOU(alice, "USD", gw), 0.001,
 			"alice USD should be unchanged")
 		require.InDelta(t, preBobUSD, env.BalanceIOU(bob, "USD", gw), 0.001,
@@ -251,7 +229,6 @@ func TestObjectCreateSequence(t *testing.T) {
 }
 
 func TestObjectCreateTicket(t *testing.T) {
-	// Create tickets inside a batch, then use a ticket for CheckCreate, then CheckCash.
 	// Reference: rippled Batch_test.cpp testObjectCreateTicket()
 	env := newBatchEnv(t)
 
@@ -263,7 +240,6 @@ func TestObjectCreateTicket(t *testing.T) {
 	env.FundAmount(gw, uint64(jtx.XRP(10000)))
 	env.Close()
 
-	// Set up trust lines and issue USD
 	usd10 := tx.NewIssuedAmountFromFloat64(10, "USD", gw.Address)
 	usd1000 := tx.NewIssuedAmountFromFloat64(1000, "USD", gw.Address)
 
@@ -280,14 +256,6 @@ func TestObjectCreateTicket(t *testing.T) {
 	preAliceUSD := env.BalanceIOU(alice, "USD", gw)
 	preBobUSD := env.BalanceIOU(bob, "USD", gw)
 
-	// Batch with 3 inner txns:
-	// 1. TicketCreate(bob, 10) using bobSeq
-	// 2. CheckCreate(bob->alice, USD(10)) using ticket bobSeq+1
-	// 3. CheckCash(alice, chkID, USD(10)) using aliceSeq+1
-	//
-	// After TicketCreate, bob's sequence advances by 10 (tickets) + 1 (for the TicketCreate).
-	// The first ticket is at bobSeq+1. CheckCreate uses ticket bobSeq+1.
-	// The check ID is derived from bob's account and the ticket sequence.
 	chkID := GetCheckIndex(bob, bobSeq+1)
 
 	batchFee := CalcBatchFeeFromEnv(env, 1, 3)
@@ -302,19 +270,13 @@ func TestObjectCreateTicket(t *testing.T) {
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
 
-	// Alice consumes sequences: outer + 1 inner = aliceSeq + 2
 	jtx.RequireSequence(t, env, alice, aliceSeq+2)
 
-	// Bob: TicketCreate uses seq bobSeq (sequence advances by 1 + 10 tickets = 11).
-	// CheckCreate uses ticket (no sequence advancement).
-	// So bob's sequence = bobSeq + 10 + 1 = bobSeq + 11
 	jtx.RequireSequence(t, env, bob, bobSeq+10+1)
 
-	// Alice pays fee; Bob XRP unchanged
 	jtx.RequireBalance(t, env, alice, preAlice-batchFee)
 	jtx.RequireBalance(t, env, bob, preBob)
 
-	// Alice gains USD(10); Bob loses USD(10)
 	require.InDelta(t, preAliceUSD+10.0, env.BalanceIOU(alice, "USD", gw), 0.001,
 		"alice should have gained USD 10")
 	require.InDelta(t, preBobUSD-10.0, env.BalanceIOU(bob, "USD", gw), 0.001,
@@ -323,9 +285,6 @@ func TestObjectCreateTicket(t *testing.T) {
 
 func TestObjectCreate3rdParty(t *testing.T) {
 	// Reference: rippled Batch_test.cpp testObjectCreate3rdParty()
-	// Carol submits a batch containing inner transactions from alice and bob.
-	// bob creates a check for alice, alice cashes it.
-	// batch::sig(alice, bob) provides authorization.
 
 	env := newBatchEnv(t)
 
@@ -340,7 +299,6 @@ func TestObjectCreate3rdParty(t *testing.T) {
 	env.FundAmount(gw, uint64(jtx.XRP(10000)))
 	env.Close()
 
-	// Set up trust lines and fund IOU
 	env.Trust(alice, tx.NewIssuedAmountFromFloat64(1000, "USD", gw.Address))
 	env.Trust(bob, tx.NewIssuedAmountFromFloat64(1000, "USD", gw.Address))
 	env.PayIOU(gw, alice, gw, "USD", 100)
@@ -356,7 +314,6 @@ func TestObjectCreate3rdParty(t *testing.T) {
 	preAliceUSD := env.BalanceIOU(alice, "USD", gw)
 	preBobUSD := env.BalanceIOU(bob, "USD", gw)
 
-	// Build the check ID from bob's current sequence
 	chkID := GetCheckIndex(bob, bobSeq)
 
 	batchFee := CalcBatchFeeFromEnv(env, 2, 2)
@@ -371,17 +328,14 @@ func TestObjectCreate3rdParty(t *testing.T) {
 	jtx.RequireTxSuccess(t, result)
 	env.Close()
 
-	// Verify sequences advanced
 	jtx.RequireSequence(t, env, alice, aliceSeq+1)
 	jtx.RequireSequence(t, env, bob, bobSeq+1)
 	jtx.RequireSequence(t, env, carol, carolSeq+1)
 
-	// Verify XRP balances: alice and bob unchanged, carol pays fee
 	jtx.RequireBalance(t, env, alice, preAlice)
 	jtx.RequireBalance(t, env, bob, preBob)
 	jtx.RequireBalance(t, env, carol, preCarol-batchFee)
 
-	// Verify IOU balances: alice gains USD(10), bob loses USD(10)
 	require.InDelta(t, preAliceUSD+10.0, env.BalanceIOU(alice, "USD", gw), 0.001,
 		"alice should have gained USD 10")
 	require.InDelta(t, preBobUSD-10.0, env.BalanceIOU(bob, "USD", gw), 0.001,
@@ -396,7 +350,6 @@ func TestBatchCalculateBaseFee(t *testing.T) {
 		env.Fund(alice, bob)
 		env.Close()
 
-		// 9 inner txns should exceed max (8)
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 0, 9)
 		builder := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing)
@@ -405,7 +358,6 @@ func TestBatchCalculateBaseFee(t *testing.T) {
 		}
 		batch := builder.MustBuild()
 
-		// Should fail validation
 		err := batch.Validate()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "exceeds 8")
@@ -442,7 +394,7 @@ func TestBatchCalculateBaseFee(t *testing.T) {
 		env.Close()
 
 		seq := env.Seq(alice)
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2) // = 40 with base fee 10
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+2)).
@@ -451,11 +403,6 @@ func TestBatchCalculateBaseFee(t *testing.T) {
 		err := batch.Validate()
 		require.NoError(t, err)
 
-		// Verify fee is correct
 		require.Equal(t, fmt.Sprintf("%d", batchFee), batch.Fee)
 	})
 }
-
-// Batch signature verification vectors
-// These exercise serializeBatch digest verification and the requiredSigners
-// coverage rule, which run in preflight (Batch.Validate).

--- a/internal/testing/batch/objects_test.go
+++ b/internal/testing/batch/objects_test.go
@@ -1,0 +1,461 @@
+package batch
+
+import (
+	"fmt"
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	batchtx "github.com/LeJamon/go-xrpl/internal/tx/batch"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountDelete(t *testing.T) {
+	t.Run("tfIndependent - account delete success", func(t *testing.T) {
+		// Reference: rippled Batch_test.cpp testAccountDelete() - tfIndependent success
+		env := newBatchEnv(t)
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.FundAmount(alice, uint64(jtx.XRP(10000)))
+		env.FundAmount(bob, uint64(jtx.XRP(10000)))
+		env.Close()
+
+		env.IncLedgerSeqForAccDel(alice)
+		for range 5 {
+			env.Close()
+		}
+
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		seq := env.Seq(alice)
+		batch := NewBatchBuilder(alice, seq, 0, batchtx.BatchFlagIndependent).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerAccountDelete(alice, bob, seq+2)).
+			// terNO_ACCOUNT: alice does not exist after deletion
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).
+			MustBuild()
+		batchFee := SetMinimumBatchFeeFromEnv(env, batch)
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		// Alice does not exist; Bob receives Alice's XRP
+		jtx.RequireAccountNotExists(t, env, alice)
+		jtx.RequireBalance(t, env, bob, preBob+(preAlice-batchFee))
+	})
+
+	t.Run("tfIndependent - account delete fails", func(t *testing.T) {
+		// Reference: rippled Batch_test.cpp testAccountDelete() - tfIndependent fails
+		env := newBatchEnv(t)
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.FundAmount(alice, uint64(jtx.XRP(10000)))
+		env.FundAmount(bob, uint64(jtx.XRP(10000)))
+		env.Close()
+
+		env.IncLedgerSeqForAccDel(alice)
+		for range 5 {
+			env.Close()
+		}
+
+		preBob := env.Balance(bob)
+
+		// Alice creates a trust line which counts as an obligation
+		env.Trust(alice, bob.IOU("USD", 1000))
+		env.Close()
+
+		seq := env.Seq(alice)
+		batch := NewBatchBuilder(alice, seq, 0, batchtx.BatchFlagIndependent).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			// tecHAS_OBLIGATIONS: alice has obligations (trust line)
+			AddInnerTx(MakeInnerAccountDelete(alice, bob, seq+2)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).
+			MustBuild()
+		SetMinimumBatchFeeFromEnv(env, batch)
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		// Alice still exists; Bob receives XRP(3) from the two successful payments
+		jtx.RequireAccountExists(t, env, alice)
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
+	})
+
+	t.Run("tfAllOrNothing - account delete fails", func(t *testing.T) {
+		// Reference: rippled Batch_test.cpp testAccountDelete() - tfAllOrNothing fails
+		env := newBatchEnv(t)
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.FundAmount(alice, uint64(jtx.XRP(10000)))
+		env.FundAmount(bob, uint64(jtx.XRP(10000)))
+		env.Close()
+
+		env.IncLedgerSeqForAccDel(alice)
+		for range 5 {
+			env.Close()
+		}
+
+		preBob := env.Balance(bob)
+
+		seq := env.Seq(alice)
+		batch := NewBatchBuilder(alice, seq, 0, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerAccountDelete(alice, bob, seq+2)).
+			// terNO_ACCOUNT: alice does not exist after deletion, causing rollback
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+3)).
+			MustBuild()
+		SetMinimumBatchFeeFromEnv(env, batch)
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		// Alice still exists (all rolled back); Bob is unchanged
+		jtx.RequireAccountExists(t, env, alice)
+		jtx.RequireBalance(t, env, bob, preBob)
+	})
+}
+
+func TestObjectCreateSequence(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// Create a CheckCreate from bob to alice, then CheckCash from alice, all in a batch.
+		// Reference: rippled Batch_test.cpp testObjectCreateSequence() - success
+		env := newBatchEnv(t)
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		gw := jtx.NewAccount("gw")
+		env.FundAmount(alice, uint64(jtx.XRP(10000)))
+		env.FundAmount(bob, uint64(jtx.XRP(10000)))
+		env.FundAmount(gw, uint64(jtx.XRP(10000)))
+		env.Close()
+
+		// Set up trust lines and issue USD
+		usd10 := tx.NewIssuedAmountFromFloat64(10, "USD", gw.Address)
+		usd1000 := tx.NewIssuedAmountFromFloat64(1000, "USD", gw.Address)
+
+		env.Trust(alice, usd1000)
+		env.Trust(bob, usd1000)
+		env.PayIOU(gw, alice, gw, "USD", 100)
+		env.PayIOU(gw, bob, gw, "USD", 100)
+		env.Close()
+
+		aliceSeq := env.Seq(alice)
+		bobSeq := env.Seq(bob)
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+		preAliceUSD := env.BalanceIOU(alice, "USD", gw)
+		preBobUSD := env.BalanceIOU(bob, "USD", gw)
+
+		// CheckCreate from bob to alice for USD(10), then CheckCash from alice
+		// chkID is derived from bob's account and bob's current seq
+		chkID := GetCheckIndex(bob, bobSeq)
+
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerCheckCreate(bob, alice, usd10, bobSeq)).
+			AddInnerTx(MakeInnerCheckCash(alice, chkID, usd10, aliceSeq+1)).
+			AddSigner(bob).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		// Alice consumes sequences (outer + 1 inner)
+		jtx.RequireSequence(t, env, alice, aliceSeq+2)
+
+		// Bob consumes sequences (1 inner)
+		jtx.RequireSequence(t, env, bob, bobSeq+1)
+
+		// Alice pays fee; Bob XRP unchanged
+		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob)
+
+		// Alice gains USD(10); Bob loses USD(10)
+		require.InDelta(t, preAliceUSD+10.0, env.BalanceIOU(alice, "USD", gw), 0.001,
+			"alice should have gained USD 10")
+		require.InDelta(t, preBobUSD-10.0, env.BalanceIOU(bob, "USD", gw), 0.001,
+			"bob should have lost USD 10")
+	})
+
+	t.Run("failure - tecDST_TAG_NEEDED", func(t *testing.T) {
+		// Alice enables asfRequireDest, so CheckCreate to alice fails with tecDST_TAG_NEEDED.
+		// In Independent mode, CheckCash then fails with tecNO_ENTRY.
+		// Reference: rippled Batch_test.cpp testObjectCreateSequence() - failure
+		env := newBatchEnv(t)
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		gw := jtx.NewAccount("gw")
+		env.FundAmount(alice, uint64(jtx.XRP(10000)))
+		env.FundAmount(bob, uint64(jtx.XRP(10000)))
+		env.FundAmount(gw, uint64(jtx.XRP(10000)))
+		env.Close()
+
+		usd10 := tx.NewIssuedAmountFromFloat64(10, "USD", gw.Address)
+		usd1000 := tx.NewIssuedAmountFromFloat64(1000, "USD", gw.Address)
+
+		env.Trust(alice, usd1000)
+		env.Trust(bob, usd1000)
+		env.PayIOU(gw, alice, gw, "USD", 100)
+		env.PayIOU(gw, bob, gw, "USD", 100)
+		env.Close()
+
+		// Enable RequireDest on alice
+		env.EnableRequireDest(alice)
+		env.Close()
+
+		aliceSeq := env.Seq(alice)
+		bobSeq := env.Seq(bob)
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+		preAliceUSD := env.BalanceIOU(alice, "USD", gw)
+		preBobUSD := env.BalanceIOU(bob, "USD", gw)
+
+		chkID := GetCheckIndex(bob, bobSeq)
+
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagIndependent).
+			AddInnerTx(MakeInnerCheckCreate(bob, alice, usd10, bobSeq)).
+			AddInnerTx(MakeInnerCheckCash(alice, chkID, usd10, aliceSeq+1)).
+			AddSigner(bob).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result) // Batch itself succeeds
+		env.Close()
+
+		// Alice consumes sequences (outer + 1 inner)
+		jtx.RequireSequence(t, env, alice, aliceSeq+2)
+
+		// Bob consumes sequences (1 inner)
+		jtx.RequireSequence(t, env, bob, bobSeq+1)
+
+		// Alice pays fee only; Bob XRP unchanged
+		jtx.RequireBalance(t, env, alice, preAlice-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob)
+
+		// USD balances unchanged (both inner txns failed)
+		require.InDelta(t, preAliceUSD, env.BalanceIOU(alice, "USD", gw), 0.001,
+			"alice USD should be unchanged")
+		require.InDelta(t, preBobUSD, env.BalanceIOU(bob, "USD", gw), 0.001,
+			"bob USD should be unchanged")
+	})
+}
+
+func TestObjectCreateTicket(t *testing.T) {
+	// Create tickets inside a batch, then use a ticket for CheckCreate, then CheckCash.
+	// Reference: rippled Batch_test.cpp testObjectCreateTicket()
+	env := newBatchEnv(t)
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	gw := jtx.NewAccount("gw")
+	env.FundAmount(alice, uint64(jtx.XRP(10000)))
+	env.FundAmount(bob, uint64(jtx.XRP(10000)))
+	env.FundAmount(gw, uint64(jtx.XRP(10000)))
+	env.Close()
+
+	// Set up trust lines and issue USD
+	usd10 := tx.NewIssuedAmountFromFloat64(10, "USD", gw.Address)
+	usd1000 := tx.NewIssuedAmountFromFloat64(1000, "USD", gw.Address)
+
+	env.Trust(alice, usd1000)
+	env.Trust(bob, usd1000)
+	env.PayIOU(gw, alice, gw, "USD", 100)
+	env.PayIOU(gw, bob, gw, "USD", 100)
+	env.Close()
+
+	aliceSeq := env.Seq(alice)
+	bobSeq := env.Seq(bob)
+	preAlice := env.Balance(alice)
+	preBob := env.Balance(bob)
+	preAliceUSD := env.BalanceIOU(alice, "USD", gw)
+	preBobUSD := env.BalanceIOU(bob, "USD", gw)
+
+	// Batch with 3 inner txns:
+	// 1. TicketCreate(bob, 10) using bobSeq
+	// 2. CheckCreate(bob->alice, USD(10)) using ticket bobSeq+1
+	// 3. CheckCash(alice, chkID, USD(10)) using aliceSeq+1
+	//
+	// After TicketCreate, bob's sequence advances by 10 (tickets) + 1 (for the TicketCreate).
+	// The first ticket is at bobSeq+1. CheckCreate uses ticket bobSeq+1.
+	// The check ID is derived from bob's account and the ticket sequence.
+	chkID := GetCheckIndex(bob, bobSeq+1)
+
+	batchFee := CalcBatchFeeFromEnv(env, 1, 3)
+	batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+		AddInnerTx(MakeInnerTicketCreate(bob, 10, bobSeq)).
+		AddInnerTx(MakeInnerCheckCreateWithTicket(bob, alice, usd10, bobSeq+1)).
+		AddInnerTx(MakeInnerCheckCash(alice, chkID, usd10, aliceSeq+1)).
+		AddSigner(bob).
+		MustBuild()
+
+	result := env.Submit(batch)
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	// Alice consumes sequences: outer + 1 inner = aliceSeq + 2
+	jtx.RequireSequence(t, env, alice, aliceSeq+2)
+
+	// Bob: TicketCreate uses seq bobSeq (sequence advances by 1 + 10 tickets = 11).
+	// CheckCreate uses ticket (no sequence advancement).
+	// So bob's sequence = bobSeq + 10 + 1 = bobSeq + 11
+	jtx.RequireSequence(t, env, bob, bobSeq+10+1)
+
+	// Alice pays fee; Bob XRP unchanged
+	jtx.RequireBalance(t, env, alice, preAlice-batchFee)
+	jtx.RequireBalance(t, env, bob, preBob)
+
+	// Alice gains USD(10); Bob loses USD(10)
+	require.InDelta(t, preAliceUSD+10.0, env.BalanceIOU(alice, "USD", gw), 0.001,
+		"alice should have gained USD 10")
+	require.InDelta(t, preBobUSD-10.0, env.BalanceIOU(bob, "USD", gw), 0.001,
+		"bob should have lost USD 10")
+}
+
+func TestObjectCreate3rdParty(t *testing.T) {
+	// Reference: rippled Batch_test.cpp testObjectCreate3rdParty()
+	// Carol submits a batch containing inner transactions from alice and bob.
+	// bob creates a check for alice, alice cashes it.
+	// batch::sig(alice, bob) provides authorization.
+
+	env := newBatchEnv(t)
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	carol := jtx.NewAccount("carol")
+	gw := jtx.NewAccount("gw")
+
+	env.FundAmount(alice, uint64(jtx.XRP(10000)))
+	env.FundAmount(bob, uint64(jtx.XRP(10000)))
+	env.FundAmount(carol, uint64(jtx.XRP(10000)))
+	env.FundAmount(gw, uint64(jtx.XRP(10000)))
+	env.Close()
+
+	// Set up trust lines and fund IOU
+	env.Trust(alice, tx.NewIssuedAmountFromFloat64(1000, "USD", gw.Address))
+	env.Trust(bob, tx.NewIssuedAmountFromFloat64(1000, "USD", gw.Address))
+	env.PayIOU(gw, alice, gw, "USD", 100)
+	env.PayIOU(gw, bob, gw, "USD", 100)
+	env.Close()
+
+	aliceSeq := env.Seq(alice)
+	bobSeq := env.Seq(bob)
+	carolSeq := env.Seq(carol)
+	preAlice := env.Balance(alice)
+	preBob := env.Balance(bob)
+	preCarol := env.Balance(carol)
+	preAliceUSD := env.BalanceIOU(alice, "USD", gw)
+	preBobUSD := env.BalanceIOU(bob, "USD", gw)
+
+	// Build the check ID from bob's current sequence
+	chkID := GetCheckIndex(bob, bobSeq)
+
+	batchFee := CalcBatchFeeFromEnv(env, 2, 2)
+	batch := NewBatchBuilder(carol, carolSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+		AddInnerTx(MakeInnerCheckCreate(bob, alice, tx.NewIssuedAmountFromFloat64(10.0, "USD", gw.Address), bobSeq)).
+		AddInnerTx(MakeInnerCheckCash(alice, chkID, tx.NewIssuedAmountFromFloat64(10.0, "USD", gw.Address), aliceSeq)).
+		AddSigner(alice).
+		AddSigner(bob).
+		MustBuild()
+
+	result := env.Submit(batch)
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	// Verify sequences advanced
+	jtx.RequireSequence(t, env, alice, aliceSeq+1)
+	jtx.RequireSequence(t, env, bob, bobSeq+1)
+	jtx.RequireSequence(t, env, carol, carolSeq+1)
+
+	// Verify XRP balances: alice and bob unchanged, carol pays fee
+	jtx.RequireBalance(t, env, alice, preAlice)
+	jtx.RequireBalance(t, env, bob, preBob)
+	jtx.RequireBalance(t, env, carol, preCarol-batchFee)
+
+	// Verify IOU balances: alice gains USD(10), bob loses USD(10)
+	require.InDelta(t, preAliceUSD+10.0, env.BalanceIOU(alice, "USD", gw), 0.001,
+		"alice should have gained USD 10")
+	require.InDelta(t, preBobUSD-10.0, env.BalanceIOU(bob, "USD", gw), 0.001,
+		"bob should have lost USD 10")
+}
+
+func TestBatchCalculateBaseFee(t *testing.T) {
+	t.Run("too many txns returns error fee", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		// 9 inner txns should exceed max (8)
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 9)
+		builder := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing)
+		for i := range 9 {
+			builder.AddInnerTx(MakeFakeInnerTx(uint32(i + 1)))
+		}
+		batch := builder.MustBuild()
+
+		// Should fail validation
+		err := batch.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds 8")
+	})
+
+	t.Run("too many signers returns error fee", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		env.Fund(alice)
+		env.Close()
+
+		bob := jtx.NewAccount("bob")
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 9, 2)
+		builder := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+2))
+		for i := range 9 {
+			signer := jtx.NewAccount(fmt.Sprintf("signer%d", i))
+			builder.AddSigner(signer)
+		}
+		batch := builder.MustBuild()
+
+		err := batch.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds 8")
+	})
+
+	t.Run("valid batch fee calculation", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2) // = 40 with base fee 10
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+2)).
+			MustBuild()
+
+		err := batch.Validate()
+		require.NoError(t, err)
+
+		// Verify fee is correct
+		require.Equal(t, fmt.Sprintf("%d", batchFee), batch.Fee)
+	})
+}
+
+// Batch signature verification vectors
+// These exercise serializeBatch digest verification and the requiredSigners
+// coverage rule, which run in preflight (Batch.Validate).

--- a/internal/testing/batch/open_ledger_test.go
+++ b/internal/testing/batch/open_ledger_test.go
@@ -10,6 +10,7 @@ import (
 	batchtx "github.com/LeJamon/go-xrpl/internal/tx/batch"
 	"github.com/LeJamon/go-xrpl/internal/tx/check"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/internal/txq"
 	"github.com/stretchr/testify/require"
 )
@@ -185,14 +186,14 @@ func TestTicketsOpenLedger(t *testing.T) {
 			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq+1)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, aliceSeq)).
 			MustBuild()
-		result = env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
+		batchResult := env.Submit(batch)
+		jtx.RequireTxSuccess(t, batchResult)
 		env.Close()
+		requireBatchLedgerData(t, env, batch, batchResult, ter.TesSUCCESS, ter.TesSUCCESS)
 
-		// After close: batch succeeds. The inner tx consumed ticket+1, so
-		// the standalone noop that used ticket+1 fails during replay
-		// (ticket already consumed). alice seq should advance.
 		env.Close()
+		closed := env.LastClosedLedger()
+		require.Zero(t, closed.TxCount())
 
 		// Verify final state: alice consumed aliceSeq (inner payment #2),
 		// ticket (batch outer), ticket+1 (inner payment #1)
@@ -220,8 +221,8 @@ func TestTicketsOpenLedger(t *testing.T) {
 			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq+1)).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, aliceSeq)).
 			MustBuild()
-		result := env.Submit(batch)
-		jtx.RequireTxSuccess(t, result)
+		batchResult := env.Submit(batch)
+		jtx.RequireTxSuccess(t, batchResult)
 
 		// AccountSet Txn using ticket+1 (already consumed by batch inner)
 		noopTxn := accounttx.NewAccountSet(alice.Address)
@@ -234,8 +235,10 @@ func TestTicketsOpenLedger(t *testing.T) {
 		noopResult := env.Submit(noopTxn)
 		jtx.RequireTxSuccess(t, noopResult)
 		env.Close()
+		requireBatchLedgerData(t, env, batch, batchResult, ter.TesSUCCESS, ter.TesSUCCESS)
 
 		env.Close()
+		require.Zero(t, env.LastClosedLedger().TxCount())
 
 		// Verify final state
 		require.Equal(t, aliceSeq+1, env.Seq(alice))
@@ -455,11 +458,16 @@ func TestSequenceOpenLedger(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// After first close: batch applied (alice seq -> aliceSeq+2).
-		// Noop at aliceSeq+2 may or may not be in first closed ledger
-		// (depends on canonical ordering and replay behavior).
-		// Close again to ensure the noop is retried if held.
+		requireBatchLedgerData(t, env, batch, result, ter.TesSUCCESS, ter.TesSUCCESS)
+
 		env.Close()
+		closed := env.LastClosedLedger()
+		require.Equal(t, uint32(1), closed.TxCount())
+		noopID, err := tx.ComputeTransactionHash(noopTxn)
+		require.NoError(t, err)
+		noopExists, err := closed.TxExists(noopID)
+		require.NoError(t, err)
+		require.True(t, noopExists)
 
 		// Final state verification:
 		// - alice's seq should be aliceSeq+3 (aliceSeq consumed by inner pay#1,

--- a/internal/testing/batch/open_ledger_test.go
+++ b/internal/testing/batch/open_ledger_test.go
@@ -1,0 +1,927 @@
+package batch
+
+import (
+	"fmt"
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	accounttx "github.com/LeJamon/go-xrpl/internal/tx/account"
+	batchtx "github.com/LeJamon/go-xrpl/internal/tx/batch"
+	"github.com/LeJamon/go-xrpl/internal/tx/check"
+	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/internal/txq"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTickets(t *testing.T) {
+	t.Run("tickets outer", func(t *testing.T) {
+		// Outer batch uses a ticket; inner transactions use regular sequences.
+		// Reference: rippled Batch_test.cpp testTickets() - "tickets outer"
+		env := newBatchEnv(t)
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.FundAmount(alice, uint64(jtx.XRP(10000)))
+		env.FundAmount(bob, uint64(jtx.XRP(10000)))
+		env.Close()
+
+		// Create 10 tickets for alice
+		aliceTicketSeq := env.CreateTickets(alice, 10)
+		env.Close()
+
+		aliceSeq := env.Seq(alice)
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		// Submit batch with outer using ticket, inner using sequences
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, aliceSeq+0)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, aliceSeq+1)).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		// Verify owner count: started with 10 tickets, consumed 1 (outer ticket) = 9
+		require.Equal(t, uint32(9), env.OwnerCount(alice), "alice should have 9 owner objects")
+		require.Equal(t, uint32(9), env.TicketCount(alice), "alice should have 9 tickets remaining")
+
+		// Alice's sequence advances by 2 (inner txns use sequences)
+		jtx.RequireSequence(t, env, alice, aliceSeq+2)
+
+		// Alice pays XRP(3) + batchFee; Bob receives XRP(3)
+		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
+	})
+
+	t.Run("tickets inner", func(t *testing.T) {
+		// Outer batch uses regular sequence; inner transactions use tickets.
+		// Reference: rippled Batch_test.cpp testTickets() - "tickets inner"
+		env := newBatchEnv(t)
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.FundAmount(alice, uint64(jtx.XRP(10000)))
+		env.FundAmount(bob, uint64(jtx.XRP(10000)))
+		env.Close()
+
+		// Create 10 tickets for alice
+		aliceTicketSeq := env.CreateTickets(alice, 10)
+		env.Close()
+
+		aliceSeq := env.Seq(alice)
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		// Submit batch with outer using sequence, inner using tickets
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq)).
+			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 2, aliceTicketSeq+1)).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		// Verify owner count: started with 10 tickets, consumed 2 (inner tickets) = 8
+		require.Equal(t, uint32(8), env.OwnerCount(alice), "alice should have 8 owner objects")
+		require.Equal(t, uint32(8), env.TicketCount(alice), "alice should have 8 tickets remaining")
+
+		// Alice's sequence advances by 1 (only outer seq increment, inner use tickets)
+		jtx.RequireSequence(t, env, alice, aliceSeq+1)
+
+		// Alice pays XRP(3) + batchFee; Bob receives XRP(3)
+		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
+	})
+
+	t.Run("tickets outer inner", func(t *testing.T) {
+		// Outer batch uses a ticket; one inner tx uses a ticket, the other uses a sequence.
+		// Reference: rippled Batch_test.cpp testTickets() - "tickets outer inner"
+		env := newBatchEnv(t)
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.FundAmount(alice, uint64(jtx.XRP(10000)))
+		env.FundAmount(bob, uint64(jtx.XRP(10000)))
+		env.Close()
+
+		// Create 10 tickets for alice
+		aliceTicketSeq := env.CreateTickets(alice, 10)
+		env.Close()
+
+		aliceSeq := env.Seq(alice)
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		// Submit batch:
+		// - outer uses ticket aliceTicketSeq
+		// - inner[0] uses ticket aliceTicketSeq+1
+		// - inner[1] uses sequence aliceSeq
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, aliceSeq)).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		// Verify owner count: started with 10 tickets, consumed 2 (outer + inner[0]) = 8
+		require.Equal(t, uint32(8), env.OwnerCount(alice), "alice should have 8 owner objects")
+		require.Equal(t, uint32(8), env.TicketCount(alice), "alice should have 8 tickets remaining")
+
+		// Alice's sequence advances by 1 (only inner[1] uses a sequence)
+		jtx.RequireSequence(t, env, alice, aliceSeq+1)
+
+		// Alice pays XRP(3) + batchFee; Bob receives XRP(3)
+		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
+	})
+}
+
+func TestTicketsOpenLedger(t *testing.T) {
+	// Reference: rippled Batch_test.cpp testTicketsOpenLedger()
+	// Tests that batch transactions using tickets interact correctly with
+	// standalone transactions using tickets from the same set.
+
+	t.Run("before batch txn with same ticket", func(t *testing.T) {
+		// Reference: rippled testTicketsOpenLedger() "Before Batch Txn w/ same ticket"
+		// The batch is applied first (canonical order), consuming the ticket
+		// used by the inner tx. The noop that also uses that ticket is
+		// overwritten.
+		env := newBatchEnv(t)
+		env.EnableOpenLedgerReplay()
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		aliceTicketSeq := env.CreateTickets(alice, 10)
+		env.Close()
+
+		aliceSeq := env.Seq(alice)
+
+		// AccountSet Txn using ticket+1
+		noopTxn := accounttx.NewAccountSet(alice.Address)
+		noopTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
+		noopTxn.SigningPubKey = alice.PublicKeyHex()
+		zero := uint32(0)
+		noopTxn.Sequence = &zero
+		ticketSeq1 := aliceTicketSeq + 1
+		noopTxn.TicketSequence = &ticketSeq1
+		result := env.Submit(noopTxn)
+		jtx.RequireTxSuccess(t, result)
+
+		// Batch Txn using ticket for outer, ticket+1 for inner payment
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, aliceSeq)).
+			MustBuild()
+		result = env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		// After close: batch succeeds. The inner tx consumed ticket+1, so
+		// the standalone noop that used ticket+1 fails during replay
+		// (ticket already consumed). alice seq should advance.
+		env.Close()
+
+		// Verify final state: alice consumed aliceSeq (inner payment #2),
+		// ticket (batch outer), ticket+1 (inner payment #1)
+		require.Equal(t, aliceSeq+1, env.Seq(alice))
+	})
+
+	t.Run("after batch txn with same ticket", func(t *testing.T) {
+		// Reference: rippled testTicketsOpenLedger() "After Batch Txn w/ same ticket"
+		env := newBatchEnv(t)
+		env.EnableOpenLedgerReplay()
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		aliceTicketSeq := env.CreateTickets(alice, 10)
+		env.Close()
+
+		aliceSeq := env.Seq(alice)
+
+		// Batch Txn first
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, aliceSeq)).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+
+		// AccountSet Txn using ticket+1 (already consumed by batch inner)
+		noopTxn := accounttx.NewAccountSet(alice.Address)
+		noopTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
+		noopTxn.SigningPubKey = alice.PublicKeyHex()
+		zero := uint32(0)
+		noopTxn.Sequence = &zero
+		ticketSeq1 := aliceTicketSeq + 1
+		noopTxn.TicketSequence = &ticketSeq1
+		noopResult := env.Submit(noopTxn)
+		jtx.RequireTxSuccess(t, noopResult)
+		env.Close()
+
+		env.Close()
+
+		// Verify final state
+		require.Equal(t, aliceSeq+1, env.Seq(alice))
+	})
+}
+
+func TestBatchTxQueue(t *testing.T) {
+	t.Run("outer batch txns count towards queue size", func(t *testing.T) {
+		// Reference: rippled Batch_test.cpp testBatchTxQueue() first sub-test
+		// "only outer batch transactions are counter towards the queue size"
+		cfg := makeSmallQueueConfig(2)
+		env := jtx.NewTestEnvWithTxQ(t, cfg)
+		env.EnableFeatureNow("Batch")
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		carol := jtx.NewAccount("carol")
+
+		// Fund across several ledgers so the TxQ metrics stay restricted.
+		// noripple funds do not enable DefaultRipple (1 tx per account instead of 2).
+		env.FundAmountNoRipple(alice, uint64(jtx.XRP(10000)))
+		env.FundAmountNoRipple(bob, uint64(jtx.XRP(10000)))
+		env.Close()
+		env.FundAmountNoRipple(carol, uint64(jtx.XRP(10000)))
+		env.Close()
+
+		// Fill the ledger: 3 noops above the threshold of 2.
+		env.Noop(alice)
+		env.Noop(alice)
+		env.Noop(alice)
+		checkMetrics(t, env, 0, nil, 3, 2)
+
+		// Carol's noop gets queued because fee escalation requires more than base fee.
+		result := env.Submit(makeNoopWithFee(carol, env.BaseFee()))
+		jtx.RequireTxFail(t, result, "terQUEUED")
+		checkMetrics(t, env, 1, nil, 3, 2)
+
+		aliceSeq := env.Seq(alice)
+		bobSeq := env.Seq(bob)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+
+		// Queue Batch: regular batch fee is too low to bypass escalation.
+		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, aliceSeq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, bobSeq)).
+			AddSigner(bob).
+			MustBuild()
+		result = env.Submit(batch)
+		jtx.RequireTxFail(t, result, "terQUEUED")
+		checkMetrics(t, env, 2, nil, 3, 2)
+
+		// Replace Queued Batch with open ledger fee.
+		olFee := env.OpenLedgerFee(batchFee)
+		batch2 := NewBatchBuilder(alice, aliceSeq, olFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, aliceSeq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, bobSeq)).
+			AddSigner(bob).
+			MustBuild()
+		result = env.Submit(batch2)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		// After close: queue drained (carol's noop applied in new ledger),
+		// maxSize = txnsExpected * ledgersInQueue.
+		// Closed ledger had: 3 noops + 1 batch outer + 2 inner = 6 txns.
+		// With NormalConsensusIncreasePercent=0, txnsExpected = 6.
+		// maxSize = 6 * 2 = 12. txInLedger = 1 (carol's noop from queue).
+		maxSize := uint64(12)
+		checkMetrics(t, env, 0, &maxSize, 1, 6)
+		closed := env.LastClosedLedger()
+		require.Equal(t, uint32(6), closed.TxCount())
+		root, err := closed.TxMapHash()
+		require.NoError(t, err)
+		require.NotEqual(t, [32]byte{}, root)
+		require.Equal(t, root, closed.Header().TxHash)
+	})
+
+	t.Run("inner batch txns count towards ledger tx count", func(t *testing.T) {
+		// Reference: rippled Batch_test.cpp testBatchTxQueue() second sub-test
+		// "inner batch transactions are counter towards the ledger tx count"
+		cfg := makeSmallQueueConfig(2)
+		env := jtx.NewTestEnvWithTxQ(t, cfg)
+		env.EnableFeatureNow("Batch")
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		carol := jtx.NewAccount("carol")
+
+		// Fund across several ledgers so the TxQ metrics stay restricted.
+		env.FundAmountNoRipple(alice, uint64(jtx.XRP(10000)))
+		env.FundAmountNoRipple(bob, uint64(jtx.XRP(10000)))
+		env.Close()
+		env.FundAmountNoRipple(carol, uint64(jtx.XRP(10000)))
+		env.Close()
+
+		// Fill the ledger leaving room for 1 more transaction at base fee.
+		env.Noop(alice)
+		env.Noop(alice)
+		checkMetrics(t, env, 0, nil, 2, 2)
+
+		aliceSeq := env.Seq(alice)
+		bobSeq := env.Seq(bob)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+
+		// Batch Successful: at txInLedger=2 (equal to threshold), batch gets in.
+		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, aliceSeq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, bobSeq)).
+			AddSigner(bob).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		// txInLedger = 3 (2 noops + 1 batch outer).
+		// The batch counts as 1 for open ledger txInLedger.
+		checkMetrics(t, env, 0, nil, 3, 2)
+
+		// Carol's noop gets queued because txInLedger=3 > txnsExpected=2.
+		result = env.Submit(makeNoopWithFee(carol, env.BaseFee()))
+		jtx.RequireTxFail(t, result, "terQUEUED")
+		checkMetrics(t, env, 1, nil, 3, 2)
+	})
+}
+
+// makeSmallQueueConfig creates a TxQ config matching rippled's Batch_test
+// makeSmallQueueConfig({{"minimum_txn_in_ledger_standalone", minTxn}}).
+// Reference: rippled Batch_test.cpp makeSmallQueueConfig()
+func makeSmallQueueConfig(minTxnStandalone uint32) txq.Config {
+	return txq.Config{
+		LedgersInQueue:                 2,
+		QueueSizeMin:                   2,
+		RetrySequencePercent:           25,
+		MinimumEscalationMultiplier:    txq.BaseLevel * 500, // 128000
+		MinimumTxnInLedger:             32,
+		MinimumTxnInLedgerStandalone:   minTxnStandalone,
+		TargetTxnInLedger:              256,
+		MaximumTxnInLedger:             0,
+		NormalConsensusIncreasePercent: 0,
+		SlowConsensusDecreasePercent:   50,
+		MaximumTxnPerAccount:           10,
+		MinimumLastLedgerBuffer:        2,
+		Standalone:                     true,
+	}
+}
+
+// makeNoopWithFee creates an AccountSet noop with a specific fee.
+// Unlike env.Noop() which auto-fills and submits, this returns the raw tx.
+func makeNoopWithFee(acc *jtx.Account, fee uint64) *accounttx.AccountSet {
+	as := accounttx.NewAccountSet(acc.Address)
+	as.Fee = fmt.Sprintf("%d", fee)
+	return as
+}
+
+// checkMetrics asserts TxQ metrics match expected values.
+// maxSize nil means skip that assertion (matches rippled's std::nullopt).
+// Reference: rippled test/jtx/TestHelpers.h checkMetrics()
+func checkMetrics(t *testing.T, env *jtx.TestEnv, expectedQueueSize uint64, expectedMaxSize *uint64, expectedTxInLedger uint64, expectedTxPerLedger uint64) {
+	t.Helper()
+	metrics := env.TxQMetrics()
+
+	require.Equal(t, expectedQueueSize, metrics.TxCount,
+		"checkMetrics: txCount (queue size) mismatch")
+
+	if expectedMaxSize != nil {
+		require.NotNil(t, metrics.TxQMaxSize, "checkMetrics: maxSize should not be nil")
+		require.Equal(t, *expectedMaxSize, *metrics.TxQMaxSize,
+			"checkMetrics: txQMaxSize mismatch")
+	}
+
+	require.Equal(t, expectedTxInLedger, metrics.TxInLedger,
+		"checkMetrics: txInLedger mismatch")
+
+	require.Equal(t, expectedTxPerLedger, metrics.TxPerLedger,
+		"checkMetrics: txPerLedger mismatch")
+}
+
+func TestSequenceOpenLedger(t *testing.T) {
+	// Reference: rippled Batch_test.cpp testSequenceOpenLedger()
+	// Tests interactions between batch inner transactions advancing sequences
+	// and standalone transactions with future sequences or the same sequences.
+
+	t.Run("before batch txn with retry following ledger", func(t *testing.T) {
+		// Reference: rippled testSequenceOpenLedger() "Before Batch Txn w/ retry following ledger"
+		// A noop at aliceSeq+2 gets terPRE_SEQ. Then a batch with carol as
+		// outer submitter and alice as inner signer advances alice's seq.
+		// After close: batch succeeds, noop retried in next ledger.
+		env := newBatchEnv(t)
+		env.EnableOpenLedgerReplay()
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		carol := jtx.NewAccount("carol")
+		env.Fund(alice, bob, carol)
+		env.Close()
+
+		aliceSeq := env.Seq(alice)
+		carolSeq := env.Seq(carol)
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		// AccountSet Txn at aliceSeq+2 -> terPRE_SEQ (future sequence)
+		noopTxn := accounttx.NewAccountSet(alice.Address)
+		noopTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
+		noopTxn.SigningPubKey = alice.PublicKeyHex()
+		futureSeq := aliceSeq + 2
+		noopTxn.Sequence = &futureSeq
+		result := env.Submit(noopTxn)
+		jtx.RequireTxFail(t, result, "terPRE_SEQ")
+
+		// Batch Txn: carol outer, alice inner signer
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(carol, carolSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, aliceSeq)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, aliceSeq+1)).
+			AddSigner(alice).
+			MustBuild()
+		result = env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		// After first close: batch applied (alice seq -> aliceSeq+2).
+		// Noop at aliceSeq+2 may or may not be in first closed ledger
+		// (depends on canonical ordering and replay behavior).
+		// Close again to ensure the noop is retried if held.
+		env.Close()
+
+		// Final state verification:
+		// - alice's seq should be aliceSeq+3 (aliceSeq consumed by inner pay#1,
+		//   aliceSeq+1 by inner pay#2, aliceSeq+2 by noop)
+		require.Equal(t, aliceSeq+3, env.Seq(alice),
+			"alice seq should have advanced by 3 (2 inner payments + 1 noop)")
+
+		// Carol consumed carolSeq for the batch outer
+		require.Equal(t, carolSeq+1, env.Seq(carol),
+			"carol seq should have advanced by 1 (batch outer)")
+
+		// alice paid XRP(1) + XRP(2) = XRP(3) to bob, plus baseFee for noop
+		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-env.BaseFee())
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
+	})
+
+	t.Run("before batch txn with same sequence", func(t *testing.T) {
+		// Reference: rippled testSequenceOpenLedger() "Before Batch Txn w/ same sequence"
+		// A noop at aliceSeq+1 gets terPRE_SEQ. Then a batch with alice as
+		// outer submitter has inner payments consuming aliceSeq+1 and aliceSeq+2.
+		// After close: batch wins (canonical order), noop overwritten.
+		env := newBatchEnv(t)
+		env.EnableOpenLedgerReplay()
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		aliceSeq := env.Seq(alice)
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		// AccountSet Txn at aliceSeq+1 -> terPRE_SEQ
+		noopTxn := accounttx.NewAccountSet(alice.Address)
+		noopTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
+		noopTxn.SigningPubKey = alice.PublicKeyHex()
+		futureSeq := aliceSeq + 1
+		noopTxn.Sequence = &futureSeq
+		result := env.Submit(noopTxn)
+		jtx.RequireTxFail(t, result, "terPRE_SEQ")
+
+		// Batch Txn: alice outer
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, aliceSeq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, aliceSeq+2)).
+			MustBuild()
+		result = env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		// After first close: batch applied. The noop at aliceSeq+1 is
+		// overwritten by the batch's inner payment at the same sequence.
+		// Close again to flush held transactions.
+		env.Close()
+
+		// Final state: batch consumed aliceSeq (outer), aliceSeq+1 (inner#1),
+		// aliceSeq+2 (inner#2). The noop at aliceSeq+1 failed (sequence
+		// already consumed by inner payment). alice seq = aliceSeq+3.
+		require.Equal(t, aliceSeq+3, env.Seq(alice),
+			"alice seq should have advanced by 3 (outer + 2 inner payments)")
+
+		// alice paid XRP(1) + XRP(2) + batchFee to bob
+		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
+	})
+
+	t.Run("after batch txn with same sequence", func(t *testing.T) {
+		// Reference: rippled testSequenceOpenLedger() "After Batch Txn w/ same sequence"
+		// Batch submitted first, then noop at aliceSeq+1.
+		// After close: batch wins (applied first), noop at same seq overwritten.
+		env := newBatchEnv(t)
+		env.EnableOpenLedgerReplay()
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		aliceSeq := env.Seq(alice)
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		// Batch Txn: alice outer
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, aliceSeq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, aliceSeq+2)).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+
+		// AccountSet Txn at aliceSeq+1 (same as inner payment #1's seq).
+		noopTxn := accounttx.NewAccountSet(alice.Address)
+		noopTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
+		noopTxn.SigningPubKey = alice.PublicKeyHex()
+		sameSeq := aliceSeq + 1
+		noopTxn.Sequence = &sameSeq
+		noopResult := env.Submit(noopTxn)
+		jtx.RequireTxSuccess(t, noopResult)
+		env.Close()
+
+		// After close: batch consumed aliceSeq (outer), aliceSeq+1 (inner#1),
+		// aliceSeq+2 (inner#2). The noop at aliceSeq+1 was overwritten.
+		env.Close()
+
+		// Final state: alice seq = aliceSeq+3
+		require.Equal(t, aliceSeq+3, env.Seq(alice),
+			"alice seq should have advanced by 3 (outer + 2 inner payments)")
+
+		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
+	})
+
+	t.Run("outer batch terPRE_SEQ", func(t *testing.T) {
+		// Reference: rippled testSequenceOpenLedger() "Outer Batch terPRE_SEQ"
+		// Batch outer has a future sequence (carolSeq+1) -> terPRE_SEQ.
+		// A noop advances carol's seq. After close: batch succeeds.
+		env := newBatchEnv(t)
+		env.EnableOpenLedgerReplay()
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		carol := jtx.NewAccount("carol")
+		env.Fund(alice, bob, carol)
+		env.Close()
+
+		aliceSeq := env.Seq(alice)
+		carolSeq := env.Seq(carol)
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		// Batch Txn with future carolSeq -> terPRE_SEQ
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(carol, carolSeq+1, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, aliceSeq)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, aliceSeq+1)).
+			AddSigner(alice).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "terPRE_SEQ")
+
+		// AccountSet noop at carolSeq -> tesSUCCESS (advances carol's seq)
+		noopTxn := accounttx.NewAccountSet(carol.Address)
+		noopTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
+		noopTxn.SigningPubKey = carol.PublicKeyHex()
+		noopTxn.Sequence = &carolSeq
+		result = env.Submit(noopTxn)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		// After close: noop advances carol's seq, then batch succeeds.
+		// Close again to flush held transactions.
+		env.Close()
+
+		// Final state:
+		// - alice consumed aliceSeq and aliceSeq+1 (inner payments)
+		require.Equal(t, aliceSeq+2, env.Seq(alice),
+			"alice seq should advance by 2 (inner payments)")
+
+		// - carol consumed carolSeq (noop) and carolSeq+1 (batch outer)
+		require.Equal(t, carolSeq+2, env.Seq(carol),
+			"carol seq should advance by 2 (noop + batch outer)")
+
+		// alice paid XRP(3) total to bob
+		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3)))
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
+	})
+}
+
+func TestObjectsOpenLedger(t *testing.T) {
+	// Reference: rippled Batch_test.cpp testObjectsOpenLedger()
+	// Tests interactions between batch inner transactions creating/consuming
+	// ledger objects and standalone transactions that depend on those objects.
+
+	t.Run("consume object before batch txn", func(t *testing.T) {
+		// Reference: rippled testObjectsOpenLedger() "Consume Object Before Batch Txn"
+		// CheckCash submitted before the batch that creates the check.
+		// In rippled, CheckCash gets tecNO_ENTRY initially (inner txns deferred).
+		// During consensus replay, batch (alice) is applied first in canonical
+		// order, creating the check. Then CheckCash (bob) succeeds.
+		//
+		// The open ledger cannot see the Check created by the Batch inner until
+		// consensus replay closes the ledger.
+		env := newBatchEnv(t)
+		env.EnableOpenLedgerReplay()
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		aliceTicketSeq := env.CreateTickets(alice, 10)
+		env.Close()
+
+		aliceSeq := env.Seq(alice)
+		bobSeq := env.Seq(bob)
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		// CheckCash Txn for a check that doesn't exist yet
+		chkID := GetCheckIndex(alice, aliceSeq)
+		cashTxn := check.NewCheckCash(bob.Address, chkID)
+		cashTxn.SetExactAmount(tx.NewXRPAmount(jtx.XRP(10)))
+		cashTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
+		cashTxn.SigningPubKey = bob.PublicKeyHex()
+		cashTxn.Sequence = &bobSeq
+		cashResult := env.Submit(cashTxn)
+		jtx.RequireTxClaimed(t, cashResult, "tecNO_ENTRY")
+
+		// Batch Txn: creates the check and pays XRP(1)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerCheckCreate(alice, bob, tx.NewXRPAmount(jtx.XRP(10)), aliceSeq)).
+			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq+1)).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		// After close (replay): batch creates check, then CheckCash succeeds.
+		env.Close()
+
+		// Final state verification:
+		// bob should have cashed XRP(10) check + received XRP(1) payment
+		// alice should have lost XRP(10) (check) + XRP(1) (payment) + batchFee + baseFee (for CheckCash on bob)
+		// bob consumes bobSeq for CheckCash
+		require.Equal(t, bobSeq+1, env.Seq(bob),
+			"bob seq should advance by 1 (CheckCash)")
+		// alice consumes aliceSeq (inner CheckCreate), aliceTicketSeq (outer), aliceTicketSeq+1 (inner payment)
+		require.Equal(t, aliceSeq+1, env.Seq(alice),
+			"alice seq should advance by 1 (inner CheckCreate)")
+
+		// Balance check: alice paid XRP(10) check + XRP(1) + batchFee
+		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(11))-batchFee)
+		// bob gained XRP(10) check + XRP(1), paid baseFee for CheckCash
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(11))-env.BaseFee())
+	})
+
+	t.Run("create object before batch txn", func(t *testing.T) {
+		// Reference: rippled testObjectsOpenLedger() "Create Object Before Batch Txn"
+		// CheckCreate submitted before the batch. The batch's inner CheckCash
+		// consumes the check. The standalone CheckCreate runs first in the
+		// open view.
+		env := newBatchEnv(t)
+		env.EnableOpenLedgerReplay()
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		aliceTicketSeq := env.CreateTickets(alice, 10)
+		env.Close()
+
+		aliceSeq := env.Seq(alice)
+		bobSeq := env.Seq(bob)
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		// CheckCreate Txn (standalone) — alice creates a check payable to bob
+		chkID := GetCheckIndex(alice, aliceSeq)
+		createTxn := check.NewCheckCreate(alice.Address, bob.Address, tx.NewXRPAmount(jtx.XRP(10)))
+		createTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
+		createTxn.SigningPubKey = alice.PublicKeyHex()
+		createTxn.Sequence = &aliceSeq
+		result := env.Submit(createTxn)
+		jtx.RequireTxSuccess(t, result)
+
+		// Batch Txn: inner CheckCash (bob cashes the check) + inner Payment
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerCheckCash(bob, chkID, tx.NewXRPAmount(jtx.XRP(10)), bobSeq)).
+			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq+1)).
+			AddSigner(bob).
+			MustBuild()
+		result = env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+
+		// Final state verification:
+		// bob cashed check XRP(10) + received XRP(1) payment
+		require.Equal(t, bobSeq+1, env.Seq(bob),
+			"bob seq should advance by 1 (inner CheckCash)")
+		require.Equal(t, aliceSeq+1, env.Seq(alice),
+			"alice seq should advance by 1 (standalone CheckCreate)")
+
+		// alice paid: XRP(10) check + XRP(1) payment + batchFee + baseFee for CheckCreate
+		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(11))-batchFee-env.BaseFee())
+		// bob gained: XRP(10) check + XRP(1) payment
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(11)))
+	})
+
+	t.Run("after batch txn", func(t *testing.T) {
+		// Reference: rippled testObjectsOpenLedger() "After Batch Txn"
+		// Batch creates a check (inner), then standalone CheckCash tries to cash it.
+		// In rippled, the CheckCash gets tecNO_ENTRY because batch inner txns
+		// are deferred. During replay, batch applies first, then CheckCash succeeds.
+		env := newBatchEnv(t)
+		env.EnableOpenLedgerReplay()
+
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		aliceTicketSeq := env.CreateTickets(alice, 10)
+		env.Close()
+
+		aliceSeq := env.Seq(alice)
+		bobSeq := env.Seq(bob)
+		preAlice := env.Balance(alice)
+		preBob := env.Balance(bob)
+
+		// Batch Txn: creates check + payment
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		chkID := GetCheckIndex(alice, aliceSeq)
+		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerCheckCreate(alice, bob, tx.NewXRPAmount(jtx.XRP(10)), aliceSeq)).
+			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq+1)).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+
+		// CheckCash Txn (standalone) — the open view has not executed Batch inners.
+		cashTxn := check.NewCheckCash(bob.Address, chkID)
+		cashTxn.SetExactAmount(tx.NewXRPAmount(jtx.XRP(10)))
+		cashTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
+		cashTxn.SigningPubKey = bob.PublicKeyHex()
+		cashTxn.Sequence = &bobSeq
+		cashResult := env.Submit(cashTxn)
+		jtx.RequireTxClaimed(t, cashResult, "tecNO_ENTRY")
+		env.Close()
+
+		// After close (replay): batch creates check, then CheckCash succeeds.
+		env.Close()
+
+		// Final state verification:
+		require.Equal(t, bobSeq+1, env.Seq(bob),
+			"bob seq should advance by 1 (CheckCash)")
+		require.Equal(t, aliceSeq+1, env.Seq(alice),
+			"alice seq should advance by 1 (inner CheckCreate)")
+
+		// alice lost XRP(10) check + XRP(1) payment + batchFee
+		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(11))-batchFee)
+		// bob gained XRP(10) check + XRP(1) payment, paid baseFee for CheckCash
+		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(11))-env.BaseFee())
+	})
+}
+
+func TestOpenLedger(t *testing.T) {
+	// Reference: rippled Batch_test.cpp testOpenLedger()
+	// Tests a mixed scenario: alice pays bob, then an atomic batch with
+	// alice+bob, then bob pays alice with a future sequence (terPRE_SEQ).
+	// The canonical ordering during consensus determines transaction placement.
+	//
+	// In rippled's canonical ordering (salted), alice's payment comes first,
+	// then the batch, then bob's payment is retried next ledger.
+	//
+	// The open ledger cannot see the sequence consumed by the Batch inner until
+	// consensus replay closes the ledger.
+	env := newBatchEnv(t)
+	env.EnableOpenLedgerReplay()
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	env.Fund(alice, bob)
+	env.Close()
+
+	// Extra noop to advance bob's seq (matching rippled: env(noop(bob)))
+	noopBob := accounttx.NewAccountSet(bob.Address)
+	noopBob.Fee = fmt.Sprintf("%d", env.BaseFee())
+	noopBob.SigningPubKey = bob.PublicKeyHex()
+	bobNoopSeq := env.Seq(bob)
+	noopBob.Sequence = &bobNoopSeq
+	result := env.Submit(noopBob)
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	aliceSeq := env.Seq(alice)
+	preAlice := env.Balance(alice)
+	preBob := env.Balance(bob)
+	bobSeq := env.Seq(bob)
+
+	// Alice Pays Bob (Open Ledger)
+	payTxn1 := payment.NewPayment(alice.Address, bob.Address, tx.NewXRPAmount(jtx.XRP(10)))
+	payTxn1.Fee = fmt.Sprintf("%d", env.BaseFee())
+	payTxn1.SigningPubKey = alice.PublicKeyHex()
+	payTxn1.Sequence = &aliceSeq
+	result = env.Submit(payTxn1)
+	jtx.RequireTxSuccess(t, result)
+
+	// Alice & Bob Atomic Batch
+	batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+	batch := NewBatchBuilder(alice, aliceSeq+1, batchFee, batchtx.BatchFlagAllOrNothing).
+		AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, aliceSeq+2)).
+		AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, bobSeq)).
+		AddSigner(bob).
+		MustBuild()
+	result = env.Submit(batch)
+	jtx.RequireTxSuccess(t, result)
+
+	// Bob pays Alice (Open Ledger) at bobSeq+1. The Batch inner that consumes
+	// bobSeq is deferred until close, so this transaction is held for retry.
+	bobPaySeq := bobSeq + 1
+	payTxn2 := payment.NewPayment(bob.Address, alice.Address, tx.NewXRPAmount(jtx.XRP(5)))
+	payTxn2.Fee = fmt.Sprintf("%d", env.BaseFee())
+	payTxn2.SigningPubKey = bob.PublicKeyHex()
+	payTxn2.Sequence = &bobPaySeq
+	payResult2 := env.Submit(payTxn2)
+	jtx.RequireTxFail(t, payResult2, "terPRE_SEQ")
+	env.Close()
+
+	// Close again to ensure any held transactions are retried
+	env.Close()
+
+	// Final state verification (matches rippled):
+	// alice: aliceSeq (pay#1) + aliceSeq+1 (batch outer) + aliceSeq+2 (inner pay) = 3 txns
+	require.Equal(t, aliceSeq+3, env.Seq(alice),
+		"alice seq should have advanced by 3")
+
+	// bob: bobSeq (inner pay to alice) + bobSeq+1 (standalone pay to alice) = 2 txns
+	require.Equal(t, bobSeq+2, env.Seq(bob),
+		"bob seq should have advanced by 2")
+
+	// Balance verification:
+	// alice: -XRP(10) pay1 - baseFee pay1 - XRP(10) inner pay - batchFee + XRP(5) inner bob->alice
+	// but also bob pays alice XRP(5) standalone
+	// Net alice: preAlice - XRP(10) - XRP(10) + XRP(5) + XRP(5) - baseFee - batchFee
+	//          = preAlice - XRP(10) - baseFee - batchFee
+	jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(10))-batchFee-env.BaseFee())
+
+	// bob: +XRP(10) pay1 + XRP(10) inner alice->bob - XRP(5) inner bob->alice
+	//      - XRP(5) standalone - baseFee for standalone
+	// Net bob: preBob + XRP(10) - baseFee
+	jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(10))-env.BaseFee())
+}
+
+func TestBadRawTxn(t *testing.T) {
+	t.Run("nil inner transaction", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+
+		// Manually build a batch with a nil inner tx
+		batch := batchtx.NewBatch(alice.Address)
+		batch.Fee = fmt.Sprintf("%d", batchFee)
+		batch.SetSequence(seq)
+		batch.SetFlags(batchtx.BatchFlagAllOrNothing)
+		batch.RawTransactions = []batchtx.RawTransaction{
+			{RawTransaction: batchtx.RawTransactionData{InnerTx: nil}}, // nil
+			{RawTransaction: batchtx.RawTransactionData{InnerTx: MakeInnerPaymentXRP(alice, bob, 1, seq+2)}},
+		}
+
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "temMALFORMED")
+		jtx.RequireSequence(t, env, alice, seq)
+	})
+}

--- a/internal/testing/batch/open_ledger_test.go
+++ b/internal/testing/batch/open_ledger_test.go
@@ -17,7 +17,6 @@ import (
 
 func TestTickets(t *testing.T) {
 	t.Run("tickets outer", func(t *testing.T) {
-		// Outer batch uses a ticket; inner transactions use regular sequences.
 		// Reference: rippled Batch_test.cpp testTickets() - "tickets outer"
 		env := newBatchEnv(t)
 
@@ -27,7 +26,6 @@ func TestTickets(t *testing.T) {
 		env.FundAmount(bob, uint64(jtx.XRP(10000)))
 		env.Close()
 
-		// Create 10 tickets for alice
 		aliceTicketSeq := env.CreateTickets(alice, 10)
 		env.Close()
 
@@ -35,7 +33,6 @@ func TestTickets(t *testing.T) {
 		preAlice := env.Balance(alice)
 		preBob := env.Balance(bob)
 
-		// Submit batch with outer using ticket, inner using sequences
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, aliceSeq+0)).
@@ -46,20 +43,16 @@ func TestTickets(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// Verify owner count: started with 10 tickets, consumed 1 (outer ticket) = 9
 		require.Equal(t, uint32(9), env.OwnerCount(alice), "alice should have 9 owner objects")
 		require.Equal(t, uint32(9), env.TicketCount(alice), "alice should have 9 tickets remaining")
 
-		// Alice's sequence advances by 2 (inner txns use sequences)
 		jtx.RequireSequence(t, env, alice, aliceSeq+2)
 
-		// Alice pays XRP(3) + batchFee; Bob receives XRP(3)
 		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
 	})
 
 	t.Run("tickets inner", func(t *testing.T) {
-		// Outer batch uses regular sequence; inner transactions use tickets.
 		// Reference: rippled Batch_test.cpp testTickets() - "tickets inner"
 		env := newBatchEnv(t)
 
@@ -69,7 +62,6 @@ func TestTickets(t *testing.T) {
 		env.FundAmount(bob, uint64(jtx.XRP(10000)))
 		env.Close()
 
-		// Create 10 tickets for alice
 		aliceTicketSeq := env.CreateTickets(alice, 10)
 		env.Close()
 
@@ -77,7 +69,6 @@ func TestTickets(t *testing.T) {
 		preAlice := env.Balance(alice)
 		preBob := env.Balance(bob)
 
-		// Submit batch with outer using sequence, inner using tickets
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq)).
@@ -88,20 +79,16 @@ func TestTickets(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// Verify owner count: started with 10 tickets, consumed 2 (inner tickets) = 8
 		require.Equal(t, uint32(8), env.OwnerCount(alice), "alice should have 8 owner objects")
 		require.Equal(t, uint32(8), env.TicketCount(alice), "alice should have 8 tickets remaining")
 
-		// Alice's sequence advances by 1 (only outer seq increment, inner use tickets)
 		jtx.RequireSequence(t, env, alice, aliceSeq+1)
 
-		// Alice pays XRP(3) + batchFee; Bob receives XRP(3)
 		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
 	})
 
 	t.Run("tickets outer inner", func(t *testing.T) {
-		// Outer batch uses a ticket; one inner tx uses a ticket, the other uses a sequence.
 		// Reference: rippled Batch_test.cpp testTickets() - "tickets outer inner"
 		env := newBatchEnv(t)
 
@@ -111,7 +98,6 @@ func TestTickets(t *testing.T) {
 		env.FundAmount(bob, uint64(jtx.XRP(10000)))
 		env.Close()
 
-		// Create 10 tickets for alice
 		aliceTicketSeq := env.CreateTickets(alice, 10)
 		env.Close()
 
@@ -119,10 +105,6 @@ func TestTickets(t *testing.T) {
 		preAlice := env.Balance(alice)
 		preBob := env.Balance(bob)
 
-		// Submit batch:
-		// - outer uses ticket aliceTicketSeq
-		// - inner[0] uses ticket aliceTicketSeq+1
-		// - inner[1] uses sequence aliceSeq
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq+1)).
@@ -133,14 +115,11 @@ func TestTickets(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// Verify owner count: started with 10 tickets, consumed 2 (outer + inner[0]) = 8
 		require.Equal(t, uint32(8), env.OwnerCount(alice), "alice should have 8 owner objects")
 		require.Equal(t, uint32(8), env.TicketCount(alice), "alice should have 8 tickets remaining")
 
-		// Alice's sequence advances by 1 (only inner[1] uses a sequence)
 		jtx.RequireSequence(t, env, alice, aliceSeq+1)
 
-		// Alice pays XRP(3) + batchFee; Bob receives XRP(3)
 		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
 	})
@@ -148,8 +127,6 @@ func TestTickets(t *testing.T) {
 
 func TestTicketsOpenLedger(t *testing.T) {
 	// Reference: rippled Batch_test.cpp testTicketsOpenLedger()
-	// Tests that batch transactions using tickets interact correctly with
-	// standalone transactions using tickets from the same set.
 
 	t.Run("before batch txn with same ticket", func(t *testing.T) {
 		// Reference: rippled testTicketsOpenLedger() "Before Batch Txn w/ same ticket"
@@ -169,7 +146,6 @@ func TestTicketsOpenLedger(t *testing.T) {
 
 		aliceSeq := env.Seq(alice)
 
-		// AccountSet Txn using ticket+1
 		noopTxn := accounttx.NewAccountSet(alice.Address)
 		noopTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
 		noopTxn.SigningPubKey = alice.PublicKeyHex()
@@ -180,7 +156,6 @@ func TestTicketsOpenLedger(t *testing.T) {
 		result := env.Submit(noopTxn)
 		jtx.RequireTxSuccess(t, result)
 
-		// Batch Txn using ticket for outer, ticket+1 for inner payment
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq+1)).
@@ -195,8 +170,6 @@ func TestTicketsOpenLedger(t *testing.T) {
 		closed := env.LastClosedLedger()
 		require.Zero(t, closed.TxCount())
 
-		// Verify final state: alice consumed aliceSeq (inner payment #2),
-		// ticket (batch outer), ticket+1 (inner payment #1)
 		require.Equal(t, aliceSeq+1, env.Seq(alice))
 	})
 
@@ -215,7 +188,6 @@ func TestTicketsOpenLedger(t *testing.T) {
 
 		aliceSeq := env.Seq(alice)
 
-		// Batch Txn first
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRPWithTicket(alice, bob, 1, aliceTicketSeq+1)).
@@ -224,7 +196,6 @@ func TestTicketsOpenLedger(t *testing.T) {
 		batchResult := env.Submit(batch)
 		jtx.RequireTxSuccess(t, batchResult)
 
-		// AccountSet Txn using ticket+1 (already consumed by batch inner)
 		noopTxn := accounttx.NewAccountSet(alice.Address)
 		noopTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
 		noopTxn.SigningPubKey = alice.PublicKeyHex()
@@ -240,7 +211,6 @@ func TestTicketsOpenLedger(t *testing.T) {
 		env.Close()
 		require.Zero(t, env.LastClosedLedger().TxCount())
 
-		// Verify final state
 		require.Equal(t, aliceSeq+1, env.Seq(alice))
 	})
 }
@@ -265,13 +235,11 @@ func TestBatchTxQueue(t *testing.T) {
 		env.FundAmountNoRipple(carol, uint64(jtx.XRP(10000)))
 		env.Close()
 
-		// Fill the ledger: 3 noops above the threshold of 2.
 		env.Noop(alice)
 		env.Noop(alice)
 		env.Noop(alice)
 		checkMetrics(t, env, 0, nil, 3, 2)
 
-		// Carol's noop gets queued because fee escalation requires more than base fee.
 		result := env.Submit(makeNoopWithFee(carol, env.BaseFee()))
 		jtx.RequireTxFail(t, result, "terQUEUED")
 		checkMetrics(t, env, 1, nil, 3, 2)
@@ -280,7 +248,6 @@ func TestBatchTxQueue(t *testing.T) {
 		bobSeq := env.Seq(bob)
 		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
 
-		// Queue Batch: regular batch fee is too low to bypass escalation.
 		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, aliceSeq+1)).
 			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, bobSeq)).
@@ -290,7 +257,6 @@ func TestBatchTxQueue(t *testing.T) {
 		jtx.RequireTxFail(t, result, "terQUEUED")
 		checkMetrics(t, env, 2, nil, 3, 2)
 
-		// Replace Queued Batch with open ledger fee.
 		olFee := env.OpenLedgerFee(batchFee)
 		batch2 := NewBatchBuilder(alice, aliceSeq, olFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, aliceSeq+1)).
@@ -334,7 +300,6 @@ func TestBatchTxQueue(t *testing.T) {
 		env.FundAmountNoRipple(carol, uint64(jtx.XRP(10000)))
 		env.Close()
 
-		// Fill the ledger leaving room for 1 more transaction at base fee.
 		env.Noop(alice)
 		env.Noop(alice)
 		checkMetrics(t, env, 0, nil, 2, 2)
@@ -343,7 +308,6 @@ func TestBatchTxQueue(t *testing.T) {
 		bobSeq := env.Seq(bob)
 		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
 
-		// Batch Successful: at txInLedger=2 (equal to threshold), batch gets in.
 		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, aliceSeq+1)).
 			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, bobSeq)).
@@ -351,11 +315,8 @@ func TestBatchTxQueue(t *testing.T) {
 			MustBuild()
 		result := env.Submit(batch)
 		jtx.RequireTxSuccess(t, result)
-		// txInLedger = 3 (2 noops + 1 batch outer).
-		// The batch counts as 1 for open ledger txInLedger.
 		checkMetrics(t, env, 0, nil, 3, 2)
 
-		// Carol's noop gets queued because txInLedger=3 > txnsExpected=2.
 		result = env.Submit(makeNoopWithFee(carol, env.BaseFee()))
 		jtx.RequireTxFail(t, result, "terQUEUED")
 		checkMetrics(t, env, 1, nil, 3, 2)
@@ -370,7 +331,7 @@ func makeSmallQueueConfig(minTxnStandalone uint32) txq.Config {
 		LedgersInQueue:                 2,
 		QueueSizeMin:                   2,
 		RetrySequencePercent:           25,
-		MinimumEscalationMultiplier:    txq.BaseLevel * 500, // 128000
+		MinimumEscalationMultiplier:    txq.BaseLevel * 500,
 		MinimumTxnInLedger:             32,
 		MinimumTxnInLedgerStandalone:   minTxnStandalone,
 		TargetTxnInLedger:              256,
@@ -438,7 +399,6 @@ func TestSequenceOpenLedger(t *testing.T) {
 		preAlice := env.Balance(alice)
 		preBob := env.Balance(bob)
 
-		// AccountSet Txn at aliceSeq+2 -> terPRE_SEQ (future sequence)
 		noopTxn := accounttx.NewAccountSet(alice.Address)
 		noopTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
 		noopTxn.SigningPubKey = alice.PublicKeyHex()
@@ -447,7 +407,6 @@ func TestSequenceOpenLedger(t *testing.T) {
 		result := env.Submit(noopTxn)
 		jtx.RequireTxFail(t, result, "terPRE_SEQ")
 
-		// Batch Txn: carol outer, alice inner signer
 		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
 		batch := NewBatchBuilder(carol, carolSeq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, aliceSeq)).
@@ -469,17 +428,12 @@ func TestSequenceOpenLedger(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, noopExists)
 
-		// Final state verification:
-		// - alice's seq should be aliceSeq+3 (aliceSeq consumed by inner pay#1,
-		//   aliceSeq+1 by inner pay#2, aliceSeq+2 by noop)
 		require.Equal(t, aliceSeq+3, env.Seq(alice),
 			"alice seq should have advanced by 3 (2 inner payments + 1 noop)")
 
-		// Carol consumed carolSeq for the batch outer
 		require.Equal(t, carolSeq+1, env.Seq(carol),
 			"carol seq should have advanced by 1 (batch outer)")
 
-		// alice paid XRP(1) + XRP(2) = XRP(3) to bob, plus baseFee for noop
 		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-env.BaseFee())
 		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
 	})
@@ -501,7 +455,6 @@ func TestSequenceOpenLedger(t *testing.T) {
 		preAlice := env.Balance(alice)
 		preBob := env.Balance(bob)
 
-		// AccountSet Txn at aliceSeq+1 -> terPRE_SEQ
 		noopTxn := accounttx.NewAccountSet(alice.Address)
 		noopTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
 		noopTxn.SigningPubKey = alice.PublicKeyHex()
@@ -510,7 +463,6 @@ func TestSequenceOpenLedger(t *testing.T) {
 		result := env.Submit(noopTxn)
 		jtx.RequireTxFail(t, result, "terPRE_SEQ")
 
-		// Batch Txn: alice outer
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, aliceSeq+1)).
@@ -520,18 +472,11 @@ func TestSequenceOpenLedger(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// After first close: batch applied. The noop at aliceSeq+1 is
-		// overwritten by the batch's inner payment at the same sequence.
-		// Close again to flush held transactions.
 		env.Close()
 
-		// Final state: batch consumed aliceSeq (outer), aliceSeq+1 (inner#1),
-		// aliceSeq+2 (inner#2). The noop at aliceSeq+1 failed (sequence
-		// already consumed by inner payment). alice seq = aliceSeq+3.
 		require.Equal(t, aliceSeq+3, env.Seq(alice),
 			"alice seq should have advanced by 3 (outer + 2 inner payments)")
 
-		// alice paid XRP(1) + XRP(2) + batchFee to bob
 		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3))-batchFee)
 		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
 	})
@@ -552,7 +497,6 @@ func TestSequenceOpenLedger(t *testing.T) {
 		preAlice := env.Balance(alice)
 		preBob := env.Balance(bob)
 
-		// Batch Txn: alice outer
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, aliceSeq+1)).
@@ -561,7 +505,6 @@ func TestSequenceOpenLedger(t *testing.T) {
 		result := env.Submit(batch)
 		jtx.RequireTxSuccess(t, result)
 
-		// AccountSet Txn at aliceSeq+1 (same as inner payment #1's seq).
 		noopTxn := accounttx.NewAccountSet(alice.Address)
 		noopTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
 		noopTxn.SigningPubKey = alice.PublicKeyHex()
@@ -571,11 +514,8 @@ func TestSequenceOpenLedger(t *testing.T) {
 		jtx.RequireTxSuccess(t, noopResult)
 		env.Close()
 
-		// After close: batch consumed aliceSeq (outer), aliceSeq+1 (inner#1),
-		// aliceSeq+2 (inner#2). The noop at aliceSeq+1 was overwritten.
 		env.Close()
 
-		// Final state: alice seq = aliceSeq+3
 		require.Equal(t, aliceSeq+3, env.Seq(alice),
 			"alice seq should have advanced by 3 (outer + 2 inner payments)")
 
@@ -601,7 +541,6 @@ func TestSequenceOpenLedger(t *testing.T) {
 		preAlice := env.Balance(alice)
 		preBob := env.Balance(bob)
 
-		// Batch Txn with future carolSeq -> terPRE_SEQ
 		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
 		batch := NewBatchBuilder(carol, carolSeq+1, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, aliceSeq)).
@@ -611,7 +550,6 @@ func TestSequenceOpenLedger(t *testing.T) {
 		result := env.Submit(batch)
 		jtx.RequireTxFail(t, result, "terPRE_SEQ")
 
-		// AccountSet noop at carolSeq -> tesSUCCESS (advances carol's seq)
 		noopTxn := accounttx.NewAccountSet(carol.Address)
 		noopTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
 		noopTxn.SigningPubKey = carol.PublicKeyHex()
@@ -620,20 +558,14 @@ func TestSequenceOpenLedger(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// After close: noop advances carol's seq, then batch succeeds.
-		// Close again to flush held transactions.
 		env.Close()
 
-		// Final state:
-		// - alice consumed aliceSeq and aliceSeq+1 (inner payments)
 		require.Equal(t, aliceSeq+2, env.Seq(alice),
 			"alice seq should advance by 2 (inner payments)")
 
-		// - carol consumed carolSeq (noop) and carolSeq+1 (batch outer)
 		require.Equal(t, carolSeq+2, env.Seq(carol),
 			"carol seq should advance by 2 (noop + batch outer)")
 
-		// alice paid XRP(3) total to bob
 		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(3)))
 		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(3)))
 	})
@@ -669,7 +601,6 @@ func TestObjectsOpenLedger(t *testing.T) {
 		preAlice := env.Balance(alice)
 		preBob := env.Balance(bob)
 
-		// CheckCash Txn for a check that doesn't exist yet
 		chkID := GetCheckIndex(alice, aliceSeq)
 		cashTxn := check.NewCheckCash(bob.Address, chkID)
 		cashTxn.SetExactAmount(tx.NewXRPAmount(jtx.XRP(10)))
@@ -679,7 +610,6 @@ func TestObjectsOpenLedger(t *testing.T) {
 		cashResult := env.Submit(cashTxn)
 		jtx.RequireTxClaimed(t, cashResult, "tecNO_ENTRY")
 
-		// Batch Txn: creates the check and pays XRP(1)
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerCheckCreate(alice, bob, tx.NewXRPAmount(jtx.XRP(10)), aliceSeq)).
@@ -689,22 +619,14 @@ func TestObjectsOpenLedger(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// After close (replay): batch creates check, then CheckCash succeeds.
 		env.Close()
 
-		// Final state verification:
-		// bob should have cashed XRP(10) check + received XRP(1) payment
-		// alice should have lost XRP(10) (check) + XRP(1) (payment) + batchFee + baseFee (for CheckCash on bob)
-		// bob consumes bobSeq for CheckCash
 		require.Equal(t, bobSeq+1, env.Seq(bob),
 			"bob seq should advance by 1 (CheckCash)")
-		// alice consumes aliceSeq (inner CheckCreate), aliceTicketSeq (outer), aliceTicketSeq+1 (inner payment)
 		require.Equal(t, aliceSeq+1, env.Seq(alice),
 			"alice seq should advance by 1 (inner CheckCreate)")
 
-		// Balance check: alice paid XRP(10) check + XRP(1) + batchFee
 		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(11))-batchFee)
-		// bob gained XRP(10) check + XRP(1), paid baseFee for CheckCash
 		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(11))-env.BaseFee())
 	})
 
@@ -729,7 +651,6 @@ func TestObjectsOpenLedger(t *testing.T) {
 		preAlice := env.Balance(alice)
 		preBob := env.Balance(bob)
 
-		// CheckCreate Txn (standalone) — alice creates a check payable to bob
 		chkID := GetCheckIndex(alice, aliceSeq)
 		createTxn := check.NewCheckCreate(alice.Address, bob.Address, tx.NewXRPAmount(jtx.XRP(10)))
 		createTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
@@ -738,7 +659,6 @@ func TestObjectsOpenLedger(t *testing.T) {
 		result := env.Submit(createTxn)
 		jtx.RequireTxSuccess(t, result)
 
-		// Batch Txn: inner CheckCash (bob cashes the check) + inner Payment
 		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
 		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerCheckCash(bob, chkID, tx.NewXRPAmount(jtx.XRP(10)), bobSeq)).
@@ -749,16 +669,12 @@ func TestObjectsOpenLedger(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		// Final state verification:
-		// bob cashed check XRP(10) + received XRP(1) payment
 		require.Equal(t, bobSeq+1, env.Seq(bob),
 			"bob seq should advance by 1 (inner CheckCash)")
 		require.Equal(t, aliceSeq+1, env.Seq(alice),
 			"alice seq should advance by 1 (standalone CheckCreate)")
 
-		// alice paid: XRP(10) check + XRP(1) payment + batchFee + baseFee for CheckCreate
 		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(11))-batchFee-env.BaseFee())
-		// bob gained: XRP(10) check + XRP(1) payment
 		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(11)))
 	})
 
@@ -783,7 +699,6 @@ func TestObjectsOpenLedger(t *testing.T) {
 		preAlice := env.Balance(alice)
 		preBob := env.Balance(bob)
 
-		// Batch Txn: creates check + payment
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 		chkID := GetCheckIndex(alice, aliceSeq)
 		batch := NewBatchBuilderWithTicket(alice, aliceTicketSeq, batchFee, batchtx.BatchFlagAllOrNothing).
@@ -793,7 +708,6 @@ func TestObjectsOpenLedger(t *testing.T) {
 		result := env.Submit(batch)
 		jtx.RequireTxSuccess(t, result)
 
-		// CheckCash Txn (standalone) — the open view has not executed Batch inners.
 		cashTxn := check.NewCheckCash(bob.Address, chkID)
 		cashTxn.SetExactAmount(tx.NewXRPAmount(jtx.XRP(10)))
 		cashTxn.Fee = fmt.Sprintf("%d", env.BaseFee())
@@ -803,18 +717,14 @@ func TestObjectsOpenLedger(t *testing.T) {
 		jtx.RequireTxClaimed(t, cashResult, "tecNO_ENTRY")
 		env.Close()
 
-		// After close (replay): batch creates check, then CheckCash succeeds.
 		env.Close()
 
-		// Final state verification:
 		require.Equal(t, bobSeq+1, env.Seq(bob),
 			"bob seq should advance by 1 (CheckCash)")
 		require.Equal(t, aliceSeq+1, env.Seq(alice),
 			"alice seq should advance by 1 (inner CheckCreate)")
 
-		// alice lost XRP(10) check + XRP(1) payment + batchFee
 		jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(11))-batchFee)
-		// bob gained XRP(10) check + XRP(1) payment, paid baseFee for CheckCash
 		jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(11))-env.BaseFee())
 	})
 }
@@ -838,7 +748,6 @@ func TestOpenLedger(t *testing.T) {
 	env.Fund(alice, bob)
 	env.Close()
 
-	// Extra noop to advance bob's seq (matching rippled: env(noop(bob)))
 	noopBob := accounttx.NewAccountSet(bob.Address)
 	noopBob.Fee = fmt.Sprintf("%d", env.BaseFee())
 	noopBob.SigningPubKey = bob.PublicKeyHex()
@@ -853,7 +762,6 @@ func TestOpenLedger(t *testing.T) {
 	preBob := env.Balance(bob)
 	bobSeq := env.Seq(bob)
 
-	// Alice Pays Bob (Open Ledger)
 	payTxn1 := payment.NewPayment(alice.Address, bob.Address, tx.NewXRPAmount(jtx.XRP(10)))
 	payTxn1.Fee = fmt.Sprintf("%d", env.BaseFee())
 	payTxn1.SigningPubKey = alice.PublicKeyHex()
@@ -861,7 +769,6 @@ func TestOpenLedger(t *testing.T) {
 	result = env.Submit(payTxn1)
 	jtx.RequireTxSuccess(t, result)
 
-	// Alice & Bob Atomic Batch
 	batchFee := CalcBatchFeeFromEnv(env, 1, 2)
 	batch := NewBatchBuilder(alice, aliceSeq+1, batchFee, batchtx.BatchFlagAllOrNothing).
 		AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, aliceSeq+2)).
@@ -882,28 +789,16 @@ func TestOpenLedger(t *testing.T) {
 	jtx.RequireTxFail(t, payResult2, "terPRE_SEQ")
 	env.Close()
 
-	// Close again to ensure any held transactions are retried
 	env.Close()
 
-	// Final state verification (matches rippled):
-	// alice: aliceSeq (pay#1) + aliceSeq+1 (batch outer) + aliceSeq+2 (inner pay) = 3 txns
 	require.Equal(t, aliceSeq+3, env.Seq(alice),
 		"alice seq should have advanced by 3")
 
-	// bob: bobSeq (inner pay to alice) + bobSeq+1 (standalone pay to alice) = 2 txns
 	require.Equal(t, bobSeq+2, env.Seq(bob),
 		"bob seq should have advanced by 2")
 
-	// Balance verification:
-	// alice: -XRP(10) pay1 - baseFee pay1 - XRP(10) inner pay - batchFee + XRP(5) inner bob->alice
-	// but also bob pays alice XRP(5) standalone
-	// Net alice: preAlice - XRP(10) - XRP(10) + XRP(5) + XRP(5) - baseFee - batchFee
-	//          = preAlice - XRP(10) - baseFee - batchFee
 	jtx.RequireBalance(t, env, alice, preAlice-uint64(jtx.XRP(10))-batchFee-env.BaseFee())
 
-	// bob: +XRP(10) pay1 + XRP(10) inner alice->bob - XRP(5) inner bob->alice
-	//      - XRP(5) standalone - baseFee for standalone
-	// Net bob: preBob + XRP(10) - baseFee
 	jtx.RequireBalance(t, env, bob, preBob+uint64(jtx.XRP(10))-env.BaseFee())
 }
 
@@ -918,13 +813,12 @@ func TestBadRawTxn(t *testing.T) {
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 
-		// Manually build a batch with a nil inner tx
 		batch := batchtx.NewBatch(alice.Address)
 		batch.Fee = fmt.Sprintf("%d", batchFee)
 		batch.SetSequence(seq)
 		batch.SetFlags(batchtx.BatchFlagAllOrNothing)
 		batch.RawTransactions = []batchtx.RawTransaction{
-			{RawTransaction: batchtx.RawTransactionData{InnerTx: nil}}, // nil
+			{RawTransaction: batchtx.RawTransactionData{InnerTx: nil}},
 			{RawTransaction: batchtx.RawTransactionData{InnerTx: MakeInnerPaymentXRP(alice, bob, 1, seq+2)}},
 		}
 

--- a/internal/testing/batch/preclaim_test.go
+++ b/internal/testing/batch/preclaim_test.go
@@ -1,0 +1,303 @@
+package batch
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	batchtx "github.com/LeJamon/go-xrpl/internal/tx/batch"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+func TestPreclaim(t *testing.T) {
+	t.Run("checkSign.checkSingleSign/tefBAD_AUTH", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batch := NewBatchBuilder(alice, seq, CalcBatchFeeFromEnv(env, 0, 2), batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 20, seq+2)).
+			MustBuild()
+		result := env.SubmitSignedWith(batch, bob)
+		jtx.RequireTxFail(t, result, "tefBAD_AUTH")
+		jtx.RequireSequence(t, env, alice, seq)
+	})
+
+	t.Run("checkSign.multisign/tesSUCCESS_with_nested_BatchSigners", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		carol := jtx.NewAccount("carol")
+		dave := jtx.NewAccount("dave")
+		env.Fund(alice, bob, carol, dave)
+		env.Close()
+		env.SetSignerList(alice, 2, []jtx.TestSigner{{Account: bob, Weight: 1}, {Account: carol, Weight: 1}})
+		env.SetSignerList(bob, 2, []jtx.TestSigner{{Account: carol, Weight: 1}, {Account: dave, Weight: 1}})
+		env.Close()
+
+		aliceSeq := env.Seq(alice)
+		bobSeq := env.Seq(bob)
+		batch := NewBatchBuilder(alice, aliceSeq, CalcBatchFeeFromEnv(env, 4, 2), batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, aliceSeq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, bobSeq)).
+			AddMultiSignBatchSigner(bob, []*jtx.Account{carol, dave}).
+			MustBuild()
+		result := env.SubmitMultiSigned(batch, []*jtx.Account{bob, carol})
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		requireBatchLedgerData(t, env, batch, result, ter.TesSUCCESS, ter.TesSUCCESS)
+	})
+
+	// The remaining cases share state in the same order as the protocol scenario.
+
+	env := newBatchEnv(t)
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	carol := jtx.NewAccount("carol")
+	dave := jtx.NewAccount("dave")
+	elsa := jtx.NewAccount("elsa")
+	frank := jtx.NewAccount("frank")
+	phantom := jtx.NewAccount("phantom") // not funded — phantom account
+
+	env.FundAmount(alice, uint64(jtx.XRP(10000)))
+	env.FundAmount(bob, uint64(jtx.XRP(10000)))
+	env.FundAmount(carol, uint64(jtx.XRP(10000)))
+	env.FundAmount(dave, uint64(jtx.XRP(10000)))
+	env.FundAmount(elsa, uint64(jtx.XRP(10000)))
+	env.FundAmount(frank, uint64(jtx.XRP(10000)))
+	env.Close()
+
+	// tefNOT_MULTI_SIGNING: SignersList not enabled for bob
+	t.Run("checkBatchSign.checkMultiSign/tefNOT_MULTI_SIGNING", func(t *testing.T) {
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddMultiSignBatchSigner(bob, []*jtx.Account{dave, carol}).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "tefNOT_MULTI_SIGNING")
+		env.Close()
+	})
+
+	// Set up signer lists for alice and bob
+	// alice: quorum=2, signers={bob:1, carol:1}
+	env.SetSignerList(alice, 2, []jtx.TestSigner{
+		{Account: bob, Weight: 1},
+		{Account: carol, Weight: 1},
+	})
+	env.Close()
+
+	// bob: quorum=2, signers={carol:1, dave:1, elsa:1}
+	env.SetSignerList(bob, 2, []jtx.TestSigner{
+		{Account: carol, Weight: 1},
+		{Account: dave, Weight: 1},
+		{Account: elsa, Weight: 1},
+	})
+	env.Close()
+
+	// tefBAD_SIGNATURE: Account not in SignersList (frank not in bob's list)
+	t.Run("checkBatchSign.checkMultiSign/tefBAD_SIGNATURE_not_in_list", func(t *testing.T) {
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddMultiSignBatchSigner(bob, []*jtx.Account{carol, frank}).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "tefBAD_SIGNATURE")
+		env.Close()
+	})
+
+	// tefBAD_SIGNATURE: Wrong publicKey type (ed25519 dave not in signer list)
+	t.Run("checkBatchSign.checkMultiSign/tefBAD_SIGNATURE_wrong_key_type", func(t *testing.T) {
+		daveEd := jtx.NewAccountWithKeyType("dave", jtx.KeyTypeEd25519)
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddMultiSignBatchSigner(bob, []*jtx.Account{carol, daveEd}).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "tefBAD_SIGNATURE")
+		env.Close()
+	})
+
+	// tefMASTER_DISABLED: elsa has master disabled
+	env.SetRegularKey(elsa, frank)
+	env.DisableMasterKey(elsa)
+	t.Run("checkBatchSign.checkMultiSign/tefMASTER_DISABLED", func(t *testing.T) {
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddMultiSignBatchSigner(bob, []*jtx.Account{carol, elsa}).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "tefMASTER_DISABLED")
+		env.Close()
+	})
+
+	// tefBAD_SIGNATURE: Signer does not exist (phantom not in ledger, not in signer list)
+	t.Run("checkBatchSign.checkMultiSign/tefBAD_SIGNATURE_phantom", func(t *testing.T) {
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddMultiSignBatchSigner(bob, []*jtx.Account{carol, phantom}).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "tefBAD_SIGNATURE")
+		env.Close()
+	})
+
+	// tefBAD_SIGNATURE: Signer has not enabled RegularKey
+	// dave signs with davo (ed25519) key, but dave has no regular key set
+	t.Run("checkBatchSign.checkMultiSign/tefBAD_SIGNATURE_no_regkey", func(t *testing.T) {
+		davo := jtx.NewAccountWithKeyType("davo", jtx.KeyTypeEd25519)
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddMultiSignBatchSignerWithRegKeys(bob, []RegKeySigner{
+				{Account: carol, SigningKey: carol}, // carol signs with own key
+				{Account: dave, SigningKey: davo},   // dave signs with davo's key (no regkey set)
+			}).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "tefBAD_SIGNATURE")
+		env.Close()
+	})
+
+	// tefBAD_SIGNATURE: Wrong RegularKey Set
+	// dave's regular key is frank, but trying to sign with davo
+	env.SetRegularKey(dave, frank)
+	t.Run("checkBatchSign.checkMultiSign/tefBAD_SIGNATURE_wrong_regkey", func(t *testing.T) {
+		davo := jtx.NewAccountWithKeyType("davo", jtx.KeyTypeEd25519)
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddMultiSignBatchSignerWithRegKeys(bob, []RegKeySigner{
+				{Account: carol, SigningKey: carol},
+				{Account: dave, SigningKey: davo}, // davo != frank (dave's regular key)
+			}).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "tefBAD_SIGNATURE")
+		env.Close()
+	})
+
+	// tefBAD_QUORUM: Only carol signs (weight 1), quorum is 2
+	t.Run("checkBatchSign.checkMultiSign/tefBAD_QUORUM", func(t *testing.T) {
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 2, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddMultiSignBatchSigner(bob, []*jtx.Account{carol}).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "tefBAD_QUORUM")
+		env.Close()
+	})
+
+	// tesSUCCESS: BatchSigners.Signers with carol + dave (weight 2, quorum 2)
+	t.Run("checkBatchSign.checkMultiSign/tesSUCCESS", func(t *testing.T) {
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddMultiSignBatchSigner(bob, []*jtx.Account{carol, dave}).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+	})
+
+	// tefBAD_AUTH: Inner Account (phantom) is not a signer — phantom doesn't exist and
+	// carol's pubkey doesn't derive to phantom's address
+	t.Run("checkBatchSign.checkSingleSign/tefBAD_AUTH_phantom", func(t *testing.T) {
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, phantom, 1000, seq+1)).
+			AddInnerTx(MakeInnerAccountSet(phantom, env.LedgerSeq())).
+			AddSignerWithRegKey(phantom, carol).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "tefBAD_AUTH")
+		env.Close()
+	})
+
+	// Bob has not authorized carol as a regular key.
+	t.Run("checkBatchSign.checkSingleSign/tefBAD_AUTH_not_signer", func(t *testing.T) {
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1000, seq+1)).
+			AddInnerTx(MakeInnerAccountSet(bob, env.LedgerSeq())).
+			AddSignerWithRegKey(bob, carol).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "tefBAD_AUTH")
+		env.Close()
+	})
+
+	// tesSUCCESS: Signed With Regular Key
+	env.SetRegularKey(bob, carol)
+	t.Run("checkBatchSign.checkSingleSign/tesSUCCESS_regular_key", func(t *testing.T) {
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 2, env.Seq(bob))).
+			AddSignerWithRegKey(bob, carol).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+	})
+
+	// tesSUCCESS: Signed With Master Key
+	t.Run("checkBatchSign.checkSingleSign/tesSUCCESS_master_key", func(t *testing.T) {
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 2, env.Seq(bob))).
+			AddSigner(bob).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+	})
+
+	// tefMASTER_DISABLED: Signed With Master Key Disabled
+	env.SetRegularKey(bob, carol)
+	env.DisableMasterKey(bob)
+	t.Run("checkBatchSign.checkSingleSign/tefMASTER_DISABLED", func(t *testing.T) {
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 2, env.Seq(bob))).
+			AddSigner(bob).
+			MustBuild()
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "tefMASTER_DISABLED")
+		env.Close()
+	})
+}

--- a/internal/testing/batch/preclaim_test.go
+++ b/internal/testing/batch/preclaim_test.go
@@ -61,7 +61,7 @@ func TestPreclaim(t *testing.T) {
 	dave := jtx.NewAccount("dave")
 	elsa := jtx.NewAccount("elsa")
 	frank := jtx.NewAccount("frank")
-	phantom := jtx.NewAccount("phantom") // not funded — phantom account
+	phantom := jtx.NewAccount("phantom")
 
 	env.FundAmount(alice, uint64(jtx.XRP(10000)))
 	env.FundAmount(bob, uint64(jtx.XRP(10000)))
@@ -71,7 +71,6 @@ func TestPreclaim(t *testing.T) {
 	env.FundAmount(frank, uint64(jtx.XRP(10000)))
 	env.Close()
 
-	// tefNOT_MULTI_SIGNING: SignersList not enabled for bob
 	t.Run("checkBatchSign.checkMultiSign/tefNOT_MULTI_SIGNING", func(t *testing.T) {
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
@@ -85,15 +84,12 @@ func TestPreclaim(t *testing.T) {
 		env.Close()
 	})
 
-	// Set up signer lists for alice and bob
-	// alice: quorum=2, signers={bob:1, carol:1}
 	env.SetSignerList(alice, 2, []jtx.TestSigner{
 		{Account: bob, Weight: 1},
 		{Account: carol, Weight: 1},
 	})
 	env.Close()
 
-	// bob: quorum=2, signers={carol:1, dave:1, elsa:1}
 	env.SetSignerList(bob, 2, []jtx.TestSigner{
 		{Account: carol, Weight: 1},
 		{Account: dave, Weight: 1},
@@ -101,7 +97,6 @@ func TestPreclaim(t *testing.T) {
 	})
 	env.Close()
 
-	// tefBAD_SIGNATURE: Account not in SignersList (frank not in bob's list)
 	t.Run("checkBatchSign.checkMultiSign/tefBAD_SIGNATURE_not_in_list", func(t *testing.T) {
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
@@ -115,7 +110,6 @@ func TestPreclaim(t *testing.T) {
 		env.Close()
 	})
 
-	// tefBAD_SIGNATURE: Wrong publicKey type (ed25519 dave not in signer list)
 	t.Run("checkBatchSign.checkMultiSign/tefBAD_SIGNATURE_wrong_key_type", func(t *testing.T) {
 		daveEd := jtx.NewAccountWithKeyType("dave", jtx.KeyTypeEd25519)
 		seq := env.Seq(alice)
@@ -130,7 +124,6 @@ func TestPreclaim(t *testing.T) {
 		env.Close()
 	})
 
-	// tefMASTER_DISABLED: elsa has master disabled
 	env.SetRegularKey(elsa, frank)
 	env.DisableMasterKey(elsa)
 	t.Run("checkBatchSign.checkMultiSign/tefMASTER_DISABLED", func(t *testing.T) {
@@ -146,7 +139,6 @@ func TestPreclaim(t *testing.T) {
 		env.Close()
 	})
 
-	// tefBAD_SIGNATURE: Signer does not exist (phantom not in ledger, not in signer list)
 	t.Run("checkBatchSign.checkMultiSign/tefBAD_SIGNATURE_phantom", func(t *testing.T) {
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
@@ -160,8 +152,6 @@ func TestPreclaim(t *testing.T) {
 		env.Close()
 	})
 
-	// tefBAD_SIGNATURE: Signer has not enabled RegularKey
-	// dave signs with davo (ed25519) key, but dave has no regular key set
 	t.Run("checkBatchSign.checkMultiSign/tefBAD_SIGNATURE_no_regkey", func(t *testing.T) {
 		davo := jtx.NewAccountWithKeyType("davo", jtx.KeyTypeEd25519)
 		seq := env.Seq(alice)
@@ -170,8 +160,8 @@ func TestPreclaim(t *testing.T) {
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
 			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
 			AddMultiSignBatchSignerWithRegKeys(bob, []RegKeySigner{
-				{Account: carol, SigningKey: carol}, // carol signs with own key
-				{Account: dave, SigningKey: davo},   // dave signs with davo's key (no regkey set)
+				{Account: carol, SigningKey: carol},
+				{Account: dave, SigningKey: davo},
 			}).
 			MustBuild()
 		result := env.Submit(batch)
@@ -179,8 +169,6 @@ func TestPreclaim(t *testing.T) {
 		env.Close()
 	})
 
-	// tefBAD_SIGNATURE: Wrong RegularKey Set
-	// dave's regular key is frank, but trying to sign with davo
 	env.SetRegularKey(dave, frank)
 	t.Run("checkBatchSign.checkMultiSign/tefBAD_SIGNATURE_wrong_regkey", func(t *testing.T) {
 		davo := jtx.NewAccountWithKeyType("davo", jtx.KeyTypeEd25519)
@@ -191,7 +179,7 @@ func TestPreclaim(t *testing.T) {
 			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
 			AddMultiSignBatchSignerWithRegKeys(bob, []RegKeySigner{
 				{Account: carol, SigningKey: carol},
-				{Account: dave, SigningKey: davo}, // davo != frank (dave's regular key)
+				{Account: dave, SigningKey: davo},
 			}).
 			MustBuild()
 		result := env.Submit(batch)
@@ -199,7 +187,6 @@ func TestPreclaim(t *testing.T) {
 		env.Close()
 	})
 
-	// tefBAD_QUORUM: Only carol signs (weight 1), quorum is 2
 	t.Run("checkBatchSign.checkMultiSign/tefBAD_QUORUM", func(t *testing.T) {
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 2, 2)
@@ -213,7 +200,6 @@ func TestPreclaim(t *testing.T) {
 		env.Close()
 	})
 
-	// tesSUCCESS: BatchSigners.Signers with carol + dave (weight 2, quorum 2)
 	t.Run("checkBatchSign.checkMultiSign/tesSUCCESS", func(t *testing.T) {
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
@@ -227,8 +213,6 @@ func TestPreclaim(t *testing.T) {
 		env.Close()
 	})
 
-	// tefBAD_AUTH: Inner Account (phantom) is not a signer — phantom doesn't exist and
-	// carol's pubkey doesn't derive to phantom's address
 	t.Run("checkBatchSign.checkSingleSign/tefBAD_AUTH_phantom", func(t *testing.T) {
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
@@ -242,7 +226,6 @@ func TestPreclaim(t *testing.T) {
 		env.Close()
 	})
 
-	// Bob has not authorized carol as a regular key.
 	t.Run("checkBatchSign.checkSingleSign/tefBAD_AUTH_not_signer", func(t *testing.T) {
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
@@ -256,7 +239,6 @@ func TestPreclaim(t *testing.T) {
 		env.Close()
 	})
 
-	// tesSUCCESS: Signed With Regular Key
 	env.SetRegularKey(bob, carol)
 	t.Run("checkBatchSign.checkSingleSign/tesSUCCESS_regular_key", func(t *testing.T) {
 		seq := env.Seq(alice)
@@ -271,7 +253,6 @@ func TestPreclaim(t *testing.T) {
 		env.Close()
 	})
 
-	// tesSUCCESS: Signed With Master Key
 	t.Run("checkBatchSign.checkSingleSign/tesSUCCESS_master_key", func(t *testing.T) {
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
@@ -285,7 +266,6 @@ func TestPreclaim(t *testing.T) {
 		env.Close()
 	})
 
-	// tefMASTER_DISABLED: Signed With Master Key Disabled
 	env.SetRegularKey(bob, carol)
 	env.DisableMasterKey(bob)
 	t.Run("checkBatchSign.checkSingleSign/tefMASTER_DISABLED", func(t *testing.T) {

--- a/internal/testing/batch/signing_test.go
+++ b/internal/testing/batch/signing_test.go
@@ -1,0 +1,342 @@
+package batch
+
+import (
+	"fmt"
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	batchtx "github.com/LeJamon/go-xrpl/internal/tx/batch"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+func TestBatchSigningVectors(t *testing.T) {
+	// temBAD_SIGNER: bob's inner makes bob a required signer, but no BatchSigners
+	// are provided at all, so the required set is never emptied (Batch.cpp:448-453).
+	t.Run("temBAD_SIGNER - foreign inner with no batch signers", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "temBAD_SIGNER")
+	})
+
+	// temBAD_SIGNER: a presented signer is not required because both inner txns
+	// belong to the outer account, so requiredSigners is empty (Batch.cpp:530-541).
+	t.Run("temBAD_SIGNER - stray signer, no inner requires it", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 5, seq+2)).
+			AddSigner(bob).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "temBAD_SIGNER")
+	})
+
+	// temBAD_SIGNER: bob's inner requires bob, but the presented signer is carol
+	// (Batch.cpp:543-552).
+	t.Run("temBAD_SIGNER - wrong signer for required inner account", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		carol := jtx.NewAccount("carol")
+		env.Fund(alice, bob, carol)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddSigner(carol).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "temBAD_SIGNER")
+	})
+
+	// temBAD_SIGNER: a required inner account (carol) is left uncovered after all
+	// presented signers are consumed (Batch.cpp:581-592).
+	t.Run("temBAD_SIGNER - required inner account uncovered", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		carol := jtx.NewAccount("carol")
+		env.Fund(alice, bob, carol)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 2, 3)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddInnerTx(MakeInnerPaymentXRP(carol, alice, 5, env.Seq(carol))).
+			AddSigner(bob).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "temBAD_SIGNER")
+	})
+
+	// temBAD_SIGNATURE: signer Account is bob (required) and the signature is made
+	// with bob's key, but the presented SigningPubKey is alice's, so the signature
+	// fails to verify against it (Batch_test.cpp:555-579).
+	// The cryptographic BatchSigner check runs in the engine's signature stage, so
+	// it is exercised with VerifySignatures enabled (the outer batch is signed by
+	// alice). This mirrors rippled, where checkBatchSign rejects in preflight before
+	// the preclaim authorization check is reached.
+	t.Run("temBAD_SIGNATURE - signature key mismatched to signing pubkey", func(t *testing.T) {
+		env := newBatchEnv(t)
+		env.VerifySignatures = true
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddMismatchedSigner(bob, alice, bob).
+			MustBuild()
+
+		result := env.SubmitSigned(batch)
+		jtx.RequireTxFail(t, result, "temBAD_SIGNATURE")
+	})
+
+	// temBAD_SIGNATURE: bob is the required signer with his own public key but a
+	// corrupted signature that does not verify over the batch digest.
+	t.Run("temBAD_SIGNATURE - garbage signature", func(t *testing.T) {
+		env := newBatchEnv(t)
+		env.VerifySignatures = true
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddGarbageSigner(bob).
+			MustBuild()
+
+		result := env.SubmitSigned(batch)
+		jtx.RequireTxFail(t, result, "temBAD_SIGNATURE")
+	})
+
+	// tesSUCCESS: a single required signer (bob) signs the batch digest with his
+	// master key — a valid single-signed BatchSigner.
+	t.Run("tesSUCCESS - valid single-signed batch signer", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 2, env.Seq(bob))).
+			AddSigner(bob).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+	})
+
+	// tesSUCCESS: same valid single-signed BatchSigner, with full signature
+	// verification enabled so bob's BatchTxnSignature is checked cryptographically
+	// over the batch digest, exercising the engine's batch single-sign crypto path.
+	t.Run("tesSUCCESS - valid single-signed batch signer (verified)", func(t *testing.T) {
+		env := newBatchEnv(t)
+		env.VerifySignatures = true
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 2, env.Seq(bob))).
+			AddSigner(bob).
+			MustBuild()
+
+		result := env.SubmitSigned(batch)
+		jtx.RequireTxSuccess(t, result)
+	})
+
+	// tesSUCCESS: bob's required signature is satisfied by a nested multi-sign
+	// BatchSigner (carol + dave on bob's signer list) — a valid multi-signed
+	// BatchSigner.
+	t.Run("tesSUCCESS - valid multi-signed batch signer", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		carol := jtx.NewAccount("carol")
+		dave := jtx.NewAccount("dave")
+		env.Fund(alice, bob, carol, dave)
+		env.Close()
+
+		env.SetSignerList(bob, 2, []jtx.TestSigner{
+			{Account: carol, Weight: 1},
+			{Account: dave, Weight: 1},
+		})
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddMultiSignBatchSigner(bob, []*jtx.Account{carol, dave}).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+	})
+
+	// tesSUCCESS: same valid multi-signed BatchSigner, but with full signature
+	// verification enabled so the nested BatchSigner signatures are checked
+	// cryptographically over the digest-plus-accountID message, exercising the
+	// engine's batch multi-sign crypto path end-to-end.
+	t.Run("tesSUCCESS - valid multi-signed batch signer (verified)", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		carol := jtx.NewAccount("carol")
+		dave := jtx.NewAccount("dave")
+		env.Fund(alice, bob, carol, dave)
+		env.Close()
+
+		// Establish bob's signer list before enabling signature verification, since
+		// the SetSignerList helper submits an unsigned SignerListSet.
+		env.SetSignerList(bob, 2, []jtx.TestSigner{
+			{Account: carol, Weight: 1},
+			{Account: dave, Weight: 1},
+		})
+		env.Close()
+		env.VerifySignatures = true
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 3, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddMultiSignBatchSigner(bob, []*jtx.Account{carol, dave}).
+			MustBuild()
+
+		result := env.SubmitSigned(batch)
+		jtx.RequireTxSuccess(t, result)
+	})
+
+	// tesSUCCESS: a single-account batch (both inners from the outer account)
+	// needs no BatchSigners at all.
+	t.Run("tesSUCCESS - single-account batch needs no signers", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 2, seq+2)).
+			MustBuild()
+
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+	})
+}
+
+// TestBatchSignerArrayBound exercises the rules-gated upper bound on a
+// multi-signed BatchSigner's nested Signers array. rippled enforces it in
+// multiSignHelper (called from Batch::preflight with ctx.rules): 32 with
+// featureExpandedSignerList, 8 without. An over-bound array there surfaces as
+// temBAD_SIGNATURE at the checkBatchSign call site (Batch.cpp:439-444).
+// Reference: rippled STTx::maxMultiSigners + Batch_test.cpp multi-sign vectors.
+func TestBatchSignerArrayBound(t *testing.T) {
+	makeNestedSigners := func(env *jtx.TestEnv, n int) []*jtx.Account {
+		signers := make([]*jtx.Account, n)
+		for i := range n {
+			s := jtx.NewAccount(fmt.Sprintf("nsigner%d", i))
+			env.FundAmount(s, uint64(jtx.XRP(1000)))
+			signers[i] = s
+		}
+		return signers
+	}
+
+	buildBatch := func(env *jtx.TestEnv, alice, bob *jtx.Account, signers []*jtx.Account) *batchtx.Batch {
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, uint32(len(signers)), 2)
+		return NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, seq+1)).
+			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, env.Seq(bob))).
+			AddMultiSignBatchSigner(bob, signers).
+			MustBuild()
+	}
+
+	t.Run("32 nested signers accepted", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.FundAmount(alice, uint64(jtx.XRP(10000)))
+		env.FundAmount(bob, uint64(jtx.XRP(10000)))
+		env.Close()
+
+		signers := makeNestedSigners(env, 32)
+		env.Close()
+		list := make([]jtx.TestSigner, len(signers))
+		for i, signer := range signers {
+			list[i] = jtx.TestSigner{Account: signer, Weight: 1}
+		}
+		env.SetSignerList(bob, uint32(len(list)), list)
+		env.Close()
+
+		batch := buildBatch(env, alice, bob, signers)
+		result := env.Submit(batch)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		requireBatchLedgerData(t, env, batch, result, ter.TesSUCCESS, ter.TesSUCCESS)
+	})
+
+	t.Run("33 nested signers rejected", func(t *testing.T) {
+		env := newBatchEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.FundAmount(alice, uint64(jtx.XRP(10000)))
+		env.FundAmount(bob, uint64(jtx.XRP(10000)))
+		env.Close()
+
+		batch := buildBatch(env, alice, bob, makeNestedSigners(env, 33))
+		env.Close()
+
+		result := env.Submit(batch)
+		jtx.RequireTxFail(t, result, "temBAD_SIGNATURE")
+	})
+}

--- a/internal/testing/batch/signing_test.go
+++ b/internal/testing/batch/signing_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestBatchSigningVectors(t *testing.T) {
-	// temBAD_SIGNER: bob's inner makes bob a required signer, but no BatchSigners
-	// are provided at all, so the required set is never emptied (Batch.cpp:448-453).
 	t.Run("temBAD_SIGNER - foreign inner with no batch signers", func(t *testing.T) {
 		env := newBatchEnv(t)
 		alice := jtx.NewAccount("alice")
@@ -30,8 +28,6 @@ func TestBatchSigningVectors(t *testing.T) {
 		jtx.RequireTxFail(t, result, "temBAD_SIGNER")
 	})
 
-	// temBAD_SIGNER: a presented signer is not required because both inner txns
-	// belong to the outer account, so requiredSigners is empty (Batch.cpp:530-541).
 	t.Run("temBAD_SIGNER - stray signer, no inner requires it", func(t *testing.T) {
 		env := newBatchEnv(t)
 		alice := jtx.NewAccount("alice")
@@ -51,8 +47,6 @@ func TestBatchSigningVectors(t *testing.T) {
 		jtx.RequireTxFail(t, result, "temBAD_SIGNER")
 	})
 
-	// temBAD_SIGNER: bob's inner requires bob, but the presented signer is carol
-	// (Batch.cpp:543-552).
 	t.Run("temBAD_SIGNER - wrong signer for required inner account", func(t *testing.T) {
 		env := newBatchEnv(t)
 		alice := jtx.NewAccount("alice")
@@ -73,8 +67,6 @@ func TestBatchSigningVectors(t *testing.T) {
 		jtx.RequireTxFail(t, result, "temBAD_SIGNER")
 	})
 
-	// temBAD_SIGNER: a required inner account (carol) is left uncovered after all
-	// presented signers are consumed (Batch.cpp:581-592).
 	t.Run("temBAD_SIGNER - required inner account uncovered", func(t *testing.T) {
 		env := newBatchEnv(t)
 		alice := jtx.NewAccount("alice")
@@ -123,8 +115,6 @@ func TestBatchSigningVectors(t *testing.T) {
 		jtx.RequireTxFail(t, result, "temBAD_SIGNATURE")
 	})
 
-	// temBAD_SIGNATURE: bob is the required signer with his own public key but a
-	// corrupted signature that does not verify over the batch digest.
 	t.Run("temBAD_SIGNATURE - garbage signature", func(t *testing.T) {
 		env := newBatchEnv(t)
 		env.VerifySignatures = true
@@ -145,8 +135,6 @@ func TestBatchSigningVectors(t *testing.T) {
 		jtx.RequireTxFail(t, result, "temBAD_SIGNATURE")
 	})
 
-	// tesSUCCESS: a single required signer (bob) signs the batch digest with his
-	// master key — a valid single-signed BatchSigner.
 	t.Run("tesSUCCESS - valid single-signed batch signer", func(t *testing.T) {
 		env := newBatchEnv(t)
 		alice := jtx.NewAccount("alice")
@@ -166,9 +154,6 @@ func TestBatchSigningVectors(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 	})
 
-	// tesSUCCESS: same valid single-signed BatchSigner, with full signature
-	// verification enabled so bob's BatchTxnSignature is checked cryptographically
-	// over the batch digest, exercising the engine's batch single-sign crypto path.
 	t.Run("tesSUCCESS - valid single-signed batch signer (verified)", func(t *testing.T) {
 		env := newBatchEnv(t)
 		env.VerifySignatures = true
@@ -189,9 +174,6 @@ func TestBatchSigningVectors(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 	})
 
-	// tesSUCCESS: bob's required signature is satisfied by a nested multi-sign
-	// BatchSigner (carol + dave on bob's signer list) — a valid multi-signed
-	// BatchSigner.
 	t.Run("tesSUCCESS - valid multi-signed batch signer", func(t *testing.T) {
 		env := newBatchEnv(t)
 		alice := jtx.NewAccount("alice")
@@ -219,10 +201,6 @@ func TestBatchSigningVectors(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 	})
 
-	// tesSUCCESS: same valid multi-signed BatchSigner, but with full signature
-	// verification enabled so the nested BatchSigner signatures are checked
-	// cryptographically over the digest-plus-accountID message, exercising the
-	// engine's batch multi-sign crypto path end-to-end.
 	t.Run("tesSUCCESS - valid multi-signed batch signer (verified)", func(t *testing.T) {
 		env := newBatchEnv(t)
 		alice := jtx.NewAccount("alice")
@@ -253,8 +231,6 @@ func TestBatchSigningVectors(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 	})
 
-	// tesSUCCESS: a single-account batch (both inners from the outer account)
-	// needs no BatchSigners at all.
 	t.Run("tesSUCCESS - single-account batch needs no signers", func(t *testing.T) {
 		env := newBatchEnv(t)
 		alice := jtx.NewAccount("alice")

--- a/internal/testing/batch/signing_test.go
+++ b/internal/testing/batch/signing_test.go
@@ -274,12 +274,12 @@ func TestBatchSigningVectors(t *testing.T) {
 	})
 }
 
-// TestBatchSignerArrayBound exercises the rules-gated upper bound on a
-// multi-signed BatchSigner's nested Signers array. rippled enforces it in
-// multiSignHelper (called from Batch::preflight with ctx.rules): 32 with
-// featureExpandedSignerList, 8 without. An over-bound array there surfaces as
-// temBAD_SIGNATURE at the checkBatchSign call site (Batch.cpp:439-444).
-// Reference: rippled STTx::maxMultiSigners + Batch_test.cpp multi-sign vectors.
+// TestBatchSignerArrayBound exercises the 32-entry upper bound on a
+// multi-signed BatchSigner's nested Signers array. ExpandedSignerList is
+// retired in rippled v3.2.0, so the legacy eight-entry regime is no longer
+// reachable. An over-bound array surfaces as temBAD_SIGNATURE at the
+// checkBatchSign call site.
+// Reference: rippled STTx.h kMaxMultiSigners and STTx.cpp multiSignHelper.
 func TestBatchSignerArrayBound(t *testing.T) {
 	makeNestedSigners := func(env *jtx.TestEnv, n int) []*jtx.Account {
 		signers := make([]*jtx.Account, n)

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -342,7 +342,6 @@ func (e *TestEnv) applyStaged(
 	txn tx.Transaction,
 	config tx.EngineConfig,
 	transactionCount uint32,
-	applyBatchInners bool,
 ) tx.ApplyResult {
 	blob, err := tx.SerializeTransaction(txn)
 	if err != nil {
@@ -368,12 +367,7 @@ func (e *TestEnv) applyStaged(
 		engine.SetInvariantViolationHookForTest(e.invariantViolationHook)
 	}
 	processor := txengine.NewBlockProcessor(engine)
-	var blockResult txengine.BlockTxResult
-	if applyBatchInners {
-		blockResult, err = processor.ApplyLedgerTransaction(txn, blob)
-	} else {
-		blockResult, err = processor.ApplyTransaction(txn, blob)
-	}
+	blockResult, err := processor.ApplyTransaction(txn, blob)
 	if err != nil {
 		e.t.Fatalf("apply transaction atomically: %v", err)
 	}
@@ -394,7 +388,7 @@ func (e *TestEnv) applyDirect(txn tx.Transaction) TxResult {
 
 	// Open-ledger admission commits only the outer Batch. Consensus replay at
 	// close applies the inner transactions in canonical order.
-	applyResult := e.applyStaged(txn, engineConfig, e.txInLedger, false)
+	applyResult := e.applyStaged(txn, engineConfig, e.txInLedger)
 
 	if applyResult.Result.IsApplied() {
 		e.txInLedger++

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -392,12 +392,12 @@ func (e *TestEnv) applyDirect(txn tx.Transaction) TxResult {
 		feeTrack:   true,
 	})
 
-	// Seed the engine's transaction count so metadata indexes continue across
-	// every outer and committed Batch-inner transaction in the current ledger.
-	applyResult := e.applyStaged(txn, engineConfig, e.txInLedger, true)
+	// Open-ledger admission commits only the outer Batch. Consensus replay at
+	// close applies the inner transactions in canonical order.
+	applyResult := e.applyStaged(txn, engineConfig, e.txInLedger, false)
 
 	if applyResult.Result.IsApplied() {
-		e.txInLedger += 1 + uint32(len(applyResult.AppliedInnerTransactions))
+		e.txInLedger++
 	}
 	if _, batch := txn.(tx.BatchInnerApplier); batch && applyResult.Applied {
 		e.needsConsensusBuild = true

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -438,12 +438,12 @@ func (e *Engine) preflightMultiSignStructure(tx txcore.Transaction, common *txco
 	return ter.TesSUCCESS
 }
 
-// preflightBatchSignerStructure enforces the rules-gated upper bound on each
+// preflightBatchSignerStructure enforces the upper bound on each
 // multi-signed BatchSigner's nested Signers array. rippled checks this inside
 // multiSignHelper (called from Batch::preflight with ctx.rules); an out-of-range
 // array there surfaces as temBAD_SIGNATURE at the checkBatchSign call site. The
-// crypto verification of those signers lives in Batch.Validate(), which has no
-// rules access, so the rules-dependent size bound is enforced here in preflight.
+// crypto verification of those signers lives in Batch.Validate(), so the size
+// bound is enforced here in preflight.
 func (e *Engine) preflightBatchSignerStructure(tx txcore.Transaction) ter.Result {
 	bsp, ok := tx.(txcore.BatchSignerProvider)
 	if !ok {


### PR DESCRIPTION
## Summary

- defer Batch inner effects until consensus close/replay so open-ledger results match rippled
- replace false-green fixtures and broad assertions with exact TER, state, metadata order, parent ID, and omission checks
- cover outer single-sign rejection, outer multisign success, nested signer boundaries, and service ingress for inner-flagged transactions
- make Batch fixture signing fail closed, keep the fixture test-only, use production fee calculation for custom inner fees, and split the monolithic suite by concern

## Test plan

- `just test-pkg ./internal/testing/batch`
- `go test -count=5 ./internal/testing/batch`
- `go test -race ./internal/testing/batch`
- `just test-pkg ./internal/ledger/service`
- `just test-integration`
- `just vet`
- `just lint`
- `just build`

Fixes #1499
