### PR TITLE
test(amm): make protocol results exact

### DIFF
--- a/internal/testing/amm/amm_bid_test.go
+++ b/internal/testing/amm/amm_bid_test.go
@@ -389,15 +389,7 @@ func TestBid(t *testing.T) {
 		env := setupAMM(t)
 
 		bidTx := amm.AMMBid(env.Alice, amm.XRP(), env.USD).Build()
-		result := env.Submit(bidTx)
-
-		// This may succeed or fail depending on auction slot state
-		// If no one owns the slot, it should succeed
-		if result.Success {
-			t.Log("Bid with auto price succeeded")
-		} else {
-			t.Logf("Bid with auto price result: %s (may be expected)", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(bidTx))
 	})
 
 	// Bid with authorized accounts

--- a/internal/testing/amm/amm_bookstep_test.go
+++ b/internal/testing/amm/amm_bookstep_test.go
@@ -1165,10 +1165,6 @@ func TestAMMBookStep_FixChangeSpotPriceQuality(t *testing.T) {
 
 // TestAMMBookStep_Malformed — moved to TestInvalidWithdraw in amm_withdraw_test.go
 // Reference: rippled AMM_test.cpp testMalformed (line 6623)
-func TestAMMBookStep_Malformed(t *testing.T) {
-	t.Log("testMalformed cases are in TestInvalidWithdraw/Malformed_* in amm_withdraw_test.go")
-}
-
 // TestAMMBookStep_FixOverflowOffer tests overflow offer fix.
 // Reference: rippled AMM_test.cpp testFixOverflowOffer (line 6682)
 // Tests multi-hop payment through AMM pool + CLOB offers with precise balance checking.
@@ -1407,7 +1403,7 @@ func TestAMMBookStep_SwapRounding(t *testing.T) {
 	offerTx := offerbuild.OfferCreate(env.Bob,
 		amm.XRPAmount(6300),
 		amm.IOUAmount(env.GW, "USD", 100000)).Build()
-	_ = env.Submit(offerTx)
+	amm.ExpectTER(t, env.Submit(offerTx), "tecUNFUNDED_OFFER")
 	env.Close()
 
 	// AMM should be unchanged
@@ -1633,7 +1629,7 @@ func TestAMMBookStep_FillModes(t *testing.T) {
 				amm.XRPAmount(100)).
 				FillOrKill().Build()
 			result := env.Submit(offerTx)
-			amm.ExpectTER(t, result, "tecKILLED", "tesSUCCESS")
+			amm.ExpectTER(t, result, "tecKILLED")
 			env.Close()
 
 			// AMM unchanged
@@ -2550,7 +2546,7 @@ func TestAMMBookStep_SellWithFillOrKill(t *testing.T) {
 			Sell().FillOrKill().Build()
 		result := env.Submit(offerTx)
 		// fix1578 enabled: tecKILLED
-		amm.ExpectTER(t, result, "tecKILLED", "tesSUCCESS")
+		amm.ExpectTER(t, result, "tecKILLED")
 	})
 
 	// Sub-test 2: tfSell | tfFillOrKill that crosses → tesSUCCESS
@@ -3029,10 +3025,6 @@ func TestAMMBookStep_RequireAuthRejectsUnauthorizedSyntheticOffer(t *testing.T) 
 // testBadPathAssert, testSellFlagBasic, testDirectToDirectPath, testRequireAuth, testMissingAuth
 // All are implemented as separate test functions in this file.
 // Reference: rippled AMMExtended_test.cpp testOffers (line 1447)
-func TestAMMBookStep_Offers(t *testing.T) {
-	t.Log("Umbrella test — individual offer tests are separate TestAMMBookStep_* functions")
-}
-
 // ===================================================================
 // AMMExtended_test.cpp BookStep-dependent tests (class AMMExtended2_test)
 // ===================================================================

--- a/internal/testing/amm/amm_calc_test.go
+++ b/internal/testing/amm/amm_calc_test.go
@@ -15,6 +15,7 @@ import (
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/testing/amm"
 	offerbuild "github.com/LeJamon/go-xrpl/internal/testing/offer"
+	"github.com/stretchr/testify/require"
 )
 
 // ───────────────────────────────────────────────────────────────────────
@@ -42,12 +43,7 @@ func TestAMMCalc_LPTokensOnCreate(t *testing.T) {
 			Amount(amm.XRPAmount(100)).
 			SingleAsset().
 			Build()
-		result := env.Submit(withdrawTx)
-		if result.Success {
-			t.Log("PASS: LP tokens created and withdrawal works")
-		} else {
-			t.Logf("Note: withdrawal got %s", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(withdrawTx))
 	})
 
 	t.Run("UnequalAmounts_XRP_USD", func(t *testing.T) {
@@ -57,13 +53,8 @@ func TestAMMCalc_LPTokensOnCreate(t *testing.T) {
 		env.Close()
 
 		createTx := amm.AMMCreate(env.Alice, amm.XRPAmount(2), amm.IOUAmount(env.GW, "USD", 1)).Build()
-		result := env.Submit(createTx)
-		if !result.Success {
-			t.Skipf("AMM create with small amounts failed: %s", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(createTx))
 		env.Close()
-
-		t.Log("PASS: AMM created with unequal small amounts")
 	})
 
 	t.Run("LargeAmounts_XRP_USD", func(t *testing.T) {
@@ -75,8 +66,6 @@ func TestAMMCalc_LPTokensOnCreate(t *testing.T) {
 		createTx := amm.AMMCreate(env.Alice, amm.XRPAmount(20000), amm.IOUAmount(env.GW, "USD", 20000)).Build()
 		jtx.RequireTxSuccess(t, env.Submit(createTx))
 		env.Close()
-
-		t.Log("PASS: AMM created with large equal amounts")
 	})
 
 	t.Run("IOU_IOU_Pool", func(t *testing.T) {
@@ -88,8 +77,6 @@ func TestAMMCalc_LPTokensOnCreate(t *testing.T) {
 		createTx := amm.AMMCreate(env.Alice, amm.IOUAmount(env.GW, "USD", 20000), amm.IOUAmount(env.GW, "BTC", 0.5)).Build()
 		jtx.RequireTxSuccess(t, env.Submit(createTx))
 		env.Close()
-
-		t.Log("PASS: IOU/IOU AMM with asymmetric amounts")
 	})
 }
 
@@ -118,14 +105,9 @@ func TestAMMCalc_SingleAssetDeposit(t *testing.T) {
 			SingleAsset().
 			Build()
 		result := env.Submit(depositTx)
+		jtx.RequireTxSuccess(t, result)
 		carolAfter := env.Balance(env.Carol)
-
-		if result.Success {
-			spent := carolBefore - carolAfter
-			t.Logf("PASS: Carol deposited XRP (spent %d drops) and received LP tokens", spent)
-		} else {
-			t.Logf("Note: single asset deposit got %s", result.Code)
-		}
+		require.Equal(t, uint64(1_000_000_010), carolBefore-carolAfter)
 	})
 
 	t.Run("DepositUSD_GetLPTokens", func(t *testing.T) {
@@ -138,20 +120,19 @@ func TestAMMCalc_SingleAssetDeposit(t *testing.T) {
 		env.Close()
 
 		// Carol deposits 1000 USD (single asset)
-		usdBefore := env.BalanceIOU(env.Carol, "USD", env.GW)
+		usdBefore := env.IOUBalance(env.Carol, env.GW, "USD")
+		require.NotNil(t, usdBefore)
 		depositTx := amm.AMMDeposit(env.Carol, amm.XRP(), env.USD).
 			Amount(amm.IOUAmount(env.GW, "USD", 1000)).
 			SingleAsset().
 			Build()
 		result := env.Submit(depositTx)
-		usdAfter := env.BalanceIOU(env.Carol, "USD", env.GW)
-
-		if result.Success {
-			spent := usdBefore - usdAfter
-			t.Logf("PASS: Carol deposited USD (spent %.2f) and received LP tokens", spent)
-		} else {
-			t.Logf("Note: single asset USD deposit got %s", result.Code)
-		}
+		jtx.RequireTxSuccess(t, result)
+		usdAfter := env.IOUBalance(env.Carol, env.GW, "USD")
+		require.NotNil(t, usdAfter)
+		spent, err := usdBefore.Sub(*usdAfter)
+		require.NoError(t, err)
+		require.Equal(t, "999.99999999999", spent.Value())
 	})
 
 	t.Run("DepositWithTradingFee", func(t *testing.T) {
@@ -172,12 +153,7 @@ func TestAMMCalc_SingleAssetDeposit(t *testing.T) {
 			Amount(amm.XRPAmount(1000)).
 			SingleAsset().
 			Build()
-		result := env.Submit(depositTx)
-		if result.Success {
-			t.Log("PASS: single-asset deposit with trading fee")
-		} else {
-			t.Logf("Note: deposit with fee got %s", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(depositTx))
 	})
 }
 
@@ -220,12 +196,7 @@ func TestAMMCalc_TwoAssetDeposit(t *testing.T) {
 			Amount2(amm.IOUAmount(env.GW, "USD", 1000)).
 			TwoAsset().
 			Build()
-		result := env.Submit(depositTx)
-		if result.Success {
-			t.Log("PASS: disproportionate two-asset deposit (excess returned or limited)")
-		} else {
-			t.Logf("Note: disproportionate deposit got %s", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(depositTx))
 	})
 }
 
@@ -248,14 +219,9 @@ func TestAMMCalc_SingleAssetWithdraw(t *testing.T) {
 			SingleAsset().
 			Build()
 		result := env.Submit(withdrawTx)
+		jtx.RequireTxSuccess(t, result)
 		aliceAfter := env.Balance(env.Alice)
-
-		if result.Success {
-			gained := aliceAfter - aliceBefore
-			t.Logf("PASS: Alice withdrew XRP (gained %d drops, fee deducted)", gained)
-		} else {
-			t.Logf("Note: single-asset XRP withdrawal got %s", result.Code)
-		}
+		require.Equal(t, uint64(499_999_989), aliceAfter-aliceBefore)
 	})
 
 	t.Run("WithdrawUSD", func(t *testing.T) {
@@ -268,20 +234,19 @@ func TestAMMCalc_SingleAssetWithdraw(t *testing.T) {
 		env.Close()
 
 		// Alice withdraws some USD
-		usdBefore := env.BalanceIOU(env.Alice, "USD", env.GW)
+		usdBefore := env.IOUBalance(env.Alice, env.GW, "USD")
+		require.NotNil(t, usdBefore)
 		withdrawTx := amm.AMMWithdraw(env.Alice, amm.XRP(), env.USD).
 			Amount(amm.IOUAmount(env.GW, "USD", 500)).
 			SingleAsset().
 			Build()
 		result := env.Submit(withdrawTx)
-		usdAfter := env.BalanceIOU(env.Alice, "USD", env.GW)
-
-		if result.Success {
-			gained := usdAfter - usdBefore
-			t.Logf("PASS: Alice withdrew USD (gained %.2f)", gained)
-		} else {
-			t.Logf("Note: single-asset USD withdrawal got %s", result.Code)
-		}
+		jtx.RequireTxSuccess(t, result)
+		usdAfter := env.IOUBalance(env.Alice, env.GW, "USD")
+		require.NotNil(t, usdAfter)
+		gained, err := usdAfter.Sub(*usdBefore)
+		require.NoError(t, err)
+		require.Zero(t, gained.Compare(amm.IOUAmount(env.GW, "USD", 500)))
 	})
 
 	t.Run("WithdrawWithTradingFee", func(t *testing.T) {
@@ -300,12 +265,7 @@ func TestAMMCalc_SingleAssetWithdraw(t *testing.T) {
 			Amount(amm.XRPAmount(500)).
 			SingleAsset().
 			Build()
-		result := env.Submit(withdrawTx)
-		if result.Success {
-			t.Log("PASS: single-asset withdrawal with trading fee")
-		} else {
-			t.Logf("Note: withdrawal with fee got %s", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(withdrawTx))
 	})
 }
 
@@ -327,12 +287,7 @@ func TestAMMCalc_DepositByLPTokens(t *testing.T) {
 			LPTokenOut(lpAmt).
 			LPToken().
 			Build()
-		result := env.Submit(depositTx)
-		if result.Success {
-			t.Log("PASS: deposit by LP token amount succeeded")
-		} else {
-			t.Logf("Note: deposit by LP tokens got %s", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(depositTx))
 	})
 
 	t.Run("OneAssetLPToken_XRP", func(t *testing.T) {
@@ -351,12 +306,7 @@ func TestAMMCalc_DepositByLPTokens(t *testing.T) {
 			LPTokenOut(lpAmt).
 			OneAssetLPToken().
 			Build()
-		result := env.Submit(depositTx)
-		if result.Success {
-			t.Log("PASS: one-asset LP token deposit succeeded")
-		} else {
-			t.Logf("Note: one-asset LP token deposit got %s", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(depositTx))
 	})
 }
 
@@ -377,12 +327,7 @@ func TestAMMCalc_WithdrawByLPTokens(t *testing.T) {
 			LPTokenIn(lpAmt).
 			LPToken().
 			Build()
-		result := env.Submit(withdrawTx)
-		if result.Success {
-			t.Log("PASS: proportional withdrawal by burning LP tokens")
-		} else {
-			t.Logf("Note: LP token burn withdrawal got %s", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(withdrawTx))
 	})
 
 	t.Run("OneAssetLPToken_USD", func(t *testing.T) {
@@ -395,18 +340,13 @@ func TestAMMCalc_WithdrawByLPTokens(t *testing.T) {
 		env.Close()
 
 		// Withdraw USD by burning specific LP tokens
-		lpAmt := amm.LPTokenAmount(env, amm.XRP(), env.USD, 500)
+		lpAmt := amm.LPTokenAmount(env, amm.XRP(), env.USD, 100000)
 		withdrawTx := amm.AMMWithdraw(env.Alice, amm.XRP(), env.USD).
-			Amount(amm.IOUAmount(env.GW, "USD", 5000)). // maximum USD to receive
+			Amount(amm.IOUAmount(env.GW, "USD", 100)).
 			LPTokenIn(lpAmt).
 			OneAssetLPToken().
 			Build()
-		result := env.Submit(withdrawTx)
-		if result.Success {
-			t.Log("PASS: one-asset LP token USD withdrawal")
-		} else {
-			t.Logf("Note: one-asset LP token withdrawal got %s", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(withdrawTx))
 	})
 }
 
@@ -423,16 +363,12 @@ func TestAMMCalc_ConstantProduct(t *testing.T) {
 		env.Close()
 
 		// Multiple deposits and withdrawals should not break the AMM
-		for i := range 5 {
+		for range 5 {
 			depositTx := amm.AMMDeposit(env.Carol, amm.XRP(), env.USD).
 				Amount(amm.XRPAmount(100)).
 				SingleAsset().
 				Build()
-			result := env.Submit(depositTx)
-			if !result.Success {
-				t.Logf("Deposit %d got %s", i, result.Code)
-				break
-			}
+			jtx.RequireTxSuccess(t, env.Submit(depositTx))
 		}
 		env.Close()
 
@@ -440,12 +376,7 @@ func TestAMMCalc_ConstantProduct(t *testing.T) {
 		withdrawTx := amm.AMMWithdraw(env.Carol, amm.XRP(), env.USD).
 			WithdrawAll().
 			Build()
-		result := env.Submit(withdrawTx)
-		if result.Success {
-			t.Log("PASS: constant product maintained after deposits and full withdrawal")
-		} else {
-			t.Logf("Note: withdraw all after deposits got %s", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(withdrawTx))
 	})
 }
 
@@ -471,15 +402,11 @@ func TestAMMCalc_SpotPriceQuality(t *testing.T) {
 
 		// Bob places a CLOB offer at a different price
 		offerTx := offerbuild.OfferCreate(env.Bob, amm.XRPAmount(1100), amm.IOUAmount(env.GW, "USD", 1000)).Build()
-		result := env.Submit(offerTx)
-		if !result.Success {
-			t.Skipf("Bob offer creation failed: %s", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(offerTx))
 		env.Close()
 
 		// Carol crosses — engine should pick best available
 		crossTx := offerbuild.OfferCreate(env.Carol, amm.IOUAmount(env.GW, "USD", 100), amm.XRPAmount(100)).Build()
-		result = env.Submit(crossTx)
-		t.Logf("AMM+CLOB crossing: success=%v code=%s", result.Success, result.Code)
+		jtx.RequireTxSuccess(t, env.Submit(crossTx))
 	})
 }

--- a/internal/testing/amm/amm_clawback_test.go
+++ b/internal/testing/amm/amm_clawback_test.go
@@ -158,27 +158,17 @@ func TestAMMClawbackTerminalIOUPoolMatrix(t *testing.T) {
 func TestAMMClawback(t *testing.T) {
 	// Test basic clawback functionality
 	t.Run("BasicClawback", func(t *testing.T) {
-		env := amm.NewAMMTestEnv(t)
-		env.FundWithIOUs(30000, 0)
-		env.Close()
+		env := setupClawbackEnvWithUSD(t, 30000, 30000, 30000)
 
 		createTx := amm.AMMCreate(env.Alice, amm.XRPAmount(10000), amm.IOUAmount(env.GW, "USD", 10000)).Build()
 		result := env.Submit(createTx)
-		if !result.Success {
-			t.Fatalf("AMM creation should succeed: %s", result.Code)
-		}
+		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
 		clawbackTx := amm.AMMClawback(env.GW, env.Alice.Address, env.USD, amm.XRP()).
 			Amount(amm.IOUAmount(env.GW, "USD", 100)).
 			Build()
-		result = env.Submit(clawbackTx)
-
-		if result.Success {
-			t.Log("Basic clawback succeeded")
-		} else {
-			t.Logf("Basic clawback result: %s (may require clawback to be enabled)", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(clawbackTx))
 	})
 
 	// Non-issuer cannot clawback
@@ -190,10 +180,7 @@ func TestAMMClawback(t *testing.T) {
 			Build()
 		result := env.Submit(clawbackTx)
 
-		if result.Success {
-			t.Fatal("Non-issuer should not be able to clawback")
-		}
-		t.Logf("Non-issuer clawback correctly failed: %s", result.Code)
+		amm.ExpectTER(t, result, amm.TemMALFORMED)
 	})
 
 	// Invalid holder account
@@ -206,10 +193,7 @@ func TestAMMClawback(t *testing.T) {
 			Build()
 		result := env.Submit(clawbackTx)
 
-		if result.Success {
-			t.Fatal("Should not allow clawback with invalid holder")
-		}
-		t.Logf("Invalid holder clawback correctly failed: %s", result.Code)
+		amm.ExpectTER(t, result, amm.TerNO_ACCOUNT)
 	})
 
 	// Clawback from non-existent AMM
@@ -306,11 +290,7 @@ func TestClawbackBasic(t *testing.T) {
 
 		// Try to enable clawback on gateway - should fail because gw already has trust lines
 		result = env.Submit(accountset.AccountSet(env.GW).AllowClawback().Build())
-		if result.Success {
-			t.Logf("Note: Expected tecOWNERS when enabling clawback after trust lines exist")
-		} else {
-			t.Logf("Correctly rejected enabling clawback after trust lines: %s", result.Code)
-		}
+		amm.ExpectTER(t, result, "tecOWNERS")
 	})
 }
 
@@ -613,8 +593,8 @@ func TestAMMClawback_ExceedBalance(t *testing.T) {
 		env.Close()
 
 		// rippled expects: alice USD = 5000, bob USD = 4000
-		t.Logf("Alice USD after clawback: %.2f (rippled expects 5000)", env.TestEnv.BalanceIOU(env.Alice, "USD", env.GW))
-		t.Logf("Bob USD unchanged: %.2f (rippled expects 4000)", env.TestEnv.BalanceIOU(env.Bob, "USD", env.GW))
+		jtx.RequireIOUBalance(t, env.TestEnv, env.Alice, env.GW, "USD", 5000)
+		jtx.RequireIOUBalance(t, env.TestEnv, env.Bob, env.GW, "USD", 4000)
 
 		// gw clawback 10 USD from bob in amm
 		clawbackTx = amm.AMMClawback(env.GW, env.Bob.Address, env.USD, amm.XRP()).
@@ -638,9 +618,7 @@ func TestAMMClawback_ExceedBalance(t *testing.T) {
 			TwoAsset().
 			Build()
 		result = env.Submit(depositTx)
-		if !result.Success {
-			t.Logf("Alice EUR deposit: %s (may fail due to implementation)", result.Code)
-		}
+		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
 		// gw2 clawback 200 EUR from alice
@@ -648,7 +626,7 @@ func TestAMMClawback_ExceedBalance(t *testing.T) {
 			Amount(amm.IOUAmount(gw2, "EUR", 200)).
 			Build()
 		result = env.Submit(clawbackTx)
-		t.Logf("gw2 clawback 200 EUR from alice: %s", result.Code)
+		jtx.RequireTxSuccess(t, result)
 
 		// Exceed: gw clawback 1000 USD from alice (exceeds remaining in pool)
 		clawbackTx = amm.AMMClawback(env.GW, env.Alice.Address, env.USD, amm.XRP()).
@@ -817,8 +795,7 @@ func TestAMMClawback_All(t *testing.T) {
 		env.Close()
 
 		aliceXrpAfter := env.TestEnv.Balance(env.Alice)
-		t.Logf("Alice XRP delta after clawback-all: %d drops (rippled expects ~200 XRP)",
-			int64(aliceXrpAfter)-int64(aliceXrpBefore))
+		require.Equal(t, int64(jtx.XRP(200))-1, int64(aliceXrpAfter)-int64(aliceXrpBefore))
 
 		// gw clawback all bob's USD in amm
 		bobXrpBefore := env.TestEnv.Balance(env.Bob)
@@ -828,8 +805,7 @@ func TestAMMClawback_All(t *testing.T) {
 		env.Close()
 
 		bobXrpAfter := env.TestEnv.Balance(env.Bob)
-		t.Logf("Bob XRP delta after clawback-all: %d drops (rippled expects ~400 XRP)",
-			int64(bobXrpAfter)-int64(bobXrpBefore))
+		require.Equal(t, int64(jtx.XRP(400)), int64(bobXrpAfter)-int64(bobXrpBefore))
 	})
 }
 
@@ -906,7 +882,7 @@ func TestAMMClawback_SameIssuerAssets(t *testing.T) {
 	env.Close()
 
 	// rippled expects: carol EUR = 7750 (8000 - 500 + 250 returned proportionally)
-	t.Logf("Carol EUR after USD clawback: %.2f (rippled expects 7750)", env.TestEnv.BalanceIOU(env.Carol, "EUR", env.GW))
+	jtx.RequireIOUBalance(t, env.TestEnv, env.Carol, env.GW, "EUR", 7750)
 
 	// gw clawback 1000 USD from bob WITH tfClawTwoAssets
 	// EUR is NOT returned to bob (both assets clawed back)
@@ -919,7 +895,7 @@ func TestAMMClawback_SameIssuerAssets(t *testing.T) {
 	env.Close()
 
 	// rippled expects: bob EUR = 8000 (no EUR returned because tfClawTwoAssets)
-	t.Logf("Bob EUR after tfClawTwoAssets: %.2f (rippled expects 8000)", env.TestEnv.BalanceIOU(env.Bob, "EUR", env.GW))
+	jtx.RequireIOUBalance(t, env.TestEnv, env.Bob, env.GW, "EUR", 8000)
 
 	// gw clawback all USD from alice with tfClawTwoAssets
 	clawbackTx = amm.AMMClawback(env.GW, env.Alice.Address, env.USD, env.EUR).
@@ -930,8 +906,8 @@ func TestAMMClawback_SameIssuerAssets(t *testing.T) {
 	env.Close()
 
 	// rippled expects: alice USD = 2000, alice EUR = 8000 (no EUR returned)
-	t.Logf("Alice USD after clawback-all: %.2f (rippled expects 2000)", env.TestEnv.BalanceIOU(env.Alice, "USD", env.GW))
-	t.Logf("Alice EUR after clawback-all: %.2f (rippled expects 8000)", env.TestEnv.BalanceIOU(env.Alice, "EUR", env.GW))
+	jtx.RequireIOUBalance(t, env.TestEnv, env.Alice, env.GW, "USD", 2000)
+	jtx.RequireIOUBalance(t, env.TestEnv, env.Alice, env.GW, "EUR", 8000)
 }
 
 // TestAMMClawback_SameCurrency tests clawback from AMM pool where both assets
@@ -1010,8 +986,8 @@ func TestAMMClawback_SameCurrency(t *testing.T) {
 	env.Close()
 
 	// rippled expects: bob gw["USD"] = 5000 (7000 - 2000 deposited), bob gw2["USD"] = 5000 (2000 + 3000 returned)
-	t.Logf("Bob gw[USD] after clawback: %.2f (rippled expects 5000)", env.TestEnv.BalanceIOU(env.Bob, "USD", env.GW))
-	t.Logf("Bob gw2[USD] after clawback: %.2f (rippled expects 5000)", env.TestEnv.BalanceIOU(env.Bob, "USD", gw2))
+	jtx.RequireIOUBalance(t, env.TestEnv, env.Bob, env.GW, "USD", 5000)
+	jtx.RequireIOUBalance(t, env.TestEnv, env.Bob, gw2, "USD", 5000)
 }
 
 // TestAMMClawback_IssuesEachOther tests clawback when two gateways issue tokens
@@ -1081,20 +1057,19 @@ func TestAMMClawback_IssuesEachOther(t *testing.T) {
 		Amount(amm.IOUAmount(env.GW, "USD", 1000)).
 		Build()
 	result = env.Submit(clawbackTx)
-	t.Logf("gw clawback 1000 USD from gw2: %s", result.Code)
+	jtx.RequireTxSuccess(t, result)
 	env.Close()
 
-	t.Logf("After gw clawback 1000 USD from gw2:")
-	t.Logf("  alice USD: %.2f (rippled expects 2000)", env.TestEnv.BalanceIOU(env.Alice, "USD", env.GW))
-	t.Logf("  gw EUR: %.2f (rippled expects 4000)", env.TestEnv.BalanceIOU(env.GW, "EUR", gw2))
-	t.Logf("  gw2 USD: %.2f (rippled expects 3000)", env.TestEnv.BalanceIOU(gw2, "USD", env.GW))
+	jtx.RequireIOUBalance(t, env.TestEnv, env.Alice, env.GW, "USD", 2000)
+	jtx.RequireIOUBalance(t, env.TestEnv, env.GW, gw2, "EUR", 4000)
+	jtx.RequireIOUBalance(t, env.TestEnv, gw2, env.GW, "USD", 3000)
 
 	// gw2 claws back 1000 EUR from gw
 	clawbackTx = amm.AMMClawback(gw2, env.GW.Address, EUR, env.USD).
 		Amount(amm.IOUAmount(gw2, "EUR", 1000)).
 		Build()
 	result = env.Submit(clawbackTx)
-	t.Logf("gw2 clawback 1000 EUR from gw: %s", result.Code)
+	jtx.RequireTxSuccess(t, result)
 	env.Close()
 
 	// gw2 claws back 4000 EUR from alice
@@ -1102,11 +1077,10 @@ func TestAMMClawback_IssuesEachOther(t *testing.T) {
 		Amount(amm.IOUAmount(gw2, "EUR", 4000)).
 		Build()
 	result = env.Submit(clawbackTx)
-	t.Logf("gw2 clawback 4000 EUR from alice: %s", result.Code)
+	jtx.RequireTxSuccess(t, result)
 	env.Close()
 
-	t.Logf("After gw2 clawback 4000 EUR from alice:")
-	t.Logf("  alice USD: %.2f (rippled expects 4000)", env.TestEnv.BalanceIOU(env.Alice, "USD", env.GW))
+	jtx.RequireIOUBalance(t, env.TestEnv, env.Alice, env.GW, "USD", 4000)
 }
 
 // TestAMMClawback_NotHoldingLPToken tests that clawback from an account that
@@ -1134,16 +1108,11 @@ func TestAMMClawback_NotHoldingLPToken(t *testing.T) {
 	env.Close()
 
 	// Alice did not deposit. rippled expects tecAMM_BALANCE.
-	// Note: Current impl may return tesSUCCESS due to hardcoded LP token split.
 	clawbackTx := amm.AMMClawback(env.GW, env.Alice.Address, env.USD, amm.XRP()).
 		Amount(amm.IOUAmount(env.GW, "USD", 1000)).
 		Build()
 	result = env.Submit(clawbackTx)
-	if result.Code == amm.TecAMM_BALANCE {
-		t.Logf("Correctly returned tecAMM_BALANCE for holder with no LP tokens")
-	} else {
-		t.Logf("Expected tecAMM_BALANCE for holder with no LP tokens, got %s (known implementation gap: holder LP token lookup not yet reading actual trust line balance)", result.Code)
-	}
+	amm.ExpectTER(t, result, amm.TecAMM_BALANCE)
 }
 
 // TestAMMClawback_AssetFrozen tests clawback when assets are frozen.
@@ -1379,8 +1348,8 @@ func TestAMMClawback_AssetFrozen(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 
-		t.Logf("Alice USD after all clawbacks: %.2f (rippled expects 2000)", env.TestEnv.BalanceIOU(env.Alice, "USD", env.GW))
-		t.Logf("Alice EUR after all clawbacks: %.2f (rippled expects 8000)", env.TestEnv.BalanceIOU(env.Alice, "EUR", env.GW))
+		jtx.RequireIOUBalance(t, env.TestEnv, env.Alice, env.GW, "USD", 2000)
+		jtx.RequireIOUBalance(t, env.TestEnv, env.Alice, env.GW, "EUR", 8000)
 	})
 }
 
@@ -1431,7 +1400,7 @@ func TestAMMClawback_SingleDepositAndClawback(t *testing.T) {
 	// rippled expects ~29.29 XRP back
 	aliceXrpAfter := env.TestEnv.Balance(env.Alice)
 	xrpDelta := int64(aliceXrpAfter) - int64(aliceXrpBefore)
-	t.Logf("Alice received %d drops XRP back (~%.6f XRP, rippled expects ~29.29 XRP)", xrpDelta, float64(xrpDelta)/1000000)
+	require.Equal(t, int64(29_289_321), xrpDelta)
 }
 
 // TestAMMClawback_LastHolderLPTokenBalance tests edge cases where the last LP
@@ -1474,27 +1443,22 @@ func TestAMMClawback_LastHolderLPTokenBalance(t *testing.T) {
 
 		// Bob deposits, then withdraws to make alice sole LP holder
 		depositTx := amm.AMMDeposit(bob, amm.XRP(), env.USD).
-			LPTokenOut(amm.IOUAmount(env.GW, "LPT", 1000000)).
+			LPTokenOut(env.LPTokenAmountFromLedger(amm.XRP(), env.USD, 1000000)).
 			LPToken().
 			Build()
 		result = env.Submit(depositTx)
-		if result.Success {
-			env.Close()
-			withdrawTx := amm.AMMWithdraw(bob, amm.XRP(), env.USD).WithdrawAll().Build()
-			result = env.Submit(withdrawTx)
-			if result.Success {
-				env.Close()
-			}
-		} else {
-			env.Close()
-		}
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		withdrawTx := amm.AMMWithdraw(bob, amm.XRP(), env.USD).WithdrawAll().Build()
+		jtx.RequireTxSuccess(t, env.Submit(withdrawTx))
+		env.Close()
 
 		// Clawback 0.5 USD from alice
 		clawbackTx := amm.AMMClawback(env.GW, alice.Address, env.USD, amm.XRP()).
 			Amount(amm.IOUAmount(env.GW, "USD", 0.5)).
 			Build()
-		result = env.Submit(clawbackTx)
-		t.Logf("Partial clawback from last holder: %s (success=%v)", result.Code, result.Success)
+		jtx.RequireTxSuccess(t, env.Submit(clawbackTx))
+		require.False(t, ammIsDeleted(t, env, env.USD, amm.XRP()))
 	})
 
 	// Sub-test 2: IOU/XRP pool - clawback all of last holder's balance
@@ -1507,25 +1471,19 @@ func TestAMMClawback_LastHolderLPTokenBalance(t *testing.T) {
 		env.Close()
 
 		depositTx := amm.AMMDeposit(bob, amm.XRP(), env.USD).
-			LPTokenOut(amm.IOUAmount(env.GW, "LPT", 1000000)).
+			LPTokenOut(env.LPTokenAmountFromLedger(amm.XRP(), env.USD, 1000000)).
 			LPToken().Build()
 		result = env.Submit(depositTx)
-		if result.Success {
-			env.Close()
-			withdrawTx := amm.AMMWithdraw(bob, amm.XRP(), env.USD).WithdrawAll().Build()
-			result = env.Submit(withdrawTx)
-			if result.Success {
-				env.Close()
-			}
-		} else {
-			env.Close()
-		}
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		withdrawTx := amm.AMMWithdraw(bob, amm.XRP(), env.USD).WithdrawAll().Build()
+		jtx.RequireTxSuccess(t, env.Submit(withdrawTx))
+		env.Close()
 
 		// Clawback all from alice
 		clawbackTx := amm.AMMClawback(env.GW, alice.Address, env.USD, amm.XRP()).Build()
-		result = env.Submit(clawbackTx)
-		// rippled: result depends on fixAMMClawbackRounding and fixAMMv1_3
-		t.Logf("Clawback all from last holder: %s (success=%v)", result.Code, result.Success)
+		jtx.RequireTxSuccess(t, env.Submit(clawbackTx))
+		require.True(t, ammIsDeleted(t, env, env.USD, amm.XRP()))
 	})
 
 	// Sub-test 3: IOU/IOU pool (different issuers)
@@ -1549,25 +1507,19 @@ func TestAMMClawback_LastHolderLPTokenBalance(t *testing.T) {
 		env.Close()
 
 		depositTx := amm.AMMDeposit(bob, env.USD, EUR).
-			LPTokenOut(amm.IOUAmount(env.GW, "LPT", 1000)).
+			LPTokenOut(env.LPTokenAmountFromLedger(env.USD, EUR, 1000)).
 			LPToken().Build()
 		result = env.Submit(depositTx)
-		if result.Success {
-			env.Close()
-			withdrawTx := amm.AMMWithdraw(bob, env.USD, EUR).WithdrawAll().Build()
-			result = env.Submit(withdrawTx)
-			if result.Success {
-				env.Close()
-			}
-		} else {
-			env.Close()
-		}
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		withdrawTx := amm.AMMWithdraw(bob, env.USD, EUR).WithdrawAll().Build()
+		jtx.RequireTxSuccess(t, env.Submit(withdrawTx))
+		env.Close()
 
 		// Clawback all from alice
 		clawbackTx := amm.AMMClawback(env.GW, alice.Address, env.USD, EUR).Build()
-		result = env.Submit(clawbackTx)
-		// rippled: with fixAMMv1_3+fixAMMClawbackRounding -> AMM deleted, else tecINTERNAL
-		t.Logf("Clawback all IOU/IOU different issuers: %s (success=%v)", result.Code, result.Success)
+		jtx.RequireTxSuccess(t, env.Submit(clawbackTx))
+		require.True(t, ammIsDeleted(t, env, env.USD, EUR))
 	})
 
 	// Sub-test 4: IOU/IOU pool (same issuer) with tfClawTwoAssets
@@ -1586,26 +1538,20 @@ func TestAMMClawback_LastHolderLPTokenBalance(t *testing.T) {
 		env.Close()
 
 		depositTx := amm.AMMDeposit(bob, env.USD, env.EUR).
-			LPTokenOut(amm.IOUAmount(env.GW, "LPT", 1000)).
+			LPTokenOut(env.LPTokenAmountFromLedger(env.USD, env.EUR, 1000)).
 			LPToken().Build()
 		result = env.Submit(depositTx)
-		if result.Success {
-			env.Close()
-			withdrawTx := amm.AMMWithdraw(bob, env.USD, env.EUR).WithdrawAll().Build()
-			result = env.Submit(withdrawTx)
-			if result.Success {
-				env.Close()
-			}
-		} else {
-			env.Close()
-		}
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		withdrawTx := amm.AMMWithdraw(bob, env.USD, env.EUR).WithdrawAll().Build()
+		jtx.RequireTxSuccess(t, env.Submit(withdrawTx))
+		env.Close()
 
 		// Clawback all with tfClawTwoAssets
 		clawbackTx := amm.AMMClawback(env.GW, alice.Address, env.USD, env.EUR).
 			ClawTwoAssets().Build()
-		result = env.Submit(clawbackTx)
-		// rippled: with fixAMMClawbackRounding -> AMM deleted, else tecINTERNAL
-		t.Logf("Clawback all IOU/IOU same issuer: %s (success=%v)", result.Code, result.Success)
+		jtx.RequireTxSuccess(t, env.Submit(clawbackTx))
+		require.True(t, ammIsDeleted(t, env, env.USD, env.EUR))
 	})
 }
 

--- a/internal/testing/amm/amm_clawback_test.go
+++ b/internal/testing/amm/amm_clawback_test.go
@@ -795,7 +795,7 @@ func TestAMMClawback_All(t *testing.T) {
 		env.Close()
 
 		aliceXrpAfter := env.TestEnv.Balance(env.Alice)
-		require.Equal(t, int64(jtx.XRP(200))-1, int64(aliceXrpAfter)-int64(aliceXrpBefore))
+		require.Equal(t, jtx.XRP(200)-1, int64(aliceXrpAfter)-int64(aliceXrpBefore))
 
 		// gw clawback all bob's USD in amm
 		bobXrpBefore := env.TestEnv.Balance(env.Bob)
@@ -805,7 +805,7 @@ func TestAMMClawback_All(t *testing.T) {
 		env.Close()
 
 		bobXrpAfter := env.TestEnv.Balance(env.Bob)
-		require.Equal(t, int64(jtx.XRP(400)), int64(bobXrpAfter)-int64(bobXrpBefore))
+		require.Equal(t, jtx.XRP(400), int64(bobXrpAfter)-int64(bobXrpBefore))
 	})
 }
 

--- a/internal/testing/amm/amm_create_test.go
+++ b/internal/testing/amm/amm_create_test.go
@@ -119,7 +119,7 @@ func TestInvalidInstance(t *testing.T) {
 		if result.Success {
 			t.Fatal("Should not allow creating AMM with zero XRP amount")
 		}
-		amm.ExpectTER(t, result, amm.TemBAD_AMOUNT, amm.TemMALFORMED)
+		amm.ExpectTER(t, result, amm.TemBAD_AMOUNT)
 	})
 
 	// Reference: AMM ammAlice1(env, alice, XRP(10'000), USD(0), ter(temBAD_AMOUNT));
@@ -134,7 +134,7 @@ func TestInvalidInstance(t *testing.T) {
 		if result.Success {
 			t.Fatal("Should not allow creating AMM with zero IOU amount")
 		}
-		amm.ExpectTER(t, result, amm.TemBAD_AMOUNT, amm.TemMALFORMED)
+		amm.ExpectTER(t, result, amm.TemBAD_AMOUNT)
 	})
 
 	// Can't have negative amounts

--- a/internal/testing/amm/amm_delete_test.go
+++ b/internal/testing/amm/amm_delete_test.go
@@ -64,13 +64,7 @@ func TestAMMDelete(t *testing.T) {
 		deleteTx := amm.AMMDelete(env.Carol, amm.XRP(), env.USD).Build()
 		result := env.Submit(deleteTx)
 
-		// Should fail - AMM is not empty
-		if result.Success {
-			t.Log("Note: AMMDelete may succeed if AMM is in special state")
-		} else {
-			// Expected to fail with some error (tecAMM_NOT_EMPTY or similar)
-			t.Logf("Delete AMM with LP tokens correctly failed: %s", result.Code)
-		}
+		amm.ExpectTER(t, result, "tecAMM_NOT_EMPTY")
 	})
 
 	// Invalid flags for AMMDelete

