### PR TITLE
fix: validate Clawback balance deltas

### DIFF
--- a/internal/tx/clawback/clawback.go
+++ b/internal/tx/clawback/clawback.go
@@ -513,6 +513,10 @@ func (c *Clawback) ClawbackAmount() tx.Amount {
 	return c.Amount
 }
 
+func (c *Clawback) ClawbackHolder() string {
+	return c.Holder
+}
+
 func (c *Clawback) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(c)
 }

--- a/internal/tx/engine/clawback_invariant_recovery_test.go
+++ b/internal/tx/engine/clawback_invariant_recovery_test.go
@@ -1,0 +1,240 @@
+package engine
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/applystate"
+	"github.com/LeJamon/go-xrpl/internal/tx/clawback"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+const clawbackInvariantHolder = "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"
+
+type clawbackInvariantTx struct {
+	*clawback.Clawback
+	apply func(*txcore.ApplyContext) ter.Result
+}
+
+func (c clawbackInvariantTx) Apply(ctx *txcore.ApplyContext) ter.Result {
+	return c.apply(ctx)
+}
+
+func newClawbackInvariantEngine(view applystate.AtomicLedgerView) *Engine {
+	rules := amendment.NewRulesBuilder().
+		FromPreset(amendment.PresetAllSupported).
+		Enable(amendment.FeatureMPTokensV1).
+		Enable(amendment.FeatureMPTokensV2).
+		Build()
+	return NewEngine(view, txcore.EngineConfig{
+		BaseFee:                   10,
+		LedgerSequence:            100,
+		Rules:                     rules,
+		SkipSignatureVerification: true,
+		OpenLedger:                false,
+	})
+}
+
+func prepareClawbackInvariantTx(c *clawback.Clawback) {
+	c.Fee = "10"
+	sequence := uint32(1)
+	c.Sequence = &sequence
+}
+
+func fundClawbackInvariantHolder(t *testing.T, view *recordingBaseView) {
+	t.Helper()
+	holder, err := state.DecodeAccountID(clawbackInvariantHolder)
+	if err != nil {
+		t.Fatalf("decode holder: %v", err)
+	}
+	if err := view.Insert(keylet.Account(holder), mustAccount(t, clawbackInvariantHolder, 1_000_000, 1)); err != nil {
+		t.Fatalf("insert holder: %v", err)
+	}
+}
+
+func serializeClawbackInvariantLine(t *testing.T, holderBalance int64) (keylet.Keylet, []byte) {
+	t.Helper()
+	holder, err := state.DecodeAccountID(clawbackInvariantHolder)
+	if err != nil {
+		t.Fatalf("decode holder: %v", err)
+	}
+	issuer, err := state.DecodeAccountID(recoveryTestAccount)
+	if err != nil {
+		t.Fatalf("decode issuer: %v", err)
+	}
+
+	balance := state.NewIssuedAmountFromValue(holderBalance, 0, "USD", state.AccountOneAddress)
+	low, high := clawbackInvariantHolder, recoveryTestAccount
+	if state.CompareAccountIDs(holder, issuer) > 0 {
+		balance = balance.Negate()
+		low, high = high, low
+	}
+	data, err := state.SerializeRippleState(&state.RippleState{
+		Balance:   balance,
+		LowLimit:  state.NewIssuedAmountFromValue(0, 0, "USD", low),
+		HighLimit: state.NewIssuedAmountFromValue(0, 0, "USD", high),
+	})
+	if err != nil {
+		t.Fatalf("serialize trust line: %v", err)
+	}
+	return keylet.Line(holder, issuer, "USD"), data
+}
+
+func requireClawbackRecovery(t *testing.T, view *recordingBaseView, accountKey keylet.Keylet, result txcore.ApplyResult) {
+	t.Helper()
+	if result.Result != ter.TecINVARIANT_FAILED || !result.Applied {
+		t.Fatalf("result/applied = %s/%v, want tecINVARIANT_FAILED/true", result.Result, result.Applied)
+	}
+	if result.Fee != 10 || view.destroyed != 10 {
+		t.Fatalf("fee/destroyed = %d/%d, want 10/10", result.Fee, view.destroyed)
+	}
+	account := readRecoveryAccount(t, view, accountKey)
+	if account.Balance != 999_990 || account.Sequence != 2 {
+		t.Fatalf("payer balance/sequence = %d/%d, want 999990/2", account.Balance, account.Sequence)
+	}
+	if result.Metadata == nil {
+		t.Fatal("fee-claiming invariant failure is missing metadata")
+	}
+	for _, node := range result.Metadata.AffectedNodes {
+		if node.LedgerEntryType == "RippleState" || node.LedgerEntryType == "MPToken" || node.LedgerEntryType == "MPTokenIssuance" {
+			t.Fatalf("recovered metadata contains rolled-back %s change", node.LedgerEntryType)
+		}
+	}
+}
+
+func TestApplyClawbackInvariantRecovery(t *testing.T) {
+	t.Run("valid full IOU deletion", func(t *testing.T) {
+		view := newRecordingBaseView()
+		fundRecoveryAccount(t, view, 1_000_000, 1)
+		fundClawbackInvariantHolder(t, view)
+		lineKey, before := serializeClawbackInvariantLine(t, 100)
+		if err := view.Insert(lineKey, before); err != nil {
+			t.Fatalf("insert trust line: %v", err)
+		}
+
+		tx := clawback.NewClawback(recoveryTestAccount,
+			state.NewIssuedAmountFromValue(100, 0, "USD", clawbackInvariantHolder))
+		prepareClawbackInvariantTx(tx)
+		result := newClawbackInvariantEngine(view).Apply(clawbackInvariantTx{
+			Clawback: tx,
+			apply: func(ctx *txcore.ApplyContext) ter.Result {
+				if err := ctx.View.Erase(lineKey); err != nil {
+					return ter.TefINTERNAL
+				}
+				return ter.TesSUCCESS
+			},
+		})
+		if result.Result != ter.TesSUCCESS || !result.Applied {
+			t.Fatalf("result/applied = %s/%v, want tesSUCCESS/true", result.Result, result.Applied)
+		}
+		line, err := view.Read(lineKey)
+		if err != nil || line != nil {
+			t.Fatalf("deleted trust line = %x, err=%v", line, err)
+		}
+	})
+
+	t.Run("invalid IOU delta", func(t *testing.T) {
+		view := newRecordingBaseView()
+		accountKey := fundRecoveryAccount(t, view, 1_000_000, 1)
+		fundClawbackInvariantHolder(t, view)
+		lineKey, before := serializeClawbackInvariantLine(t, 100)
+		_, invalidAfter := serializeClawbackInvariantLine(t, 80)
+		if err := view.Insert(lineKey, before); err != nil {
+			t.Fatalf("insert trust line: %v", err)
+		}
+
+		tx := clawback.NewClawback(recoveryTestAccount,
+			state.NewIssuedAmountFromValue(10, 0, "USD", clawbackInvariantHolder))
+		prepareClawbackInvariantTx(tx)
+		result := newClawbackInvariantEngine(view).Apply(clawbackInvariantTx{
+			Clawback: tx,
+			apply: func(ctx *txcore.ApplyContext) ter.Result {
+				if err := ctx.View.Update(lineKey, invalidAfter); err != nil {
+					return ter.TefINTERNAL
+				}
+				return ter.TesSUCCESS
+			},
+		})
+		requireClawbackRecovery(t, view, accountKey, result)
+		after, err := view.Read(lineKey)
+		if err != nil || !bytes.Equal(after, before) {
+			t.Fatalf("trust line was not rolled back: err=%v", err)
+		}
+	})
+
+	t.Run("invalid MPT delta", func(t *testing.T) {
+		view := newRecordingBaseView()
+		accountKey := fundRecoveryAccount(t, view, 1_000_000, 1)
+		issuer, err := state.DecodeAccountID(recoveryTestAccount)
+		if err != nil {
+			t.Fatalf("decode issuer: %v", err)
+		}
+		holder, err := state.DecodeAccountID(clawbackInvariantHolder)
+		if err != nil {
+			t.Fatalf("decode holder: %v", err)
+		}
+		issuanceID := keylet.MakeMPTID(1, issuer)
+		issuanceKey := keylet.MPTIssuance(issuanceID)
+		tokenKey := keylet.MPToken(issuanceKey.Key, holder)
+		beforeIssuance, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+			Issuer: issuer, Sequence: 1, OutstandingAmount: 100,
+		})
+		if err != nil {
+			t.Fatalf("serialize issuance: %v", err)
+		}
+		invalidIssuance, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+			Issuer: issuer, Sequence: 1, OutstandingAmount: 80,
+		})
+		if err != nil {
+			t.Fatalf("serialize invalid issuance: %v", err)
+		}
+		beforeToken, err := state.SerializeMPToken(&state.MPTokenData{
+			Account: holder, MPTokenIssuanceID: issuanceID, MPTAmount: 100,
+		})
+		if err != nil {
+			t.Fatalf("serialize token: %v", err)
+		}
+		invalidToken, err := state.SerializeMPToken(&state.MPTokenData{
+			Account: holder, MPTokenIssuanceID: issuanceID, MPTAmount: 80,
+		})
+		if err != nil {
+			t.Fatalf("serialize invalid token: %v", err)
+		}
+		if err := view.Insert(issuanceKey, beforeIssuance); err != nil {
+			t.Fatalf("insert issuance: %v", err)
+		}
+		if err := view.Insert(tokenKey, beforeToken); err != nil {
+			t.Fatalf("insert token: %v", err)
+		}
+
+		tx := clawback.NewMPTokenClawback(recoveryTestAccount, clawbackInvariantHolder,
+			state.NewMPTAmountWithIssuanceID(10, recoveryTestAccount, hex.EncodeToString(issuanceID[:])))
+		prepareClawbackInvariantTx(tx)
+		result := newClawbackInvariantEngine(view).Apply(clawbackInvariantTx{
+			Clawback: tx,
+			apply: func(ctx *txcore.ApplyContext) ter.Result {
+				if err := ctx.View.Update(tokenKey, invalidToken); err != nil {
+					return ter.TefINTERNAL
+				}
+				if err := ctx.View.Update(issuanceKey, invalidIssuance); err != nil {
+					return ter.TefINTERNAL
+				}
+				return ter.TesSUCCESS
+			},
+		})
+		requireClawbackRecovery(t, view, accountKey, result)
+		afterToken, err := view.Read(tokenKey)
+		if err != nil || !bytes.Equal(afterToken, beforeToken) {
+			t.Fatalf("MPToken was not rolled back: err=%v", err)
+		}
+		afterIssuance, err := view.Read(issuanceKey)
+		if err != nil || !bytes.Equal(afterIssuance, beforeIssuance) {
+			t.Fatalf("MPTokenIssuance was not rolled back: err=%v", err)
+		}
+	})
+}

