### PR TITLE
test(amm): remove false-green fixtures

### DIFF
--- a/internal/ledger/openledger/amm_parenthash_test.go
+++ b/internal/ledger/openledger/amm_parenthash_test.go
@@ -55,7 +55,7 @@ func TestApplyTxs_BuildLedgerMode_AMMCreateUsesParentHash(t *testing.T) {
 	}
 
 	aliceSeq := env.Seq(alice)
-	ammTx := ammtest.AMMCreate(alice, amount1, amount2).Build()
+	ammTx := ammtest.AMMCreate(alice, amount1, amount2).Fee("50000000").Build()
 	ammTx.GetCommon().Sequence = &aliceSeq
 
 	blob := buildSignedBlob(t, env, ammTx, alice)
@@ -127,7 +127,7 @@ func TestTxqAdapter_ApplyTransaction_AMMCreateUsesParentHash(t *testing.T) {
 	}
 
 	aliceSeq := env.Seq(alice)
-	ammTx := ammtest.AMMCreate(alice, amount1, amount2).Build()
+	ammTx := ammtest.AMMCreate(alice, amount1, amount2).Fee("50000000").Build()
 	ammTx.GetCommon().Sequence = &aliceSeq
 
 	blob := buildSignedBlob(t, env, ammTx, alice)

--- a/internal/testing/accountdelete/accountdelete_test.go
+++ b/internal/testing/accountdelete/accountdelete_test.go
@@ -448,8 +448,11 @@ func TestAccountDelete_FeeAndFlags(t *testing.T) {
 			edit: func(d *acctx.AccountDelete, _ *jtx.TestEnv) { d.SetFlags(0x00020000) },
 		},
 		{
-			name: "default fee",
+			name: "base fee",
 			code: "telINSUF_FEE_P",
+			edit: func(d *acctx.AccountDelete, env *jtx.TestEnv) {
+				d.Fee = fmt.Sprintf("%d", env.BaseFee())
+			},
 		},
 		{
 			name: "one drop below reserve increment",

--- a/internal/testing/amm/amm_bid_test.go
+++ b/internal/testing/amm/amm_bid_test.go
@@ -302,7 +302,6 @@ func TestBid(t *testing.T) {
 		}
 		env.Close()
 
-		t.Log("Bid with bidMin passed")
 	})
 
 	// Bid with exact min/max
@@ -332,7 +331,6 @@ func TestBid(t *testing.T) {
 		}
 		env.Close()
 
-		t.Log("Bid with exact min/max passed")
 	})
 
 	// Bid with min/max range
@@ -351,7 +349,6 @@ func TestBid(t *testing.T) {
 		}
 		env.Close()
 
-		t.Log("Bid with min/max range passed")
 	})
 
 	// Bid with just bidMax
@@ -380,7 +377,6 @@ func TestBid(t *testing.T) {
 		}
 		env.Close()
 
-		t.Log("Bid with bidMax only passed")
 	})
 
 	// Bid without price (auto-calculate)
@@ -423,7 +419,6 @@ func TestBid(t *testing.T) {
 		}
 		env.Close()
 
-		t.Log("Bid with auth accounts passed")
 	})
 
 	// Outbid previous slot owner
@@ -462,7 +457,6 @@ func TestBid(t *testing.T) {
 		}
 		env.Close()
 
-		t.Log("Outbid previous owner passed")
 	})
 }
 

--- a/internal/testing/amm/amm_bid_test.go
+++ b/internal/testing/amm/amm_bid_test.go
@@ -301,7 +301,6 @@ func TestBid(t *testing.T) {
 			t.Fatalf("Bid with bidMin should succeed: %s - %s", result.Code, result.Message)
 		}
 		env.Close()
-
 	})
 
 	// Bid with exact min/max
@@ -330,7 +329,6 @@ func TestBid(t *testing.T) {
 			t.Fatalf("Bid with exact min/max should succeed: %s - %s", result.Code, result.Message)
 		}
 		env.Close()
-
 	})
 
 	// Bid with min/max range
@@ -348,7 +346,6 @@ func TestBid(t *testing.T) {
 			t.Fatalf("Bid with min/max range should succeed: %s - %s", result.Code, result.Message)
 		}
 		env.Close()
-
 	})
 
 	// Bid with just bidMax
@@ -376,7 +373,6 @@ func TestBid(t *testing.T) {
 			t.Fatalf("Bid with bidMax only should succeed: %s - %s", result.Code, result.Message)
 		}
 		env.Close()
-
 	})
 
 	// Bid without price (auto-calculate)
@@ -418,7 +414,6 @@ func TestBid(t *testing.T) {
 			t.Fatalf("Bid with auth accounts should succeed: %s - %s", result.Code, result.Message)
 		}
 		env.Close()
-
 	})
 
 	// Outbid previous slot owner
@@ -456,7 +451,6 @@ func TestBid(t *testing.T) {
 			t.Fatalf("Alice's outbid should succeed: %s - %s", result.Code, result.Message)
 		}
 		env.Close()
-
 	})
 }
 

--- a/internal/testing/amm/amm_bookstep_test.go
+++ b/internal/testing/amm/amm_bookstep_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	paymenttx "github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/stretchr/testify/require"
 )
 
 // ===================================================================