--- a/internal/testing/amm/amm_deposit_test.go
+++ b/internal/testing/amm/amm_deposit_test.go
@@ -206,7 +206,7 @@ func TestInvalidDeposit(t *testing.T) {
 
 		// Create AMM
 		createTx := amm.AMMCreate(env.Alice, amm.XRPAmount(10000), amm.IOUAmount(env.GW, "USD", 10000)).Build()
-		env.Submit(createTx)
+		jtx.RequireTxSuccess(t, env.Submit(createTx))
 		env.Close()
 
 		// Carol tries to deposit 1000 USD (but only has 100)
@@ -367,19 +367,11 @@ func TestDeposit(t *testing.T) {
 		env := setupAMM(t)
 
 		depositTx := amm.AMMDeposit(env.Carol, amm.XRP(), env.USD).
-			LPTokenOut(amm.IOUAmount(env.GW, "LPT", 100000)).
+			LPTokenOut(env.LPTokenAmountFromLedger(amm.XRP(), env.USD, 100000)).
 			Amount(amm.IOUAmount(env.GW, "USD", 205)).
 			OneAssetLPToken().
 			Build()
-		result := env.Submit(depositTx)
-
-		// May fail due to calculated amount exceeding limit
-		if result.Success {
-			t.Log("Single deposit with token amount succeeded")
-		} else {
-			// tecAMM_FAILED is expected if calculated amount exceeds limit
-			t.Logf("Single deposit with token amount result: %s (may be expected)", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(depositTx))
 	})
 
 	// Deposit with effective price limit (LimitLPToken)
@@ -395,14 +387,7 @@ func TestDeposit(t *testing.T) {
 			EPrice(ePrice).
 			LimitLPToken().
 			Build()
-		result := env.Submit(depositTx)
-
-		// Result depends on whether effective price is within limit
-		if result.Success {
-			t.Log("Deposit with price limit succeeded")
-		} else {
-			t.Logf("Deposit with price limit result: %s", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(depositTx))
 	})
 }
 

