### PR TITLE
fix: reject vault shares in AMM creation

### DIFF
--- a/internal/testing/amm/amm_vault_share_test.go
+++ b/internal/testing/amm/amm_vault_share_test.go
@@ -1,0 +1,213 @@
+package amm_test
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/accountset"
+	ammtest "github.com/LeJamon/go-xrpl/internal/testing/amm"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	ammtx "github.com/LeJamon/go-xrpl/internal/tx/amm"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/internal/tx/vault"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+const ammCreateFee = uint64(50_000_000)
+
+type vaultShareFixture struct {
+	env        *jtx.TestEnv
+	creator    *jtx.Account
+	shareID    [24]byte
+	share      tx.Amount
+	xrp        tx.Amount
+	shareAsset tx.Asset
+	xrpAsset   tx.Asset
+}
+
+func newVaultShareFixture(t *testing.T, creatorIsIssuer bool) vaultShareFixture {
+	t.Helper()
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("SingleAssetVault")
+	env.EnableFeature("MPTokensV2")
+	env.Close()
+	issuer := jtx.NewAccount("issuer")
+	holder := jtx.NewAccount("holder")
+	creator := holder
+	if creatorIsIssuer {
+		creator = issuer
+	}
+	env.Fund(issuer, holder)
+	jtx.RequireTxSuccess(t, env.Submit(accountset.AccountSet(issuer).DefaultRipple().Build()))
+
+	const currency = "USD"
+	if !creatorIsIssuer {
+		env.Trust(holder, tx.NewIssuedAmountFromFloat64(1_000, currency, issuer.Address))
+		env.PayIOU(issuer, holder, issuer, currency, 500)
+	}
+
+	vaultSequence := env.Seq(creator)
+	create := vault.NewVaultCreate(creator.Address, tx.Asset{Currency: currency, Issuer: issuer.Address})
+	create.Fee = "50000000"
+	jtx.RequireTxSuccess(t, env.Submit(create))
+	vaultKey := keylet.Vault(creator.AccountID(), vaultSequence)
+	vaultID := strings.ToUpper(hex.EncodeToString(vaultKey.Key[:]))
+	jtx.RequireTxSuccess(t, env.Submit(vault.NewVaultDeposit(
+		creator.Address,
+		vaultID,
+		tx.NewIssuedAmountFromFloat64(200, currency, issuer.Address),
+	)))
+
+	info, err := vault.ReadVaultInfo(env.Ledger(), vaultKey)
+	require.NoError(t, err)
+	shareID := info.ShareMPTID
+	shareIDHex := mptutil.EncodeID(shareID)
+	shareIssuer := state.EncodeAccountIDSafe(mptutil.Issuer(shareID))
+	share := state.NewMPTAmountWithIssuanceID(100_000_000, shareIssuer, shareIDHex)
+
+	return vaultShareFixture{
+		env:        env,
+		creator:    creator,
+		shareID:    shareID,
+		share:      share,
+		xrp:        tx.NewXRPAmount(100_000_000),
+		shareAsset: tx.Asset{MPTIssuanceID: shareIDHex},
+		xrpAsset:   tx.Asset{Currency: "XRP"},
+	}
+}
+
+func vaultShareBalance(t *testing.T, fixture vaultShareFixture) uint64 {
+	t.Helper()
+	holding, _, result := mptutil.ReadHolding(fixture.env.Ledger(), fixture.shareID, fixture.creator.ID)
+	require.Equal(t, ter.TesSUCCESS, result)
+	return holding.MPTAmount
+}
+
+func TestAMMCreateRejectsVaultShares(t *testing.T) {
+	tests := []struct {
+		name            string
+		creatorIsIssuer bool
+		shareFirst      bool
+	}{
+		{name: "holder_amount", shareFirst: true},
+		{name: "holder_amount2"},
+		{name: "underlying_issuer_amount", creatorIsIssuer: true, shareFirst: true},
+		{name: "underlying_issuer_amount2", creatorIsIssuer: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newVaultShareFixture(t, test.creatorIsIssuer)
+			amount, amount2 := fixture.xrp, fixture.share
+			if test.shareFirst {
+				amount, amount2 = fixture.share, fixture.xrp
+			}
+
+			balanceBefore := fixture.env.Balance(fixture.creator)
+			sequenceBefore := fixture.env.Seq(fixture.creator)
+			sharesBefore := vaultShareBalance(t, fixture)
+			result := fixture.env.Submit(ammtest.AMMCreate(fixture.creator, amount, amount2).Build())
+
+			jtx.RequireTxFail(t, result, "tecWRONG_ASSET")
+			require.True(t, result.Applied)
+			require.Equal(t, ammCreateFee, result.Fee)
+			require.NotNil(t, result.Metadata)
+			require.Equal(t, sequenceBefore+1, fixture.env.Seq(fixture.creator))
+			require.Equal(t, balanceBefore-ammCreateFee, fixture.env.Balance(fixture.creator))
+			require.Equal(t, sharesBefore, vaultShareBalance(t, fixture))
+			require.False(t, fixture.env.LedgerEntryExists(
+				ammtx.ComputeAMMKeylet(fixture.shareAsset, fixture.xrpAsset),
+			))
+		})
+	}
+}
+
+func TestAMMCreateRejectsNestedVaultShareAmounts(t *testing.T) {
+	fixture := newVaultShareFixture(t, false)
+	tests := []struct {
+		name       string
+		shareFirst bool
+	}{
+		{name: "Amount", shareFirst: true},
+		{name: "Amount2"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			amount, amount2 := fixture.xrp, fixture.share
+			if test.shareFirst {
+				amount, amount2 = fixture.share, fixture.xrp
+			}
+			create := ammtest.AMMCreate(fixture.creator, amount, amount2).Build()
+			create.SetSequence(fixture.env.Seq(fixture.creator))
+			blob, err := tx.SerializeTransaction(create)
+			require.NoError(t, err)
+			parsedTx, err := tx.ParseFromBinary(blob)
+			require.NoError(t, err)
+			parsed, ok := parsedTx.(*ammtx.AMMCreate)
+			require.True(t, ok)
+			if test.shareFirst {
+				require.Equal(t, fixture.share.MPTIssuanceID(), parsed.Amount.MPTIssuanceID())
+			} else {
+				require.Equal(t, fixture.share.MPTIssuanceID(), parsed.Amount2.MPTIssuanceID())
+			}
+
+			result := parsed.Preclaim(fixture.env.Ledger(), tx.EngineConfig{
+				ReserveBase:      10_000_000,
+				ReserveIncrement: ammCreateFee,
+				Rules:            amendment.AllSupportedRules(),
+			})
+			require.Equal(t, ter.TecWRONG_ASSET, result)
+		})
+	}
+}
+
+func TestAMMCreateVaultShareGateOffPreservesLegacyBehavior(t *testing.T) {
+	fixture := newVaultShareFixture(t, false)
+	rules := amendment.NewRulesBuilder().
+		FromPreset(amendment.PresetAllSupported).
+		Disable(amendment.FeatureSingleAssetVault).
+		Build()
+	create := ammtest.AMMCreate(fixture.creator, fixture.xrp, fixture.share).Build()
+	result := create.Preclaim(fixture.env.Ledger(), tx.EngineConfig{
+		ReserveBase:      10_000_000,
+		ReserveIncrement: ammCreateFee,
+		Rules:            rules,
+	})
+
+	require.Equal(t, ter.TesSUCCESS, result)
+}
+
+func TestAMMCreateVaultShareAddressCollisionPrecedesAssetCheck(t *testing.T) {
+	fixture := newVaultShareFixture(t, false)
+	ammKey := ammtx.ComputeAMMKeylet(fixture.shareAsset, fixture.xrpAsset)
+	parentHash := fixture.env.Ledger().ParentHash()
+	for range 256 {
+		accountID := ammtx.PseudoAccountAddress(fixture.env.Ledger(), parentHash, ammKey.Key)
+		require.NotZero(t, accountID)
+		account := &state.AccountRoot{
+			Account:  state.EncodeAccountIDSafe(accountID),
+			Balance:  1,
+			Sequence: 1,
+		}
+		data, err := state.SerializeAccountRoot(account)
+		require.NoError(t, err)
+		require.NoError(t, fixture.env.Ledger().Insert(keylet.Account(accountID), data))
+	}
+
+	create := ammtest.AMMCreate(fixture.creator, fixture.share, fixture.xrp).Build()
+	result := create.Preclaim(fixture.env.Ledger(), tx.EngineConfig{
+		ReserveBase:      10_000_000,
+		ReserveIncrement: ammCreateFee,
+		ParentHash:       parentHash,
+		Rules:            amendment.AllSupportedRules(),
+	})
+
+	require.Equal(t, ter.TerADDRESS_COLLISION, result)
+}

