### PR TITLE
test(amm): fail closed on ledger reads

### DIFF
--- a/internal/testing/amm/helpers.go
+++ b/internal/testing/amm/helpers.go
@@ -3,6 +3,7 @@
 package amm
 
 import (
+	"fmt"
 	"testing"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
@@ -13,6 +14,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	coreAmm "github.com/LeJamon/go-xrpl/internal/tx/amm"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
@@ -515,31 +517,38 @@ func (e *AMMTestEnv) AccountOffers(acc *jtx.Account) []*state.LedgerOffer {
 
 	var offers []*state.LedgerOffer
 	dirKey := keylet.OwnerDir(acc.ID)
-	_ = state.DirForEach(e.Ledger(), dirKey, func(itemKey [32]byte) error {
-		// Read the raw entry (Read doesn't check type)
-		k := keylet.Keylet{Key: itemKey, Type: entry.TypeOffer}
+	err := state.DirForEach(e.Ledger(), dirKey, func(itemKey [32]byte) error {
+		k := keylet.Keylet{Key: itemKey}
 		data, err := e.Ledger().Read(k)
-		if err != nil || data == nil {
+		if err != nil {
+			return fmt.Errorf("read owned entry: %w", err)
+		}
+		if data == nil {
+			return fmt.Errorf("owned entry %x has no data", itemKey)
+		}
+		typ, err := state.DecodeType(data)
+		if err != nil {
+			return fmt.Errorf("decode owned entry type: %w", err)
+		}
+		if typ != entry.TypeOffer {
 			return nil
 		}
-		// Check if the first bytes indicate an offer SLE.
-		// Offer entries have LedgerEntryType = 0x006F.
-		// The binary codec prefix starts with type/field codes; check for offer signature.
 		offer, err := state.ParseLedgerOffer(data)
 		if err != nil {
-			return nil
+			return fmt.Errorf("parse owned offer: %w", err)
 		}
-		// Only include if the offer has a valid account and non-zero amounts
-		if offer.Account == "" || (offer.TakerPays.IsZero() && offer.TakerGets.IsZero()) {
-			return nil // Not a valid offer entry
+		if offer.Account == "" || offer.TakerPays.IsZero() || offer.TakerGets.IsZero() {
+			return fmt.Errorf("owned offer %x is malformed", itemKey)
 		}
-		// Verify it belongs to the account we're querying
 		if offer.Account != acc.Address {
-			return nil
+			return fmt.Errorf("owned offer %x belongs to %s, want %s", itemKey, offer.Account, acc.Address)
 		}
 		offers = append(offers, offer)
 		return nil
 	})
+	if err != nil {
+		e.T.Fatalf("AccountOffers(%s): %v", acc.Name, err)
+	}
 
 	return offers
 }
@@ -591,26 +600,77 @@ func (e *AMMTestEnv) AMMTradingFee(asset1, asset2 tx.Asset) uint16 {
 // ReadAMMData reads and parses the AMM SLE for the given asset pair.
 func (e *AMMTestEnv) ReadAMMData(asset1, asset2 tx.Asset) *coreAmm.AMMData {
 	e.T.Helper()
-	ammKey := coreAmm.ComputeAMMKeylet(asset1, asset2)
-	exists, err := e.Ledger().Exists(ammKey)
+	ammData, found, err := lookupAMMData(e.Ledger(), asset1, asset2)
 	if err != nil {
-		e.T.Fatalf("ReadAMMData: existence check failed: %v", err)
+		e.T.Fatalf("ReadAMMData: %v", err)
 	}
-	if !exists {
+	if !found {
 		return nil
 	}
-	data, err := e.Ledger().Read(ammKey)
+	return ammData
+}
+
+type ammLedgerReader interface {
+	Exists(keylet.Keylet) (bool, error)
+	Read(keylet.Keylet) ([]byte, error)
+}
+
+func validateAMMAsset(asset tx.Asset) error {
+	if asset.IsMPT() {
+		if asset.Currency != "" || asset.Issuer != "" {
+			return fmt.Errorf("MPT asset cannot include currency or issuer")
+		}
+		if _, err := mptutil.DecodeID(asset.MPTIssuanceID); err != nil {
+			return fmt.Errorf("invalid MPT issuance ID: %w", err)
+		}
+		return nil
+	}
+	if asset.IsNative() {
+		return nil
+	}
+	if asset.Currency == "" || asset.Issuer == "" {
+		return fmt.Errorf("issued asset requires currency and issuer")
+	}
+	if _, err := state.DecodeAccountID(asset.Issuer); err != nil {
+		return fmt.Errorf("invalid asset issuer: %w", err)
+	}
+	return nil
+}
+
+func lookupAMMData(reader ammLedgerReader, asset1, asset2 tx.Asset) (*coreAmm.AMMData, bool, error) {
+	if err := validateAMMAsset(asset1); err != nil {
+		return nil, false, err
+	}
+	if err := validateAMMAsset(asset2); err != nil {
+		return nil, false, err
+	}
+	ammKey := coreAmm.ComputeAMMKeylet(asset1, asset2)
+	exists, err := reader.Exists(ammKey)
 	if err != nil {
-		e.T.Fatalf("ReadAMMData: read failed: %v", err)
+		return nil, false, fmt.Errorf("existence check failed: %w", err)
+	}
+	if !exists {
+		return nil, false, nil
+	}
+	data, err := reader.Read(ammKey)
+	if err != nil {
+		return nil, false, fmt.Errorf("read failed: %w", err)
 	}
 	if data == nil {
-		e.T.Fatal("ReadAMMData: ledger reported an AMM without data")
+		return nil, false, fmt.Errorf("ledger reported an AMM without data")
+	}
+	typ, err := state.DecodeType(data)
+	if err != nil {
+		return nil, false, fmt.Errorf("decode ledger entry type: %w", err)
+	}
+	if typ != entry.TypeAMM {
+		return nil, false, fmt.Errorf("ledger entry has type %v, want AMM", typ)
 	}
 	ammData, err := coreAmm.ParseAMMData(data)
 	if err != nil {
-		e.T.Fatalf("ReadAMMData: parse error: %v", err)
+		return nil, false, fmt.Errorf("parse AMM: %w", err)
 	}
-	return ammData
+	return ammData, true, nil
 }
 
 // AMMAssetOut computes the asset amount received for burning LP tokens.

--- a/internal/testing/amm/helpers.go
+++ b/internal/testing/amm/helpers.go
@@ -620,8 +620,12 @@ func validateAMMAsset(asset tx.Asset) error {
 		if asset.Currency != "" || asset.Issuer != "" {
 			return fmt.Errorf("MPT asset cannot include currency or issuer")
 		}
-		if _, err := mptutil.DecodeID(asset.MPTIssuanceID); err != nil {
+		id, err := mptutil.DecodeID(asset.MPTIssuanceID)
+		if err != nil {
 			return fmt.Errorf("invalid MPT issuance ID: %w", err)
+		}
+		if mptutil.Issuer(id) == ([20]byte{}) {
+			return fmt.Errorf("MPT issuance ID has zero issuer")
 		}
 		return nil
 	}
@@ -631,8 +635,16 @@ func validateAMMAsset(asset tx.Asset) error {
 	if asset.Currency == "" || asset.Issuer == "" {
 		return fmt.Errorf("issued asset requires currency and issuer")
 	}
-	if _, err := state.DecodeAccountID(asset.Issuer); err != nil {
+	currency, err := keylet.ParseCurrency(asset.Currency)
+	if err != nil || currency == ([20]byte{}) {
+		return fmt.Errorf("invalid asset currency: %q", asset.Currency)
+	}
+	issuer, err := state.DecodeAccountID(asset.Issuer)
+	if err != nil {
 		return fmt.Errorf("invalid asset issuer: %w", err)
+	}
+	if issuer == ([20]byte{}) {
+		return fmt.Errorf("asset issuer cannot be the zero account")
 	}
 	return nil
 }

--- a/internal/testing/amm/helpers_test.go
+++ b/internal/testing/amm/helpers_test.go
@@ -1,0 +1,47 @@
+package amm
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+type stubAMMReader struct {
+	exists    bool
+	existsErr error
+	data      []byte
+	readErr   error
+}
+
+func (r stubAMMReader) Exists(keylet.Keylet) (bool, error) { return r.exists, r.existsErr }
+func (r stubAMMReader) Read(keylet.Keylet) ([]byte, error) { return r.data, r.readErr }
+
+func TestLookupAMMDataFailsClosed(t *testing.T) {
+	xrp := tx.Asset{Currency: "XRP"}
+	usd := tx.Asset{Currency: "USD", Issuer: "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"}
+
+	data, found, err := lookupAMMData(stubAMMReader{}, xrp, usd)
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Nil(t, data)
+
+	for name, reader := range map[string]stubAMMReader{
+		"exists error": {existsErr: errors.New("exists failed")},
+		"read error":   {exists: true, readErr: errors.New("read failed")},
+		"missing data": {exists: true},
+		"malformed":    {exists: true, data: []byte{0xff}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := lookupAMMData(reader, xrp, usd)
+			require.Error(t, err)
+		})
+	}
+
+	_, _, err = lookupAMMData(stubAMMReader{}, xrp, tx.Asset{Currency: "USD", Issuer: "invalid"})
+	require.Error(t, err)
+	_, _, err = lookupAMMData(stubAMMReader{}, xrp, tx.Asset{MPTIssuanceID: "invalid"})
+	require.Error(t, err)
+}

--- a/internal/testing/amm/helpers_test.go
+++ b/internal/testing/amm/helpers_test.go
@@ -44,4 +44,18 @@ func TestLookupAMMDataFailsClosed(t *testing.T) {
 	require.Error(t, err)
 	_, _, err = lookupAMMData(stubAMMReader{}, xrp, tx.Asset{MPTIssuanceID: "invalid"})
 	require.Error(t, err)
+
+	for name, asset := range map[string]tx.Asset{
+		"XRP with issuer":       {Currency: "XRP", Issuer: usd.Issuer},
+		"malformed currency":    {Currency: "US D", Issuer: usd.Issuer},
+		"zero currency":         {Currency: "0000000000000000000000000000000000000000", Issuer: usd.Issuer},
+		"zero issuer":           {Currency: "USD", Issuer: "rrrrrrrrrrrrrrrrrrrrrhoLvTp"},
+		"MPT with zero issuer":  {MPTIssuanceID: "000000000000000000000000000000000000000000000000"},
+		"MPT with issue fields": {Currency: "USD", Issuer: usd.Issuer, MPTIssuanceID: "00000001BAA9375DB1D7557B5E9E47D91098911DAF5CA558"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := lookupAMMData(stubAMMReader{}, xrp, asset)
+			require.Error(t, err)
+		})
+	}
 }

--- a/internal/testing/amm/lp_token_transfer_test.go
+++ b/internal/testing/amm/lp_token_transfer_test.go
@@ -129,22 +129,18 @@ func TestLPTokenTransfer_DirectStep(t *testing.T) {
 	})
 
 	t.Run("CannotTransferToAMMAccount", func(t *testing.T) {
-		// Cannot transfer LP tokens to the AMM pseudo-account itself.
-		// The AMM pseudo-account is not a normal account and should reject
-		// direct payments. We verify this by attempting a send.
 		env := setupLPTokenEnv(t)
+		ammAcc := amm.AMMAccount(t, env, amm.XRP(), env.USD)
+		currency := coreAmm.GenerateAMMLPTCurrencyForAssets(amm.XRP(), env.USD)
+		before := env.IOUBalance(env.Bob, ammAcc, currency)
+		require.NotNil(t, before)
 
-		lpAmt := amm.LPTokenAmount(env, amm.XRP(), env.USD, 100)
-		// Attempt to pay to a non-existent account (stand-in for AMM pseudo-account).
-		// In practice, the AMM account rejects direct payments.
-		nonExistent := jtx.NewAccount("amm_pseudo")
-		payTx := payment.PayIssued(env.Bob, nonExistent, lpAmt).Build()
-		result := env.Submit(payTx)
-		if !result.Success {
-			t.Logf("PASS: cannot send LP tokens to non-existent/AMM account (got %s)", result.Code)
-		} else {
-			t.Log("Note: LP token transfer to non-existent account succeeded")
-		}
+		payTx := payment.PayIssued(env.Bob, ammAcc, env.LPTokenAmountFromLedger(amm.XRP(), env.USD, 100)).Build()
+		amm.ExpectTER(t, env.Submit(payTx), amm.TecNO_PERMISSION)
+
+		after := env.IOUBalance(env.Bob, ammAcc, currency)
+		require.NotNil(t, after)
+		require.Equal(t, before.Value(), after.Value())
 	})
 }
 


### PR DESCRIPTION
## Summary

- Make AMM and owner-directory queries distinguish authoritative absence from malformed or unreadable ledger state.
- Add injected-error coverage for AMM data, trust lines, account offers, and directory traversal.
- Exercise LP-token transfer denial against the actual AMM pseudo-account with exact state assertions.

## Testing

- `go test ./internal/testing ./internal/testing/amm -count=1`

Stack layer 3 of 5. Depends on #1640. Refs #1498.