@@ -123,68 +124,64 @@ func TestAMMBookStep_BasicPaymentEngine(t *testing.T) {
 // Reference: rippled AMM_test.cpp testAMMAndCLOB (line 4953)
 // If AMM is replaced with an equivalent CLOB offer, the result must be equivalent.
 func TestAMMBookStep_AMMAndCLOB(t *testing.T) {
-	// Setup: GW offers XRP(11.5B) for TST(1B). LP1 and LP2 each offer TST(25) for XRP(287.5M).
-	// With AMM: LP1 creates AMM TST(25)/XRP(250). Then LP2 creates offer TST(25)/XRP(287.5M).
-	// Capture LP2's TST balance and remaining offer.
-	// With CLOB: LP1 creates equivalent passive CLOB offer. Same LP2 offer.
-	// Compare LP2's state — should be identical.
-
-	env := amm.NewAMMTestEnv(t)
-
-	lp1 := jtx.NewAccount("lp1")
-	lp2 := jtx.NewAccount("lp2")
-
-	// Fund
-	env.TestEnv.FundAmount(env.GW, uint64(jtx.XRP(30000000000)))
-	env.TestEnv.FundAmount(lp1, uint64(jtx.XRP(10000)))
-	env.TestEnv.FundAmount(lp2, uint64(jtx.XRP(10000)))
-	env.Close()
-
-	// GW sells XRP for TST: offer(gw, XRP(11.5B), TST(1B))
-	env.Trust(lp1, env.GW, "TST", 1000000000000)
-	env.Trust(lp2, env.GW, "TST", 1000000000000)
-	env.Close()
-
-	gwOfferTx := offerbuild.OfferCreate(env.GW,
-		tx.NewXRPAmount(11_500_000_000*1_000_000),
-		amm.IOUAmount(env.GW, "TST", 1000000000)).Build()
-	jtx.RequireTxSuccess(t, env.Submit(gwOfferTx))
-	env.Close()
-
-	// LP1 offer: TST(25) for XRP(287.5M)
-	lp1OfferTx := offerbuild.OfferCreate(lp1,
-		amm.IOUAmount(env.GW, "TST", 25),
-		tx.NewXRPAmount(287_500_000*1_000_000)).Build()
-	jtx.RequireTxSuccess(t, env.Submit(lp1OfferTx))
-	env.Close()
-
-	// LP1 creates AMM: TST(25)/XRP(250)
-	ammCreateTx := amm.AMMCreate(lp1,
-		amm.IOUAmount(env.GW, "TST", 25),
-		tx.NewXRPAmount(250*1_000_000)).TradingFee(0).Build()
-	jtx.RequireTxSuccess(t, env.Submit(ammCreateTx))
-	env.Close()
-
-	// LP2 offer: TST(25) for XRP(287.5M)
-	lp2OfferTx := offerbuild.OfferCreate(lp2,
-		amm.IOUAmount(env.GW, "TST", 25),
-		tx.NewXRPAmount(287_500_000*1_000_000)).Build()
-	jtx.RequireTxSuccess(t, env.Submit(lp2OfferTx))
-	env.Close()
-
-	// Capture LP2's TST balance — should have received some TST from crossing
-	lp2TSTBalance := env.TestEnv.BalanceIOU(lp2, "TST", env.GW)
-	t.Logf("LP2 TST balance: %f", lp2TSTBalance)
-
-	// LP2's offer crossed (fully or partially) against the AMM + GW's offer.
-	// The key assertion: LP2 got some TST (offer was crossed via AMM liquidity).
-	if lp2TSTBalance <= 0 {
-		t.Errorf("LP2 should have positive TST balance after crossing, got %f", lp2TSTBalance)
+	type result struct {
+		balance   string
+		takerPays string
+		takerGets string
 	}
 
-	// LP2's remaining offers (may be 0 if fully consumed, or 1 if partially filled)
-	lp2Offers := env.AccountOffers(lp2)
-	t.Logf("LP2 remaining offers: %d", len(lp2Offers))
+	run := func(t *testing.T, withAMM bool) result {
+		env := amm.NewAMMTestEnv(t)
+		env.DisableFeature("SingleAssetVault")
+		env.DisableFeature("LendingProtocol")
+		lp1 := jtx.NewAccount("lp1")
+		lp2 := jtx.NewAccount("lp2")
+
+		env.TestEnv.FundAmount(env.GW, uint64(jtx.XRP(30_000_000_000)))
+		env.TestEnv.FundAmount(lp1, uint64(jtx.XRP(10_000)))
+		env.TestEnv.FundAmount(lp2, uint64(jtx.XRP(10_000)))
+		env.Close()
+		env.Trust(lp1, env.GW, "TST", 1_000_000_000_000)
+		env.Trust(lp2, env.GW, "TST", 1_000_000_000_000)
+		env.Close()
+
+		jtx.RequireTxSuccess(t, env.Submit(offerbuild.OfferCreate(env.GW,
+			tx.NewXRPAmount(11_500_000_000*1_000_000),
+			amm.IOUAmount(env.GW, "TST", 1_000_000_000)).Build()))
+		jtx.RequireTxSuccess(t, env.Submit(offerbuild.OfferCreate(lp1,
+			amm.IOUAmount(env.GW, "TST", 25),
+			tx.NewXRPAmount(287_500_000)).Build()))
+		env.Close()
+
+		if withAMM {
+			jtx.RequireTxSuccess(t, env.Submit(amm.AMMCreate(lp1,
+				amm.IOUAmount(env.GW, "TST", 25),
+				tx.NewXRPAmount(250*1_000_000)).Build()))
+		} else {
+			jtx.RequireTxSuccess(t, env.Submit(offerbuild.OfferCreate(lp1,
+				tx.NewXRPAmount(18_095_132),
+				state.NewIssuedAmountFromValue(168_737_976_189_735, -14, "TST", env.GW.Address)).
+				Passive().Build()))
+		}
+		env.Close()
+
+		jtx.RequireTxSuccess(t, env.Submit(offerbuild.OfferCreate(lp2,
+			amm.IOUAmount(env.GW, "TST", 25),
+			tx.NewXRPAmount(287_500_000)).Build()))
+		env.Close()
+
+		offers := env.AccountOffers(lp2)
+		require.Len(t, offers, 1)
+		return result{
+			balance:   env.TestEnv.IOUBalance(lp2, env.GW, "TST").Value(),
+			takerPays: offers[0].TakerPays.Value(),
+			takerGets: offers[0].TakerGets.Value(),
+		}
+	}
+
+	ammResult := run(t, true)
+	clobResult := run(t, false)
+	require.Equal(t, ammResult, clobResult)
 }
 
 // TestAMMBookStep_TradingFee tests trading fees on payments through AMM.
@@ -300,11 +297,9 @@ func TestAMMBookStep_TradingFee(t *testing.T) {
 
 			// With 0.5% fee, Carol gets less EUR for USD compared to no-fee scenario.
 			// The fee goes to the AMM pool.
-			carolUSD := env.TestEnv.BalanceIOU(env.Carol, "USD", env.GW)
 			carolEUR := env.TestEnv.BalanceIOU(env.Carol, "EUR", env.GW)
 			// After 3 offers: first two cancel out, third loses fee to pool.
 			// Carol should have less USD and more EUR than 30000 each.
-			t.Logf("Carol USD: %f, EUR: %f", carolUSD, carolEUR)
 			// The fee-bearing offer should give Carol fewer EUR than the 10 she asked for
 			// (some went to the pool as fee)
 			if carolEUR >= 30010 {
@@ -1096,14 +1091,7 @@ func TestAMMBookStep_FixChangeSpotPriceQuality(t *testing.T) {
 							}
 						}
 					case Fail:
-						// Fail but got success — unexpected (could be ok for Fail status with zero quality)
-						if tc.quality.Value != 0 {
-							// Verify the tiny offer quality is < target
-							tinyQ := offerQ
-							if !(tinyQ.WorseThan(tc.quality)) && tinyQ.Value != tc.quality.Value {
-								t.Logf("[%d] Fail but got amounts — quality check: q=%d target=%d", i, offerQ.Value, tc.quality.Value)
-							}
-						}
+						t.Errorf("[%d] Fail: expected no result, got quality=%d target=%d", i, offerQ.Value, tc.quality.Value)
 					}
 				} else {
 					// No result
@@ -2103,33 +2091,6 @@ func TestAMMBookStep_OfferFeesConsumeFunds(t *testing.T) {
 	}
 }
 
-// TestAMMBookStep_OfferCreateThenCross tests creating an offer then crossing.
-// Reference: rippled AMMExtended_test.cpp testOfferCreateThenCross (line 601)
-func TestAMMBookStep_OfferCreateThenCross(t *testing.T) {
-	// Pool: XRP(10000)/USD(10100)
-	// Bob creates offer to buy XRP for USD, crosses against AMM.
-	pool := [2]tx.Amount{
-		amm.XRPAmount(10000),
-		amm.IOUAmount(nil, "USD", 10100),
-	}
-	amm.TestAMM(t, &pool, 0, func(env *amm.AMMTestEnv, ammAcc *jtx.Account) {
-		env.FundBob(30000, 20000)
-		env.Close()
-
-		// Bob creates offer: buy XRP(100) sell USD(100) — crosses AMM
-		offerTx := offerbuild.OfferCreate(env.Bob, amm.XRPAmount(100), amm.IOUAmount(env.GW, "USD", 100)).Build()
-		result := env.Submit(offerTx)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		// AMM should have gained 100 USD: XRP(10000-~100), USD(10100+~100)
-		// With the exact pool values, 100 USD buys exactly ~99.01 XRP from AMM
-		// But since the offer is TakerPays=XRP(100), TakerGets=USD(100), and
-		// the AMM quality is 10100/10000 = 1.01, the taker gets all 100 XRP at this quality
-		t.Logf("AMM XRP: %d, USD: %f", env.AMMPoolXRP(ammAcc), env.AMMPoolIOU(ammAcc, env.GW, "USD"))
-	})
-}
-
 // TestAMMBookStep_SellFlagBasic tests basic sell flag behavior.
 // Reference: rippled AMMExtended_test.cpp testSellFlagBasic (line 632)
 // Pool: XRP(9900)/USD(10100). Carol sells XRP(100) for USD with tfSell.
@@ -2262,8 +2223,12 @@ func TestAMMBookStep_SellFlagExceedLimit(t *testing.T) {
 // Bob does a self-payment: buy XXX(1) with sendmax XTS(1.5), tfPartialPayment.
 // With fixAMMv1_1: AMM → XTS(101.01010101010110), XXX(99). Bob XTS ≈ 98.9898989898989.
 func TestAMMBookStep_GatewayCrossCurrency(t *testing.T) {
-	t.Skip("Self-payment cross-currency through AMM gets tecPATH_DRY - needs build_path/auto-pathfind support")
 	env := amm.NewAMMTestEnv(t)
+	env.DisableFeature("SingleAssetVault")
+	env.DisableFeature("LendingProtocol")
+	require.True(t, env.TestEnv.FeatureEnabled("fixAMMv1_1"))
+	require.False(t, env.TestEnv.FeatureEnabled("SingleAssetVault"))
+	require.False(t, env.TestEnv.FeatureEnabled("LendingProtocol"))
 
 	// starting_xrp = XRP(100.1) + reserve(env,1) + 2*baseFee
 	startingXRP := uint64(100_100_000) + env.TestEnv.ReserveBase() + env.TestEnv.ReserveIncrement() + 20
@@ -2274,10 +2239,11 @@ func TestAMMBookStep_GatewayCrossCurrency(t *testing.T) {
 	env.Close()
 
 	// Trust + fund XTS and XXX for alice and bob
-	env.Trust(env.Alice, env.GW, "XTS", 100)
-	env.Trust(env.Alice, env.GW, "XXX", 100)
-	env.Trust(env.Bob, env.GW, "XTS", 100)
-	env.Trust(env.Bob, env.GW, "XXX", 100)
+	// rippled's AMM fund helper sets trust limits to twice the funded amount.
+	env.Trust(env.Alice, env.GW, "XTS", 200)
+	env.Trust(env.Alice, env.GW, "XXX", 200)
+	env.Trust(env.Bob, env.GW, "XTS", 200)
+	env.Trust(env.Bob, env.GW, "XXX", 200)
 	env.Close()
 
 	env.PayIOU(env.GW, env.Alice, "XTS", 100)
@@ -2294,26 +2260,23 @@ func TestAMMBookStep_GatewayCrossCurrency(t *testing.T) {
 	env.Close()
 
 	// Bob self-payment: buy XXX(1) with sendmax XTS(1.5), tfPartialPayment
-	payTx := payment.PayIssued(env.Bob, env.Bob, amm.IOUAmount(env.GW, "XXX", 1)).
-		SendMax(amm.IOUAmount(env.GW, "XTS", 1.5)).
+	destinationAmount := amm.IOUAmount(env.GW, "XXX", 1)
+	sendMax := amm.IOUAmount(env.GW, "XTS", 1.5)
+	payTx := payment.PayIssued(env.Bob, env.Bob, destinationAmount).
+		SendMax(sendMax).
+		Paths([][]paymenttx.PathStep{{{Currency: "XXX", Issuer: env.GW.Address}}}).
 		PartialPayment().
 		Build()
 	jtx.RequireTxSuccess(t, env.Submit(payTx))
 	env.Close()
 
-	// With fixAMMv1_1:
-	// AMM: XTS ≈ 101.01010101010110, XXX = 99
-	// Bob XTS ≈ 98.9898989898989, Bob XXX = 101
-	bobXXX := env.TestEnv.BalanceIOU(env.Bob, "XXX", env.GW)
-	if math.Abs(bobXXX-101) > 0.0001 {
-		t.Errorf("Bob XXX: got %f, want 101", bobXXX)
-	}
-
-	bobXTS := env.TestEnv.BalanceIOU(env.Bob, "XTS", env.GW)
-	// Expect ~98.9898989898989
-	if math.Abs(bobXTS-98.9898989898989) > 0.001 {
-		t.Errorf("Bob XTS: got %f, want ~98.99", bobXTS)
-	}
+	ammAccount := amm.AMMAccount(t, env,
+		tx.Asset{Currency: "XTS", Issuer: env.GW.Address},
+		tx.Asset{Currency: "XXX", Issuer: env.GW.Address})
+	require.Equal(t, "101.0101010101011", env.AMMPoolIOUPrecise(ammAccount, env.GW, "XTS").Value())
+	require.Equal(t, "99", env.AMMPoolIOUPrecise(ammAccount, env.GW, "XXX").Value())
+	require.Equal(t, "98.9898989898989", env.TestEnv.IOUBalance(env.Bob, env.GW, "XTS").Value())
+	require.Equal(t, "101", env.TestEnv.IOUBalance(env.Bob, env.GW, "XXX").Value())
 }
 
 // TestAMMBookStep_BridgedCross tests bridged crossing with AMM.
@@ -3578,7 +3541,6 @@ func TestAMMBookStep_StepLimit(t *testing.T) {
 
 	// Alice should have gotten some USD (from bob's first offer + possibly AMM)
 	aliceUSD := env.TestEnv.BalanceIOU(env.Alice, "USD", env.GW)
-	t.Logf("Alice USD after first offer: %e", aliceUSD)
 	if aliceUSD <= 0 {
 		t.Errorf("Alice should have some USD, got %f", aliceUSD)
 	}
@@ -3598,7 +3560,7 @@ func TestAMMBookStep_StepLimit(t *testing.T) {
 	// Bob's owner count should be ~1001 (999 removed as unfunded)
 	bobOwners := env.TestEnv.OwnerCount(env.Bob)
 	if bobOwners != 1001 {
-		t.Logf("Bob owner count: %d (expected ~1001)", bobOwners)
+		t.Errorf("Bob owner count: got %d, want 1001", bobOwners)
 	}
 
 	// Dan still has 1 USD and 2 owners
@@ -3759,7 +3721,7 @@ func TestAMMBookStep_RippleState(t *testing.T) {
 	// Alice creates AMM: XRP(500)/USD(105) using G1's USD
 	createTx := amm.AMMCreate(env.Alice,
 		amm.XRPAmount(500),
-		amm.IOU(g1, "USD", 105)).Build()
+		amm.IOUAmount(g1, "USD", 105)).Build()
 	jtx.RequireTxSuccess(t, env.Submit(createTx))
 	env.Close()
 
@@ -3780,7 +3742,7 @@ func TestAMMBookStep_RippleState(t *testing.T) {
 
 	// After freeze: bob can buy more (offer crossing AMM)
 	offerTx := offerbuild.OfferCreate(env.Bob,
-		amm.IOU(g1, "USD", 5),
+		amm.IOUAmount(g1, "USD", 5),
 		amm.XRPAmount(25)).Build()
 	jtx.RequireTxSuccess(t, env.Submit(offerTx))
 	env.Close()
@@ -3792,7 +3754,7 @@ func TestAMMBookStep_RippleState(t *testing.T) {
 	// After freeze: bob cannot sell from that line
 	offerTx2 := offerbuild.OfferCreate(env.Bob,
 		amm.XRPAmount(1),
-		amm.IOU(g1, "USD", 5)).Build()
+		amm.IOUAmount(g1, "USD", 5)).Build()
 	result := env.Submit(offerTx2)
 	amm.ExpectTER(t, result, "tecUNFUNDED_OFFER")
 

--- a/internal/testing/amm/amm_create_test.go
+++ b/internal/testing/amm/amm_create_test.go
@@ -29,7 +29,6 @@ func TestInstanceCreate(t *testing.T) {
 		env.Close()
 
 		// Verify AMM exists (would check balances in full implementation)
-		t.Log("XRP to IOU AMM creation passed")
 	})
 
 	// IOU to IOU
@@ -47,7 +46,6 @@ func TestInstanceCreate(t *testing.T) {
 		}
 		env.Close()
 
-		t.Log("IOU to IOU AMM creation passed")
 	})
 
 	// Trading fee
@@ -67,7 +65,6 @@ func TestInstanceCreate(t *testing.T) {
 		}
 		env.Close()
 
-		t.Log("AMM creation with trading fee passed")
 	})
 }
 

--- a/internal/testing/amm/amm_create_test.go
+++ b/internal/testing/amm/amm_create_test.go
@@ -45,7 +45,6 @@ func TestInstanceCreate(t *testing.T) {
 			t.Fatalf("Failed to create IOU/IOU AMM: %s - %s", result.Code, result.Message)
 		}
 		env.Close()
-
 	})
 
 	// Trading fee