--- a/internal/testing/amm/amm_extended_test.go
+++ b/internal/testing/amm/amm_extended_test.go
@@ -1022,7 +1022,7 @@ func TestAMMExtended_MissingAuth(t *testing.T) {
 		// Alice has no USD trust line, so no funds
 		createTx := amm.AMMCreate(env.Alice, amm.IOUAmount(env.GW, "USD", 1000), amm.XRPAmount(1000)).Build()
 		result := env.Submit(createTx)
-		amm.ExpectTER(t, result, amm.TecUNFUNDED_AMM, "tecNO_LINE")
+		amm.ExpectTER(t, result, amm.TecUNFUNDED_AMM)
 	})
 
 	// GW sets RequireAuth, authorizes bob but not alice
@@ -1048,7 +1048,7 @@ func TestAMMExtended_MissingAuth(t *testing.T) {
 		// Alice has no trust line at all -> tecNO_LINE
 		createTx := amm.AMMCreate(env.Alice, amm.IOUAmount(env.GW, "USD", 1000), amm.XRPAmount(1000)).Build()
 		result := env.Submit(createTx)
-		amm.ExpectTER(t, result, "tecNO_LINE", amm.TecUNFUNDED_AMM)
+		amm.ExpectTER(t, result, "tecNO_LINE")
 	})
 
 	// GW has trust line for alice but NOT authorized -> tecNO_AUTH
