### PR TITLE
fix: align persistent tec cleanup

### DIFF
--- a/internal/testing/offer/offer_fill_modes_test.go
+++ b/internal/testing/offer/offer_fill_modes_test.go
@@ -9,6 +9,8 @@ import (
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	ledgerentry "github.com/LeJamon/go-xrpl/ledger/entry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,6 +48,7 @@ func testFillModes(t *testing.T, disabledFeatures []string) {
 		env.Close()
 
 		// bob creates an offer that expires before the next ledger close.
+		expiredOfferSequence := env.Seq(bob)
 		result := env.Submit(
 			OfferCreate(bob, USD(500), jtx.XRPTxAmountFromXRP(500)).
 				Expiration(LastClose(env) + 1).Build())
@@ -55,6 +58,7 @@ func testFillModes(t *testing.T, disabledFeatures []string) {
 		RequireOfferCount(t, env, bob, 1)
 
 		// bob creates the offer that will be crossed.
+		fundedOfferSequence := env.Seq(bob)
 		result = env.Submit(
 			OfferCreate(bob, USD(500), jtx.XRPTxAmountFromXRP(500)).Build())
 		jtx.RequireTxSuccess(t, result)
@@ -82,6 +86,8 @@ func testFillModes(t *testing.T, disabledFeatures []string) {
 		jtx.RequireIOUBalance(t, env, bob, gw, "USD", 0)
 		jtx.RequireOwnerCount(t, env, bob, 1)
 		RequireOfferCount(t, env, bob, 1)
+		RequireNoOfferInLedger(t, env, bob, expiredOfferSequence)
+		RequireOfferInLedger(t, env, bob, fundedOfferSequence)
 
 		// Order that can be filled
 		result = env.Submit(
@@ -321,6 +327,75 @@ func TestOffer_FillOrKill(t *testing.T) {
 	for _, fs := range offerFeatureSets {
 		t.Run(fs.name, func(t *testing.T) {
 			testFillOrKill(t, fs.disabled)
+		})
+	}
+}
+
+func TestOffer_FillOrKillPreservesTentativelyConsumedFundedOffer(t *testing.T) {
+	featureSets := append([]featureSet(nil), offerFeatureSets...)
+	featureSets = append(featureSets, featureSet{
+		name: "cleanupOn",
+	})
+	for _, tc := range featureSets {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newEnvWithFeatures(t, tc.disabled)
+			if tc.name == "cleanupOn" {
+				env.EnableFeature("fixCleanup3_3_0")
+			}
+			issuer := jtx.NewAccount("issuer")
+			maker := jtx.NewAccount("maker")
+			taker := jtx.NewAccount("taker")
+			USD := func(amount float64) tx.Amount { return jtx.USD(issuer, amount) }
+
+			for _, account := range []*jtx.Account{issuer, maker, taker} {
+				env.FundAmount(account, uint64(jtx.XRP(10_000)))
+			}
+			env.Close()
+
+			makerSequence := env.Seq(maker)
+			result := env.Submit(OfferCreate(maker, USD(500), jtx.XRPTxAmountFromXRP(500)).Build())
+			jtx.RequireTxSuccess(t, result)
+			env.Close()
+			original := GetOffer(env, maker, makerSequence)
+			if original == nil {
+				t.Fatal("maker offer was not created")
+			}
+
+			env.Trust(taker, USD(1_000))
+			result = env.Submit(payment.PayIssued(issuer, taker, USD(1_000)).Build())
+			jtx.RequireTxSuccess(t, result)
+
+			takerBalance := env.Balance(taker)
+			takerSequence := env.Seq(taker)
+			result = env.Submit(OfferCreate(taker, jtx.XRPTxAmountFromXRP(1_000), USD(1_000)).FillOrKill().Build())
+			jtx.RequireTxClaimed(t, result, jtx.TecKILLED)
+			if !result.Applied || result.Fee != env.BaseFee() {
+				t.Fatalf("applied/fee = %v/%d, want true/%d", result.Applied, result.Fee, env.BaseFee())
+			}
+			if env.Seq(taker) != takerSequence+1 {
+				t.Fatalf("taker sequence = %d, want %d", env.Seq(taker), takerSequence+1)
+			}
+
+			got := GetOffer(env, maker, makerSequence)
+			if got == nil {
+				t.Fatal("failed Fill-or-Kill deleted a funded maker offer")
+			}
+			if got.TakerPays.Compare(original.TakerPays) != 0 || got.TakerGets.Compare(original.TakerGets) != 0 {
+				t.Fatalf("maker offer changed: got pays/gets %s/%s, want %s/%s",
+					got.TakerPays.Value(), got.TakerGets.Value(), original.TakerPays.Value(), original.TakerGets.Value())
+			}
+			RequireOfferCount(t, env, maker, 1)
+			RequireOfferCount(t, env, taker, 0)
+			jtx.RequireIOUBalance(t, env, taker, issuer, "USD", 1_000)
+			jtx.RequireBalance(t, env, taker, takerBalance-env.BaseFee())
+			if result.Metadata == nil || result.Metadata.TransactionResult != ter.TecKILLED {
+				t.Fatalf("metadata result = %v, want tecKILLED", result.Metadata)
+			}
+			for _, node := range result.Metadata.AffectedNodes {
+				if node.LedgerEntryType == ledgerentry.TypeOffer.String() {
+					t.Fatal("rolled-back maker offer appeared in tecKILLED metadata")
+				}
+			}
 		})
 	}
 }

--- a/internal/testing/offer/offer_fill_modes_test.go
+++ b/internal/testing/offer/offer_fill_modes_test.go
@@ -332,16 +332,9 @@ func TestOffer_FillOrKill(t *testing.T) {
 }
 
 func TestOffer_FillOrKillPreservesTentativelyConsumedFundedOffer(t *testing.T) {
-	featureSets := append([]featureSet(nil), offerFeatureSets...)
-	featureSets = append(featureSets, featureSet{
-		name: "cleanupOn",
-	})
-	for _, tc := range featureSets {
+	for _, tc := range offerFeatureSets {
 		t.Run(tc.name, func(t *testing.T) {
 			env := newEnvWithFeatures(t, tc.disabled)
-			if tc.name == "cleanupOn" {
-				env.EnableFeature("fixCleanup3_3_0")
-			}
 			issuer := jtx.NewAccount("issuer")
 			maker := jtx.NewAccount("maker")
 			taker := jtx.NewAccount("taker")

--- a/internal/tx/engine/do_apply.go
+++ b/internal/tx/engine/do_apply.go
@@ -529,13 +529,6 @@ func isUnfundedOfferDeletion(tracked *applystate.TrackedEntry) bool {
 	if err != nil {
 		return false
 	}
-	if before.TakerPays.IsNative() != after.TakerPays.IsNative() ||
-		before.TakerPays.IsMPT() != after.TakerPays.IsMPT() ||
-		before.TakerPays.Currency != after.TakerPays.Currency ||
-		before.TakerPays.Issuer != after.TakerPays.Issuer ||
-		before.TakerPays.MPTIssuanceID() != after.TakerPays.MPTIssuanceID() {
-		return false
-	}
 	cmp, err := before.TakerPays.CompareChecked(after.TakerPays)
 	return err == nil && cmp == 0
 }
@@ -617,28 +610,54 @@ func (e *Engine) removeDeletedTrustLines(tecTable *applystate.ApplyStateTable, k
 		if decodeErr != nil {
 			continue
 		}
-		lowDirKey := keylet.OwnerDir(lowID)
-		state.DirRemove(tecTable, lowDirKey, rs.LowNode, lineKey, false)
-		highDirKey := keylet.OwnerDir(highID)
-		state.DirRemove(tecTable, highDirKey, rs.HighNode, lineKey, false)
-		// Erase the trust line
-		_ = tecTable.Erase(lineKL)
-		// Decrement OwnerCount for the non-AMM side that has a reserve.
-		// Reference: rippled View.cpp deleteAMMTrustLine lines 2759-2763
-		lowAcctData, _ := tecTable.Read(keylet.Account(lowID))
-		highAcctData, _ := tecTable.Read(keylet.Account(highID))
-		if lowAcctData != nil && highAcctData != nil {
-			lowAcct, _ := state.ParseAccountRoot(lowAcctData)
-			highAcct, _ := state.ParseAccountRoot(highAcctData)
-			zeroHash := [32]byte{}
-			ammLow := lowAcct.AMMID != zeroHash
-			ammHigh := highAcct.AMMID != zeroHash
-			if rs.Flags&state.LsfLowReserve != 0 && !ammLow {
-				_ = txcore.DecreaseOwnerCountOnView(tecTable, lowID, rs.LowSponsor, 1)
-			}
-			if rs.Flags&state.LsfHighReserve != 0 && !ammHigh {
-				_ = txcore.DecreaseOwnerCountOnView(tecTable, highID, rs.HighSponsor, 1)
-			}
+		lowAcctData, readErr := tecTable.Read(keylet.Account(lowID))
+		if readErr != nil || lowAcctData == nil {
+			e.logger.Error("failed to re-delete AMM trust line", "reason", "missing low account")
+			continue
+		}
+		lowAcct, parseErr := state.ParseAccountRoot(lowAcctData)
+		if parseErr != nil {
+			e.logger.Error("failed to re-delete AMM trust line", "reason", "invalid low account")
+			continue
+		}
+		highAcctData, readErr := tecTable.Read(keylet.Account(highID))
+		if readErr != nil || highAcctData == nil {
+			e.logger.Error("failed to re-delete AMM trust line", "reason", "missing high account")
+			continue
+		}
+		highAcct, parseErr := state.ParseAccountRoot(highAcctData)
+		if parseErr != nil {
+			e.logger.Error("failed to re-delete AMM trust line", "reason", "invalid high account")
+			continue
+		}
+
+		zeroHash := [32]byte{}
+		ammLow := lowAcct.AMMID != zeroHash
+		ammHigh := highAcct.AMMID != zeroHash
+		if ammLow == ammHigh {
+			e.logger.Error("failed to re-delete AMM trust line", "reason", "invalid AMM ownership")
+			continue
+		}
+
+		if result := txcore.TrustDelete(tecTable, lineKL, lowID, highID, rs.LowNode, rs.HighNode); result != ter.TesSUCCESS {
+			e.logger.Error("failed to re-delete AMM trust line", "result", result)
+			continue
+		}
+
+		nonAMMID := lowID
+		reserveFlag := uint32(state.LsfLowReserve)
+		sponsor := rs.LowSponsor
+		if ammLow {
+			nonAMMID = highID
+			reserveFlag = state.LsfHighReserve
+			sponsor = rs.HighSponsor
+		}
+		if rs.Flags&reserveFlag == 0 {
+			e.logger.Error("failed to re-delete AMM trust line", "reason", "missing reserve flag")
+			continue
+		}
+		if err := txcore.DecreaseOwnerCountOnView(tecTable, nonAMMID, sponsor, 1); err != nil {
+			e.logger.Error("failed to re-delete AMM trust line owner count", "err", err)
 		}
 	}
 }

--- a/internal/tx/engine/do_apply.go
+++ b/internal/tx/engine/do_apply.go
@@ -355,11 +355,7 @@ func isReapplyOnRetryTec(r ter.Result) bool {
 // helpers (removeUnfundedOffers, removeDeletedTrustLines,
 // removeExpiredNFTokenOffers).
 func (e *Engine) applyTecRecovery(st *applyState, result ter.Result) ter.Result {
-	// Collect keys-to-redelete from the to-be-discarded sandbox.
-	removedOfferKeys := collectErasedKeysOfType(st.table, entry.TypeOffer, result == ter.TecOVERSIZE || result == ter.TecKILLED, 1000)
-	removedTrustLineKeys := collectErasedKeysOfType(st.table, entry.TypeRippleState, result == ter.TecINCOMPLETE, 512)
-	expiredNFTokenOfferKeys := collectErasedKeysOfType(st.table, entry.TypeNFTokenOffer, result == ter.TecEXPIRED, 256)
-	expiredCredentialKeys := collectErasedKeysOfType(st.table, entry.TypeCredential, result == ter.TecEXPIRED, 0)
+	deleted := collectPersistentDeletions(st.table, result)
 
 	// Discard the transaction table — all doApply() side effects are lost.
 	// Reference: rippled Transactor.cpp — reset() discards the sandbox.
@@ -396,25 +392,30 @@ func (e *Engine) applyTecRecovery(st *applyState, result ter.Result) ter.Result 
 
 	// tecINCOMPLETE (AMMDelete): re-delete trust lines after reset so cleanup
 	// owner-count changes cannot be overwritten by the recovered source account.
-	if len(removedTrustLineKeys) > 0 {
-		e.removeDeletedTrustLines(tecTable, removedTrustLineKeys)
+	if len(deleted.trustLines) > 0 {
+		e.removeDeletedTrustLines(tecTable, deleted.trustLines)
 	}
 
 	// tecOVERSIZE/tecKILLED: re-delete offers that were found during processing.
 	// These offers were deleted in the (now discarded) sandbox.
 	// Reference: rippled Transactor.cpp lines 1198-1201: removeUnfundedOffers()
-	if len(removedOfferKeys) > 0 {
-		e.removeUnfundedOffers(tecTable, removedOfferKeys)
+	if len(deleted.offers) > 0 {
+		e.removeUnfundedOffers(tecTable, deleted.offers)
 	}
 
 	// tecEXPIRED: re-delete expired NFTokenOffers and credentials.
 	// Reference: rippled Transactor.cpp lines 1203-1205: removeExpiredNFTokenOffers()
 	if result == ter.TecEXPIRED {
 		// Re-delete NFTokenOffers through tecTable
-		for _, offerKey := range expiredNFTokenOfferKeys {
+		replayExistingWithLimit(deleted.nftOffers, expiredNFTokenOfferRemoveLimit, func(offerKey [32]byte) bool {
 			offerKL := keylet.Keylet{Key: offerKey}
+			offerData, err := tecTable.Read(offerKL)
+			if err != nil || offerData == nil {
+				return false
+			}
 			deleteNFTokenOfferOnView(tecTable, offerKL)
-		}
+			return true
+		})
 
 		tecCtx := &txcore.ApplyContext{
 			View:             tecTable,
@@ -429,7 +430,7 @@ func (e *Engine) applyTecRecovery(st *applyState, result ter.Result) ter.Result 
 			Log:              e.logger,
 			Ctx:              st.ctx,
 		}
-		for _, credentialKey := range expiredCredentialKeys {
+		for _, credentialKey := range deleted.credentials {
 			credentialKL := keylet.Keylet{Key: credentialKey}
 			credentialData, err := tecTable.Read(credentialKL)
 			if err != nil || credentialData == nil {
@@ -472,34 +473,84 @@ func (e *Engine) applyTecRecovery(st *applyState, result ter.Result) ter.Result 
 	return result
 }
 
-// collectErasedKeysOfType walks the ApplyStateTable and collects up to `limit`
-// keys whose entries are erased ledger entries of the given type. A non-positive
-// limit collects every matching key. When enabled is false, it returns nil.
-// Used by tec recovery to re-apply specific deletions after the sandbox is discarded.
-func collectErasedKeysOfType(table *applystate.ApplyStateTable, entryType entry.Type, enabled bool, limit int) [][32]byte {
-	if !enabled {
-		return nil
+const (
+	unfundedOfferRemoveLimit       = 1000
+	expiredNFTokenOfferRemoveLimit = 256
+	maxDeletableAMMTrustLines      = 512
+)
+
+type persistentDeletions struct {
+	offers      [][32]byte
+	trustLines  [][32]byte
+	nftOffers   [][32]byte
+	credentials [][32]byte
+}
+
+func collectPersistentDeletions(table *applystate.ApplyStateTable, result ter.Result) persistentDeletions {
+	var deleted persistentDeletions
+	switch result {
+	case ter.TecOVERSIZE, ter.TecKILLED:
+		deleted.offers = collectErasedKeysOfType(table, entry.TypeOffer, isUnfundedOfferDeletion)
+	case ter.TecINCOMPLETE:
+		deleted.trustLines = collectErasedKeysOfType(table, entry.TypeRippleState, nil)
+	case ter.TecEXPIRED:
+		deleted.nftOffers = collectErasedKeysOfType(table, entry.TypeNFTokenOffer, nil)
+		deleted.credentials = collectErasedKeysOfType(table, entry.TypeCredential, nil)
 	}
+	return deleted
+}
+
+func collectErasedKeysOfType(table *applystate.ApplyStateTable, entryType entry.Type, include func(*applystate.TrackedEntry) bool) [][32]byte {
 	var keys [][32]byte
-	for key, entry := range table.GetItems() {
-		if entry.Action != applystate.ActionErase {
+	for key, tracked := range table.GetItems() {
+		if tracked.Action != applystate.ActionErase {
 			continue
 		}
-		t, err := state.DecodeType(entry.Original)
-		if err != nil && entry.Current != nil {
-			t, err = state.DecodeType(entry.Current)
+		t, err := state.DecodeType(tracked.Original)
+		if err != nil && tracked.Current != nil {
+			t, err = state.DecodeType(tracked.Current)
 		}
-		if err == nil && t == entryType {
+		if err == nil && t == entryType && (include == nil || include(tracked)) {
 			keys = append(keys, key)
-			if limit > 0 && len(keys) >= limit {
-				break
-			}
 		}
 	}
 	sort.Slice(keys, func(i, j int) bool {
 		return bytes.Compare(keys[i][:], keys[j][:]) < 0
 	})
 	return keys
+}
+
+func isUnfundedOfferDeletion(tracked *applystate.TrackedEntry) bool {
+	before, err := state.ParseLedgerOffer(tracked.Original)
+	if err != nil {
+		return false
+	}
+	after, err := state.ParseLedgerOffer(tracked.Current)
+	if err != nil {
+		return false
+	}
+	if before.TakerPays.IsNative() != after.TakerPays.IsNative() ||
+		before.TakerPays.IsMPT() != after.TakerPays.IsMPT() ||
+		before.TakerPays.Currency != after.TakerPays.Currency ||
+		before.TakerPays.Issuer != after.TakerPays.Issuer ||
+		before.TakerPays.MPTIssuanceID() != after.TakerPays.MPTIssuanceID() {
+		return false
+	}
+	cmp, err := before.TakerPays.CompareChecked(after.TakerPays)
+	return err == nil && cmp == 0
+}
+
+func replayExistingWithLimit(keys [][32]byte, limit int, replay func([32]byte) bool) {
+	replayed := 0
+	for _, key := range keys {
+		if !replay(key) {
+			continue
+		}
+		replayed++
+		if replayed == limit {
+			return
+		}
+	}
 }
 
 // consumeTicketForRecovery consumes the ticket through the supplied recovery
@@ -544,6 +595,10 @@ func (e *Engine) eraseTicketEntry(st *applyState, table *applystate.ApplyStateTa
 // the recovery table.
 // Reference: rippled View.cpp deleteAMMTrustLine + Transactor.cpp lines 1207-1209.
 func (e *Engine) removeDeletedTrustLines(tecTable *applystate.ApplyStateTable, keys [][32]byte) {
+	if len(keys) > maxDeletableAMMTrustLines {
+		e.logger.Error("deleted AMM trust lines exceed recovery limit", "count", len(keys))
+		return
+	}
 	for _, lineKey := range keys {
 		lineKL := keylet.Keylet{Key: lineKey}
 		lineData, readErr := tecTable.Read(lineKL)
@@ -592,24 +647,25 @@ func (e *Engine) removeDeletedTrustLines(tecTable *applystate.ApplyStateTable, k
 // table.
 // Reference: rippled Transactor.cpp lines 1198-1201: removeUnfundedOffers().
 func (e *Engine) removeUnfundedOffers(tecTable *applystate.ApplyStateTable, keys [][32]byte) {
-	for _, offerKey := range keys {
+	replayExistingWithLimit(keys, unfundedOfferRemoveLimit, func(offerKey [32]byte) bool {
 		offerKL := keylet.Keylet{Key: offerKey}
 		offerData, readErr := e.view.Read(offerKL)
 		if readErr != nil || offerData == nil {
-			continue
+			return false
 		}
 		offerObj, parseErr := state.ParseLedgerOffer(offerData)
 		if parseErr != nil {
-			continue
+			return false
 		}
 		ownerID, decodeErr := state.DecodeAccountID(offerObj.Account)
 		if decodeErr != nil {
-			continue
+			return false
 		}
-		if removed, deleteErr := state.DeleteOffer(tecTable, offerKL, offerObj); deleteErr == nil && removed {
+		if success, deleteErr := state.DeleteOffer(tecTable, offerKL, offerObj); deleteErr == nil && success {
 			adjustOwnerCountOnView(tecTable, ownerID, -1)
 		}
-	}
+		return true
+	})
 }
 
 // writeRecoveryAccount applies the fee/seq/ticket-count/PreviousTxn/AccountTxnID

--- a/internal/tx/engine/do_apply.go
+++ b/internal/tx/engine/do_apply.go
@@ -645,7 +645,7 @@ func (e *Engine) removeDeletedTrustLines(tecTable *applystate.ApplyStateTable, k
 		}
 
 		nonAMMID := lowID
-		reserveFlag := uint32(state.LsfLowReserve)
+		reserveFlag := state.LsfLowReserve
 		sponsor := rs.LowSponsor
 		if ammLow {
 			nonAMMID = highID

--- a/internal/tx/engine/engine.go
+++ b/internal/tx/engine/engine.go
@@ -175,7 +175,10 @@ func deleteNFTokenOfferOnView(view txcore.LedgerView, offerKL keylet.Keylet) {
 	}
 
 	ownerDirKey := keylet.OwnerDir(offer.Owner)
-	state.DirRemove(view, ownerDirKey, offer.OwnerNode, offerKL.Key, false)
+	ownerResult, err := state.DirRemove(view, ownerDirKey, offer.OwnerNode, offerKL.Key, false)
+	if err != nil || !ownerResult.Success {
+		return
+	}
 
 	// Remove from NFTBuys or NFTSells directory
 	isSellOffer := offer.Flags&entry.LsfSellNFToken != 0
@@ -185,8 +188,13 @@ func deleteNFTokenOfferOnView(view txcore.LedgerView, offerKL keylet.Keylet) {
 	} else {
 		tokenDirKey = keylet.NFTBuys(offer.NFTokenID)
 	}
-	state.DirRemove(view, tokenDirKey, offer.NFTokenOfferNode, offerKL.Key, false)
+	tokenResult, err := state.DirRemove(view, tokenDirKey, offer.NFTokenOfferNode, offerKL.Key, false)
+	if err != nil || !tokenResult.Success {
+		return
+	}
 
-	_ = view.Erase(offerKL)
+	if err := view.Erase(offerKL); err != nil {
+		return
+	}
 	adjustOwnerCountOnView(view, offer.Owner, -1)
 }

--- a/internal/tx/engine/persistent_cleanup_test.go
+++ b/internal/tx/engine/persistent_cleanup_test.go
@@ -1,0 +1,252 @@
+package engine
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/applystate"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	ledgerentry "github.com/LeJamon/go-xrpl/ledger/entry"
+)
+
+func ledgerTypeBytes(t ledgerentry.Type) []byte {
+	data := []byte{0x11, 0, 0}
+	binary.BigEndian.PutUint16(data[1:], uint16(t))
+	return data
+}
+
+func persistentTestOffer(t *testing.T, pays int64) []byte {
+	t.Helper()
+	data, err := state.SerializeLedgerOffer(&state.LedgerOffer{
+		Account:   recoveryTestAccount,
+		Sequence:  1,
+		TakerPays: state.NewXRPAmountFromInt(pays),
+		TakerGets: state.NewXRPAmountFromInt(100),
+	})
+	if err != nil {
+		t.Fatalf("SerializeLedgerOffer: %v", err)
+	}
+	return data
+}
+
+func TestCollectPersistentDeletionsResultMatrix(t *testing.T) {
+	table := applystate.NewApplyStateTable(newRecordingBaseView(), [32]byte{}, 1, nil)
+	keys := struct {
+		unfundedOffer [32]byte
+		fundedOffer   [32]byte
+		trustLine     [32]byte
+		nftOffer      [32]byte
+		credential    [32]byte
+		mpt           [32]byte
+	}{
+		unfundedOffer: [32]byte{1},
+		fundedOffer:   [32]byte{2},
+		trustLine:     [32]byte{3},
+		nftOffer:      [32]byte{4},
+		credential:    [32]byte{5},
+		mpt:           [32]byte{6},
+	}
+	items := table.GetItems()
+	unchangedOffer := persistentTestOffer(t, 100)
+	items[keys.unfundedOffer] = &applystate.TrackedEntry{
+		Action: applystate.ActionErase, Original: unchangedOffer, Current: unchangedOffer,
+	}
+	items[keys.fundedOffer] = &applystate.TrackedEntry{
+		Action:   applystate.ActionErase,
+		Original: persistentTestOffer(t, 100),
+		Current:  persistentTestOffer(t, 50),
+	}
+	items[keys.trustLine] = erasedType(ledgerentry.TypeRippleState)
+	items[keys.nftOffer] = erasedType(ledgerentry.TypeNFTokenOffer)
+	items[keys.credential] = erasedType(ledgerentry.TypeCredential)
+	items[keys.mpt] = erasedType(ledgerentry.TypeMPToken)
+
+	tests := []struct {
+		name        string
+		result      ter.Result
+		offers      [][32]byte
+		trustLines  [][32]byte
+		nftOffers   [][32]byte
+		credentials [][32]byte
+	}{
+		{name: "oversize", result: ter.TecOVERSIZE, offers: [][32]byte{keys.unfundedOffer}},
+		{name: "killed", result: ter.TecKILLED, offers: [][32]byte{keys.unfundedOffer}},
+		{name: "incomplete", result: ter.TecINCOMPLETE, trustLines: [][32]byte{keys.trustLine}},
+		{name: "expired", result: ter.TecEXPIRED, nftOffers: [][32]byte{keys.nftOffer}, credentials: [][32]byte{keys.credential}},
+		{name: "generic tec", result: ter.TecPATH_DRY},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := collectPersistentDeletions(table, tc.result)
+			assertKeysEqual(t, "offers", got.offers, tc.offers)
+			assertKeysEqual(t, "trust lines", got.trustLines, tc.trustLines)
+			assertKeysEqual(t, "NFT offers", got.nftOffers, tc.nftOffers)
+			assertKeysEqual(t, "credentials", got.credentials, tc.credentials)
+		})
+	}
+}
+
+func TestCollectPersistentDeletionsSortsAllReplayCandidates(t *testing.T) {
+	tests := []struct {
+		name      string
+		result    ter.Result
+		entryType ledgerentry.Type
+		count     int
+		selectKey func(persistentDeletions) [][32]byte
+	}{
+		{
+			name: "offers over replay limit", result: ter.TecKILLED,
+			entryType: ledgerentry.TypeOffer, count: unfundedOfferRemoveLimit + 1,
+			selectKey: func(deleted persistentDeletions) [][32]byte { return deleted.offers },
+		},
+		{
+			name: "NFT offers over replay limit", result: ter.TecEXPIRED,
+			entryType: ledgerentry.TypeNFTokenOffer, count: expiredNFTokenOfferRemoveLimit + 1,
+			selectKey: func(deleted persistentDeletions) [][32]byte { return deleted.nftOffers },
+		},
+		{
+			name: "trust lines over replay limit", result: ter.TecINCOMPLETE,
+			entryType: ledgerentry.TypeRippleState, count: maxDeletableAMMTrustLines + 1,
+			selectKey: func(deleted persistentDeletions) [][32]byte { return deleted.trustLines },
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			table := applystate.NewApplyStateTable(newRecordingBaseView(), [32]byte{}, 1, nil)
+			for i := tc.count; i > 0; i-- {
+				var key [32]byte
+				binary.BigEndian.PutUint32(key[28:], uint32(i))
+				if tc.entryType == ledgerentry.TypeOffer {
+					offer := persistentTestOffer(t, 100)
+					table.GetItems()[key] = &applystate.TrackedEntry{
+						Action: applystate.ActionErase, Original: offer, Current: offer,
+					}
+				} else {
+					table.GetItems()[key] = erasedType(tc.entryType)
+				}
+			}
+
+			got := tc.selectKey(collectPersistentDeletions(table, tc.result))
+			if len(got) != tc.count {
+				t.Fatalf("candidate count = %d, want %d", len(got), tc.count)
+			}
+			for i := range got {
+				want := uint32(i + 1)
+				if binary.BigEndian.Uint32(got[i][28:]) != want {
+					t.Fatalf("candidate[%d] = %d, want %d", i, binary.BigEndian.Uint32(got[i][28:]), want)
+				}
+			}
+		})
+	}
+}
+
+func TestReplayExistingWithLimit(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit int
+	}{
+		{name: "offers", limit: unfundedOfferRemoveLimit},
+		{name: "NFT offers", limit: expiredNFTokenOfferRemoveLimit},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			keys := make([][32]byte, tc.limit+2)
+			var replayed [][32]byte
+			replayExistingWithLimit(keys, tc.limit, func(key [32]byte) bool {
+				if len(replayed) == 0 {
+					replayed = append(replayed, key)
+					return false
+				}
+				replayed = append(replayed, key)
+				return true
+			})
+			if len(replayed) != tc.limit+1 {
+				t.Fatalf("replay attempts = %d, want %d", len(replayed), tc.limit+1)
+			}
+		})
+	}
+}
+
+func erasedType(t ledgerentry.Type) *applystate.TrackedEntry {
+	data := ledgerTypeBytes(t)
+	return &applystate.TrackedEntry{Action: applystate.ActionErase, Original: data, Current: data}
+}
+
+func assertKeysEqual(t *testing.T, name string, got, want [][32]byte) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s = %x, want %x", name, got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("%s[%d] = %x, want %x", name, i, got[i], want[i])
+		}
+	}
+}
+
+type eraseMPTokenTecTx struct {
+	*txcore.BaseTx
+	key keylet.Keylet
+}
+
+func (tx eraseMPTokenTecTx) Apply(ctx *txcore.ApplyContext) ter.Result {
+	if err := ctx.View.Erase(tx.key); err != nil {
+		return ter.TefINTERNAL
+	}
+	return ter.TecINCOMPLETE
+}
+
+func TestApplyTecIncompleteRollsBackDeletedMPToken(t *testing.T) {
+	view := newRecordingBaseView()
+	accountKey := fundRecoveryAccount(t, view, 1_000_000, 1)
+	holder, err := state.DecodeAccountID(recoveryTestAccount)
+	if err != nil {
+		t.Fatalf("DecodeAccountID: %v", err)
+	}
+	var issuanceID [24]byte
+	issuanceID[0] = 1
+	tokenKey := keylet.MPTokenByID(issuanceID, holder)
+	tokenData, err := state.SerializeMPToken(&state.MPTokenData{
+		Account:           holder,
+		MPTokenIssuanceID: issuanceID,
+		MPTAmount:         100,
+	})
+	if err != nil {
+		t.Fatalf("SerializeMPToken: %v", err)
+	}
+	if err := view.Insert(tokenKey, tokenData); err != nil {
+		t.Fatalf("Insert MPToken: %v", err)
+	}
+
+	result := recoveryEngine(view, txcore.TapNONE).Apply(eraseMPTokenTecTx{
+		BaseTx: recoveryTx(10, 1),
+		key:    tokenKey,
+	})
+	if result.Result != ter.TecINCOMPLETE || !result.Applied || result.Fee != 10 {
+		t.Fatalf("result/applied/fee = %s/%v/%d, want tecINCOMPLETE/true/10",
+			result.Result, result.Applied, result.Fee)
+	}
+	if result.Metadata == nil || result.Metadata.TransactionResult != ter.TecINCOMPLETE {
+		t.Fatalf("metadata result = %v, want tecINCOMPLETE", result.Metadata)
+	}
+	for _, node := range result.Metadata.AffectedNodes {
+		if node.LedgerEntryType == ledgerentry.TypeMPToken.String() {
+			t.Fatal("rolled-back MPToken deletion appeared in tecINCOMPLETE metadata")
+		}
+	}
+	got, err := view.Read(tokenKey)
+	if err != nil {
+		t.Fatalf("Read MPToken: %v", err)
+	}
+	if !bytes.Equal(got, tokenData) {
+		t.Fatalf("MPToken changed after tecINCOMPLETE: got %x, want %x", got, tokenData)
+	}
+	account := readRecoveryAccount(t, view, accountKey)
+	if account.Balance != 999_990 || account.Sequence != 2 {
+		t.Fatalf("payer balance/sequence = %d/%d, want 999990/2", account.Balance, account.Sequence)
+	}
+}

--- a/internal/tx/engine/persistent_cleanup_test.go
+++ b/internal/tx/engine/persistent_cleanup_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/applystate"
@@ -90,6 +91,32 @@ func TestCollectPersistentDeletionsResultMatrix(t *testing.T) {
 	}
 }
 
+func TestIsUnfundedOfferDeletionIgnoresIOUIssuer(t *testing.T) {
+	issuerA := recoveryTestAccount
+	issuerB := state.EncodeAccountIDSafe([20]byte{1})
+	serialize := func(issuer string) []byte {
+		data, err := state.SerializeLedgerOffer(&state.LedgerOffer{
+			Account:   recoveryTestAccount,
+			Sequence:  1,
+			TakerPays: state.NewIssuedAmountFromValue(100, 0, "USD", issuer),
+			TakerGets: state.NewXRPAmountFromInt(100),
+		})
+		if err != nil {
+			t.Fatalf("SerializeLedgerOffer: %v", err)
+		}
+		return data
+	}
+
+	tracked := &applystate.TrackedEntry{
+		Action:   applystate.ActionErase,
+		Original: serialize(issuerA),
+		Current:  serialize(issuerB),
+	}
+	if !isUnfundedOfferDeletion(tracked) {
+		t.Fatal("equal IOU TakerPays values with different issuers must compare unchanged")
+	}
+}
+
 func TestCollectPersistentDeletionsSortsAllReplayCandidates(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -168,6 +195,36 @@ func TestReplayExistingWithLimit(t *testing.T) {
 				t.Fatalf("replay attempts = %d, want %d", len(replayed), tc.limit+1)
 			}
 		})
+	}
+}
+
+func TestRemoveDeletedTrustLinesPreservesLineWhenAccountMissing(t *testing.T) {
+	view := newRecordingBaseView()
+	lowID := [20]byte{1}
+	highID := [20]byte{2}
+	lineKey := keylet.Keylet{Key: [32]byte{9}}
+	lineData, err := state.SerializeRippleState(&state.RippleState{
+		Balance:   state.NewIssuedAmountFromValue(0, 0, "USD", state.AccountOneAddress),
+		LowLimit:  state.NewIssuedAmountFromValue(0, 0, "USD", state.EncodeAccountIDSafe(lowID)),
+		HighLimit: state.NewIssuedAmountFromValue(0, 0, "USD", state.EncodeAccountIDSafe(highID)),
+		LowNode:   0,
+		HighNode:  0,
+	})
+	if err != nil {
+		t.Fatalf("SerializeRippleState: %v", err)
+	}
+	if err := view.Insert(lineKey, lineData); err != nil {
+		t.Fatalf("Insert RippleState: %v", err)
+	}
+
+	table := applystate.NewApplyStateTable(view, [32]byte{}, 1, amendment.AllSupportedRules())
+	recoveryEngine(view, txcore.TapNONE).removeDeletedTrustLines(table, [][32]byte{lineKey.Key})
+	got, err := table.Read(lineKey)
+	if err != nil {
+		t.Fatalf("Read RippleState: %v", err)
+	}
+	if !bytes.Equal(got, lineData) {
+		t.Fatalf("RippleState changed when an endpoint account was missing: got %x, want %x", got, lineData)
 	}
 }
 

--- a/internal/tx/ripple_credit.go
+++ b/internal/tx/ripple_credit.go
@@ -301,6 +301,14 @@ func rippleCreditCreate(view LedgerView, sender, receiver [20]byte, amount Amoun
 // erases it, mirroring rippled's trustDelete (View.cpp lines 1532-1570). Owner
 // count adjustments are the caller's responsibility.
 func TrustDelete(view LedgerView, lineKey keylet.Keylet, lowID, highID [20]byte, lowNode, highNode uint64) ter.Result {
+	lineData, err := view.Read(lineKey)
+	if err != nil || lineData == nil {
+		return ter.TefBAD_LEDGER
+	}
+	line, err := state.ParseRippleState(lineData)
+	if err != nil {
+		return ter.TefBAD_LEDGER
+	}
 	lowResult, err := state.DirRemove(view, keylet.OwnerDir(lowID), lowNode, lineKey.Key, false)
 	if err != nil || !lowResult.Success {
 		return ter.TefBAD_LEDGER
@@ -308,6 +316,15 @@ func TrustDelete(view LedgerView, lineKey keylet.Keylet, lowID, highID [20]byte,
 	highResult, err := state.DirRemove(view, keylet.OwnerDir(highID), highNode, lineKey.Key, false)
 	if err != nil || !highResult.Success {
 		return ter.TefBAD_LEDGER
+	}
+	line.LowSponsor = ""
+	line.HighSponsor = ""
+	updated, err := state.SerializeRippleState(line)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if err := view.Update(lineKey, updated); err != nil {
+		return ter.TefINTERNAL
 	}
 	if err := view.Erase(lineKey); err != nil {
 		return ter.TefINTERNAL


### PR DESCRIPTION
## Summary

- match rippled v3.3.0's result-to-ledger-entry persistence matrix for `tecOVERSIZE`, `tecKILLED`, `tecINCOMPLETE`, and `tecEXPIRED`
- preserve funded offers tentatively consumed by failed Fill-or-Kill transactions while retaining stale/unfunded offer cleanup
- collect cleanup candidates deterministically before applying the 1000-offer, 256-NFT-offer, and 512-trust-line boundaries
- roll back MPToken deletions under `tecINCOMPLETE` and retain exact fee, sequence, ledger, and metadata effects

## Verification

- `just test`
- `just test-tx`
- `just test-integration`
- `just build`
- `just vet`
- `golangci-lint run --allow-parallel-runners --config .golangci-warnings.yml`
- focused engine, Offer, AMM, NFT, and credential regressions
- independent review against local rippled v3.3.0 tag `00a178fb92ca49521b937ae1a99d863765ea8a90`

Fixes #1384