@@ -64,7 +63,6 @@ func TestInstanceCreate(t *testing.T) {
 			t.Fatalf("Failed to create AMM with trading fee: %s - %s", result.Code, result.Message)
 		}
 		env.Close()
-
 	})
 }
 

--- a/internal/testing/amm/amm_delete_test.go
+++ b/internal/testing/amm/amm_delete_test.go
@@ -114,7 +114,6 @@ func TestAMMDeleteAfterWithdraw(t *testing.T) {
 		}
 		amm.ExpectTER(t, result, amm.TerNO_AMM)
 
-		t.Log("AMM correctly deleted after full withdrawal")
 	})
 }
 

--- a/internal/testing/amm/amm_delete_test.go
+++ b/internal/testing/amm/amm_delete_test.go
@@ -113,7 +113,6 @@ func TestAMMDeleteAfterWithdraw(t *testing.T) {
 			t.Fatal("Should not allow operations on deleted AMM")
 		}
 		amm.ExpectTER(t, result, amm.TerNO_AMM)
-
 	})
 }
 

--- a/internal/testing/amm/amm_deposit_test.go
+++ b/internal/testing/amm/amm_deposit_test.go
@@ -273,7 +273,6 @@ func TestDeposit(t *testing.T) {
 			t.Fatal("XRP balance should have decreased after deposit")
 		}
 
-		t.Log("Equal deposit by tokens passed")
 	})
 
 	// Single asset deposit with XRP
@@ -299,7 +298,6 @@ func TestDeposit(t *testing.T) {
 			t.Fatal("XRP balance should have decreased after deposit")
 		}
 
-		t.Log("Single asset XRP deposit passed")
 	})
 
 	// Single asset deposit with IOU
@@ -325,7 +323,6 @@ func TestDeposit(t *testing.T) {
 			t.Fatal("USD balance should have decreased after deposit")
 		}
 
-		t.Log("Single asset IOU deposit passed")
 	})
 
 	// Two asset deposit
@@ -358,7 +355,6 @@ func TestDeposit(t *testing.T) {
 			t.Fatal("USD balance should have decreased after two asset deposit")
 		}
 
-		t.Log("Two asset deposit passed")
 	})
 
 	// Single deposit with token amount (OneAssetLPToken)

--- a/internal/testing/amm/amm_deposit_test.go
+++ b/internal/testing/amm/amm_deposit_test.go
@@ -272,7 +272,6 @@ func TestDeposit(t *testing.T) {
 		if finalBalance >= initialBalance {
 			t.Fatal("XRP balance should have decreased after deposit")
 		}
-
 	})
 
 	// Single asset deposit with XRP
@@ -297,7 +296,6 @@ func TestDeposit(t *testing.T) {
 		if finalBalance >= initialBalance {
 			t.Fatal("XRP balance should have decreased after deposit")
 		}
-
 	})
 
 	// Single asset deposit with IOU
@@ -322,7 +320,6 @@ func TestDeposit(t *testing.T) {
 		if finalBalance >= initialBalance {
 			t.Fatal("USD balance should have decreased after deposit")
 		}
-
 	})
 
 	// Two asset deposit
@@ -354,7 +351,6 @@ func TestDeposit(t *testing.T) {
 		if finalUSD >= initialUSD {
 			t.Fatal("USD balance should have decreased after two asset deposit")
 		}
-
 	})
 
 	// Single deposit with token amount (OneAssetLPToken)

--- a/internal/testing/amm/amm_enabled_test.go
+++ b/internal/testing/amm/amm_enabled_test.go
@@ -84,7 +84,6 @@ func TestEnabled(t *testing.T) {
 		env.Close()
 	})
 
-	t.Log("testEnabled passed")
 }
 
 // TestFixUniversalNumberDisabled tests that AMM requires fixUniversalNumber amendment.

--- a/internal/testing/amm/amm_enabled_test.go
+++ b/internal/testing/amm/amm_enabled_test.go
@@ -83,7 +83,6 @@ func TestEnabled(t *testing.T) {
 		}
 		env.Close()
 	})
-
 }
 
 // TestFixUniversalNumberDisabled tests that AMM requires fixUniversalNumber amendment.

--- a/internal/testing/amm/amm_extended_test.go
+++ b/internal/testing/amm/amm_extended_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
 	paymenttx "github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/stretchr/testify/require"
 )
 
 // ───────────────────────────────────────────────────────────────────────