--- a/internal/testing/nft/nftoken_cancel_zero_id_test.go
+++ b/internal/testing/nft/nftoken_cancel_zero_id_test.go
@@ -35,13 +35,42 @@ func TestNFTokenCancelOffer_ZeroOfferID(t *testing.T) {
 	t.Run("PureZero", func(t *testing.T) {
 		t.Run("enabled_temMALFORMED", func(t *testing.T) {
 			env, alice := newEnv(t, true)
+			balanceBefore := env.Balance(alice)
+			sequenceBefore := env.Seq(alice)
 			res := env.Submit(nft.NFTokenCancelOffer(alice, zeroID).Build())
 			jtx.RequireTxFail(t, res, "temMALFORMED")
+			require.False(t, res.Applied)
+			require.Zero(t, res.Fee)
+			require.Nil(t, res.Metadata)
+			require.Equal(t, balanceBefore, env.Balance(alice))
+			require.Equal(t, sequenceBefore, env.Seq(alice))
 		})
 		t.Run("disabled_tesSUCCESS", func(t *testing.T) {
 			env, alice := newEnv(t, false)
+			balanceBefore := env.Balance(alice)
+			sequenceBefore := env.Seq(alice)
 			res := env.Submit(nft.NFTokenCancelOffer(alice, zeroID).Build())
 			jtx.RequireTxSuccess(t, res)
+			require.True(t, res.Applied)
+			require.Equal(t, uint64(10), res.Fee)
+			require.NotNil(t, res.Metadata)
+			require.Equal(t, balanceBefore-10, env.Balance(alice))
+			require.Equal(t, sequenceBefore+1, env.Seq(alice))
+		})
+	})
+
+	t.Run("Precedence", func(t *testing.T) {
+		t.Run("invalid_flag", func(t *testing.T) {
+			env, alice := newEnv(t, true)
+			cancel := nft.NFTokenCancelOffer(alice, zeroID).Build()
+			cancel.GetCommon().SetFlags(1)
+			jtx.RequireTxFail(t, env.Submit(cancel), "temINVALID_FLAG")
+		})
+		t.Run("bad_fee", func(t *testing.T) {
+			env, alice := newEnv(t, true)
+			cancel := nft.NFTokenCancelOffer(alice, zeroID).Build()
+			cancel.GetCommon().Fee = "-1"
+			jtx.RequireTxFail(t, env.Submit(cancel), "temBAD_FEE")
 		})
 	})
 
@@ -64,8 +93,15 @@ func TestNFTokenCancelOffer_ZeroOfferID(t *testing.T) {
 
 		t.Run("enabled_temMALFORMED", func(t *testing.T) {
 			env, alice, realOfferID, offerKL := setup(t, true)
+			balanceBefore := env.Balance(alice)
+			sequenceBefore := env.Seq(alice)
 			res := env.Submit(nft.NFTokenCancelOffer(alice, realOfferID, zeroID).Build())
 			jtx.RequireTxFail(t, res, "temMALFORMED")
+			require.False(t, res.Applied)
+			require.Zero(t, res.Fee)
+			require.Nil(t, res.Metadata)
+			require.Equal(t, balanceBefore, env.Balance(alice))
+			require.Equal(t, sequenceBefore, env.Seq(alice))
 			require.True(t, env.LedgerEntryExists(offerKL), "offer must survive a rejected cancel")
 		})
 		t.Run("disabled_cancelsReal", func(t *testing.T) {

--- a/internal/tx/amm/amm_create.go
+++ b/internal/tx/amm/amm_create.go
@@ -190,6 +190,16 @@ func (a *AMMCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Res
 		if tx.PseudoAccountAddress(view, config.ParentHash, ammKey.Key) == ([20]byte{}) {
 			return ter.TerADDRESS_COLLISION
 		}
+		isMPTIssuerPseudo := func(asset tx.Asset) bool {
+			if !asset.IsMPT() {
+				return false
+			}
+			issuer, result := assetIssuerID(asset)
+			return result == ter.TesSUCCESS && tx.IsPseudoAccountID(view, issuer)
+		}
+		if isMPTIssuerPseudo(asset1) || isMPTIssuerPseudo(asset2) {
+			return ter.TecWRONG_ASSET
+		}
 	}
 
 	if result := canMPTTradeAndTransfer(view, asset1, accountID, accountID); result != ter.TesSUCCESS {


### PR DESCRIPTION
## Summary

- reject pseudo-account-issued MPT assets in `AMMCreate` under `SingleAssetVault`, matching rippled v3.3.0 ordering and `tecWRONG_ASSET`
- cover both AMM asset positions, holder and underlying-issuer vault creators, wire round trips, amendment-off behavior, collision precedence, and fee/state rollback
- verify the already-landed `NFTokenCancelOffer` zero-ID behavior preserves amendment gates, common-preflight precedence, and non-applied state effects

## Test plan

- [x] focused AMM, NFT, and retained Number regression tests
- [x] five-run AMM/NFT stability check
- [x] `just build-all`
- [x] `just vet`
- [x] `just lint`
- [x] `just test-tx`
- [x] `just test-integration`
- [x] independent conformance review against clean rippled tag `3.3.0` (`00a178fb92ca49521b937ae1a99d863765ea8a90`)

Fixes #1381