@@ -1070,7 +1070,7 @@ func TestAMMExtended_MissingAuth(t *testing.T) {
 		// Alice tries to create AMM -> tecNO_AUTH (trust line exists but not authorized)
 		createTx := amm.AMMCreate(env.Alice, amm.IOUAmount(env.GW, "USD", 1000), amm.XRPAmount(1000)).Build()
 		result := env.Submit(createTx)
-		amm.ExpectTER(t, result, amm.TecNO_AUTH, amm.TecUNFUNDED_AMM)
+		amm.ExpectTER(t, result, amm.TecNO_AUTH)
 	})
 
 	// Finally authorize alice -> AMM creation succeeds

--- a/internal/testing/amm/amm_payment_test.go
+++ b/internal/testing/amm/amm_payment_test.go
@@ -100,7 +100,7 @@ func TestInvalidAMMPayment(t *testing.T) {
 		t.Run("PayIOU", func(t *testing.T) {
 			payTx := payment.PayIssued(env.Carol, ammAcc, amm.IOUAmount(env.GW, "USD", 10)).Build()
 			result := env.Submit(payTx)
-			amm.ExpectTER(t, result, amm.TecNO_PERMISSION, "tecPATH_DRY")
+			amm.ExpectTER(t, result, amm.TecNO_PERMISSION)
 		})
 	})
 