@@ -45,13 +46,7 @@ func TestAMMExtended_RippleStateFreeze(t *testing.T) {
 		// Carol tries to sell USD via offer — should fail
 		offerTx := offerbuild.OfferCreate(env.Carol, amm.XRPAmount(100), amm.IOUAmount(env.GW, "USD", 100)).Build()
 		result := env.Submit(offerTx)
-		if result.Code == "tecUNFUNDED_OFFER" || result.Code == "tecFROZEN" {
-			t.Logf("PASS: frozen Carol cannot sell USD (got %s)", result.Code)
-		} else if result.Success {
-			t.Log("SKIP: Engine gap - frozen account should not create sell offer")
-		} else {
-			t.Logf("Got %s for frozen sell offer", result.Code)
-		}
+		jtx.RequireTxClaimed(t, result, jtx.TecUNFUNDED_OFFER)
 	})
 
 	t.Run("FrozenCanReceivePayment", func(t *testing.T) {
@@ -66,12 +61,7 @@ func TestAMMExtended_RippleStateFreeze(t *testing.T) {
 
 		// GW pays USD to frozen Carol — should succeed (receiving is allowed)
 		payTx := payment.PayIssued(env.GW, env.Carol, amm.IOUAmount(env.GW, "USD", 100)).Build()
-		result := env.Submit(payTx)
-		if result.Success {
-			t.Log("PASS: frozen Carol can receive payment")
-		} else {
-			t.Logf("Note: frozen Carol cannot receive (got %s) - may depend on freeze direction", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(payTx))
 	})
 
 	t.Run("FrozenCannotMakePayment", func(t *testing.T) {
@@ -92,12 +82,7 @@ func TestAMMExtended_RippleStateFreeze(t *testing.T) {
 
 		// Carol tries to pay Bob USD — should fail (sending from frozen line)
 		payTx := payment.PayIssued(env.Carol, env.Bob, amm.IOUAmount(env.GW, "USD", 100)).Build()
-		result := env.Submit(payTx)
-		if !result.Success {
-			t.Logf("PASS: frozen Carol cannot send USD (got %s)", result.Code)
-		} else {
-			t.Log("SKIP: Engine gap - frozen Carol should not be able to send USD")
-		}
+		jtx.RequireTxClaimed(t, env.Submit(payTx), jtx.TecPATH_DRY)
 	})
 
 	t.Run("UnfreezeRestoresAbility", func(t *testing.T) {
@@ -158,12 +143,7 @@ func TestAMMExtended_GlobalFreeze(t *testing.T) {
 
 		// Alice tries to pay Bob USD via rippling
 		payTx := payment.PayIssued(env.Carol, env.Bob, amm.IOUAmount(env.GW, "USD", 100)).Build()
-		result := env.Submit(payTx)
-		if !result.Success {
-			t.Logf("PASS: global freeze blocks via-rippling payment (got %s)", result.Code)
-		} else {
-			t.Log("SKIP: Engine gap - global freeze should block via-rippling")
-		}
+		jtx.RequireTxClaimed(t, env.Submit(payTx), jtx.TecPATH_DRY)
 	})
 
 	t.Run("DirectIssueStillWorks", func(t *testing.T) {
@@ -177,12 +157,7 @@ func TestAMMExtended_GlobalFreeze(t *testing.T) {
 
 		// GW can still issue USD to Carol directly
 		payTx := payment.PayIssued(env.GW, env.Carol, amm.IOUAmount(env.GW, "USD", 100)).Build()
-		result := env.Submit(payTx)
-		if result.Success {
-			t.Log("PASS: gateway can still issue directly under global freeze")
-		} else {
-			t.Logf("Note: gateway direct issue failed (got %s)", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(payTx))
 	})
 
 	t.Run("DirectRedemptionStillWorks", func(t *testing.T) {
@@ -196,12 +171,7 @@ func TestAMMExtended_GlobalFreeze(t *testing.T) {
 
 		// Carol pays USD back to GW (redemption)
 		payTx := payment.PayIssued(env.Carol, env.GW, amm.IOUAmount(env.GW, "USD", 100)).Build()
-		result := env.Submit(payTx)
-		if result.Success {
-			t.Log("PASS: direct redemption works under global freeze")
-		} else {
-			t.Logf("Note: direct redemption failed (got %s)", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(payTx))
 	})
 }
 
@@ -213,8 +183,7 @@ func TestAMMExtended_GlobalFreeze(t *testing.T) {
 // TestAMMExtended_DepositAuth tests deposit authorization with AMM payments.
 // Reference: rippled AMMExtended_test.cpp testPayment and testPayIOU
 func TestAMMExtended_DepositAuth(t *testing.T) {
-	t.Run("DepositAuth_SelfPayment", func(t *testing.T) {
-		// A user with DepositAuth can pay themselves through AMM.
+	t.Run("RedundantDirectSelfPayment", func(t *testing.T) {
 		env := amm.NewAMMTestEnv(t)
 		env.FundWithIOUs(30000, 0)
 
@@ -233,14 +202,9 @@ func TestAMMExtended_DepositAuth(t *testing.T) {
 		env.EnableDepositAuth(env.Bob)
 		env.Close()
 
-		// Bob pays himself USD through XRP→AMM path (self-payment should work)
+		// This is a direct same-issue self-payment, not an AMM path.
 		payTx := payment.PayIssued(env.Bob, env.Bob, amm.IOUAmount(env.GW, "USD", 10)).Build()
-		result := env.Submit(payTx)
-		if result.Success {
-			t.Log("PASS: self-payment with DepositAuth succeeds")
-		} else {
-			t.Logf("Note: self-payment with DepositAuth got %s", result.Code)
-		}
+		jtx.RequireTxFail(t, env.Submit(payTx), jtx.TemREDUNDANT)
 	})
 
 	t.Run("DepositAuth_BlocksIncoming", func(t *testing.T) {
@@ -258,14 +222,7 @@ func TestAMMExtended_DepositAuth(t *testing.T) {
 
 		// Alice tries to send USD to DepositAuth Bob — should fail
 		payTx := payment.PayIssued(env.Alice, env.Bob, amm.IOUAmount(env.GW, "USD", 50)).Build()
-		result := env.Submit(payTx)
-		if result.Code == "tecNO_PERMISSION" {
-			t.Log("PASS: DepositAuth blocks incoming IOU payment")
-		} else if result.Success {
-			t.Log("SKIP: Engine gap - DepositAuth should block incoming IOU payment")
-		} else {
-			t.Logf("Got %s for DepositAuth incoming payment", result.Code)
-		}
+		jtx.RequireTxClaimed(t, env.Submit(payTx), jtx.TecNO_PERMISSION)
 	})
 
 	t.Run("DepositAuth_ClearedAllows", func(t *testing.T) {
@@ -420,12 +377,7 @@ func TestAMMExtended_DeliverMin(t *testing.T) {
 		payTx := payment.PayIssued(env.Alice, env.Carol, amm.IOUAmount(env.GW, "USD", 10)).
 			DeliverMin(amm.IOUAmount(env.GW, "USD", 10)).
 			Build()
-		result := env.Submit(payTx)
-		if result.Code == "temBAD_AMOUNT" {
-			t.Log("PASS: DeliverMin = Amount without partial payment rejected")
-		} else {
-			t.Logf("Note: got %s (expected temBAD_AMOUNT)", result.Code)
-		}
+		jtx.RequireTxFail(t, env.Submit(payTx), jtx.TemBAD_AMOUNT)
 	})
 
 	t.Run("DeliverMinNegative_Rejected", func(t *testing.T) {
@@ -438,12 +390,7 @@ func TestAMMExtended_DeliverMin(t *testing.T) {
 			DeliverMin(amm.IOUAmount(env.GW, "USD", -1)).
 			PartialPayment().
 			Build()
-		result := env.Submit(payTx)
-		if result.Code == "temBAD_AMOUNT" {
-			t.Log("PASS: negative DeliverMin rejected")
-		} else {
-			t.Logf("Note: got %s (expected temBAD_AMOUNT)", result.Code)
-		}
+		jtx.RequireTxFail(t, env.Submit(payTx), jtx.TemBAD_AMOUNT)
 	})
 
 	t.Run("DeliverMinWrongCurrency_Rejected", func(t *testing.T) {
@@ -456,12 +403,7 @@ func TestAMMExtended_DeliverMin(t *testing.T) {
 			DeliverMin(amm.XRPAmount(7)). // wrong currency
 			PartialPayment().
 			Build()
-		result := env.Submit(payTx)
-		if result.Code == "temBAD_AMOUNT" {
-			t.Log("PASS: DeliverMin wrong currency rejected")
-		} else {
-			t.Logf("Note: got %s (expected temBAD_AMOUNT)", result.Code)
-		}
+		jtx.RequireTxFail(t, env.Submit(payTx), jtx.TemBAD_AMOUNT)
 	})
 
 	t.Run("DeliverMinExceedsAmount_Rejected", func(t *testing.T) {
@@ -474,12 +416,7 @@ func TestAMMExtended_DeliverMin(t *testing.T) {
 			DeliverMin(amm.IOUAmount(env.GW, "USD", 20)).
 			PartialPayment().
 			Build()
-		result := env.Submit(payTx)
-		if result.Code == "temBAD_AMOUNT" {
-			t.Log("PASS: DeliverMin > Amount rejected")
-		} else {
-			t.Logf("Note: got %s (expected temBAD_AMOUNT)", result.Code)
-		}
+		jtx.RequireTxFail(t, env.Submit(payTx), jtx.TemBAD_AMOUNT)
 	})
 }
 
@@ -508,20 +445,15 @@ func TestAMMExtended_CrossingLimits(t *testing.T) {
 		env.Close()
 
 		// Bob creates multiple offers (simulating a book with many entries)
-		for i := range 20 {
+		for range 20 {
 			offerTx := offerbuild.OfferCreate(env.Bob, amm.IOUAmount(env.GW, "USD", 10), amm.XRPAmount(10)).Build()
-			result := env.Submit(offerTx)
-			if !result.Success {
-				t.Logf("Offer %d failed: %s", i, result.Code)
-				break
-			}
+			jtx.RequireTxSuccess(t, env.Submit(offerTx))
 		}
 		env.Close()
 
 		// Carol creates a crossing offer that should consume some of Bob's offers
 		offerTx := offerbuild.OfferCreate(env.Carol, amm.XRPAmount(100), amm.IOUAmount(env.GW, "USD", 100)).Build()
-		result := env.Submit(offerTx)
-		t.Logf("Crossing result: success=%v code=%s", result.Success, result.Code)
+		jtx.RequireTxSuccess(t, env.Submit(offerTx))
 	})
 }
 
@@ -558,12 +490,8 @@ func TestAMMExtended_OfferCrossWithXRP(t *testing.T) {
 		crossTx := offerbuild.OfferCreate(env.Carol, amm.IOUAmount(env.GW, "USD", 500), amm.XRPAmount(500)).Build()
 		result := env.Submit(crossTx)
 		carolAfter := env.Balance(env.Carol)
-
-		if result.Success {
-			t.Logf("PASS: XRP offer crossing succeeded (carol XRP: %d → %d)", carolBefore, carolAfter)
-		} else {
-			t.Logf("Note: XRP offer crossing failed (got %s)", result.Code)
-		}
+		jtx.RequireTxSuccess(t, result)
+		require.Less(t, carolAfter, carolBefore)
 	})
 }
 
@@ -593,8 +521,7 @@ func TestAMMExtended_CurrencyConversion(t *testing.T) {
 
 		// Carol consumes the entire offer
 		crossTx := offerbuild.OfferCreate(env.Carol, amm.IOUAmount(env.GW, "USD", 1000), amm.XRPAmount(1000)).Build()
-		result := env.Submit(crossTx)
-		t.Logf("Entire conversion: success=%v code=%s", result.Success, result.Code)
+		jtx.RequireTxSuccess(t, env.Submit(crossTx))
 	})
 
 	t.Run("InPartsConversion", func(t *testing.T) {
@@ -620,8 +547,7 @@ func TestAMMExtended_CurrencyConversion(t *testing.T) {
 
 		// Carol consumes half
 		crossTx1 := offerbuild.OfferCreate(env.Carol, amm.IOUAmount(env.GW, "USD", 500), amm.XRPAmount(500)).Build()
-		result := env.Submit(crossTx1)
-		t.Logf("First half: success=%v code=%s", result.Success, result.Code)
+		jtx.RequireTxSuccess(t, env.Submit(crossTx1))
 	})
 }
 
@@ -644,16 +570,12 @@ func TestAMMExtended_OfferWithTransferRate(t *testing.T) {
 
 		// Create AMM (creator is charged transfer fee on IOU)
 		createTx := amm.AMMCreate(env.Alice, amm.XRPAmount(10000), amm.IOUAmount(env.GW, "USD", 10000)).Build()
-		result := env.Submit(createTx)
-		if !result.Success {
-			t.Skipf("AMM create with transfer rate failed: %s", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(createTx))
 		env.Close()
 
 		// Bob creates offer
 		offerTx := offerbuild.OfferCreate(env.Bob, amm.XRPAmount(100), amm.IOUAmount(env.GW, "USD", 100)).Build()
-		result = env.Submit(offerTx)
-		t.Logf("Offer with transfer rate: success=%v code=%s", result.Success, result.Code)
+		jtx.RequireTxSuccess(t, env.Submit(offerTx))
 	})
 }
 
@@ -683,12 +605,7 @@ func TestAMMExtended_FillModes(t *testing.T) {
 		// Carol creates a FillOrKill offer that should fully fill
 		fokTx := offerbuild.OfferCreate(env.Carol, amm.IOUAmount(env.GW, "USD", 100), amm.XRPAmount(100)).
 			FillOrKill().Build()
-		result := env.Submit(fokTx)
-		if result.Success {
-			t.Log("PASS: FillOrKill offer fully filled")
-		} else {
-			t.Logf("FillOrKill result: %s", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(fokTx))
 	})
 
 	t.Run("FillOrKill_Killed", func(t *testing.T) {
@@ -704,12 +621,7 @@ func TestAMMExtended_FillModes(t *testing.T) {
 		// Carol creates FillOrKill for more than available - should be killed
 		fokTx := offerbuild.OfferCreate(env.Carol, amm.IOUAmount(env.GW, "USD", 10000), amm.XRPAmount(10000)).
 			FillOrKill().Build()
-		result := env.Submit(fokTx)
-		if !result.Success {
-			t.Logf("PASS: FillOrKill killed when insufficient liquidity (got %s)", result.Code)
-		} else {
-			t.Log("Note: FillOrKill succeeded (may have partial fill semantics)")
-		}
+		jtx.RequireTxClaimed(t, env.Submit(fokTx), jtx.TecKILLED)
 	})
 }
 
@@ -734,12 +646,7 @@ func TestAMMExtended_PayStrand(t *testing.T) {
 		payTx := payment.PayIssued(env.Bob, env.Carol, amm.IOUAmount(env.GW, "USD", 100)).
 			SendMax(amm.XRPAmount(200)).
 			Build()
-		result := env.Submit(payTx)
-		if result.Success {
-			t.Log("PASS: cross-currency XRP→USD payment through AMM")
-		} else {
-			t.Logf("Note: cross-currency via AMM got %s", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(payTx))
 	})
 
 	t.Run("CrossCurrencyEndWithXRP", func(t *testing.T) {
@@ -762,12 +669,7 @@ func TestAMMExtended_PayStrand(t *testing.T) {
 		payTx := payment.Pay(env.Bob, env.Carol, uint64(jtx.XRP(100))).
 			SendMax(amm.IOUAmount(env.GW, "USD", 200)).
 			Build()
-		result := env.Submit(payTx)
-		if result.Success {
-			t.Log("PASS: cross-currency USD→XRP payment through AMM")
-		} else {
-			t.Logf("Note: cross-currency via AMM got %s", result.Code)
-		}
+		jtx.RequireTxSuccess(t, env.Submit(payTx))
 	})
 }
 
@@ -861,11 +763,6 @@ func TestAMMExtended_RmFundedOffer(t *testing.T) {
 
 	// Carol's first BTC→XRP offer should still exist (funded but unused)
 	carolOffers := env.AccountOffers(env.Carol)
-	t.Logf("Carol has %d offers remaining:", len(carolOffers))
-	for i, o := range carolOffers {
-		t.Logf("  Offer %d: TakerPays=%s(%s) TakerGets=%s(%s)",
-			i, o.TakerPays.Currency, o.TakerPays.Value(), o.TakerGets.Currency, o.TakerGets.Value())
-	}
 	foundOffer := false
 	for _, o := range carolOffers {
 		// XRP amounts have empty currency; BTC is IOU

--- a/internal/testing/amm/amm_lptoken_reconcile_deletion_test.go
+++ b/internal/testing/amm/amm_lptoken_reconcile_deletion_test.go
@@ -94,7 +94,6 @@ func TestAMMWithdraw_LastLPDeletionRecordsReconciledLPTokenBalance(t *testing.T)
 	gwLPT := env.IOUBalance(env.GW, ammAcc, lptRef.Currency)
 	reconciled := gwLPT.Value()
 
-	t.Logf("gw trustline (reconciled)=%s  stored (stale)=%s", reconciled, stale)
 	if reconciled == stale {
 		t.Fatalf("VACUOUS: gw trustline (%s) == stored LPTokenBalance (%s); the reconcile is a no-op so this test cannot distinguish the fix", reconciled, stale)
 	}

--- a/internal/testing/amm/amm_vote_test.go
+++ b/internal/testing/amm/amm_vote_test.go
@@ -129,7 +129,6 @@ func TestFeeVote(t *testing.T) {
 		}
 		env.Close()
 
-		t.Log("Single vote to set fee to 1% passed")
 	})
 
 	// Vote with zero fee
@@ -144,7 +143,6 @@ func TestFeeVote(t *testing.T) {
 		}
 		env.Close()
 
-		t.Log("Vote for zero fee passed")
 	})
 
 	// Multiple LPs voting
@@ -211,7 +209,6 @@ func TestFeeVote(t *testing.T) {
 		}
 		env.Close()
 
-		t.Log("Change vote passed")
 	})
 
 	// Vote after deposit
@@ -238,7 +235,6 @@ func TestFeeVote(t *testing.T) {
 		}
 		env.Close()
 
-		t.Log("Vote after deposit passed")
 	})
 
 	// Vote at maximum fee (1000 basis points = 1%)
@@ -253,7 +249,6 @@ func TestFeeVote(t *testing.T) {
 		}
 		env.Close()
 
-		t.Log("Maximum fee vote passed")
 	})
 }
 

--- a/internal/testing/amm/amm_vote_test.go
+++ b/internal/testing/amm/amm_vote_test.go
@@ -128,7 +128,6 @@ func TestFeeVote(t *testing.T) {
 			t.Fatalf("Vote should succeed: %s - %s", result.Code, result.Message)
 		}
 		env.Close()
-
 	})
 
 	// Vote with zero fee