--- a/internal/tx/engine/invariants_adapter.go
+++ b/internal/tx/engine/invariants_adapter.go
@@ -48,6 +48,16 @@ func (a *invariantsTxAdapter) ClawbackAmount() invariants.Amount {
 	return invariants.Amount{}
 }
 
+func (a *invariantsTxAdapter) ClawbackHolder() string {
+	type provider interface {
+		ClawbackHolder() string
+	}
+	if p, ok := a.tx.(provider); ok {
+		return p.ClawbackHolder()
+	}
+	return ""
+}
+
 // HasHolder implements invariants.HolderFieldProvider.
 func (a *invariantsTxAdapter) HasHolder() bool {
 	type provider interface {

--- a/internal/tx/engine/invariants_adapter_asset_test.go
+++ b/internal/tx/engine/invariants_adapter_asset_test.go
@@ -3,7 +3,9 @@ package engine
 import (
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/clawback"
 )
 
 // TestToInvariantsAsset_PreservesMPTIssuanceID guards the fix for the adapter
@@ -28,5 +30,25 @@ func TestToInvariantsAsset_PreservesMPTIssuanceID(t *testing.T) {
 	xrp := toInvariantsAsset(txcore.Asset{Currency: "XRP"})
 	if !xrp.IsNative() || xrp.IsMPT() {
 		t.Fatalf("XRP conversion wrong: %+v", xrp)
+	}
+}
+
+func TestInvariantsAdapterClawbackHolder(t *testing.T) {
+	transaction := clawback.NewMPTokenClawback(
+		"rIssuer",
+		"rHolder",
+		state.NewMPTAmountWithIssuanceID(
+			10,
+			"rIssuer",
+			"00000001C35BFC42B69F7A19B7C4C5B5D5E7F9A1B3C5D7E9",
+		),
+	)
+	adapted := wrapTxForInvariants(transaction)
+	provider, ok := adapted.(interface{ ClawbackHolder() string })
+	if !ok {
+		t.Fatal("Clawback holder provider is missing")
+	}
+	if got := provider.ClawbackHolder(); got != "rHolder" {
+		t.Fatalf("ClawbackHolder = %q, want rHolder", got)
 	}
 }

--- a/internal/tx/invariants/clawback.go
+++ b/internal/tx/invariants/clawback.go
@@ -1,148 +1,232 @@
 package invariants
 
 import (
+	"encoding/hex"
 	"fmt"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
 
-// ---------------------------------------------------------------------------
-// ValidClawback
-// ---------------------------------------------------------------------------
-//
-// Reference: rippled InvariantCheck.cpp — ValidClawback (lines 1288-1362)
-//
-// For ttCLAWBACK only:
-//   - visitEntry: count modified RippleState entries (before exists) and
-//     modified MPToken entries (before exists).
-//   - finalize (success): at most 1 trust line changed; at most 1 MPToken
-//     changed. If 1 trust line changed, holder balance must be non-negative.
-//   - finalize (failure): no trust lines or MPTokens should have changed.
+type clawbackEntry struct {
+	key    [32]byte
+	before []byte
+	after  []byte
+}
 
-func checkValidClawback(tx Transaction, result Result, entries []InvariantEntry, view ReadView) *InvariantViolation {
+func checkValidClawback(tx Transaction, result Result, entries []InvariantEntry, view ReadView, rules *amendment.Rules, numberContext ...state.NumberContext) *InvariantViolation {
 	if tx.TxType() != TypeClawback {
 		return nil
 	}
 
-	// visitEntry phase: count entries where before exists and type matches.
-	// In rippled, visitEntry checks (before && before->getType() == ltXXX).
-	// Entries with before present include both modified and deleted entries.
-	// Created entries (before == nil) are NOT counted.
 	var trustlinesChanged, mptokensChanged int
+	var iou, mpt clawbackEntry
 	for _, e := range entries {
-		if e.Before == nil {
-			continue
-		}
-		if e.EntryType == entry.TypeRippleState {
+		if e.Before != nil && e.EntryType == entry.TypeRippleState {
 			trustlinesChanged++
+			iou = clawbackEntry{key: e.Key, before: e.Before, after: e.After}
 		}
-		if e.EntryType == entry.TypeMPToken {
+		if e.Before != nil && e.EntryType == entry.TypeMPToken {
 			mptokensChanged++
+			mpt = clawbackEntry{key: e.Key, before: e.Before, after: e.After}
 		}
 	}
 
-	// finalize phase
-	if result == TesSUCCESS {
-		if trustlinesChanged > 1 {
-			return &InvariantViolation{
-				Name:    "ValidClawback",
-				Message: "more than one trustline changed",
-			}
-		}
-		if mptokensChanged > 1 {
-			return &InvariantViolation{
-				Name:    "ValidClawback",
-				Message: "more than one mptoken changed",
-			}
-		}
-
-		// If exactly 1 trust line changed, verify holder balance is non-negative.
-		if trustlinesChanged == 1 {
-			if v := checkClawbackHolderBalance(tx, view); v != nil {
-				return v
-			}
-		}
-	} else {
-		// On failure, no trust lines or MPTokens should have changed.
+	if result != TesSUCCESS {
 		if trustlinesChanged != 0 {
-			return &InvariantViolation{
-				Name:    "ValidClawback",
-				Message: "some trustlines were changed despite failure of the transaction",
-			}
+			return clawbackViolation("some trustlines were changed despite failure of the transaction")
 		}
 		if mptokensChanged != 0 {
-			return &InvariantViolation{
-				Name:    "ValidClawback",
-				Message: "some mptokens were changed despite failure of the transaction",
-			}
+			return clawbackViolation("some mptokens were changed despite failure of the transaction")
 		}
+		return nil
 	}
 
+	if trustlinesChanged > 1 {
+		return clawbackViolation("more than one trustline changed")
+	}
+	if mptokensChanged > 1 {
+		return clawbackViolation("more than one mptoken changed")
+	}
+
+	mptV2Enabled := rules != nil && rules.Enabled(amendment.FeatureMPTokensV2)
+	if trustlinesChanged != 0 && mptokensChanged != 0 && mptV2Enabled {
+		return clawbackViolation("trustline and MPToken both changed")
+	}
+	if trustlinesChanged == 0 && mptokensChanged == 0 {
+		return nil
+	}
+
+	provider, ok := tx.(ClawbackAmountProvider)
+	if !ok {
+		return nil
+	}
+	amount := provider.ClawbackAmount()
+	if !mptV2Enabled {
+		if trustlinesChanged == 1 && !amount.IsMPT() && view != nil {
+			return checkClawbackHolderBalance(tx, view)
+		}
+		return nil
+	}
+	if amount.IsMPT() {
+		return checkMPTClawbackDelta(tx, amount, mpt)
+	}
+	return checkIOUClawbackDelta(tx, amount, iou, view, numberContext...)
+}
+
+func checkIOUClawbackDelta(tx Transaction, amount Amount, changed clawbackEntry, view ReadView, numberContext ...state.NumberContext) *InvariantViolation {
+	issuer, err := state.DecodeAccountID(tx.TxAccount())
+	if err != nil {
+		return clawbackViolation("trustline clawback changed the wrong line")
+	}
+	holder, err := state.DecodeAccountID(amount.Issuer)
+	if err != nil {
+		return clawbackViolation("trustline clawback changed the wrong line")
+	}
+
+	if view != nil {
+		if violation := checkClawbackHolderBalance(tx, view); violation != nil {
+			return violation
+		}
+	}
+	if changed.before == nil || changed.key != keylet.Line(holder, issuer, amount.Currency).Key {
+		return clawbackViolation("trustline clawback changed the wrong line")
+	}
+
+	before, err := clawbackTrustLineBalance(changed.before, holder, issuer, amount.Currency, tx.TxAccount())
+	if err != nil {
+		return clawbackViolation("trustline clawback changed the wrong line")
+	}
+	after, err := clawbackTrustLineBalance(changed.after, holder, issuer, amount.Currency, tx.TxAccount())
+	if err != nil {
+		return clawbackViolation("trustline clawback changed the wrong line")
+	}
+	if before.Currency != amount.Currency || after.Currency != amount.Currency {
+		return clawbackViolation("trustline clawback balance change is invalid")
+	}
+	clawAmount := amount
+	clawAmount.Issuer = tx.TxAccount()
+	if clawAmount.Signum() <= 0 {
+		return clawbackViolation("trustline clawback amount is invalid")
+	}
+	if after.Compare(before) > 0 {
+		return clawbackViolation("trustline clawback balance change is invalid")
+	}
+	context := state.NewNumberContext(state.MantissaScaleSmall, false)
+	if len(numberContext) != 0 {
+		context = numberContext[0]
+	}
+	delta, err := before.SubWithNumberContext(after, context, state.RoundToNearest)
+	if err != nil {
+		return clawbackViolation("trustline clawback balance change is invalid")
+	}
+	expected := clawAmount
+	if before.Compare(clawAmount) < 0 {
+		expected = before
+	}
+	if delta.Compare(expected) != 0 {
+		return clawbackViolation("trustline clawback balance change is invalid")
+	}
 	return nil
 }
 
-// checkClawbackHolderBalance reads the trust line from the view and verifies
-// that the holder's balance is non-negative after clawback.
-// Reference: rippled InvariantCheck.cpp lines 1328-1342 — uses accountHolds().
-func checkClawbackHolderBalance(tx Transaction, view ReadView) *InvariantViolation {
-	if view == nil {
-		return nil // no view available — skip balance check
+func clawbackTrustLineBalance(data []byte, holder, issuer [20]byte, currency, issuerAddress string) (Amount, error) {
+	if data == nil {
+		return state.NewIssuedAmountFromValue(0, 0, currency, issuerAddress), nil
 	}
-
-	// Get the Amount from the transaction to determine holder and currency.
-	cap, ok := tx.(ClawbackAmountProvider)
-	if !ok {
-		return nil // unable to inspect Amount — skip
-	}
-	amt := cap.ClawbackAmount()
-
-	// issuer = tx.Account (the clawback submitter)
-	issuerAddr := tx.TxAccount()
-	issuerID, err := state.DecodeAccountID(issuerAddr)
+	line, err := state.ParseRippleState(data)
 	if err != nil {
-		return nil
+		return Amount{}, err
 	}
-
-	// holder = Amount.Issuer (for IOU clawback, the Issuer field is the holder)
-	holderAddr := amt.Issuer
-	holderID, err := state.DecodeAccountID(holderAddr)
-	if err != nil {
-		return nil
-	}
-	currency := amt.Currency
-
-	// Read the trust line between holder and issuer
-	lineKey := keylet.Line(holderID, issuerID, currency)
-	lineData, err := view.Read(lineKey)
-	if err != nil || lineData == nil {
-		// Trust line doesn't exist — balance is effectively zero, which is non-negative.
-		return nil
-	}
-
-	rs, err := state.ParseRippleState(lineData)
-	if err != nil {
-		return &InvariantViolation{
-			Name:    "ValidClawback",
-			Message: fmt.Sprintf("could not parse RippleState SLE: %v", err),
-		}
-	}
-
-	// accountHolds logic: get balance in holder's terms.
-	// Trust line balance: positive = low account owes high.
-	// If holder > issuer, negate to put balance in holder terms.
-	balance := rs.Balance
-	if state.CompareAccountIDs(holderID, issuerID) > 0 {
+	balance := line.Balance
+	if state.CompareAccountIDs(holder, issuer) > 0 {
 		balance = balance.Negate()
 	}
+	balance.Issuer = issuerAddress
+	return balance, nil
+}
 
-	if balance.Signum() < 0 {
-		return &InvariantViolation{
-			Name:    "ValidClawback",
-			Message: "trustline balance is negative",
-		}
+func checkMPTClawbackDelta(tx Transaction, amount Amount, changed clawbackEntry) *InvariantViolation {
+	holderProvider, ok := tx.(ClawbackHolderProvider)
+	if !ok || holderProvider.ClawbackHolder() == "" {
+		return clawbackViolation("MPT clawback missing holder")
+	}
+	holder, err := state.DecodeAccountID(holderProvider.ClawbackHolder())
+	if err != nil {
+		return clawbackViolation("MPT clawback changed the wrong token")
+	}
+	idBytes, err := hex.DecodeString(amount.MPTIssuanceID())
+	if err != nil || len(idBytes) != 24 {
+		return clawbackViolation("MPT clawback changed the wrong token")
+	}
+	var issuanceID [24]byte
+	copy(issuanceID[:], idBytes)
+	if changed.before == nil || changed.after == nil {
+		return clawbackViolation("MPT clawback token is missing")
+	}
+	if changed.key != keylet.MPToken(keylet.MPTIssuance(issuanceID).Key, holder).Key {
+		return clawbackViolation("MPT clawback changed the wrong token")
 	}
 
+	before, err := state.ParseMPToken(changed.before)
+	if err != nil {
+		return clawbackViolation(fmt.Sprintf("could not parse MPToken SLE: %v", err))
+	}
+	after, err := state.ParseMPToken(changed.after)
+	if err != nil {
+		return clawbackViolation(fmt.Sprintf("could not parse MPToken SLE: %v", err))
+	}
+	if before.Account != holder || after.Account != holder || before.MPTokenIssuanceID != issuanceID || after.MPTokenIssuanceID != issuanceID {
+		return clawbackViolation("MPT clawback changed the wrong token")
+	}
+	clawAmount, ok := amount.MPTRaw()
+	if !ok || clawAmount <= 0 {
+		return clawbackViolation("MPT clawback amount is invalid")
+	}
+	if after.MPTAmount > before.MPTAmount {
+		return clawbackViolation("MPT clawback balance change is invalid")
+	}
+	expected := min(before.MPTAmount, uint64(clawAmount))
+	if before.MPTAmount-after.MPTAmount != expected {
+		return clawbackViolation("MPT clawback balance change is invalid")
+	}
+	return nil
+}
+
+func clawbackViolation(message string) *InvariantViolation {
+	return &InvariantViolation{Name: "ValidClawback", Message: message}
+}
+
+func checkClawbackHolderBalance(tx Transaction, view ReadView) *InvariantViolation {
+	provider, ok := tx.(ClawbackAmountProvider)
+	if !ok {
+		return nil
+	}
+	amount := provider.ClawbackAmount()
+	issuer, err := state.DecodeAccountID(tx.TxAccount())
+	if err != nil {
+		return nil
+	}
+	holder, err := state.DecodeAccountID(amount.Issuer)
+	if err != nil {
+		return nil
+	}
+	lineData, err := view.Read(keylet.Line(holder, issuer, amount.Currency))
+	if err != nil || lineData == nil {
+		return nil
+	}
+	line, err := state.ParseRippleState(lineData)
+	if err != nil {
+		return clawbackViolation(fmt.Sprintf("could not parse RippleState SLE: %v", err))
+	}
+	balance := line.Balance
+	if state.CompareAccountIDs(holder, issuer) > 0 {
+		balance = balance.Negate()
+	}
+	if balance.Signum() < 0 {
+		return clawbackViolation("trustline or MPT balance is negative")
+	}
 	return nil
 }

--- a/internal/tx/invariants/clawback.go
+++ b/internal/tx/invariants/clawback.go
@@ -1,8 +1,10 @@
 package invariants
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
+	"slices"
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
@@ -11,9 +13,10 @@ import (
 )
 
 type clawbackEntry struct {
-	key    [32]byte
-	before []byte
-	after  []byte
+	beforeKey [32]byte
+	afterKey  [32]byte
+	before    []byte
+	after     []byte
 }
 
 func checkValidClawback(tx Transaction, result Result, entries []InvariantEntry, view ReadView, rules *amendment.Rules, numberContext ...state.NumberContext) *InvariantViolation {
@@ -23,14 +26,30 @@ func checkValidClawback(tx Transaction, result Result, entries []InvariantEntry,
 
 	var trustlinesChanged, mptokensChanged int
 	var iou, mpt clawbackEntry
-	for _, e := range entries {
-		if e.Before != nil && e.EntryType == entry.TypeRippleState {
+	orderedEntries := slices.Clone(entries)
+	slices.SortFunc(orderedEntries, func(a, b InvariantEntry) int {
+		return bytes.Compare(a.Key[:], b.Key[:])
+	})
+	for _, e := range orderedEntries {
+		beforeType, _ := state.DecodeType(e.Before)
+		afterType, _ := state.DecodeType(e.After)
+		if e.Before != nil && beforeType == entry.TypeRippleState {
 			trustlinesChanged++
-			iou = clawbackEntry{key: e.Key, before: e.Before, after: e.After}
+			iou.beforeKey = e.Key
+			iou.before = e.Before
 		}
-		if e.Before != nil && e.EntryType == entry.TypeMPToken {
+		if !e.IsDelete && e.After != nil && afterType == entry.TypeRippleState {
+			iou.afterKey = e.Key
+			iou.after = e.After
+		}
+		if e.Before != nil && beforeType == entry.TypeMPToken {
 			mptokensChanged++
-			mpt = clawbackEntry{key: e.Key, before: e.Before, after: e.After}
+			mpt.beforeKey = e.Key
+			mpt.before = e.Before
+		}
+		if !e.IsDelete && e.After != nil && afterType == entry.TypeMPToken {
+			mpt.afterKey = e.Key
+			mpt.after = e.After
 		}
 	}
 
@@ -65,8 +84,8 @@ func checkValidClawback(tx Transaction, result Result, entries []InvariantEntry,
 	}
 	amount := provider.ClawbackAmount()
 	if !mptV2Enabled {
-		if trustlinesChanged == 1 && !amount.IsMPT() && view != nil {
-			return checkClawbackHolderBalance(tx, view)
+		if trustlinesChanged == 1 && !amount.IsMPT() {
+			return checkLegacyIOUClawback(tx, amount, iou, view)
 		}
 		return nil
 	}
@@ -91,7 +110,8 @@ func checkIOUClawbackDelta(tx Transaction, amount Amount, changed clawbackEntry,
 			return violation
 		}
 	}
-	if changed.before == nil || changed.key != keylet.Line(holder, issuer, amount.Currency).Key {
+	expectedKey := keylet.Line(holder, issuer, amount.Currency).Key
+	if changed.before == nil || changed.beforeKey != expectedKey || changed.after != nil && changed.afterKey != expectedKey {
 		return clawbackViolation("trustline clawback changed the wrong line")
 	}
 
@@ -166,10 +186,6 @@ func checkMPTClawbackDelta(tx Transaction, amount Amount, changed clawbackEntry)
 	if changed.before == nil || changed.after == nil {
 		return clawbackViolation("MPT clawback token is missing")
 	}
-	if changed.key != keylet.MPToken(keylet.MPTIssuance(issuanceID).Key, holder).Key {
-		return clawbackViolation("MPT clawback changed the wrong token")
-	}
-
 	before, err := state.ParseMPToken(changed.before)
 	if err != nil {
 		return clawbackViolation(fmt.Sprintf("could not parse MPToken SLE: %v", err))
@@ -191,6 +207,38 @@ func checkMPTClawbackDelta(tx Transaction, amount Amount, changed clawbackEntry)
 	expected := min(before.MPTAmount, uint64(clawAmount))
 	if before.MPTAmount-after.MPTAmount != expected {
 		return clawbackViolation("MPT clawback balance change is invalid")
+	}
+	return nil
+}
+
+func checkLegacyIOUClawback(tx Transaction, amount Amount, changed clawbackEntry, view ReadView) *InvariantViolation {
+	if view != nil {
+		if violation := checkClawbackHolderBalance(tx, view); violation != nil {
+			return violation
+		}
+	}
+	issuer, err := state.DecodeAccountID(tx.TxAccount())
+	if err != nil {
+		return nil
+	}
+	holder, err := state.DecodeAccountID(amount.Issuer)
+	if err != nil {
+		return nil
+	}
+	expectedKey := keylet.Line(holder, issuer, amount.Currency).Key
+	if changed.before == nil || changed.beforeKey != expectedKey || changed.after != nil && changed.afterKey != expectedKey {
+		return nil
+	}
+	before, err := clawbackTrustLineBalance(changed.before, holder, issuer, amount.Currency, tx.TxAccount())
+	if err != nil {
+		return clawbackViolation("trustline clawback balance change is invalid")
+	}
+	after, err := clawbackTrustLineBalance(changed.after, holder, issuer, amount.Currency, tx.TxAccount())
+	if err != nil {
+		return clawbackViolation("trustline clawback balance change is invalid")
+	}
+	if before.Currency != amount.Currency || after.Currency != amount.Currency {
+		return clawbackViolation("trustline clawback balance change is invalid")
 	}
 	return nil
 }

--- a/internal/tx/invariants/clawback_delta_test.go
+++ b/internal/tx/invariants/clawback_delta_test.go
@@ -1,0 +1,265 @@
+package invariants
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+	"github.com/stretchr/testify/require"
+)
+
+func clawbackRules(enabled bool) *amendment.Rules {
+	builder := amendment.NewRulesBuilder()
+	if enabled {
+		builder.Enable(amendment.FeatureMPTokensV2)
+	}
+	return builder.Build()
+}
+
+func clawbackLine(t *testing.T, holderBalance int64) []byte {
+	t.Helper()
+	holder, err := state.DecodeAccountID(addrHolderA)
+	require.NoError(t, err)
+	issuer, err := state.DecodeAccountID(addrIssuer)
+	require.NoError(t, err)
+
+	balance := state.NewIssuedAmountFromValue(holderBalance, 0, "USD", state.AccountOneAddress)
+	if state.CompareAccountIDs(holder, issuer) > 0 {
+		balance = balance.Negate()
+	}
+	lowLimit := state.NewIssuedAmountFromValue(0, 0, "USD", addrHolderA)
+	highLimit := state.NewIssuedAmountFromValue(0, 0, "USD", addrIssuer)
+	data, err := state.SerializeRippleState(&state.RippleState{
+		Balance:   balance,
+		LowLimit:  lowLimit,
+		HighLimit: highLimit,
+	})
+	require.NoError(t, err)
+	return data
+}
+
+func clawbackLineEntry(t *testing.T, before, after *int64) InvariantEntry {
+	t.Helper()
+	holder, err := state.DecodeAccountID(addrHolderA)
+	require.NoError(t, err)
+	issuer, err := state.DecodeAccountID(addrIssuer)
+	require.NoError(t, err)
+	result := InvariantEntry{Key: keylet.Line(holder, issuer, "USD").Key, EntryType: entry.TypeRippleState}
+	if before != nil {
+		result.Before = clawbackLine(t, *before)
+	}
+	if after != nil {
+		result.After = clawbackLine(t, *after)
+	} else if before != nil {
+		result.IsDelete = true
+	}
+	return result
+}
+
+func clawbackMPTEntry(t *testing.T, holder string, issuanceID [24]byte, before, after *uint64) InvariantEntry {
+	t.Helper()
+	holderID, err := state.DecodeAccountID(holder)
+	require.NoError(t, err)
+	result := InvariantEntry{
+		Key:       keylet.MPToken(keylet.MPTIssuance(issuanceID).Key, holderID).Key,
+		EntryType: entry.TypeMPToken,
+	}
+	serialize := func(value uint64) []byte {
+		data, err := state.SerializeMPToken(&state.MPTokenData{
+			Account:           holderID,
+			MPTokenIssuanceID: issuanceID,
+			MPTAmount:         value,
+		})
+		require.NoError(t, err)
+		return data
+	}
+	if before != nil {
+		result.Before = serialize(*before)
+	}
+	if after != nil {
+		result.After = serialize(*after)
+	} else if before != nil {
+		result.IsDelete = true
+	}
+	return result
+}
+
+func TestValidClawbackIOUBalanceDelta(t *testing.T) {
+	amount := func(value int64) Amount {
+		return state.NewIssuedAmountFromValue(value, 0, "USD", addrHolderA)
+	}
+	tx := func(value int64) clawbackTx {
+		return clawbackTx{account: addrIssuer, amount: amount(value)}
+	}
+	ptr := func(value int64) *int64 { return &value }
+
+	tests := []struct {
+		name   string
+		before *int64
+		after  *int64
+		amount int64
+		mutate func(*InvariantEntry)
+		want   string
+	}{
+		{name: "partial", before: ptr(100), after: ptr(90), amount: 10},
+		{name: "full deletion", before: ptr(100), amount: 100},
+		{name: "over clawback zeros balance", before: ptr(100), amount: 150},
+		{name: "wrong delta", before: ptr(100), after: ptr(80), amount: 10, want: "trustline clawback balance change is invalid"},
+		{name: "wrong direction", before: ptr(100), after: ptr(110), amount: 10, want: "trustline clawback balance change is invalid"},
+		{name: "partial deletion", before: ptr(100), amount: 10, want: "trustline clawback balance change is invalid"},
+		{name: "zero amount", before: ptr(100), after: ptr(90), amount: 0, want: "trustline clawback amount is invalid"},
+		{name: "wrong trustline", before: ptr(100), after: ptr(90), amount: 10, mutate: func(e *InvariantEntry) { e.Key[0] ^= 1 }, want: "trustline clawback changed the wrong line"},
+		{name: "wrong before balance currency", before: ptr(100), after: ptr(90), amount: 10, mutate: func(e *InvariantEntry) {
+			line, err := state.ParseRippleState(e.Before)
+			require.NoError(t, err)
+			line.Balance.Currency = "EUR"
+			e.Before, err = state.SerializeRippleState(line)
+			require.NoError(t, err)
+		}, want: "trustline clawback balance change is invalid"},
+		{name: "wrong after balance currency", before: ptr(100), after: ptr(90), amount: 10, mutate: func(e *InvariantEntry) {
+			line, err := state.ParseRippleState(e.After)
+			require.NoError(t, err)
+			line.Balance.Currency = "EUR"
+			e.After, err = state.SerializeRippleState(line)
+			require.NoError(t, err)
+		}, want: "trustline clawback balance change is invalid"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			changed := clawbackLineEntry(t, test.before, test.after)
+			if test.mutate != nil {
+				test.mutate(&changed)
+			}
+			violation := checkValidClawback(tx(test.amount), TesSUCCESS, []InvariantEntry{changed}, stubView{}, clawbackRules(true))
+			if test.want == "" {
+				require.Nil(t, violation)
+				return
+			}
+			require.NotNil(t, violation)
+			require.Equal(t, test.want, violation.Message)
+		})
+	}
+
+	invalid := clawbackLineEntry(t, ptr(100), ptr(80))
+	require.Nil(t, checkValidClawback(tx(10), TesSUCCESS, []InvariantEntry{invalid}, stubView{}, clawbackRules(false)))
+
+	negative := clawbackLineEntry(t, ptr(100), ptr(-10))
+	violation := checkValidClawback(tx(10), TesSUCCESS, []InvariantEntry{negative}, lineView{line: negative.After}, clawbackRules(true))
+	require.NotNil(t, violation)
+	require.Equal(t, "trustline or MPT balance is negative", violation.Message)
+}
+
+func TestValidClawbackMPTBalanceDelta(t *testing.T) {
+	issuer, err := state.DecodeAccountID(addrIssuer)
+	require.NoError(t, err)
+	id := keylet.MakeMPTID(1, issuer)
+	mptID := hex.EncodeToString(id[:])
+	tx := func(value int64) clawbackTx {
+		return clawbackTx{
+			account: addrIssuer,
+			holder:  addrHolderA,
+			amount:  state.NewMPTAmountWithIssuanceID(value, addrIssuer, mptID),
+		}
+	}
+	ptr := func(value uint64) *uint64 { return &value }
+
+	tests := []struct {
+		name   string
+		before *uint64
+		after  *uint64
+		amount int64
+		mutate func(*clawbackTx, *InvariantEntry)
+		want   string
+	}{
+		{name: "partial", before: ptr(100), after: ptr(90), amount: 10},
+		{name: "over clawback zeros balance", before: ptr(100), after: ptr(0), amount: 150},
+		{name: "wrong delta", before: ptr(100), after: ptr(80), amount: 10, want: "MPT clawback balance change is invalid"},
+		{name: "wrong direction", before: ptr(100), after: ptr(110), amount: 10, want: "MPT clawback balance change is invalid"},
+		{name: "zero amount", before: ptr(100), after: ptr(90), amount: 0, want: "MPT clawback amount is invalid"},
+		{name: "deleted token", before: ptr(100), amount: 100, want: "MPT clawback token is missing"},
+		{name: "missing holder", before: ptr(100), after: ptr(90), amount: 10, mutate: func(tx *clawbackTx, _ *InvariantEntry) { tx.holder = "" }, want: "MPT clawback missing holder"},
+		{name: "wrong token", before: ptr(100), after: ptr(90), amount: 10, mutate: func(_ *clawbackTx, e *InvariantEntry) { e.Key[0] ^= 1 }, want: "MPT clawback changed the wrong token"},
+		{name: "wrong token contents", before: ptr(100), after: ptr(90), amount: 10, mutate: func(_ *clawbackTx, e *InvariantEntry) {
+			other, err := state.DecodeAccountID(addrHolderB)
+			require.NoError(t, err)
+			token, err := state.ParseMPToken(e.After)
+			require.NoError(t, err)
+			token.Account = other
+			e.After, err = state.SerializeMPToken(token)
+			require.NoError(t, err)
+		}, want: "MPT clawback changed the wrong token"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transaction := tx(test.amount)
+			changed := clawbackMPTEntry(t, addrHolderA, id, test.before, test.after)
+			if test.mutate != nil {
+				test.mutate(&transaction, &changed)
+			}
+			violation := checkValidClawback(transaction, TesSUCCESS, []InvariantEntry{changed}, stubView{}, clawbackRules(true))
+			if test.want == "" {
+				require.Nil(t, violation)
+				return
+			}
+			require.NotNil(t, violation)
+			require.Equal(t, test.want, violation.Message)
+		})
+	}
+
+	invalid := clawbackMPTEntry(t, addrHolderA, id, ptr(100), ptr(80))
+	require.Nil(t, checkValidClawback(tx(10), TesSUCCESS, []InvariantEntry{invalid}, stubView{}, clawbackRules(false)))
+}
+
+func TestValidClawbackRejectsAssetArmMismatch(t *testing.T) {
+	issuer, err := state.DecodeAccountID(addrIssuer)
+	require.NoError(t, err)
+	id := keylet.MakeMPTID(1, issuer)
+	mptID := hex.EncodeToString(id[:])
+	mptBefore, mptAfter := uint64(100), uint64(90)
+	mptEntry := clawbackMPTEntry(t, addrHolderA, id, &mptBefore, &mptAfter)
+	iouTx := clawbackTx{
+		account: addrIssuer,
+		amount:  state.NewIssuedAmountFromValue(10, 0, "USD", addrHolderA),
+	}
+	violation := checkValidClawback(iouTx, TesSUCCESS, []InvariantEntry{mptEntry}, stubView{}, clawbackRules(true))
+	require.NotNil(t, violation)
+	require.Equal(t, "trustline clawback changed the wrong line", violation.Message)
+
+	lineBefore, lineAfter := int64(100), int64(90)
+	lineEntry := clawbackLineEntry(t, &lineBefore, &lineAfter)
+	mptTx := clawbackTx{
+		account: addrIssuer,
+		holder:  addrHolderA,
+		amount:  state.NewMPTAmountWithIssuanceID(10, addrIssuer, mptID),
+	}
+	violation = checkValidClawback(mptTx, TesSUCCESS, []InvariantEntry{lineEntry}, stubView{}, clawbackRules(true))
+	require.NotNil(t, violation)
+	require.Equal(t, "MPT clawback token is missing", violation.Message)
+}
+
+func TestValidClawbackRejectsMixedAssetMutation(t *testing.T) {
+	issuer, err := state.DecodeAccountID(addrIssuer)
+	require.NoError(t, err)
+	id := keylet.MakeMPTID(1, issuer)
+	mptID := hex.EncodeToString(id[:])
+	lineBefore, lineAfter := int64(100), int64(90)
+	mptBefore, mptAfter := uint64(100), uint64(90)
+	entries := []InvariantEntry{
+		clawbackLineEntry(t, &lineBefore, &lineAfter),
+		clawbackMPTEntry(t, addrHolderA, id, &mptBefore, &mptAfter),
+	}
+	tx := clawbackTx{
+		account: addrIssuer,
+		holder:  addrHolderA,
+		amount:  state.NewMPTAmountWithIssuanceID(10, addrIssuer, mptID),
+	}
+	violation := checkValidClawback(tx, TesSUCCESS, entries, stubView{}, clawbackRules(true))
+	require.NotNil(t, violation)
+	require.Equal(t, "trustline and MPToken both changed", violation.Message)
+	require.Nil(t, checkValidClawback(tx, TesSUCCESS, entries, stubView{}, clawbackRules(false)))
+}

--- a/internal/tx/invariants/clawback_delta_test.go
+++ b/internal/tx/invariants/clawback_delta_test.go
@@ -146,9 +146,18 @@ func TestValidClawbackIOUBalanceDelta(t *testing.T) {
 
 	invalid := clawbackLineEntry(t, ptr(100), ptr(80))
 	require.Nil(t, checkValidClawback(tx(10), TesSUCCESS, []InvariantEntry{invalid}, stubView{}, clawbackRules(false)))
+	legacyCurrency := clawbackLineEntry(t, ptr(100), ptr(90))
+	legacyAfter, err := state.ParseRippleState(legacyCurrency.After)
+	require.NoError(t, err)
+	legacyAfter.Balance.Currency = "EUR"
+	legacyCurrency.After, err = state.SerializeRippleState(legacyAfter)
+	require.NoError(t, err)
+	violation := checkValidClawback(tx(10), TesSUCCESS, []InvariantEntry{legacyCurrency}, stubView{}, clawbackRules(false))
+	require.NotNil(t, violation)
+	require.Equal(t, "trustline clawback balance change is invalid", violation.Message)
 
 	negative := clawbackLineEntry(t, ptr(100), ptr(-10))
-	violation := checkValidClawback(tx(10), TesSUCCESS, []InvariantEntry{negative}, lineView{line: negative.After}, clawbackRules(true))
+	violation = checkValidClawback(tx(10), TesSUCCESS, []InvariantEntry{negative}, lineView{line: negative.After}, clawbackRules(true))
 	require.NotNil(t, violation)
 	require.Equal(t, "trustline or MPT balance is negative", violation.Message)
 }
@@ -182,13 +191,36 @@ func TestValidClawbackMPTBalanceDelta(t *testing.T) {
 		{name: "zero amount", before: ptr(100), after: ptr(90), amount: 0, want: "MPT clawback amount is invalid"},
 		{name: "deleted token", before: ptr(100), amount: 100, want: "MPT clawback token is missing"},
 		{name: "missing holder", before: ptr(100), after: ptr(90), amount: 10, mutate: func(tx *clawbackTx, _ *InvariantEntry) { tx.holder = "" }, want: "MPT clawback missing holder"},
-		{name: "wrong token", before: ptr(100), after: ptr(90), amount: 10, mutate: func(_ *clawbackTx, e *InvariantEntry) { e.Key[0] ^= 1 }, want: "MPT clawback changed the wrong token"},
-		{name: "wrong token contents", before: ptr(100), after: ptr(90), amount: 10, mutate: func(_ *clawbackTx, e *InvariantEntry) {
+		{name: "ledger key does not define token identity", before: ptr(100), after: ptr(90), amount: 10, mutate: func(_ *clawbackTx, e *InvariantEntry) { e.Key[0] ^= 1 }},
+		{name: "wrong before holder", before: ptr(100), after: ptr(90), amount: 10, mutate: func(_ *clawbackTx, e *InvariantEntry) {
+			other, err := state.DecodeAccountID(addrHolderB)
+			require.NoError(t, err)
+			token, err := state.ParseMPToken(e.Before)
+			require.NoError(t, err)
+			token.Account = other
+			e.Before, err = state.SerializeMPToken(token)
+			require.NoError(t, err)
+		}, want: "MPT clawback changed the wrong token"},
+		{name: "wrong after holder", before: ptr(100), after: ptr(90), amount: 10, mutate: func(_ *clawbackTx, e *InvariantEntry) {
 			other, err := state.DecodeAccountID(addrHolderB)
 			require.NoError(t, err)
 			token, err := state.ParseMPToken(e.After)
 			require.NoError(t, err)
 			token.Account = other
+			e.After, err = state.SerializeMPToken(token)
+			require.NoError(t, err)
+		}, want: "MPT clawback changed the wrong token"},
+		{name: "wrong before issuance", before: ptr(100), after: ptr(90), amount: 10, mutate: func(_ *clawbackTx, e *InvariantEntry) {
+			token, err := state.ParseMPToken(e.Before)
+			require.NoError(t, err)
+			token.MPTokenIssuanceID[0] ^= 1
+			e.Before, err = state.SerializeMPToken(token)
+			require.NoError(t, err)
+		}, want: "MPT clawback changed the wrong token"},
+		{name: "wrong after issuance", before: ptr(100), after: ptr(90), amount: 10, mutate: func(_ *clawbackTx, e *InvariantEntry) {
+			token, err := state.ParseMPToken(e.After)
+			require.NoError(t, err)
+			token.MPTokenIssuanceID[0] ^= 1
 			e.After, err = state.SerializeMPToken(token)
 			require.NoError(t, err)
 		}, want: "MPT clawback changed the wrong token"},
@@ -213,6 +245,44 @@ func TestValidClawbackMPTBalanceDelta(t *testing.T) {
 
 	invalid := clawbackMPTEntry(t, addrHolderA, id, ptr(100), ptr(80))
 	require.Nil(t, checkValidClawback(tx(10), TesSUCCESS, []InvariantEntry{invalid}, stubView{}, clawbackRules(false)))
+}
+
+func TestValidClawbackCapturesAfterEntriesInLedgerKeyOrder(t *testing.T) {
+	lineBefore, lineAfter := int64(100), int64(90)
+	line := clawbackLineEntry(t, &lineBefore, &lineAfter)
+	insertedLine := clawbackLineEntry(t, nil, &lineAfter)
+	var highKey [32]byte
+	for i := range highKey {
+		highKey[i] = 0xff
+	}
+	insertedLine.Key = highKey
+	iouTx := clawbackTx{
+		account: addrIssuer,
+		amount:  state.NewIssuedAmountFromValue(10, 0, "USD", addrHolderA),
+	}
+	violation := checkValidClawback(iouTx, TesSUCCESS, []InvariantEntry{insertedLine, line}, stubView{}, clawbackRules(true))
+	require.NotNil(t, violation)
+	require.Equal(t, "trustline clawback changed the wrong line", violation.Message)
+	insertedLine.Key = [32]byte{}
+	require.Nil(t, checkValidClawback(iouTx, TesSUCCESS, []InvariantEntry{line, insertedLine}, stubView{}, clawbackRules(true)))
+
+	issuer, err := state.DecodeAccountID(addrIssuer)
+	require.NoError(t, err)
+	id := keylet.MakeMPTID(1, issuer)
+	mptBefore, mptAfter := uint64(100), uint64(90)
+	token := clawbackMPTEntry(t, addrHolderA, id, &mptBefore, &mptAfter)
+	insertedToken := clawbackMPTEntry(t, addrHolderB, id, nil, &mptAfter)
+	insertedToken.Key = highKey
+	mptTx := clawbackTx{
+		account: addrIssuer,
+		holder:  addrHolderA,
+		amount:  state.NewMPTAmountWithIssuanceID(10, addrIssuer, hex.EncodeToString(id[:])),
+	}
+	violation = checkValidClawback(mptTx, TesSUCCESS, []InvariantEntry{insertedToken, token}, stubView{}, clawbackRules(true))
+	require.NotNil(t, violation)
+	require.Equal(t, "MPT clawback changed the wrong token", violation.Message)
+	insertedToken.Key = [32]byte{}
+	require.Nil(t, checkValidClawback(mptTx, TesSUCCESS, []InvariantEntry{token, insertedToken}, stubView{}, clawbackRules(true)))
 }
 
 func TestValidClawbackRejectsAssetArmMismatch(t *testing.T) {

--- a/internal/tx/invariants/highrisk_test.go
+++ b/internal/tx/invariants/highrisk_test.go
@@ -230,6 +230,7 @@ func TestValidAMM_DeleteMustRemoveObject(t *testing.T) {
 // holder-balance branch of ValidClawback can run.
 type clawbackTx struct {
 	account string
+	holder  string
 	amount  Amount
 }
 
@@ -238,6 +239,7 @@ func (t clawbackTx) TxAccount() string                { return t.account }
 func (t clawbackTx) TxHasField(string) bool           { return false }
 func (t clawbackTx) Flatten() (map[string]any, error) { return map[string]any{}, nil }
 func (t clawbackTx) ClawbackAmount() Amount           { return t.amount }
+func (t clawbackTx) ClawbackHolder() string           { return t.holder }
 
 // lineView returns the same trust-line bytes for every Read, enough for the
 // single accountHolds() lookup ValidClawback performs.
@@ -259,7 +261,7 @@ func TestValidClawback_TooManyEntries(t *testing.T) {
 		{EntryType: entry.TypeRippleState, Before: nonNil},
 		{EntryType: entry.TypeRippleState, Before: nonNil},
 	}
-	if v := checkValidClawback(tx, TesSUCCESS, twoLines, stubView{}); v == nil {
+	if v := checkValidClawback(tx, TesSUCCESS, twoLines, stubView{}, nil); v == nil {
 		t.Fatal("expected ValidClawback violation: more than one trustline changed")
 	} else if v.Name != "ValidClawback" {
 		t.Fatalf("unexpected violation name %q", v.Name)
@@ -269,14 +271,14 @@ func TestValidClawback_TooManyEntries(t *testing.T) {
 		{EntryType: entry.TypeMPToken, Before: nonNil},
 		{EntryType: entry.TypeMPToken, Before: nonNil},
 	}
-	if v := checkValidClawback(tx, TesSUCCESS, twoMPTokens, stubView{}); v == nil {
+	if v := checkValidClawback(tx, TesSUCCESS, twoMPTokens, stubView{}, nil); v == nil {
 		t.Fatal("expected ValidClawback violation: more than one mptoken changed")
 	}
 
 	// Exactly one trust line and no Amount provider: the ==1 branch skips the
 	// balance check and the invariant is satisfied.
 	oneLine := []InvariantEntry{{EntryType: entry.TypeRippleState, Before: nonNil}}
-	if v := checkValidClawback(tx, TesSUCCESS, oneLine, stubView{}); v != nil {
+	if v := checkValidClawback(tx, TesSUCCESS, oneLine, stubView{}, nil); v != nil {
 		t.Fatalf("single trustline: unexpected violation %v", v)
 	}
 }
@@ -290,11 +292,11 @@ func TestValidClawback_ChangesOnFailure(t *testing.T) {
 	const failure Result = 100 // any non-tesSUCCESS result
 
 	changed := []InvariantEntry{{EntryType: entry.TypeRippleState, Before: nonNil}}
-	if v := checkValidClawback(tx, failure, changed, stubView{}); v == nil {
+	if v := checkValidClawback(tx, failure, changed, stubView{}, nil); v == nil {
 		t.Fatal("expected ValidClawback violation: trustline changed despite failure")
 	}
 
-	if v := checkValidClawback(tx, failure, nil, stubView{}); v != nil {
+	if v := checkValidClawback(tx, failure, nil, stubView{}, nil); v != nil {
 		t.Fatalf("failed clawback with no changes: unexpected violation %v", v)
 	}
 }
@@ -345,14 +347,14 @@ func TestValidClawback_HolderBalanceSign(t *testing.T) {
 	}
 
 	neg := line(true)
-	if v := checkValidClawback(tx, TesSUCCESS, entries(neg), lineView{line: neg}); v == nil {
+	if v := checkValidClawback(tx, TesSUCCESS, entries(neg), lineView{line: neg}, nil); v == nil {
 		t.Fatal("expected ValidClawback violation: negative holder balance")
 	} else if v.Name != "ValidClawback" {
 		t.Fatalf("unexpected violation name %q", v.Name)
 	}
 
 	pos := line(false)
-	if v := checkValidClawback(tx, TesSUCCESS, entries(pos), lineView{line: pos}); v != nil {
+	if v := checkValidClawback(tx, TesSUCCESS, entries(pos), lineView{line: pos}, nil); v != nil {
 		t.Fatalf("non-negative holder balance: unexpected violation %v", v)
 	}
 }

--- a/internal/tx/invariants/highrisk_test.go
+++ b/internal/tx/invariants/highrisk_test.go
@@ -254,12 +254,12 @@ func (v lineView) Read(k keylet.Keylet) ([]byte, error) { return v.line, nil }
 // trust line and one MPToken; more than one of either trips ValidClawback.
 // Reference: rippled InvariantCheck.cpp ValidClawback (lines 1288-1362).
 func TestValidClawback_TooManyEntries(t *testing.T) {
-	nonNil := []byte{0x01}
 	tx := stubTx{txType: TypeClawback}
+	line := clawbackLine(t, 1)
 
 	twoLines := []InvariantEntry{
-		{EntryType: entry.TypeRippleState, Before: nonNil},
-		{EntryType: entry.TypeRippleState, Before: nonNil},
+		{Key: [32]byte{1}, EntryType: entry.TypeRippleState, Before: line},
+		{Key: [32]byte{2}, EntryType: entry.TypeRippleState, Before: line},
 	}
 	if v := checkValidClawback(tx, TesSUCCESS, twoLines, stubView{}, nil); v == nil {
 		t.Fatal("expected ValidClawback violation: more than one trustline changed")
@@ -267,9 +267,15 @@ func TestValidClawback_TooManyEntries(t *testing.T) {
 		t.Fatalf("unexpected violation name %q", v.Name)
 	}
 
+	issuer, err := state.DecodeAccountID(addrIssuer)
+	if err != nil {
+		t.Fatalf("DecodeAccountID: %v", err)
+	}
+	id := keylet.MakeMPTID(1, issuer)
+	value := uint64(1)
 	twoMPTokens := []InvariantEntry{
-		{EntryType: entry.TypeMPToken, Before: nonNil},
-		{EntryType: entry.TypeMPToken, Before: nonNil},
+		clawbackMPTEntry(t, addrHolderA, id, &value, nil),
+		clawbackMPTEntry(t, addrHolderB, id, &value, nil),
 	}
 	if v := checkValidClawback(tx, TesSUCCESS, twoMPTokens, stubView{}, nil); v == nil {
 		t.Fatal("expected ValidClawback violation: more than one mptoken changed")
@@ -277,7 +283,7 @@ func TestValidClawback_TooManyEntries(t *testing.T) {
 
 	// Exactly one trust line and no Amount provider: the ==1 branch skips the
 	// balance check and the invariant is satisfied.
-	oneLine := []InvariantEntry{{EntryType: entry.TypeRippleState, Before: nonNil}}
+	oneLine := []InvariantEntry{{EntryType: entry.TypeRippleState, Before: line}}
 	if v := checkValidClawback(tx, TesSUCCESS, oneLine, stubView{}, nil); v != nil {
 		t.Fatalf("single trustline: unexpected violation %v", v)
 	}
@@ -287,11 +293,10 @@ func TestValidClawback_TooManyEntries(t *testing.T) {
 // any trust line or MPToken.
 // Reference: rippled InvariantCheck.cpp lines 1344-1361.
 func TestValidClawback_ChangesOnFailure(t *testing.T) {
-	nonNil := []byte{0x01}
 	tx := stubTx{txType: TypeClawback}
 	const failure Result = 100 // any non-tesSUCCESS result
 
-	changed := []InvariantEntry{{EntryType: entry.TypeRippleState, Before: nonNil}}
+	changed := []InvariantEntry{{EntryType: entry.TypeRippleState, Before: clawbackLine(t, 1)}}
 	if v := checkValidClawback(tx, failure, changed, stubView{}, nil); v == nil {
 		t.Fatal("expected ValidClawback violation: trustline changed despite failure")
 	}

--- a/internal/tx/invariants/invariants.go
+++ b/internal/tx/invariants/invariants.go
@@ -193,7 +193,7 @@ func CheckInvariants(tx Transaction, result Result, fee uint64, txDeclaredFee ui
 			return checkNFTokenCountTracking(txType, result, entries)
 		},
 		func() *InvariantViolation {
-			return checkValidClawback(tx, result, entries, view)
+			return checkValidClawback(tx, result, entries, view, rules, numberContext...)
 		},
 		func() *InvariantViolation {
 			return checkValidMPTIssuance(tx, result, entries, view, rules)
@@ -251,6 +251,10 @@ func CheckInvariants(tx Transaction, result Result, fee uint64, txDeclaredFee ui
 // clawback subpackage.
 type ClawbackAmountProvider interface {
 	ClawbackAmount() Amount
+}
+
+type ClawbackHolderProvider interface {
+	ClawbackHolder() string
 }
 
 // HolderFieldProvider is optionally implemented by transactions that have a

--- a/internal/tx/invariants/predicate_residuals_test.go
+++ b/internal/tx/invariants/predicate_residuals_test.go
@@ -327,7 +327,7 @@ func TestParseError_HardFails(t *testing.T) {
 			amount:  amount,
 		}
 		entries := []InvariantEntry{{EntryType: entry.TypeRippleState, Before: rsBad, After: rsBad}}
-		if v := checkValidClawback(tx, TesSUCCESS, entries, lineView{line: rsBad}); v == nil {
+		if v := checkValidClawback(tx, TesSUCCESS, entries, lineView{line: rsBad}, nil); v == nil {
 			t.Fatal("expected ValidClawback violation for unparseable trust line")
 		}
 	})


### PR DESCRIPTION
## Summary
- validate IOU and MPT Clawback invariants against the actual before/after holder balance transition
- preserve deleted trust-line state as a zero post-balance while rejecting deleted MPT holdings and unrelated mutations
- retain pre-MPTokensV2 compatibility and add oracle-derived delta, identity, amendment, and fee-only rollback coverage

## Test plan
- [x] `go test ./internal/tx/invariants ./internal/tx/engine ./internal/tx/clawback ./internal/testing/clawback ./internal/testing/mpt`
- [x] `go test -race ./internal/tx/invariants ./internal/tx/engine ./internal/tx/clawback ./internal/testing/clawback ./internal/testing/mpt`
- [x] `just build-all`
- [x] `just vet`
- [x] `just lint`
- [x] `just test-tx`
- [x] `just test-integration`

Fixes #1386
