### PR TITLE
feat(amm): support pools backed by MPTs

### DIFF
--- a/internal/testing/amm/amm_mpt_test.go
+++ b/internal/testing/amm/amm_mpt_test.go
@@ -1,0 +1,142 @@
+package amm_test
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/amm"
+	"github.com/LeJamon/go-xrpl/internal/testing/mpt"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	coreAmm "github.com/LeJamon/go-xrpl/internal/tx/amm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAMMMPTLifecycleAndLPTransfer(t *testing.T) {
+	env := amm.NewAMMTestEnv(t)
+	env.EnableFeature("MPTokensV2")
+	env.DisableFeature("SingleAssetVault")
+	env.DisableFeature("LendingProtocol")
+	env.Close()
+	issuer := jtx.NewAccount("mptIssuer")
+	token := mpt.NewMPTTester(t, env.TestEnv, issuer, mpt.MPTInit{
+		Holders:    []*jtx.Account{env.Alice, env.Carol},
+		XRP:        uint64(jtx.XRP(100_000)),
+		XRPHolders: uint64(jtx.XRP(100_000)),
+	})
+	token.Create(mpt.CreateOpts{Flags: mpt.TfMPTCanTrade | mpt.TfMPTCanTransfer})
+	token.Authorize(mpt.AuthorizeOpts{Account: env.Alice})
+	token.Authorize(mpt.AuthorizeOpts{Account: env.Carol})
+	token.Pay(issuer, env.Alice, 30_000)
+	token.Pay(issuer, env.Carol, 30_000)
+	env.Close()
+
+	mptAsset := tx.Asset{MPTIssuanceID: token.IssuanceID()}
+	jtx.RequireTxSuccess(t, env.Submit(amm.AMMCreate(
+		env.Alice,
+		amm.XRPAmount(10_000),
+		token.MPTAmount(10_000),
+	).Build()))
+	env.Close()
+
+	ammAcc := amm.AMMAccount(t, env, amm.XRP(), mptAsset)
+	token.RequireMPTokenAmount(ammAcc, 10_000)
+	require.Equal(t, uint64(jtx.XRP(10_000)), env.Balance(ammAcc))
+	ammData := env.ReadAMMData(amm.XRP(), mptAsset)
+	require.NotNil(t, ammData)
+	require.Equal(t, "10000000", ammData.LPTokenBalance.Value())
+
+	lpCurrency := coreAmm.GenerateAMMLPTCurrencyForAssets(amm.XRP(), mptAsset)
+	env.Trust(env.Carol, ammAcc, lpCurrency, 20_000_000)
+	env.Close()
+
+	transfer := tx.NewIssuedAmountFromFloat64(100, lpCurrency, ammAcc.Address)
+	jtx.RequireTxSuccess(t, env.Submit(payment.PayIssued(env.Alice, env.Carol, transfer).Build()))
+	env.Close()
+
+	aliceLP, found := env.LookupIOUBalance(env.Alice, ammAcc, lpCurrency)
+	require.True(t, found)
+	carolLP, found := env.LookupIOUBalance(env.Carol, ammAcc, lpCurrency)
+	require.True(t, found)
+	require.Equal(t, "9999900", aliceLP.Value())
+	require.Equal(t, "100", carolLP.Value())
+	require.Equal(t, "10000000", env.ReadAMMData(amm.XRP(), mptAsset).LPTokenBalance.Value())
+}
+
+func TestAMMMPTPaymentPath(t *testing.T) {
+	env := amm.NewAMMTestEnv(t)
+	env.EnableFeature("MPTokensV2")
+	env.DisableFeature("SingleAssetVault")
+	env.DisableFeature("LendingProtocol")
+	env.Close()
+	issuer := jtx.NewAccount("mptIssuer")
+	token := mpt.NewMPTTester(t, env.TestEnv, issuer, mpt.MPTInit{
+		Holders:    []*jtx.Account{env.Alice, env.Carol},
+		XRP:        uint64(jtx.XRP(100_000)),
+		XRPHolders: uint64(jtx.XRP(100_000)),
+	})
+	token.Create(mpt.CreateOpts{Flags: mpt.TfMPTCanTrade | mpt.TfMPTCanTransfer})
+	token.Authorize(mpt.AuthorizeOpts{Account: env.Alice})
+	token.Authorize(mpt.AuthorizeOpts{Account: env.Carol})
+	token.Pay(issuer, env.Alice, 20_000)
+	token.Pay(issuer, env.Carol, 20_000)
+	env.TestEnv.Fund(env.Bob)
+	env.Close()
+
+	mptAsset := tx.Asset{MPTIssuanceID: token.IssuanceID()}
+	jtx.RequireTxSuccess(t, env.Submit(amm.AMMCreate(
+		env.Alice,
+		token.MPTAmount(10_000),
+		amm.XRPAmount(10_100),
+	).Build()))
+	env.Close()
+
+	ammAcc := amm.AMMAccount(t, env, amm.XRP(), mptAsset)
+	lpBefore := env.ReadAMMData(amm.XRP(), mptAsset).LPTokenBalance
+	bobXRP := env.Balance(env.Bob)
+	result := env.Submit(
+		payment.Pay(env.Carol, env.Bob, uint64(jtx.XRP(100))).
+			SendMax(token.MPTAmount(100)).
+			PathsXRP().
+			NoDirectRipple().
+			Build(),
+	)
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	token.RequireMPTokenAmount(env.Carol, 19_900)
+	token.RequireMPTokenAmount(ammAcc, 10_100)
+	require.Equal(t, bobXRP+uint64(jtx.XRP(100)), env.Balance(env.Bob))
+	require.Equal(t, uint64(jtx.XRP(10_000)), env.Balance(ammAcc))
+	require.Equal(t, lpBefore, env.ReadAMMData(amm.XRP(), mptAsset).LPTokenBalance)
+}
+
+func TestAMMMPTFeatureGate(t *testing.T) {
+	env := amm.NewAMMTestEnv(t)
+	env.EnableFeature("MPTokensV2")
+	env.DisableFeature("SingleAssetVault")
+	env.DisableFeature("LendingProtocol")
+	env.Close()
+	issuer := jtx.NewAccount("mptIssuer")
+	token := mpt.NewMPTTester(t, env.TestEnv, issuer, mpt.MPTInit{
+		Holders:    []*jtx.Account{env.Alice},
+		XRP:        uint64(jtx.XRP(100_000)),
+		XRPHolders: uint64(jtx.XRP(100_000)),
+	})
+	token.Create(mpt.CreateOpts{Flags: mpt.TfMPTCanTrade | mpt.TfMPTCanTransfer})
+	token.Authorize(mpt.AuthorizeOpts{Account: env.Alice})
+	token.Pay(issuer, env.Alice, 20_000)
+	env.Close()
+
+	mptAsset := tx.Asset{MPTIssuanceID: token.IssuanceID()}
+	env.DisableFeature("MPTokensV2")
+	env.Close()
+	result := env.Submit(amm.AMMCreate(
+		env.Alice,
+		amm.XRPAmount(10_000),
+		token.MPTAmount(10_000),
+	).Build())
+	jtx.RequireTxFail(t, result, jtx.TemDISABLED)
+	require.Nil(t, env.ReadAMMData(amm.XRP(), mptAsset))
+	token.RequireMPTokenAmount(env.Alice, 20_000)
+}