@@ -142,7 +141,6 @@ func TestFeeVote(t *testing.T) {
 			t.Fatalf("Vote for zero fee should succeed: %s - %s", result.Code, result.Message)
 		}
 		env.Close()
-
 	})
 
 	// Multiple LPs voting
@@ -208,7 +206,6 @@ func TestFeeVote(t *testing.T) {
 			t.Fatalf("Vote change should succeed: %s", result.Code)
 		}
 		env.Close()
-
 	})
 
 	// Vote after deposit
@@ -234,7 +231,6 @@ func TestFeeVote(t *testing.T) {
 			t.Fatalf("Carol vote should succeed: %s", result.Code)
 		}
 		env.Close()
-
 	})
 
 	// Vote at maximum fee (1000 basis points = 1%)
@@ -248,7 +244,6 @@ func TestFeeVote(t *testing.T) {
 			t.Fatalf("Vote for maximum fee should succeed: %s - %s", result.Code, result.Message)
 		}
 		env.Close()
-
 	})
 }
 

--- a/internal/testing/amm/amm_withdraw_test.go
+++ b/internal/testing/amm/amm_withdraw_test.go
@@ -461,7 +461,6 @@ func TestWithdraw(t *testing.T) {
 		if finalBalance <= initialBalance {
 			t.Fatal("XRP balance should have increased after withdrawal")
 		}
-
 	})
 
 	// Equal withdrawal with limit
@@ -480,7 +479,6 @@ func TestWithdraw(t *testing.T) {
 			t.Fatalf("Equal withdrawal with limit should succeed: %s - %s", result.Code, result.Message)
 		}
 		env.Close()
-
 	})
 
 	// Single withdrawal by amount - XRP
@@ -505,7 +503,6 @@ func TestWithdraw(t *testing.T) {
 		if finalBalance <= initialBalance {
 			t.Fatal("XRP balance should have increased after withdrawal")
 		}
-
 	})
 
 	// Single withdrawal by tokens
@@ -524,7 +521,6 @@ func TestWithdraw(t *testing.T) {
 			t.Fatalf("Single withdrawal by tokens should succeed: %s - %s", result.Code, result.Message)
 		}
 		env.Close()
-
 	})
 
 	// Withdraw all tokens - deletes AMM
@@ -572,7 +568,6 @@ func TestWithdraw(t *testing.T) {
 			t.Fatalf("Withdraw all in USD should succeed: %s - %s", result.Code, result.Message)
 		}
 		env.Close()
-
 	})
 
 	// Single deposit then withdraw all in XRP
@@ -602,7 +597,6 @@ func TestWithdraw(t *testing.T) {
 			t.Fatalf("Withdraw all in XRP should succeed: %s - %s", result.Code, result.Message)
 		}
 		env.Close()
-
 	})
 
 	// Equal deposit 10%, withdraw all tokens
@@ -631,7 +625,6 @@ func TestWithdraw(t *testing.T) {
 			t.Fatalf("Withdraw all should succeed: %s - %s", result.Code, result.Message)
 		}
 		env.Close()
-
 	})
 }
 

--- a/internal/testing/amm/amm_withdraw_test.go
+++ b/internal/testing/amm/amm_withdraw_test.go
@@ -462,7 +462,6 @@ func TestWithdraw(t *testing.T) {
 			t.Fatal("XRP balance should have increased after withdrawal")
 		}
 
-		t.Log("Equal withdrawal by tokens passed")
 	})
 
 	// Equal withdrawal with limit
@@ -482,7 +481,6 @@ func TestWithdraw(t *testing.T) {
 		}
 		env.Close()
 
-		t.Log("Equal withdrawal with limit passed")
 	})
 
 	// Single withdrawal by amount - XRP
@@ -508,7 +506,6 @@ func TestWithdraw(t *testing.T) {
 			t.Fatal("XRP balance should have increased after withdrawal")
 		}
 
-		t.Log("Single XRP withdrawal passed")
 	})
 
 	// Single withdrawal by tokens
@@ -528,7 +525,6 @@ func TestWithdraw(t *testing.T) {
 		}
 		env.Close()
 
-		t.Log("Single withdrawal by tokens passed")
 	})
 
 	// Withdraw all tokens - deletes AMM
@@ -577,7 +573,6 @@ func TestWithdraw(t *testing.T) {
 		}
 		env.Close()
 
-		t.Log("Deposit then withdraw all in USD passed")
 	})
 
 	// Single deposit then withdraw all in XRP
@@ -608,7 +603,6 @@ func TestWithdraw(t *testing.T) {
 		}
 		env.Close()
 
-		t.Log("Deposit then withdraw all in XRP passed")
 	})
 
 	// Equal deposit 10%, withdraw all tokens
@@ -638,7 +632,6 @@ func TestWithdraw(t *testing.T) {
 		}
 		env.Close()
 
-		t.Log("Equal deposit then withdraw all passed")
 	})
 }
 

--- a/internal/testing/amm/builder.go
+++ b/internal/testing/amm/builder.go
@@ -19,12 +19,15 @@ type AMMCreateBuilder struct {
 }
 
 // AMMCreate creates a new AMMCreateBuilder.
+// AMMCreate charges one owner reserve increment, which is 50 XRP under the
+// default test ledger settings.
 func AMMCreate(account *jtx.Account, amount1, amount2 tx.Amount) *AMMCreateBuilder {
 	return &AMMCreateBuilder{
 		account:    account,
 		amount1:    amount1,
 		amount2:    amount2,
 		tradingFee: 0,
+		fee:        "50000000",
 	}
 }
 

--- a/internal/testing/amm/builder.go
+++ b/internal/testing/amm/builder.go
@@ -19,15 +19,12 @@ type AMMCreateBuilder struct {
 }
 
 // AMMCreate creates a new AMMCreateBuilder.
-// The default fee matches rippled's AMMCreate::calculateBaseFee — one owner
-// reserve increment (50,000,000 drops).
 func AMMCreate(account *jtx.Account, amount1, amount2 tx.Amount) *AMMCreateBuilder {
 	return &AMMCreateBuilder{
 		account:    account,
 		amount1:    amount1,
 		amount2:    amount2,
 		tradingFee: 0,
-		fee:        "50000000",
 	}
 }
 
@@ -69,7 +66,6 @@ type AMMDepositBuilder struct {
 	lpTokenOut *tx.Amount
 	ePrice     *tx.Amount
 	tradingFee *uint16
-	fee        string
 	flags      uint32
 }
 
@@ -79,7 +75,6 @@ func AMMDeposit(account *jtx.Account, asset, asset2 tx.Asset) *AMMDepositBuilder
 		account: account,
 		asset:   asset,
 		asset2:  asset2,
-		fee:     "10",
 	}
 }
 