--- a/internal/testing/amm/amm_rounding_test.go
+++ b/internal/testing/amm/amm_rounding_test.go
@@ -24,6 +24,7 @@ import (
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/testing/amm"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/stretchr/testify/require"
 )
 
 // setupGBPEURPoolWithBob creates a GBP/EUR AMM and funds Bob with
@@ -541,8 +542,7 @@ func TestWithdrawRounding(t *testing.T) {
 			jtx.RequireTxSuccess(t, env.Submit(wdTx))
 			env.Close()
 
-			// After withdraw-all, invariant holds trivially (balances go to zero)
-			env.CheckInvariant(env.GBP, env.EUR, fixV1_3, false, "with2")
+			require.Nil(t, env.ReadAMMData(env.GBP, env.EUR))
 		})
 
 		// tfTwoAsset withdraw mode

--- a/internal/testing/amm/amm_withdraw_test.go
+++ b/internal/testing/amm/amm_withdraw_test.go
@@ -8,6 +8,7 @@ import (
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/testing/amm"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/stretchr/testify/require"
 )
 
 // TestInvalidWithdraw tests invalid withdrawal scenarios.
@@ -545,20 +546,7 @@ func TestWithdraw(t *testing.T) {
 		}
 		env.Close()
 
-		// AMM should be deleted after this
-		// Verify by trying to deposit - should fail with terNO_AMM
-		depositTx := amm.AMMDeposit(env.Carol, amm.XRP(), env.USD).
-			Amount(amm.XRPAmount(100)).
-			SingleAsset().
-			Build()
-		result = env.Submit(depositTx)
-
-		if result.Success {
-			t.Log("Note: AMM may not have been deleted if other LPs exist")
-		} else {
-			amm.ExpectTER(t, result, amm.TerNO_AMM)
-			t.Log("Withdraw all and AMM deletion passed")
-		}
+		require.Nil(t, env.ReadAMMData(amm.XRP(), env.USD))
 	})
 
 	// Single deposit then withdraw all in USD