--- a/internal/tx/invariants/amm.go
+++ b/internal/tx/invariants/amm.go
@@ -99,6 +99,26 @@ func ammPoolHoldsForInvariant(view ReadView, ammAccountID [20]byte, asset1, asse
 // For XRP: reads from the AMM account's AccountRoot.Balance
 // For IOU: reads from the trustline between AMM account and issuer
 func ammAccountHoldsForInvariant(view ReadView, ammAccountID [20]byte, asset Asset) Amount {
+	if asset.IsMPT() {
+		var id [24]byte
+		decoded, err := hex.DecodeString(asset.MPTIssuanceID)
+		if err != nil || len(decoded) != len(id) {
+			return state.NewMPTAmountWithIssuanceID(0, "", asset.MPTIssuanceID)
+		}
+		copy(id[:], decoded)
+		var issuerID [20]byte
+		copy(issuerID[:], id[4:])
+		issuer := state.EncodeAccountIDSafe(issuerID)
+		data, err := view.Read(keylet.MPTokenByID(id, ammAccountID))
+		if err != nil || data == nil {
+			return state.NewMPTAmountWithIssuanceID(0, issuer, asset.MPTIssuanceID)
+		}
+		token, err := state.ParseMPToken(data)
+		if err != nil {
+			return state.NewMPTAmountWithIssuanceID(0, issuer, asset.MPTIssuanceID)
+		}
+		return state.NewMPTAmountWithIssuanceID(int64(token.MPTAmount), issuer, asset.MPTIssuanceID)
+	}
 	if asset.Currency == "" || asset.Currency == "XRP" {
 		// XRP: read from AccountRoot
 		accountKey := keylet.Account(ammAccountID)
@@ -112,7 +132,6 @@ func ammAccountHoldsForInvariant(view ReadView, ammAccountID [20]byte, asset Ass
 		}
 		return state.NewXRPAmountFromInt(int64(account.Balance))
 	}
-
 	// IOU: read from trustline
 	issuerID, err := state.DecodeAccountID(asset.Issuer)
 	if err != nil {

--- a/internal/tx/invariants/amm.go
+++ b/internal/tx/invariants/amm.go
@@ -235,7 +235,8 @@ func checkValidAMM(tx Transaction, result Result, entries []InvariantEntry, view
 
 	// --- visitEntry phase ---
 	// Track AMM entries: extract account ID and LPTokenBalance from before/after.
-	// Track pool changes: RippleState with lsfAMMNode flag, or AccountRoot with non-zero AMMID.
+	// Track pool changes: RippleState with lsfAMMNode, AccountRoot with AMMID,
+	// or MPToken with lsfMPTAMM.
 	var (
 		ammAccount     *[20]byte
 		lptAfter       *Amount
@@ -278,6 +279,11 @@ func checkValidAMM(tx Transaction, result Result, entries []InvariantEntry, view
 					if acct.AMMID != zeroHash {
 						ammPoolChanged = true
 					}
+				}
+			} else if e.EntryType == entry.TypeMPToken {
+				token, err := state.ParseMPToken(e.After)
+				if err == nil && token.Flags&entry.LsfMPTAMM != 0 {
+					ammPoolChanged = true
 				}
 			}
 		}

--- a/internal/tx/invariants/highrisk_test.go
+++ b/internal/tx/invariants/highrisk_test.go
@@ -200,6 +200,22 @@ func TestValidAMM_VoteRejectsLPTokenIssueChange(t *testing.T) {
 	}
 }
 
+func TestValidAMM_MPTPoolChange(t *testing.T) {
+	entries := []InvariantEntry{
+		mptInvariantEntry(t, addrHolderA, addrIssuer, false, entry.LsfMPTAMM),
+	}
+	for _, txType := range []TxType{TypeAMMBid, TypeAMMVote} {
+		t.Run(txType.String(), func(t *testing.T) {
+			transaction := stubTx{txType: txType}
+			if v := checkValidAMM(transaction, TesSUCCESS, entries, stubView{}, amendment.AllSupportedRules()); v == nil {
+				t.Fatalf("expected ValidAMM violation: %s changed an MPT pool holding", txType)
+			} else if v.Name != "ValidAMM" {
+				t.Fatalf("unexpected violation name %q", v.Name)
+			}
+		})
+	}
+}
+
 // TestValidAMM_DeleteMustRemoveObject: a successful AMMDelete that leaves the
 // AMM object behind must trip ValidAMM; a delete that removes it satisfies.
 // Reference: rippled InvariantCheck.cpp finalizeDelete (lines 1864-1880).
@@ -390,7 +406,7 @@ func mptIssuanceInvariantEntry(t *testing.T, referenceHolding *string, deleted b
 	return InvariantEntry{EntryType: entry.TypeMPTokenIssuance, After: data}
 }
 
-func mptInvariantEntry(t *testing.T, account, issuer string, deleted bool) InvariantEntry {
+func mptInvariantEntry(t *testing.T, account, issuer string, deleted bool, flags ...uint32) InvariantEntry {
 	t.Helper()
 	accountID, err := state.DecodeAccountID(account)
 	if err != nil {
@@ -403,9 +419,14 @@ func mptInvariantEntry(t *testing.T, account, issuer string, deleted bool) Invar
 	var issuanceID [24]byte
 	issuanceID[3] = 1
 	copy(issuanceID[4:], issuerID[:])
+	var tokenFlags uint32
+	for _, flag := range flags {
+		tokenFlags |= flag
+	}
 	data, err := state.SerializeMPToken(&state.MPTokenData{
 		Account:           accountID,
 		MPTokenIssuanceID: issuanceID,
+		Flags:             tokenFlags,
 	})
 	if err != nil {
 		t.Fatalf("serialize MPToken: %v", err)

--- a/internal/tx/invariants/highrisk_test.go
+++ b/internal/tx/invariants/highrisk_test.go
@@ -588,6 +588,46 @@ func TestValidMPTIssuance_MayAuthorizePrivilege(t *testing.T) {
 	}
 }
 
+func TestValidMPTIssuance_AMMPrivileges(t *testing.T) {
+	created := mptInvariantEntry(t, addrHolderA, addrIssuer, false)
+	deleted := mptInvariantEntry(t, addrHolderA, addrIssuer, true)
+	rules := amendment.NewRulesBuilder().Enable(amendment.FeatureMPTokensV2).Build()
+
+	for _, count := range []int{0, 1, 2} {
+		entries := make([]InvariantEntry, count)
+		for i := range entries {
+			entries[i] = created
+		}
+		if v := checkValidMPTIssuance(stubTx{txType: TypeAMMCreate}, TesSUCCESS, entries, stubView{}, rules); v != nil {
+			t.Fatalf("AMMCreate with %d MPToken creations: %v", count, v)
+		}
+	}
+	if v := checkValidMPTIssuance(stubTx{txType: TypeAMMCreate}, TesSUCCESS,
+		[]InvariantEntry{created, created, created}, stubView{}, rules); v == nil {
+		t.Fatal("expected AMMCreate with three MPToken creations to violate ValidMPTIssuance")
+	}
+
+	for _, txType := range []TxType{TypeAMMWithdraw, TypeAMMClawback} {
+		if v := checkValidMPTIssuance(stubTx{txType: txType}, TesSUCCESS,
+			[]InvariantEntry{created, deleted, deleted}, stubView{}, rules); v != nil {
+			t.Fatalf("%s valid holding reconciliation: %v", txType, v)
+		}
+		if v := checkValidMPTIssuance(stubTx{txType: txType}, TesSUCCESS,
+			[]InvariantEntry{created, created}, stubView{}, rules); v == nil {
+			t.Fatalf("expected %s with two MPToken creations to violate ValidMPTIssuance", txType)
+		}
+	}
+
+	if v := checkValidMPTIssuance(stubTx{txType: TypeAMMDelete}, TesSUCCESS,
+		[]InvariantEntry{deleted, deleted}, stubView{}, rules); v != nil {
+		t.Fatalf("AMMDelete with two MPToken deletions: %v", v)
+	}
+	if v := checkValidMPTIssuance(stubTx{txType: TypeAMMDelete}, TesSUCCESS,
+		[]InvariantEntry{deleted, deleted, deleted}, stubView{}, rules); v == nil {
+		t.Fatal("expected AMMDelete with three MPToken deletions to violate ValidMPTIssuance")
+	}
+}
+
 func TestValidMPTIssuance_EscrowFinishFeatureGate(t *testing.T) {
 	issuance := []InvariantEntry{mptIssuanceInvariantEntry(t, nil, false)}
 	escrowFinish := stubTx{txType: TypeEscrowFinish}

--- a/internal/tx/invariants/highrisk_test.go
+++ b/internal/tx/invariants/highrisk_test.go
@@ -588,7 +588,7 @@ func TestValidMPTIssuance_MayAuthorizePrivilege(t *testing.T) {
 	}
 }
 
-func TestValidMPTIssuance_AMMPrivileges(t *testing.T) {
+func TestValidMPTIssuance_AMMCreateAndReconciliation(t *testing.T) {
 	created := mptInvariantEntry(t, addrHolderA, addrIssuer, false)
 	deleted := mptInvariantEntry(t, addrHolderA, addrIssuer, true)
 	rules := amendment.NewRulesBuilder().Enable(amendment.FeatureMPTokensV2).Build()

--- a/internal/tx/trustset/trustset.go
+++ b/internal/tx/trustset/trustset.go
@@ -329,8 +329,7 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) ter.Result {
 				if amm.IsAMMEmpty(ammData) {
 					return ter.TecAMM_EMPTY
 				}
-				// Compute LP token currency from the AMM's asset pair
-				lptCurrency := amm.GenerateAMMLPTCurrency(ammData.Asset.Currency, ammData.Asset2.Currency)
+				lptCurrency := ammData.LPTokenBalance.Currency
 				if lptCurrency != t.LimitAmount.Currency {
 					return ter.TecNO_PERMISSION
 				}


### PR DESCRIPTION
## Summary

- Validate and account for MPT-backed AMM pools through create, withdraw, clawback, invariant, and deletion paths.
- Align transaction invariant privileges and LP-token currency checks with rippled v3.2.0.
- Add lifecycle, feature-gate, path-payment, and invariant-privilege coverage.

## Testing

- `go test ./internal/testing/amm ./internal/tx/amm ./internal/tx/payment ./internal/tx/trustset ./internal/tx/invariants -count=1`

Stack layer 4 of 5. Depends on #1641. Refs #1498.