@@ -111,12 +106,6 @@ func (b *AMMDepositBuilder) EPrice(amt tx.Amount) *AMMDepositBuilder {
 // a pointer) matters: every other deposit mode rejects a present sfTradingFee.
 func (b *AMMDepositBuilder) TradingFee(fee uint16) *AMMDepositBuilder {
 	b.tradingFee = &fee
-	return b
-}
-
-// Fee sets the transaction fee.
-func (b *AMMDepositBuilder) Fee(fee string) *AMMDepositBuilder {
-	b.fee = fee
 	return b
 }
 
@@ -165,7 +154,6 @@ func (b *AMMDepositBuilder) TwoAssetIfEmpty() *AMMDepositBuilder {
 // Build creates the AMMDeposit transaction.
 func (b *AMMDepositBuilder) Build() *amm.AMMDeposit {
 	ammTx := amm.NewAMMDeposit(b.account.Address, b.asset, b.asset2)
-	ammTx.Fee = b.fee
 	ammTx.Amount = b.amount
 	ammTx.Amount2 = b.amount2
 	ammTx.LPTokenOut = b.lpTokenOut
@@ -186,7 +174,6 @@ type AMMWithdrawBuilder struct {
 	amount2   *tx.Amount
 	lpTokenIn *tx.Amount
 	ePrice    *tx.Amount
-	fee       string
 	flags     uint32
 }
 
@@ -196,7 +183,6 @@ func AMMWithdraw(account *jtx.Account, asset, asset2 tx.Asset) *AMMWithdrawBuild
 		account: account,
 		asset:   asset,
 		asset2:  asset2,
-		fee:     "10",
 	}
 }
 
@@ -221,12 +207,6 @@ func (b *AMMWithdrawBuilder) LPTokenIn(amt tx.Amount) *AMMWithdrawBuilder {
 // EPrice sets the effective price limit.
 func (b *AMMWithdrawBuilder) EPrice(amt tx.Amount) *AMMWithdrawBuilder {
 	b.ePrice = &amt
-	return b
-}
-
-// Fee sets the transaction fee.
-func (b *AMMWithdrawBuilder) Fee(fee string) *AMMWithdrawBuilder {
-	b.fee = fee
 	return b
 }
 
@@ -281,7 +261,6 @@ func (b *AMMWithdrawBuilder) LimitLPToken() *AMMWithdrawBuilder {
 // Build creates the AMMWithdraw transaction.
 func (b *AMMWithdrawBuilder) Build() *amm.AMMWithdraw {
 	ammTx := amm.NewAMMWithdraw(b.account.Address, b.asset, b.asset2)
-	ammTx.Fee = b.fee
 	ammTx.Amount = b.amount
 	ammTx.Amount2 = b.amount2
 	ammTx.LPTokenIn = b.lpTokenIn
@@ -298,7 +277,6 @@ type AMMVoteBuilder struct {
 	asset      tx.Asset
 	asset2     tx.Asset
 	tradingFee uint16
-	fee        string
 	flags      uint32
 }
 
@@ -309,14 +287,7 @@ func AMMVote(account *jtx.Account, asset, asset2 tx.Asset, tradingFee uint16) *A
 		asset:      asset,
 		asset2:     asset2,
 		tradingFee: tradingFee,
-		fee:        "10",
 	}
-}
-
-// Fee sets the transaction fee.
-func (b *AMMVoteBuilder) Fee(fee string) *AMMVoteBuilder {
-	b.fee = fee
-	return b
 }
 
 // Flags sets the transaction flags.
@@ -328,7 +299,6 @@ func (b *AMMVoteBuilder) Flags(flags uint32) *AMMVoteBuilder {
 // Build creates the AMMVote transaction.
 func (b *AMMVoteBuilder) Build() *amm.AMMVote {
 	ammTx := amm.NewAMMVote(b.account.Address, b.asset, b.asset2, b.tradingFee)
-	ammTx.Fee = b.fee
 	if b.flags != 0 {
 		ammTx.SetFlags(b.flags)
 	}
@@ -343,7 +313,6 @@ type AMMBidBuilder struct {
 	bidMin       *tx.Amount
 	bidMax       *tx.Amount
 	authAccounts []amm.AuthAccount
-	fee          string
 	flags        uint32
 }
 
@@ -353,7 +322,6 @@ func AMMBid(account *jtx.Account, asset, asset2 tx.Asset) *AMMBidBuilder {
 		account: account,
 		asset:   asset,
 		asset2:  asset2,
-		fee:     "10",
 	}
 }
 
@@ -380,12 +348,6 @@ func (b *AMMBidBuilder) AuthAccounts(accounts ...string) *AMMBidBuilder {
 	return b
 }
 
-// Fee sets the transaction fee.
-func (b *AMMBidBuilder) Fee(fee string) *AMMBidBuilder {
-	b.fee = fee
-	return b
-}
-
 // Flags sets the transaction flags.
 func (b *AMMBidBuilder) Flags(flags uint32) *AMMBidBuilder {
 	b.flags = flags
@@ -395,7 +357,6 @@ func (b *AMMBidBuilder) Flags(flags uint32) *AMMBidBuilder {
 // Build creates the AMMBid transaction.
 func (b *AMMBidBuilder) Build() *amm.AMMBid {
 	ammTx := amm.NewAMMBid(b.account.Address, b.asset, b.asset2)
-	ammTx.Fee = b.fee
 	ammTx.BidMin = b.bidMin
 	ammTx.BidMax = b.bidMax
 	ammTx.AuthAccounts = b.authAccounts
@@ -410,7 +371,6 @@ type AMMDeleteBuilder struct {
 	account *jtx.Account
 	asset   tx.Asset
 	asset2  tx.Asset
-	fee     string
 	flags   uint32
 }
 
@@ -420,14 +380,7 @@ func AMMDelete(account *jtx.Account, asset, asset2 tx.Asset) *AMMDeleteBuilder {
 		account: account,
 		asset:   asset,
 		asset2:  asset2,
-		fee:     "10",
 	}
-}
-
-// Fee sets the transaction fee.
-func (b *AMMDeleteBuilder) Fee(fee string) *AMMDeleteBuilder {
-	b.fee = fee
-	return b
 }
 
 // Flags sets the transaction flags.
@@ -439,7 +392,6 @@ func (b *AMMDeleteBuilder) Flags(flags uint32) *AMMDeleteBuilder {
 // Build creates the AMMDelete transaction.
 func (b *AMMDeleteBuilder) Build() *amm.AMMDelete {
 	ammTx := amm.NewAMMDelete(b.account.Address, b.asset, b.asset2)
-	ammTx.Fee = b.fee
 	if b.flags != 0 {
 		ammTx.SetFlags(b.flags)
 	}
@@ -453,7 +405,6 @@ type AMMClawbackBuilder struct {
 	asset   tx.Asset
 	asset2  tx.Asset
 	amount  *tx.Amount
-	fee     string
 	flags   uint32
 }
 
@@ -464,19 +415,12 @@ func AMMClawback(account *jtx.Account, holder string, asset, asset2 tx.Asset) *A
 		holder:  holder,
 		asset:   asset,
 		asset2:  asset2,
-		fee:     "10",
 	}
 }
 
 // Amount sets the clawback amount.
 func (b *AMMClawbackBuilder) Amount(amt tx.Amount) *AMMClawbackBuilder {
 	b.amount = &amt
-	return b
-}
-
-// Fee sets the transaction fee.
-func (b *AMMClawbackBuilder) Fee(fee string) *AMMClawbackBuilder {
-	b.fee = fee
 	return b
 }
 
@@ -495,7 +439,6 @@ func (b *AMMClawbackBuilder) ClawTwoAssets() *AMMClawbackBuilder {
 // Build creates the AMMClawback transaction.
 func (b *AMMClawbackBuilder) Build() *amm.AMMClawback {
 	ammTx := amm.NewAMMClawback(b.account.Address, b.holder, b.asset, b.asset2)
-	ammTx.Fee = b.fee
 	ammTx.Amount = b.amount
 	if b.flags != 0 {
 		ammTx.SetFlags(b.flags)

--- a/internal/testing/amm/builder.go
+++ b/internal/testing/amm/builder.go
@@ -19,15 +19,13 @@ type AMMCreateBuilder struct {
 }
 
 // AMMCreate creates a new AMMCreateBuilder.
-// AMMCreate charges one owner reserve increment, which is 50 XRP under the
-// default test ledger settings.
+// The test environment fills the current owner reserve increment as its fee.
 func AMMCreate(account *jtx.Account, amount1, amount2 tx.Amount) *AMMCreateBuilder {
 	return &AMMCreateBuilder{
 		account:    account,
 		amount1:    amount1,
 		amount2:    amount2,
 		tradingFee: 0,
-		fee:        "50000000",
 	}
 }
 

--- a/internal/testing/amm/helpers.go
+++ b/internal/testing/amm/helpers.go
@@ -221,11 +221,6 @@ func IOUAmount(issuer *jtx.Account, currency string, amount float64) tx.Amount {
 	return tx.NewIssuedAmountFromFloat64(amount, currency, issuer.Address)
 }
 
-// IOU creates an IOU amount (alias for IOUAmount).
-func IOU(issuer *jtx.Account, currency string, amount float64) tx.Amount {
-	return IOUAmount(issuer, currency, amount)
-}
-
 // LPTokenAmount creates an LP token amount for the given AMM asset pair.
 // It generates the proper LP token currency (starting with 03) and resolves
 // the AMM pseudo-account issuer from env's ledger when the AMM exists.
@@ -496,14 +491,6 @@ func (e *AMMTestEnv) ExpectAMMBalances(t *testing.T, ammAcc *jtx.Account, xrpDro
 	}
 }
 
-// WithAMM sets up an AMM and calls the test callback.
-// This matches rippled's testAMM helper function.
-func WithAMM(t *testing.T, amount1, amount2 tx.Amount, tradingFee uint16, callback TestAMMCallback) {
-	t.Helper()
-	pool := [2]tx.Amount{amount1, amount2}
-	TestAMM(t, &pool, tradingFee, callback)
-}
-
 // WithDefaultAMM sets up an AMM with XRP(10000)/USD(10000) and no trading fee.
 func WithDefaultAMM(t *testing.T, callback TestAMMCallback) {
 	t.Helper()
@@ -723,28 +710,5 @@ func (e *AMMTestEnv) ExpectLPTokens(account *jtx.Account, asset1, asset2 tx.Asse
 	}
 	if diff > tolerance {
 		e.T.Errorf("ExpectLPTokens(%s): got %f, want %f (diff=%f)", account.Name, actual, expected, diff)
-	}
-}
-
-// ExpectLPTokensPrecise checks LP token balance with precise Amount comparison.
-func (e *AMMTestEnv) ExpectLPTokensPrecise(account *jtx.Account, asset1, asset2 tx.Asset, expected tx.Amount) {
-	e.T.Helper()
-
-	ammAcc := e.ReadAMMAccount(asset1, asset2)
-	if ammAcc == nil {
-		e.T.Errorf("ExpectLPTokensPrecise(%s): AMM not found", account.Name)
-		return
-	}
-	lptCurrency := coreAmm.GenerateAMMLPTCurrency(asset1.Currency, asset2.Currency)
-
-	balance := e.TestEnv.IOUBalance(account, ammAcc, lptCurrency)
-	if balance == nil {
-		e.T.Errorf("ExpectLPTokensPrecise(%s): no trust line", account.Name)
-		return
-	}
-
-	if balance.Mantissa() != expected.Mantissa() || balance.Exponent() != expected.Exponent() {
-		e.T.Errorf("ExpectLPTokensPrecise(%s): got %de%d, want %de%d",
-			account.Name, balance.Mantissa(), balance.Exponent(), expected.Mantissa(), expected.Exponent())
 	}
 }

--- a/internal/testing/amm/helpers_test.go
+++ b/internal/testing/amm/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/stretchr/testify/require"
@@ -14,6 +15,15 @@ type stubAMMReader struct {
 	existsErr error
 	data      []byte
 	readErr   error
+}
+
+func TestAMMCreateBuilderFee(t *testing.T) {
+	account := jtx.NewAccount("alice")
+	amount1 := XRPAmount(1)
+	amount2 := XRPAmount(2)
+
+	require.Empty(t, AMMCreate(account, amount1, amount2).Build().Fee)
+	require.Equal(t, "123", AMMCreate(account, amount1, amount2).Fee("123").Build().Fee)
 }
 
 func (r stubAMMReader) Exists(keylet.Keylet) (bool, error) { return r.exists, r.existsErr }

--- a/internal/testing/amm/lp_token_transfer_test.go
+++ b/internal/testing/amm/lp_token_transfer_test.go
@@ -75,59 +75,6 @@ func setupLPTokenEnv(t *testing.T) *amm.AMMTestEnv {
 // TestLPTokenTransfer_DirectStep tests direct payment of LP tokens.
 // Reference: rippled LPTokenTransfer_test.cpp testDirectStep
 func TestLPTokenTransfer_DirectStep(t *testing.T) {
-	t.Run("TransferBetweenLPs", func(t *testing.T) {
-		env := setupLPTokenEnv(t)
-
-		// Bob sends LP tokens to Carol (both are LPs)
-		lpAmt := amm.LPTokenAmount(env, amm.XRP(), env.USD, 100)
-		payTx := payment.PayIssued(env.Bob, env.Carol, lpAmt).Build()
-		result := env.Submit(payTx)
-		if result.Success {
-			t.Log("PASS: LP token direct transfer succeeded")
-		} else {
-			t.Logf("Note: LP token direct transfer got %s (may need LP token payment path support)", result.Code)
-		}
-	})
-
-	t.Run("FrozenUSD_BlocksSender", func(t *testing.T) {
-		// When Carol's USD trust line is frozen, Carol should not be able to
-		// send LP tokens (with fixFrozenLPTokenTransfer).
-		env := setupLPTokenEnv(t)
-
-		// Freeze Carol's USD trust line
-		env.FreezeTrustLine(env.GW, env.Carol, "USD")
-		env.Close()
-
-		// Carol tries to send LP tokens to Bob
-		lpAmt := amm.LPTokenAmount(env, amm.XRP(), env.USD, 100)
-		payTx := payment.PayIssued(env.Carol, env.Bob, lpAmt).Build()
-		result := env.Submit(payTx)
-		if !result.Success {
-			t.Logf("PASS: frozen Carol cannot send LP tokens (got %s)", result.Code)
-		} else {
-			t.Log("Note: frozen Carol can still send LP tokens - fixFrozenLPTokenTransfer may not be active")
-		}
-	})
-
-	t.Run("FrozenUSD_ReceiveAllowed", func(t *testing.T) {
-		// A frozen account should still be able to receive LP tokens.
-		env := setupLPTokenEnv(t)
-
-		// Freeze Carol's USD trust line
-		env.FreezeTrustLine(env.GW, env.Carol, "USD")
-		env.Close()
-
-		// Bob sends LP tokens to frozen Carol - should succeed
-		lpAmt := amm.LPTokenAmount(env, amm.XRP(), env.USD, 100)
-		payTx := payment.PayIssued(env.Bob, env.Carol, lpAmt).Build()
-		result := env.Submit(payTx)
-		if result.Success {
-			t.Log("PASS: frozen Carol can receive LP tokens")
-		} else {
-			t.Logf("Note: frozen Carol cannot receive LP tokens (got %s)", result.Code)
-		}
-	})
-
 	t.Run("CannotTransferToAMMAccount", func(t *testing.T) {
 		env := setupLPTokenEnv(t)
 		ammAcc := amm.AMMAccount(t, env, amm.XRP(), env.USD)
@@ -141,313 +88,6 @@ func TestLPTokenTransfer_DirectStep(t *testing.T) {
 		after := env.IOUBalance(env.Bob, ammAcc, currency)
 		require.NotNil(t, after)
 		require.Equal(t, before.Value(), after.Value())
-	})
-}
-
-// TestLPTokenTransfer_BookStep tests LP token transfers via offer book.
-// Reference: rippled LPTokenTransfer_test.cpp testBookStep
-func TestLPTokenTransfer_BookStep(t *testing.T) {
-	t.Run("FrozenCurrency_BlocksOfferConsumption", func(t *testing.T) {
-		// With fixFrozenLPTokenTransfer, frozen currencies prevent consuming
-		// offers to sell LP tokens.
-		env := setupLPTokenEnv(t)
-
-		// Carol creates an offer selling LP tokens for XRP
-		lpAmt := amm.LPTokenAmount(env, amm.XRP(), env.USD, 500)
-		offerTx := offerbuild.OfferCreate(env.Carol, amm.XRPAmount(500), lpAmt).Build()
-		result := env.Submit(offerTx)
-		if !result.Success {
-			t.Skipf("Carol offer creation failed: %s", result.Code)
-		}
-		env.Close()
-
-		// Freeze Carol's USD trust line
-		env.FreezeTrustLine(env.GW, env.Carol, "USD")
-		env.Close()
-
-		// Bob tries to buy LP tokens via offer crossing
-		buyTx := offerbuild.OfferCreate(env.Bob, lpAmt, amm.XRPAmount(500)).Build()
-		result = env.Submit(buyTx)
-		// With fix: Carol's offer should not be consumed because her USD is frozen
-		// Without fix: offer crossing proceeds normally
-		t.Logf("Frozen offer crossing result: success=%v code=%s", result.Success, result.Code)
-	})
-
-	t.Run("BuyingLPTokens_WorksWhenSellerFrozen", func(t *testing.T) {
-		// Buying LP tokens should work even when seller's currency is frozen
-		// (the buyer is acquiring LP tokens, not the seller sending them).
-		env := setupLPTokenEnv(t)
-
-		// Bob creates an offer to sell LP tokens for XRP
-		lpAmt := amm.LPTokenAmount(env, amm.XRP(), env.USD, 500)
-		offerTx := offerbuild.OfferCreate(env.Bob, amm.XRPAmount(500), lpAmt).Build()
-		result := env.Submit(offerTx)
-		if !result.Success {
-			t.Skipf("Bob offer creation failed: %s", result.Code)
-		}
-		env.Close()
-
-		// Carol tries to buy LP tokens (Carol's USD is NOT frozen)
-		buyTx := offerbuild.OfferCreate(env.Carol, lpAmt, amm.XRPAmount(500)).Build()
-		result = env.Submit(buyTx)
-		t.Logf("Buy LP tokens result: success=%v code=%s", result.Success, result.Code)
-	})
-}
-
-// TestLPTokenTransfer_OfferCreation tests creating offers with LP token backing.
-// Reference: rippled LPTokenTransfer_test.cpp testOfferCreation
-func TestLPTokenTransfer_OfferCreation(t *testing.T) {
-	t.Run("FrozenCurrency_BlocksSellOffer", func(t *testing.T) {
-		// With fixFrozenLPTokenTransfer, cannot create sell offers for LP tokens
-		// when backing currency is frozen.
-		env := setupLPTokenEnv(t)
-
-		// Freeze Carol's USD trust line
-		env.FreezeTrustLine(env.GW, env.Carol, "USD")
-		env.Close()
-
-		// Carol tries to create offer selling LP tokens
-		lpAmt := amm.LPTokenAmount(env, amm.XRP(), env.USD, 500)
-		offerTx := offerbuild.OfferCreate(env.Carol, amm.XRPAmount(500), lpAmt).Build()
-		result := env.Submit(offerTx)
-		if !result.Success {
-			t.Logf("PASS: frozen Carol cannot create sell offer for LP tokens (got %s)", result.Code)
-		} else {
-			t.Log("Note: frozen Carol can create LP sell offer - fixFrozenLPTokenTransfer may not be active")
-		}
-	})
-
-	t.Run("FrozenCurrency_BuyOfferAllowed", func(t *testing.T) {
-		// Buying offers for LP tokens can be created even with frozen backing currency.
-		env := setupLPTokenEnv(t)
-
-		// Freeze Carol's USD trust line
-		env.FreezeTrustLine(env.GW, env.Carol, "USD")
-		env.Close()
-
-		// Carol tries to create offer buying LP tokens (pays XRP, gets LP tokens)
-		lpAmt := amm.LPTokenAmount(env, amm.XRP(), env.USD, 500)
-		offerTx := offerbuild.OfferCreate(env.Carol, lpAmt, amm.XRPAmount(500)).Build()
-		result := env.Submit(offerTx)
-		t.Logf("Frozen Carol buy LP offer: success=%v code=%s", result.Success, result.Code)
-	})
-}
-
-// TestLPTokenTransfer_OfferCrossing tests offer crossing with two LP tokens.
-// Reference: rippled LPTokenTransfer_test.cpp testOfferCrossing
-func TestLPTokenTransfer_OfferCrossing(t *testing.T) {
-	t.Run("CrossingBlockedWhenFrozen", func(t *testing.T) {
-		// With fixFrozenLPTokenTransfer, offers don't cross when LP token's
-		// underlying currency is frozen.
-		env := setupLPTokenEnv(t)
-
-		lpAmt := amm.LPTokenAmount(env, amm.XRP(), env.USD, 200)
-
-		// Bob creates an offer selling LP tokens for XRP
-		sellTx := offerbuild.OfferCreate(env.Bob, amm.XRPAmount(200), lpAmt).Build()
-		result := env.Submit(sellTx)
-		if !result.Success {
-			t.Skipf("Bob sell offer failed: %s", result.Code)
-		}
-		env.Close()
-
-		// Freeze Bob's USD trust line
-		env.FreezeTrustLine(env.GW, env.Bob, "USD")
-		env.Close()
-
-		// Carol creates a crossing offer to buy LP tokens
-		buyTx := offerbuild.OfferCreate(env.Carol, lpAmt, amm.XRPAmount(200)).Build()
-		result = env.Submit(buyTx)
-		// With fix: Bob's offer should NOT be consumed
-		// Without fix: crossing proceeds
-		t.Logf("Crossing with frozen LP result: success=%v code=%s", result.Success, result.Code)
-	})
-}
-
-// TestLPTokenTransfer_GlobalFreeze tests LP token behavior under global freeze.
-// Reference: rippled LPTokenTransfer_test.cpp (global freeze variant)
-func TestLPTokenTransfer_GlobalFreeze(t *testing.T) {
-	t.Run("GlobalFreezeBlocksLPTransfer", func(t *testing.T) {
-		env := setupLPTokenEnv(t)
-
-		// Enable global freeze on gateway
-		env.EnableGlobalFreeze(env.GW)
-		env.Close()
-
-		// Bob tries to send LP tokens to Carol
-		lpAmt := amm.LPTokenAmount(env, amm.XRP(), env.USD, 100)
-		payTx := payment.PayIssued(env.Bob, env.Carol, lpAmt).Build()
-		result := env.Submit(payTx)
-		if !result.Success {
-			t.Logf("PASS: global freeze blocks LP token transfer (got %s)", result.Code)
-		} else {
-			t.Log("Note: LP token transfer succeeded despite global freeze")
-		}
-	})
-
-	t.Run("GlobalFreezeBlocksWithdrawal", func(t *testing.T) {
-		env := setupLPTokenEnv(t)
-
-		// Enable global freeze on gateway
-		env.EnableGlobalFreeze(env.GW)
-		env.Close()
-
-		// Carol tries to withdraw from AMM
-		withdrawTx := amm.AMMWithdraw(env.Carol, amm.XRP(), env.USD).
-			Amount(amm.IOUAmount(env.GW, "USD", 100)).
-			SingleAsset().
-			Build()
-		result := env.Submit(withdrawTx)
-		if !result.Success {
-			t.Logf("PASS: global freeze blocks AMM withdrawal (got %s)", result.Code)
-		} else {
-			t.Log("Note: AMM withdrawal succeeded despite global freeze")
-		}
-	})
-}
-
-// TestLPTokenTransfer_MultipleLPs tests LP token balance tracking with multiple providers.
-// Reference: rippled AMM_test.cpp testLPTokenBalance (multiple liquidity providers)
-func TestLPTokenTransfer_MultipleLPs(t *testing.T) {
-	t.Run("XRP_IOU_MultipleLPs", func(t *testing.T) {
-		// More than one Liquidity Provider - XRP/IOU
-		env := amm.NewAMMTestEnv(t)
-		env.FundWithIOUs(30000, 0)
-		env.Close()
-
-		// Alice creates AMM
-		createTx := amm.AMMCreate(env.Alice, amm.XRPAmount(10), amm.IOUAmount(env.GW, "USD", 10)).Build()
-		result := env.Submit(createTx)
-		if !result.Success {
-			t.Fatalf("AMM create failed: %s", result.Code)
-		}
-		env.Close()
-
-		// Carol deposits using LPToken mode
-		depositTx := amm.AMMDeposit(env.Carol, amm.XRP(), env.USD).
-			LPTokenOut(amm.LPTokenAmount(env, amm.XRP(), env.USD, 1000)).
-			LPToken().
-			Build()
-		result = env.Submit(depositTx)
-		if !result.Success {
-			t.Skipf("Carol deposit failed: %s", result.Code)
-		}
-		env.Close()
-
-		// Both should have LP tokens but neither is the only provider
-		t.Log("PASS: multiple LPs with XRP/IOU AMM")
-	})
-
-	t.Run("IOU_IOU_MultipleLPs", func(t *testing.T) {
-		// More than one Liquidity Provider - IOU/IOU
-		env := amm.NewAMMTestEnv(t)
-		env.FundWithIOUs(30000, 0)
-
-		// Set up EUR
-		env.Trust(env.Alice, env.GW, "EUR", 100000)
-		env.Trust(env.Carol, env.GW, "EUR", 100000)
-		env.Close()
-		env.PayIOU(env.GW, env.Alice, "EUR", 20000)
-		env.PayIOU(env.GW, env.Carol, "EUR", 20000)
-		env.Close()
-
-		// Alice creates IOU/IOU AMM
-		createTx := amm.AMMCreate(env.Alice, amm.IOUAmount(env.GW, "EUR", 10), amm.IOUAmount(env.GW, "USD", 10)).Build()
-		result := env.Submit(createTx)
-		if !result.Success {
-			t.Fatalf("IOU/IOU AMM create failed: %s", result.Code)
-		}
-		env.Close()
-
-		// Carol deposits using LPToken mode
-		depositTx := amm.AMMDeposit(env.Carol, env.EUR, env.USD).
-			LPTokenOut(amm.LPTokenAmount(env, env.EUR, env.USD, 100)).
-			LPToken().
-			Build()
-		result = env.Submit(depositTx)
-		if !result.Success {
-			t.Skipf("Carol deposit failed: %s", result.Code)
-		}
-		env.Close()
-
-		t.Log("PASS: multiple LPs with IOU/IOU AMM")
-	})
-}
-
-// TestLPTokenTransfer_WithdrawAllAsLastLP tests behavior when last LP withdraws all tokens.
-// Reference: rippled AMM_test.cpp testLPTokenBalance (last liquidity provider scenarios)
-func TestLPTokenTransfer_WithdrawAllAsLastLP(t *testing.T) {
-	t.Run("LastLPWithdrawsAll", func(t *testing.T) {
-		env := amm.NewAMMTestEnv(t)
-		env.FundWithIOUs(30000, 0)
-		env.Close()
-
-		// Alice creates AMM
-		createTx := amm.AMMCreate(env.Alice, amm.XRPAmount(10000), amm.IOUAmount(env.GW, "USD", 10000)).Build()
-		result := env.Submit(createTx)
-		if !result.Success {
-			t.Fatalf("AMM create failed: %s", result.Code)
-		}
-		env.Close()
-
-		// Alice withdraws all (she's the only LP)
-		withdrawTx := amm.AMMWithdraw(env.Alice, amm.XRP(), env.USD).
-			WithdrawAll().
-			Build()
-		result = env.Submit(withdrawTx)
-		if result.Success {
-			t.Log("PASS: last LP can withdraw all, AMM should be deleted")
-		} else {
-			t.Logf("Note: last LP withdraw all got %s", result.Code)
-		}
-	})
-
-	t.Run("TwoLPsWithdrawSequentially", func(t *testing.T) {
-		env := amm.NewAMMTestEnv(t)
-		env.FundWithIOUs(30000, 0)
-		env.Close()
-
-		// Alice creates AMM
-		createTx := amm.AMMCreate(env.Alice, amm.XRPAmount(1000), amm.IOUAmount(env.GW, "USD", 1000)).Build()
-		result := env.Submit(createTx)
-		if !result.Success {
-			t.Fatalf("AMM create failed: %s", result.Code)
-		}
-		env.Close()
-
-		// Carol deposits using LPToken mode
-		depositTx := amm.AMMDeposit(env.Carol, amm.XRP(), env.USD).
-			LPTokenOut(amm.LPTokenAmount(env, amm.XRP(), env.USD, 100000)).
-			LPToken().
-			Build()
-		result = env.Submit(depositTx)
-		if !result.Success {
-			t.Skipf("Carol deposit failed: %s", result.Code)
-		}
-		env.Close()
-
-		// Carol withdraws all her LP tokens
-		withdrawTx1 := amm.AMMWithdraw(env.Carol, amm.XRP(), env.USD).
-			WithdrawAll().
-			Build()
-		result = env.Submit(withdrawTx1)
-		if !result.Success {
-			t.Logf("Note: Carol withdraw all got %s", result.Code)
-		}
-		env.Close()
-
-		// Alice withdraws all (now she's the last LP)
-		withdrawTx2 := amm.AMMWithdraw(env.Alice, amm.XRP(), env.USD).
-			WithdrawAll().
-			Build()
-		result = env.Submit(withdrawTx2)
-		if result.Success {
-			t.Log("PASS: sequential LP withdrawals succeeded")
-		} else {
-			// With fixAMMv1_1: this should succeed
-			// Without fixAMMv1_1: may get tecAMM_BALANCE
-			t.Logf("Note: last LP withdraw got %s (may depend on fixAMMv1_1)", result.Code)
-		}
 	})
 }
 
@@ -474,7 +114,6 @@ func TestAMMTokens_LPTokenXRPOfferCrossing(t *testing.T) {
 			lpTotal := amm.LPTokenAmount(env, xrpAsset, usdAsset, 10_000_000)
 			lpHalf := amm.LPTokenAmount(env, xrpAsset, usdAsset, 5_000_000)
 			priceXRP := amm.AMMAssetOut(xrpBalance, lpTotal, lpHalf, 0)
-			t.Logf("priceXRP for 5M LP tokens: %s", priceXRP.Value())
 
 			// Carol places an order to buy LPTokens: she pays priceXRP, receives 5M LP tokens
 			carolOfferTx := offerbuild.OfferCreate(env.Carol, lpHalf, priceXRP).Build()
@@ -550,18 +189,11 @@ func TestAMMTokens_LPTokenXRPOfferCrossing(t *testing.T) {
 			// Expected: ~7,499,950,000 XRP drops returned
 			// Carol XRP ≈ 22.5B - 50 + 7,499,950,000 - 10 = 29,999,949,940
 			// Rippled expects 29,999,949,999 - 5*baseFee (with different setup fees)
-			// Allow ±2 drops tolerance for rounding differences
-			actualCarolXRP2 := env.TestEnv.Balance(env.Carol)
 			// expectedCarolXRP2 is setup-adjusted: 30B - 7.5B + ammAssetOut - 6*baseFee
 			// We compute the expected using ammAssetOut:
 			lpAfterBid := amm.LPTokenAmount(env, xrpAsset, usdAsset, 9_999_900)
 			carolLPAfterBid := amm.LPTokenAmount(env, xrpAsset, usdAsset, 4_999_900)
 			priceXRP2 := amm.AMMAssetOut(xrpBalance, lpAfterBid, carolLPAfterBid, 0)
-			t.Logf("priceXRP2 (carol withdraw): %s", priceXRP2.Value())
-
-			// Carol XRP = beforeWithdraw + priceXRP2 - withdrawFee
-			beforeWithdraw := actualCarolXRP2 // already charged, just check it's reasonable
-			_ = beforeWithdraw
 
 			// Pool should have only alice's LP tokens remaining
 			env.ExpectLPTokens(env.Alice, xrpAsset, usdAsset, 5_000_000)
@@ -715,25 +347,26 @@ func TestAMMTokens_DirectLPTokenPayment(t *testing.T) {
 		LPTokenOut(amm.LPTokenAmount(env, amm.XRP(), env.USD, 1000000)).
 		LPToken().
 		Build()
-	result = env.Submit(depositTx)
-	if !result.Success {
-		t.Skipf("Carol LP deposit failed: %s - LP token direct payment test needs working LP deposit", result.Code)
-	}
+	jtx.RequireTxSuccess(t, env.Submit(depositTx))
 	env.Close()
 
 	// Alice pays Carol 100 LP tokens.
 	// Pool balance should not change, only LP token balances shift.
 	payAmt := env.LPTokenAmountFromLedger(amm.XRP(), env.USD, 100)
 	payTx := payment.PayIssued(env.Alice, env.Carol, payAmt).Build()
-	result = env.Submit(payTx)
-	if !result.Success {
-		t.Fatalf("Alice -> Carol LP token payment failed: %s - %s", result.Code, result.Message)
-	}
+	jtx.RequireTxSuccess(t, env.Submit(payTx))
 	env.Close()
 
 	// Expected: Alice LP = 10,000,000 - 100 = 9,999,900
 	//           Carol LP = 1,000,000 + 100 = 1,000,100
-	t.Log("Alice -> Carol LP token payment succeeded")
+	ammAcc := amm.AMMAccount(t, env, amm.XRP(), env.USD)
+	lpCurrency := coreAmm.GenerateAMMLPTCurrencyForAssets(amm.XRP(), env.USD)
+	aliceLP, found := env.LookupIOUBalance(env.Alice, ammAcc, lpCurrency)
+	require.True(t, found)
+	carolLP, found := env.LookupIOUBalance(env.Carol, ammAcc, lpCurrency)
+	require.True(t, found)
+	require.Equal(t, "9999900", aliceLP.Value())
+	require.Equal(t, "1000100", carolLP.Value())
 
 	// Alice sets trust line for LP tokens (limit 20,000,000) to receive back.
 	// Alice's auto-created trust line from AMMCreate also has limit 0.
@@ -746,21 +379,16 @@ func TestAMMTokens_DirectLPTokenPayment(t *testing.T) {
 
 	// Carol pays Alice 100 LP tokens back.
 	payTx2 := payment.PayIssued(env.Carol, env.Alice, payAmt).Build()
-	result = env.Submit(payTx2)
-	if !result.Success {
-		t.Fatalf("Carol -> Alice LP token payment failed: %s - %s", result.Code, result.Message)
-	}
+	jtx.RequireTxSuccess(t, env.Submit(payTx2))
 	env.Close()
 
 	// Expected: back to original balances
 	//   Alice LP = 10,000,000
 	//   Carol LP = 1,000,000
-	t.Log("Carol -> Alice LP token payment succeeded, balances restored")
+	aliceLP, found = env.LookupIOUBalance(env.Alice, ammAcc, lpCurrency)
+	require.True(t, found)
+	carolLP, found = env.LookupIOUBalance(env.Carol, ammAcc, lpCurrency)
+	require.True(t, found)
+	require.Equal(t, "10000000", aliceLP.Value())
+	require.Equal(t, "1000000", carolLP.Value())
 }
-
-// Suppress unused import warnings
-var (
-	_ = offerbuild.OfferCreate
-	_ = payment.Pay
-	_ = trustset.TrustLine
-)

--- a/internal/testing/env_signing.go
+++ b/internal/testing/env_signing.go
@@ -183,7 +183,8 @@ func (e *TestEnv) autoFill(txn tx.Transaction, options SubmitOptions) {
 	}
 	common := txn.GetCommon()
 	if !options.SkipFee && common.Fee == "" {
-		common.Fee = formatUint64(e.baseFee)
+		config := e.engineConfig(e.ledger, engineConfigOpts{openLedger: e.openLedger})
+		common.Fee = formatUint64(sign.CalculateBaseFee(txn, e.ledger, config))
 	}
 	if !options.SkipSequence && common.Sequence == nil {
 		_, accountID, err := addresscodec.DecodeClassicAddressToAccountID(common.Account)

--- a/internal/testing/testing_test.go
+++ b/internal/testing/testing_test.go
@@ -235,7 +235,7 @@ func TestSubmitAutofill(t *testing.T) {
 	transaction := accounttx.NewAccountDelete(alice.Address, destination.Address)
 	env.autoFill(transaction, SubmitOptions{})
 	common := transaction.GetCommon()
-	require.Equal(t, "10", common.Fee)
+	require.Equal(t, formatUint64(env.ReserveIncrement()), common.Fee)
 	require.NotNil(t, common.Sequence)
 	require.Equal(t, env.Seq(alice), *common.Sequence)
 	require.NotNil(t, common.NetworkID)


### PR DESCRIPTION
## Summary

- Replace weak and duplicate AMM fixtures with exact rippled v3.2.0 transaction and ledger-state checks.
- Correct AMM/CLOB and gateway cross-currency setup, trust limits, feature selection, and expected rounding.
- Use calculated base fees in test autofill and remove obsolete helper APIs and diagnostic-only logging.

## Testing

- `just vet`
- `just lint`
- `just build-all`
- `just test-tx`
- `just test-integration`

Stack layer 5 of 5. Depends on #1642. Fixes #1498.