--- a/internal/testing/amm/helpers.go
+++ b/internal/testing/amm/helpers.go
@@ -3,7 +3,6 @@
 package amm
 
 import (
-	"slices"
 	"testing"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
@@ -199,17 +198,10 @@ func ToIOUForCalc(amt tx.Amount) tx.Amount {
 }
 
 // ExpectTER checks if the result matches one of the expected TER codes.
-func ExpectTER(t *testing.T, result jtx.TxResult, expectedCodes ...string) {
+func ExpectTER(t *testing.T, result jtx.TxResult, expectedCode string) {
 	t.Helper()
-
-	if slices.Contains(expectedCodes, result.Code) {
-		return
-	}
-
-	if len(expectedCodes) == 1 {
-		t.Fatalf("Expected %s, got %s: %s", expectedCodes[0], result.Code, result.Message)
-	} else {
-		t.Fatalf("Expected one of %v, got %s: %s", expectedCodes, result.Code, result.Message)
+	if result.Code != expectedCode {
+		t.Fatalf("expected %s, got %s: %s", expectedCode, result.Code, result.Message)
 	}
 }
 
@@ -397,9 +389,9 @@ func (e *AMMTestEnv) AMMPoolIOU(ammAcc *jtx.Account, issuer *jtx.Account, curren
 // AMMPoolIOUPrecise returns the precise IOU balance of the AMM pool (full mantissa/exponent).
 func (e *AMMTestEnv) AMMPoolIOUPrecise(ammAcc *jtx.Account, issuer *jtx.Account, currency string) tx.Amount {
 	e.T.Helper()
-	balance := e.TestEnv.IOUBalance(ammAcc, issuer, currency)
-	if balance == nil {
-		return tx.NewIssuedAmountFromFloat64(0, currency, issuer.Address)
+	balance, found := e.TestEnv.LookupIOUBalance(ammAcc, issuer, currency)
+	if !found {
+		e.T.Fatalf("AMMPoolIOUPrecise: missing %s trust line", currency)
 	}
 	return *balance
 }
@@ -424,8 +416,10 @@ func (e *AMMTestEnv) AMMBalances(asset1, asset2 tx.Asset) (tx.Amount, tx.Amount,
 
 	ammAcc := e.ReadAMMAccount(asset1, asset2)
 	if ammAcc == nil {
-		zero := tx.NewIssuedAmountFromFloat64(0, "", "")
-		return zero, zero, zero
+		e.T.Fatalf("AMMBalances: AMM not found for %s/%s", asset1.Currency, asset2.Currency)
+	}
+	if asset1.IsNative() || asset2.IsNative() || asset1.IsMPT() || asset2.IsMPT() {
+		e.T.Fatalf("AMMBalances: only IOU/IOU pools are supported")
 	}
 
 	// Get pool IOU balances — must decode issuer addresses to get proper account IDs
@@ -437,9 +431,7 @@ func (e *AMMTestEnv) AMMBalances(asset1, asset2 tx.Asset) (tx.Amount, tx.Amount,
 	// Get LP token balance from AMM SLE
 	ammData := e.ReadAMMData(asset1, asset2)
 	if ammData == nil {
-		// AMM deleted (e.g., after WithdrawAll) — all balances are zero
-		zero := tx.NewIssuedAmountFromFloat64(0, "", "")
-		return zero, zero, zero
+		e.T.Fatalf("AMMBalances: AMM disappeared while reading balances")
 	}
 	lptBalance := ammData.LPTokenBalance
 
@@ -599,36 +591,26 @@ func (e *AMMTestEnv) AMMTradingFee(asset1, asset2 tx.Asset) uint16 {
 // ReadAMMData reads and parses the AMM SLE for the given asset pair.
 func (e *AMMTestEnv) ReadAMMData(asset1, asset2 tx.Asset) *coreAmm.AMMData {
 	e.T.Helper()
-	// Build the keylet the same way the amm code does internally
-	issuer1 := decodeIssuer(asset1.Issuer)
-	currency1 := keylet.CurrencyBytes(asset1.Currency)
-	issuer2 := decodeIssuer(asset2.Issuer)
-	currency2 := keylet.CurrencyBytes(asset2.Currency)
-
-	ammKey := keylet.AMM(issuer1, currency1, issuer2, currency2)
-	data, err := e.Ledger().Read(ammKey)
-	if err != nil || data == nil {
+	ammKey := coreAmm.ComputeAMMKeylet(asset1, asset2)
+	exists, err := e.Ledger().Exists(ammKey)
+	if err != nil {
+		e.T.Fatalf("ReadAMMData: existence check failed: %v", err)
+	}
+	if !exists {
 		return nil
+	}
+	data, err := e.Ledger().Read(ammKey)
+	if err != nil {
+		e.T.Fatalf("ReadAMMData: read failed: %v", err)
+	}
+	if data == nil {
+		e.T.Fatal("ReadAMMData: ledger reported an AMM without data")
 	}
 	ammData, err := coreAmm.ParseAMMData(data)
 	if err != nil {
 		e.T.Fatalf("ReadAMMData: parse error: %v", err)
 	}
 	return ammData
-}
-
-// decodeIssuer converts issuer address to [20]byte.
-func decodeIssuer(issuer string) [20]byte {
-	if issuer == "" {
-		return [20]byte{}
-	}
-	_, bytes, err := addresscodec.DecodeClassicAddressToAccountID(issuer)
-	if err != nil {
-		return [20]byte{}
-	}
-	var id [20]byte
-	copy(id[:], bytes)
-	return id
 }
 
 // AMMAssetOut computes the asset amount received for burning LP tokens.
@@ -645,19 +627,13 @@ func (e *AMMTestEnv) ExpectLPTokens(account *jtx.Account, asset1, asset2 tx.Asse
 
 	ammAcc := e.ReadAMMAccount(asset1, asset2)
 	if ammAcc == nil {
-		if expected != 0 {
-			e.T.Errorf("ExpectLPTokens(%s): AMM not found, want %f", account.Name, expected)
-		}
-		return
+		e.T.Fatalf("ExpectLPTokens(%s): AMM not found", account.Name)
 	}
 	lptCurrency := coreAmm.GenerateAMMLPTCurrency(asset1.Currency, asset2.Currency)
 
-	balance := e.TestEnv.IOUBalance(account, ammAcc, lptCurrency)
-	if balance == nil {
-		if expected != 0 {
-			e.T.Errorf("ExpectLPTokens(%s): no trust line, want %f", account.Name, expected)
-		}
-		return
+	balance, found := e.TestEnv.LookupIOUBalance(account, ammAcc, lptCurrency)
+	if !found {
+		e.T.Fatalf("ExpectLPTokens(%s): no trust line", account.Name)
 	}
 	actual := balance.Float64()
 

--- a/internal/testing/amm/lp_token_transfer_test.go
+++ b/internal/testing/amm/lp_token_transfer_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	coreAmm "github.com/LeJamon/go-xrpl/internal/tx/amm"
+	"github.com/stretchr/testify/require"
 )
 
 // setupLPTokenEnv creates an AMM with two liquidity providers holding LP tokens.
@@ -567,7 +569,7 @@ func TestAMMTokens_LPTokenXRPOfferCrossing(t *testing.T) {
 
 			// Pool should have only alice's LP tokens remaining
 			env.ExpectLPTokens(env.Alice, xrpAsset, usdAsset, 5_000_000)
-			env.ExpectLPTokens(env.Carol, xrpAsset, usdAsset, 0)
+			jtx.RequireTrustLineNotExists(t, env.TestEnv, env.Carol, ammAcc, coreAmm.GenerateAMMLPTCurrencyForAssets(xrpAsset, usdAsset))
 
 			// Verify pool USD is unchanged (OneAssetWithdrawAll takes only XRP)
 			actualUSD := env.AMMPoolIOU(ammAcc, env.GW, "USD")
@@ -578,7 +580,7 @@ func TestAMMTokens_LPTokenXRPOfferCrossing(t *testing.T) {
 			// Verify pool XRP decreased by priceXRP2
 			actualPoolXRP := env.AMMPoolXRP(ammAcc)
 			expectedPoolXRP := 10_000_000_000 - uint64(priceXRP2.Drops())
-			t.Logf("Pool XRP: actual=%d, expected≈%d", actualPoolXRP, expectedPoolXRP)
+			require.Equal(t, expectedPoolXRP, actualPoolXRP)
 		})
 	})
 }

--- a/internal/testing/env_queries.go
+++ b/internal/testing/env_queries.go
@@ -74,6 +74,17 @@ func (e *TestEnv) Balance(acc *Account) uint64 {
 // Positive means the holder has tokens, negative means they owe tokens.
 func (e *TestEnv) IOUBalance(holder, issuer *Account, currency string) *state.Amount {
 	e.t.Helper()
+	balance, found := e.LookupIOUBalance(holder, issuer, currency)
+	if found {
+		return balance
+	}
+	zero := state.NewIssuedAmountFromFloat64(0, currency, issuer.Address)
+	return &zero
+}
+
+// LookupIOUBalance returns the holder's balance and whether the trust line exists.
+func (e *TestEnv) LookupIOUBalance(holder, issuer *Account, currency string) (*state.Amount, bool) {
+	e.t.Helper()
 
 	lineKey := keylet.Line(holder.ID, issuer.ID, currency)
 	rs, exists, err := readRippleState(e.ledger, lineKey)
@@ -81,8 +92,7 @@ func (e *TestEnv) IOUBalance(holder, issuer *Account, currency string) *state.Am
 		e.t.Fatalf("Failed to read trust line: %v", err)
 	}
 	if !exists {
-		zero := state.NewIssuedAmountFromFloat64(0, currency, issuer.Address)
-		return &zero
+		return nil, false
 	}
 
 	// Determine if holder is low or high account
@@ -100,7 +110,7 @@ func (e *TestEnv) IOUBalance(holder, issuer *Account, currency string) *state.Am
 	// This ensures amounts returned here can be used directly in payments.
 	balance.Issuer = issuer.Address
 
-	return &balance
+	return &balance, true
 }
 
 // BalanceIOU returns the IOU balance of an account for a specific currency and issuer as float64.


### PR DESCRIPTION
## Summary

- Make transaction-result assertions require one exact TER instead of accepting alternatives.
- Replace ignored AMM submissions and log-only checks with exact result and ledger-state assertions.
- Port the AMM calculation and clawback expectations to the rippled v3.2.0 amendment matrix.

## Testing

- `go test ./internal/testing/amm -count=1`

Stack layer 2 of 5. Depends on #1639. Refs #1498.