### PR TITLE
fix: unify pseudo-account asset checks

### DIFF
--- a/internal/tx/amm/amm_deposit.go
+++ b/internal/tx/amm/amm_deposit.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -247,10 +248,24 @@ func (a *AMMDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Re
 	lptKey := keylet.Line(accountID, ammAccountID, lptCurrency)
 	lptExists, _ := view.Exists(lptKey)
 
-	// Check authorization and freeze status for BOTH pool assets — only when
-	// AMMClawback is enabled.
+	// Check authorization and freeze status for BOTH pool assets. fixCleanup3_3_0
+	// uses the unified pseudo-account deposit rules; the legacy path remains
+	// unchanged when the amendment is disabled.
 	// Reference: rippled AMMDeposit.cpp lines 244-273
-	if config.RequireRules().Enabled(amendment.FeatureAMMClawback) {
+	if config.RequireRules().Enabled(amendment.FeatureFixCleanup3_3_0) {
+		checkAsset := func(asset tx.Asset) ter.Result {
+			if result := requireAssetAuth(view, asset, accountID, false, config.ParentCloseTime); result != ter.TesSUCCESS {
+				return result
+			}
+			return mptutil.CheckDepositFreeze(view, accountID, ammAccountID, asset)
+		}
+		if result := checkAsset(a.Asset); result != ter.TesSUCCESS {
+			return result
+		}
+		if result := checkAsset(a.Asset2); result != ter.TesSUCCESS {
+			return result
+		}
+	} else if config.RequireRules().Enabled(amendment.FeatureAMMClawback) {
 		if result := requireAssetAuth(view, a.Asset, accountID, false, config.ParentCloseTime); result != ter.TesSUCCESS {
 			return result
 		}
@@ -273,11 +288,13 @@ func (a *AMMDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Re
 		if result := requireAssetAuth(view, amtAsset, accountID, true, config.ParentCloseTime); result != ter.TesSUCCESS {
 			return result
 		}
-		if assetFrozen(view, ammAccountID, amtAsset) {
-			return frozenAssetResult(amtAsset)
-		}
-		if assetIndividuallyFrozen(view, accountID, amtAsset) {
-			return frozenAssetResult(amtAsset)
+		if !config.RequireRules().Enabled(amendment.FeatureFixCleanup3_3_0) {
+			if assetFrozen(view, ammAccountID, amtAsset) {
+				return frozenAssetResult(amtAsset)
+			}
+			if assetIndividuallyFrozen(view, accountID, amtAsset) {
+				return frozenAssetResult(amtAsset)
+			}
 		}
 		if checkBalance {
 			if isXRPAsset(amtAsset) {

--- a/internal/tx/amm/amm_withdraw.go
+++ b/internal/tx/amm/amm_withdraw.go
@@ -234,11 +234,17 @@ func (a *AMMWithdraw) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.R
 		if result := requireAssetAuth(view, amtAsset, accountID, false, config.ParentCloseTime); result != ter.TesSUCCESS {
 			return result
 		}
-		if assetFrozen(view, ammAccountID, amtAsset) {
-			return frozenAssetResult(amtAsset)
-		}
-		if assetIndividuallyFrozen(view, accountID, amtAsset) {
-			return frozenAssetResult(amtAsset)
+		if config.RequireRules().Enabled(amendment.FeatureFixCleanup3_3_0) {
+			if result := mptutil.CheckWithdrawFreeze(view, ammAccountID, accountID, accountID, amtAsset); result != ter.TesSUCCESS {
+				return result
+			}
+		} else {
+			if assetFrozen(view, ammAccountID, amtAsset) {
+				return frozenAssetResult(amtAsset)
+			}
+			if assetIndividuallyFrozen(view, accountID, amtAsset) {
+				return frozenAssetResult(amtAsset)
+			}
 		}
 		return ter.TesSUCCESS
 	}

--- a/internal/tx/credential/credential_create.go
+++ b/internal/tx/credential/credential_create.go
@@ -138,6 +138,9 @@ func (c *CredentialCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) 
 	if exists, _ := view.Exists(keylet.Credential(subjectID, issuerID, credTypeBytes)); exists {
 		return ter.TecDUPLICATE
 	}
+	if config.RequireRules().Enabled(amendment.FeatureFixCleanup3_3_0) && tx.IsPseudoAccountID(view, subjectID) {
+		return ter.TecPSEUDO_ACCOUNT
+	}
 	return ter.TesSUCCESS
 }
 

--- a/internal/tx/credential/fix_cleanup330_target_test.go
+++ b/internal/tx/credential/fix_cleanup330_target_test.go
@@ -1,0 +1,48 @@
+package credential
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCredentialCreatePseudoSubjectCleanup330(t *testing.T) {
+	issuerID := [20]byte{1}
+	pseudoID := [20]byte{2}
+	issuer := state.EncodeAccountIDSafe(issuerID)
+	pseudo := state.EncodeAccountIDSafe(pseudoID)
+	view := newMapView()
+	pseudoRaw, err := state.SerializeAccountRoot(&state.AccountRoot{
+		Account: pseudo,
+		VaultID: [32]byte{1},
+	})
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(keylet.Account(pseudoID), pseudoRaw))
+
+	newTx := func() *CredentialCreate {
+		return NewCredentialCreate(issuer, pseudo, "4B5943")
+	}
+	off := amendment.NewRules(nil)
+	on := amendment.NewRules([][32]byte{amendment.FeatureFixCleanup3_3_0})
+	require.Equal(t, ter.TesSUCCESS, newTx().Preclaim(view, tx.EngineConfig{Rules: off}))
+	require.Equal(t, ter.TecPSEUDO_ACCOUNT, newTx().Preclaim(view, tx.EngineConfig{Rules: on}))
+
+	credKey := keylet.Credential(pseudoID, issuerID, []byte("KYC"))
+	require.NoError(t, view.Insert(credKey, []byte{1}))
+	require.Equal(t, ter.TecDUPLICATE, newTx().Preclaim(view, tx.EngineConfig{Rules: on}))
+}
+
+func TestCredentialCreateMissingSubjectRemainsNoTarget(t *testing.T) {
+	issuerID := [20]byte{1}
+	issuer := state.EncodeAccountIDSafe(issuerID)
+	missing := state.EncodeAccountIDSafe([20]byte{2})
+	view := newMapView()
+	create := NewCredentialCreate(issuer, missing, "4B5943")
+	on := amendment.NewRules([][32]byte{amendment.FeatureFixCleanup3_3_0})
+	require.Equal(t, ter.TecNO_TARGET, create.Preclaim(view, tx.EngineConfig{Rules: on}))
+}

--- a/internal/tx/depositpreauth/depositpreauth.go
+++ b/internal/tx/depositpreauth/depositpreauth.go
@@ -314,6 +314,9 @@ func (d *DepositPreauth) Preclaim(view tx.LedgerView, config tx.EngineConfig) te
 		if !exists {
 			return ter.TecNO_TARGET
 		}
+		if config.RequireRules().Enabled(amendment.FeatureFixCleanup3_3_0) && tx.IsPseudoAccountID(view, authorizedID) {
+			return ter.TecPSEUDO_ACCOUNT
+		}
 		exists, err = view.Exists(keylet.DepositPreauth(accountID, authorizedID))
 		if err != nil {
 			return ter.TefEXCEPTION

--- a/internal/tx/depositpreauth/fix_cleanup330_target_test.go
+++ b/internal/tx/depositpreauth/fix_cleanup330_target_test.go
@@ -1,0 +1,55 @@
+package depositpreauth
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDepositPreauthPseudoTargetCleanup330(t *testing.T) {
+	ownerID := [20]byte{1}
+	pseudoID := [20]byte{2}
+	owner := state.EncodeAccountIDSafe(ownerID)
+	pseudo := state.EncodeAccountIDSafe(pseudoID)
+	view := newFaultView()
+	pseudoRaw, err := state.SerializeAccountRoot(&state.AccountRoot{
+		Account: pseudo,
+		VaultID: [32]byte{1},
+	})
+	require.NoError(t, err)
+	view.data[keylet.Account(pseudoID).Key] = pseudoRaw
+
+	newTx := func() *DepositPreauth {
+		txn := NewDepositPreauth(owner)
+		txn.Authorize = pseudo
+		return txn
+	}
+	off := amendment.NewRules(nil)
+	on := amendment.NewRules([][32]byte{amendment.FeatureFixCleanup3_3_0})
+	require.Equal(t, ter.TesSUCCESS, newTx().Preclaim(view, tx.EngineConfig{Rules: off}))
+	require.Equal(t, ter.TecPSEUDO_ACCOUNT, newTx().Preclaim(view, tx.EngineConfig{Rules: on}))
+
+	preauthKey := keylet.DepositPreauth(ownerID, pseudoID)
+	view.data[preauthKey.Key] = []byte{1}
+	require.Equal(t, ter.TecPSEUDO_ACCOUNT, newTx().Preclaim(view, tx.EngineConfig{Rules: on}))
+
+	unauthorize := NewDepositPreauth(owner)
+	unauthorize.Unauthorize = pseudo
+	require.Equal(t, ter.TesSUCCESS, unauthorize.Preclaim(view, tx.EngineConfig{Rules: on}))
+}
+
+func TestDepositPreauthMissingTargetRemainsNoTarget(t *testing.T) {
+	ownerID := [20]byte{1}
+	owner := state.EncodeAccountIDSafe(ownerID)
+	missing := state.EncodeAccountIDSafe([20]byte{2})
+	view := newFaultView()
+	txn := NewDepositPreauth(owner)
+	txn.Authorize = missing
+	on := amendment.NewRules([][32]byte{amendment.FeatureFixCleanup3_3_0})
+	require.Equal(t, ter.TecNO_TARGET, txn.Preclaim(view, tx.EngineConfig{Rules: on}))
+}

--- a/internal/tx/lending/loan_broker_apply.go
+++ b/internal/tx/lending/loan_broker_apply.go
@@ -334,6 +334,9 @@ func (l *LoanBrokerCoverDeposit) Preclaim(view tx.LedgerView, config tx.EngineCo
 	if !amountAssetMatches(l.Amount, asset) {
 		return ter.TecWRONG_ASSET
 	}
+	if res := mptutil.CanTransferAsset(view, asset, accountID, b.Account, false); res != ter.TesSUCCESS {
+		return res
+	}
 	if config.RequireRules().Enabled(amendment.FeatureFixCleanup3_3_0) {
 		if res := mptutil.CheckDepositFreeze(view, accountID, b.Account, asset); res != ter.TesSUCCESS {
 			return res
@@ -438,6 +441,9 @@ func (l *LoanBrokerCoverWithdraw) Preclaim(view tx.LedgerView, config tx.EngineC
 	fix320 := config.RequireRules().FixCleanup3_2_0Enabled()
 	integral := assetIntegral(asset)
 	if res := canApplyToBrokerCover(fix320, lendNumForRules(b.CoverAvailable, config.RequireRules()), amountToLendNumForRules(l.Amount, config.RequireRules()), integral); res != ter.TesSUCCESS {
+		return res
+	}
+	if res := mptutil.CanTransferAsset(view, asset, b.Account, dstID, fix320); res != ter.TesSUCCESS {
 		return res
 	}
 	if accountID != dstID {

--- a/internal/tx/lending/loan_broker_apply.go
+++ b/internal/tx/lending/loan_broker_apply.go
@@ -334,13 +334,19 @@ func (l *LoanBrokerCoverDeposit) Preclaim(view tx.LedgerView, config tx.EngineCo
 	if !amountAssetMatches(l.Amount, asset) {
 		return ter.TecWRONG_ASSET
 	}
-	if res := tx.AssetFrozen(view, accountID, asset); res != ter.TesSUCCESS {
-		return res
+	if config.RequireRules().Enabled(amendment.FeatureFixCleanup3_3_0) {
+		if res := mptutil.CheckDepositFreeze(view, accountID, b.Account, asset); res != ter.TesSUCCESS {
+			return res
+		}
+	} else {
+		if res := tx.AssetFrozen(view, accountID, asset); res != ter.TesSUCCESS {
+			return res
+		}
+		if res := tx.AssetFrozen(view, b.Account, asset); res != ter.TesSUCCESS {
+			return res
+		}
 	}
-	if res := tx.AssetFrozen(view, b.Account, asset); res != ter.TesSUCCESS {
-		return res
-	}
-	if res := tx.RequireAuth(view, asset, accountID); res != ter.TesSUCCESS {
+	if res := mptutil.RequireAssetAuthAt(view, asset, accountID, mptutil.StrongAuth, config.ParentCloseTime); res != ter.TesSUCCESS {
 		return res
 	}
 	amount, cres := roundCoverDeposit(config.RequireRules().FixCleanup3_2_0Enabled(),
@@ -439,8 +445,17 @@ func (l *LoanBrokerCoverWithdraw) Preclaim(view tx.LedgerView, config tx.EngineC
 			return res
 		}
 	}
-	if res := tx.RequireAuth(view, asset, dstID); res != ter.TesSUCCESS {
+	authType := mptutil.WeakAuth
+	if accountID != dstID {
+		authType = mptutil.StrongAuth
+	}
+	if res := mptutil.RequireAssetAuthAt(view, asset, dstID, authType, config.ParentCloseTime); res != ter.TesSUCCESS {
 		return res
+	}
+	if config.RequireRules().Enabled(amendment.FeatureFixCleanup3_3_0) {
+		if res := mptutil.CheckWithdrawFreeze(view, b.Account, accountID, dstID, asset); res != ter.TesSUCCESS {
+			return res
+		}
 	}
 
 	amount := amountToLendNumForRules(l.Amount, config.RequireRules())

--- a/internal/tx/lending/loan_broker_auth_test.go
+++ b/internal/tx/lending/loan_broker_auth_test.go
@@ -1,0 +1,132 @@
+package lending
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+type coverAuthFixture struct {
+	base   *coverClawbackFixture
+	owner  [20]byte
+	dest   [20]byte
+	amount tx.Amount
+	broker string
+}
+
+func newCoverAuthFixture(t *testing.T) *coverAuthFixture {
+	t.Helper()
+	base := newCoverClawbackFixture(t, 0)
+	owner := repeatedAccountID(0x34)
+	dest := repeatedAccountID(0x35)
+
+	brokerKey := keylet.LoanBrokerByID(base.brokerID)
+	broker, err := readLoanBroker(base.view, brokerKey)
+	if err != nil || broker == nil {
+		t.Fatalf("read broker: broker=%v err=%v", broker, err)
+	}
+	broker.Owner = owner
+	brokerBytes, err := serializeLoanBrokerForRules(broker, base.view.rules)
+	if err != nil {
+		t.Fatalf("serialize broker: %v", err)
+	}
+	base.view.data[brokerKey.Key] = brokerBytes
+
+	putAccount := func(id [20]byte) {
+		t.Helper()
+		raw, err := state.SerializeAccountRoot(&state.AccountRoot{
+			Account:  encodeTestAccount(t, id),
+			Balance:  1_000_000_000,
+			Sequence: 1,
+		})
+		if err != nil {
+			t.Fatalf("serialize account: %v", err)
+		}
+		base.view.data[keylet.Account(id).Key] = raw
+	}
+	putAccount(base.issuerID)
+	putAccount(owner)
+	putAccount(dest)
+
+	issuer := encodeTestAccount(t, base.issuerID)
+	amount := state.NewMPTAmountWithIssuanceID(
+		100,
+		issuer,
+		hex.EncodeToString(base.mptID[:]),
+	)
+	return &coverAuthFixture{
+		base:   base,
+		owner:  owner,
+		dest:   dest,
+		amount: amount,
+		broker: strings.ToUpper(hex.EncodeToString(base.brokerID[:])),
+	}
+}
+
+func (f *coverAuthFixture) putHolding(t *testing.T, account [20]byte) {
+	t.Helper()
+	raw, err := state.SerializeMPToken(&state.MPTokenData{
+		Account:           account,
+		MPTokenIssuanceID: f.base.mptID,
+		MPTAmount:         10_000,
+	})
+	if err != nil {
+		t.Fatalf("serialize holding: %v", err)
+	}
+	f.base.view.data[keylet.MPTokenByID(f.base.mptID, account).Key] = raw
+}
+
+func (f *coverAuthFixture) ownerAddress(t *testing.T) string {
+	t.Helper()
+	return encodeTestAccount(t, f.owner)
+}
+
+func (f *coverAuthFixture) destinationAddress(t *testing.T) string {
+	t.Helper()
+	return encodeTestAccount(t, f.dest)
+}
+
+func TestLoanBrokerCoverDepositRequiresMPTHolding(t *testing.T) {
+	fixture := newCoverAuthFixture(t)
+	deposit := NewLoanBrokerCoverDeposit(fixture.ownerAddress(t), fixture.broker, fixture.amount)
+
+	if got := deposit.Preclaim(fixture.base.view, fixture.base.config); got != ter.TecNO_AUTH {
+		t.Fatalf("missing depositor holding: got %v, want tecNO_AUTH", got)
+	}
+
+	fixture.putHolding(t, fixture.owner)
+	if got := deposit.Preclaim(fixture.base.view, fixture.base.config); got != ter.TesSUCCESS {
+		t.Fatalf("existing depositor holding: got %v, want tesSUCCESS", got)
+	}
+}
+
+func TestLoanBrokerCoverWithdrawAuthModeDependsOnDestination(t *testing.T) {
+	t.Run("self withdrawal uses weak auth", func(t *testing.T) {
+		fixture := newCoverAuthFixture(t)
+		withdraw := NewLoanBrokerCoverWithdraw(fixture.ownerAddress(t), fixture.broker, fixture.amount)
+
+		if got := withdraw.Preclaim(fixture.base.view, fixture.base.config); got != ter.TesSUCCESS {
+			t.Fatalf("missing self holding: got %v, want tesSUCCESS", got)
+		}
+	})
+
+	t.Run("third-party withdrawal uses strong auth", func(t *testing.T) {
+		fixture := newCoverAuthFixture(t)
+		withdraw := NewLoanBrokerCoverWithdraw(fixture.ownerAddress(t), fixture.broker, fixture.amount)
+		withdraw.Destination = fixture.destinationAddress(t)
+
+		if got := withdraw.Preclaim(fixture.base.view, fixture.base.config); got != ter.TecNO_AUTH {
+			t.Fatalf("missing destination holding: got %v, want tecNO_AUTH", got)
+		}
+
+		fixture.putHolding(t, fixture.dest)
+		if got := withdraw.Preclaim(fixture.base.view, fixture.base.config); got != ter.TesSUCCESS {
+			t.Fatalf("existing destination holding: got %v, want tesSUCCESS", got)
+		}
+	})
+}

--- a/internal/tx/lending/loan_broker_auth_test.go
+++ b/internal/tx/lending/loan_broker_auth_test.go
@@ -5,10 +5,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
 
 type coverAuthFixture struct {
@@ -21,7 +23,7 @@ type coverAuthFixture struct {
 
 func newCoverAuthFixture(t *testing.T) *coverAuthFixture {
 	t.Helper()
-	base := newCoverClawbackFixture(t, 0)
+	base := newCoverClawbackFixture(t, entry.LsfMPTCanTransfer)
 	owner := repeatedAccountID(0x34)
 	dest := repeatedAccountID(0x35)
 
@@ -68,6 +70,21 @@ func newCoverAuthFixture(t *testing.T) *coverAuthFixture {
 	}
 }
 
+func (f *coverAuthFixture) setIssuanceFlags(t *testing.T, flags uint32) {
+	t.Helper()
+	raw := f.base.view.data[keylet.MPTIssuance(f.base.mptID).Key]
+	issuance, err := state.ParseMPTokenIssuance(raw)
+	if err != nil {
+		t.Fatalf("parse issuance: %v", err)
+	}
+	issuance.Flags = flags
+	raw, err = state.SerializeMPTokenIssuance(issuance)
+	if err != nil {
+		t.Fatalf("serialize issuance: %v", err)
+	}
+	f.base.view.data[keylet.MPTIssuance(f.base.mptID).Key] = raw
+}
+
 func (f *coverAuthFixture) putHolding(t *testing.T, account [20]byte) {
 	t.Helper()
 	raw, err := state.SerializeMPToken(&state.MPTokenData{
@@ -102,6 +119,44 @@ func TestLoanBrokerCoverDepositRequiresMPTHolding(t *testing.T) {
 	fixture.putHolding(t, fixture.owner)
 	if got := deposit.Preclaim(fixture.base.view, fixture.base.config); got != ter.TesSUCCESS {
 		t.Fatalf("existing depositor holding: got %v, want tesSUCCESS", got)
+	}
+}
+
+func TestLoanBrokerCoverDepositRequiresTransferableMPT(t *testing.T) {
+	fixture := newCoverAuthFixture(t)
+	fixture.putHolding(t, fixture.owner)
+	fixture.setIssuanceFlags(t, 0)
+	deposit := NewLoanBrokerCoverDeposit(fixture.ownerAddress(t), fixture.broker, fixture.amount)
+
+	if got := deposit.Preclaim(fixture.base.view, fixture.base.config); got != ter.TecNO_AUTH {
+		t.Fatalf("non-transferable MPT deposit: got %v, want tecNO_AUTH", got)
+	}
+}
+
+func TestLoanBrokerCoverWithdrawTransferabilityWaiver(t *testing.T) {
+	fixture := newCoverAuthFixture(t)
+	fixture.setIssuanceFlags(t, 0)
+	withdraw := NewLoanBrokerCoverWithdraw(fixture.ownerAddress(t), fixture.broker, fixture.amount)
+
+	fixture.base.view.rules = amendment.NewRules([][32]byte{
+		amendment.FeatureMPTokensV1,
+		amendment.FeatureSingleAssetVault,
+		amendment.FeatureLendingProtocol,
+	})
+	fixture.base.config.Rules = fixture.base.view.rules
+	if got := withdraw.Preclaim(fixture.base.view, fixture.base.config); got != ter.TecNO_AUTH {
+		t.Fatalf("legacy non-transferable MPT withdraw: got %v, want tecNO_AUTH", got)
+	}
+
+	fixture.base.view.rules = amendment.NewRules([][32]byte{
+		amendment.FeatureMPTokensV1,
+		amendment.FeatureSingleAssetVault,
+		amendment.FeatureLendingProtocol,
+		amendment.FeatureFixCleanup3_2_0,
+	})
+	fixture.base.config.Rules = fixture.base.view.rules
+	if got := withdraw.Preclaim(fixture.base.view, fixture.base.config); got != ter.TesSUCCESS {
+		t.Fatalf("cleanup recovery withdraw: got %v, want tesSUCCESS", got)
 	}
 }
 

--- a/internal/tx/mptutil/mpt.go
+++ b/internal/tx/mptutil/mpt.go
@@ -196,6 +196,177 @@ func IsAssetFrozen(view state.LedgerView, asset tx.Asset, account [20]byte) bool
 	return isIOUFrozen(view, account, asset)
 }
 
+// CheckDepositFreeze applies the freeze rules for sending an asset from a
+// regular account into a pseudo-account. A regular freeze on the source is
+// bypassed when the source is the issuer; pseudo-accounts must always be able
+// to withdraw what they receive, so their individual freeze is checked too.
+func CheckDepositFreeze(view state.LedgerView, srcAcct, pseudoAcct [20]byte, asset tx.Asset) ter.Result {
+	if asset.IsNative() {
+		return ter.TesSUCCESS
+	}
+
+	if result := checkGlobalFrozen(view, asset); result != ter.TesSUCCESS {
+		return result
+	}
+	issuer, result := assetIssuer(asset)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	if srcAcct != issuer {
+		if result := checkIndividualFrozen(view, srcAcct, asset); result != ter.TesSUCCESS {
+			return result
+		}
+	}
+	return checkIndividualFrozen(view, pseudoAcct, asset)
+}
+
+// CheckWithdrawFreeze applies the freeze rules for sending an asset from a
+// pseudo-account through the submitting account to the destination. Issuer
+// redemption is always allowed; a regular freeze on a self-withdrawing
+// submitter is allowed, while a deep freeze still prevents the withdrawal.
+func CheckWithdrawFreeze(view state.LedgerView, pseudoAcct, submitterAcct, dstAcct [20]byte, asset tx.Asset) ter.Result {
+	if asset.IsNative() {
+		return ter.TesSUCCESS
+	}
+
+	issuer, result := assetIssuer(asset)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	if dstAcct == issuer {
+		return ter.TesSUCCESS
+	}
+	if result := checkGlobalFrozen(view, asset); result != ter.TesSUCCESS {
+		return result
+	}
+	if result := checkIndividualFrozen(view, pseudoAcct, asset); result != ter.TesSUCCESS {
+		return result
+	}
+	if submitterAcct != dstAcct {
+		if result := checkIndividualFrozen(view, submitterAcct, asset); result != ter.TesSUCCESS {
+			return result
+		}
+	}
+	return checkDeepFrozen(view, dstAcct, asset)
+}
+
+func assetIssuer(asset tx.Asset) ([20]byte, ter.Result) {
+	if asset.IsMPT() {
+		id, err := DecodeID(asset.MPTIssuanceID)
+		if err != nil {
+			return [20]byte{}, ter.TefINTERNAL
+		}
+		return Issuer(id), ter.TesSUCCESS
+	}
+	issuer, err := state.DecodeAccountID(asset.Issuer)
+	if err != nil {
+		return [20]byte{}, ter.TefINTERNAL
+	}
+	return issuer, ter.TesSUCCESS
+}
+
+func checkGlobalFrozen(view state.LedgerView, asset tx.Asset) ter.Result {
+	if asset.IsMPT() {
+		id, err := DecodeID(asset.MPTIssuanceID)
+		if err != nil {
+			return ter.TefINTERNAL
+		}
+		if IsGlobalFrozen(view, id) {
+			return ter.TecLOCKED
+		}
+		return ter.TesSUCCESS
+	}
+	if isIOUGlobalFrozen(view, asset.Issuer) {
+		return ter.TecFROZEN
+	}
+	return ter.TesSUCCESS
+}
+
+func checkIndividualFrozen(view state.LedgerView, account [20]byte, asset tx.Asset) ter.Result {
+	if asset.IsMPT() {
+		id, err := DecodeID(asset.MPTIssuanceID)
+		if err != nil {
+			return ter.TefINTERNAL
+		}
+		if IsIndividualFrozen(view, id, account) {
+			return ter.TecLOCKED
+		}
+		return ter.TesSUCCESS
+	}
+	if isIOUIndividualFrozen(view, account, asset) {
+		return ter.TecFROZEN
+	}
+	return ter.TesSUCCESS
+}
+
+func checkDeepFrozen(view state.LedgerView, account [20]byte, asset tx.Asset) ter.Result {
+	if asset.IsMPT() {
+		id, err := DecodeID(asset.MPTIssuanceID)
+		if err != nil {
+			return ter.TefINTERNAL
+		}
+		if IsFrozen(view, id, account) {
+			return ter.TecLOCKED
+		}
+		return ter.TesSUCCESS
+	}
+	issuer, err := state.DecodeAccountID(asset.Issuer)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if isIOUDeepFrozen(view, account, issuer, asset.Currency) {
+		return ter.TecFROZEN
+	}
+	return ter.TesSUCCESS
+}
+
+func isIOUGlobalFrozen(view state.LedgerView, issuerAddress string) bool {
+	issuer, err := state.DecodeAccountID(issuerAddress)
+	if err != nil {
+		return false
+	}
+	raw, err := view.Read(keylet.Account(issuer))
+	if err != nil || raw == nil {
+		return false
+	}
+	account, err := state.ParseAccountRoot(raw)
+	return err == nil && account.Flags&state.LsfGlobalFreeze != 0
+}
+
+func isIOUIndividualFrozen(view state.LedgerView, account [20]byte, asset tx.Asset) bool {
+	if asset.IsNative() || asset.Currency == "XRP" {
+		return false
+	}
+	issuer, err := state.DecodeAccountID(asset.Issuer)
+	if err != nil || account == issuer {
+		return false
+	}
+	raw, err := view.Read(keylet.Line(account, issuer, asset.Currency))
+	if err != nil || raw == nil {
+		return false
+	}
+	line, err := state.ParseRippleState(raw)
+	if err != nil {
+		return false
+	}
+	if state.CompareAccountIDs(issuer, account) > 0 {
+		return line.Flags&state.LsfHighFreeze != 0
+	}
+	return line.Flags&state.LsfLowFreeze != 0
+}
+
+func isIOUDeepFrozen(view state.LedgerView, account, issuer [20]byte, currency string) bool {
+	if currency == "" || currency == "XRP" || account == issuer {
+		return false
+	}
+	raw, err := view.Read(keylet.Line(account, issuer, currency))
+	if err != nil || raw == nil {
+		return false
+	}
+	line, err := state.ParseRippleState(raw)
+	return err == nil && line.Flags&(state.LsfLowDeepFreeze|state.LsfHighDeepFreeze) != 0
+}
+
 func isAnyAssetFrozen(view state.LedgerView, asset tx.Asset, accounts [][20]byte, depth uint8) bool {
 	if asset.IsMPT() {
 		id, err := DecodeID(asset.MPTIssuanceID)

--- a/internal/tx/mptutil/mpt.go
+++ b/internal/tx/mptutil/mpt.go
@@ -217,7 +217,10 @@ func CheckDepositFreeze(view state.LedgerView, srcAcct, pseudoAcct [20]byte, ass
 			return result
 		}
 	}
-	return checkIndividualFrozen(view, pseudoAcct, asset)
+	if result := checkIndividualFrozen(view, pseudoAcct, asset); result != ter.TesSUCCESS {
+		return result
+	}
+	return checkPseudoAccountBackingFreeze(view, pseudoAcct, asset)
 }
 
 // CheckWithdrawFreeze applies the freeze rules for sending an asset from a
@@ -247,7 +250,24 @@ func CheckWithdrawFreeze(view state.LedgerView, pseudoAcct, submitterAcct, dstAc
 			return result
 		}
 	}
-	return checkDeepFrozen(view, dstAcct, asset)
+	if result := checkDeepFrozen(view, dstAcct, asset); result != ter.TesSUCCESS {
+		return result
+	}
+	return checkPseudoAccountBackingFreeze(view, pseudoAcct, asset)
+}
+
+func checkPseudoAccountBackingFreeze(view state.LedgerView, pseudoAcct [20]byte, asset tx.Asset) ter.Result {
+	if !asset.IsMPT() {
+		return ter.TesSUCCESS
+	}
+	id, err := DecodeID(asset.MPTIssuanceID)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if isVaultPseudoAccountFrozen(view, id, pseudoAcct, 0) {
+		return ter.TecINTERNAL
+	}
+	return ter.TesSUCCESS
 }
 
 func assetIssuer(asset tx.Asset) ([20]byte, ter.Result) {
@@ -428,6 +448,17 @@ func requireAuthAt(view state.LedgerView, id [24]byte, account [20]byte, authTyp
 	if issuance.Issuer == account {
 		return ter.TesSUCCESS
 	}
+	rules := view.Rules()
+	fix330 := rules != nil && rules.Enabled(amendment.FeatureFixCleanup3_3_0)
+	if fix330 {
+		exempt, result := pseudoAccountAuthExempt(view, account, rules)
+		if result != ter.TesSUCCESS {
+			return result
+		}
+		if exempt {
+			return ter.TesSUCCESS
+		}
+	}
 	if rules := view.Rules(); rules != nil && rules.Enabled(amendment.FeatureSingleAssetVault) {
 		if depth >= maxAssetCheckDepth {
 			return ter.TecINTERNAL
@@ -476,25 +507,35 @@ func requireAuthAt(view state.LedgerView, id [24]byte, account [20]byte, authTyp
 		return ter.TesSUCCESS
 	}
 
-	rules := view.Rules()
-	if rules == nil || (!rules.Enabled(amendment.FeatureSingleAssetVault) && !rules.Enabled(amendment.FeatureMPTokensV2)) {
+	if fix330 {
 		return ter.TecNO_AUTH
 	}
-	accountRaw, err := view.Read(keylet.Account(account))
-	if err != nil {
-		return ter.TefINTERNAL
+	exempt, result := pseudoAccountAuthExempt(view, account, rules)
+	if result != ter.TesSUCCESS {
+		return result
 	}
-	if accountRaw == nil {
-		return ter.TecNO_AUTH
-	}
-	accountRoot, err := state.ParseAccountRoot(accountRaw)
-	if err != nil {
-		return ter.TefINTERNAL
-	}
-	if accountRoot.IsPseudoAccount() {
+	if exempt {
 		return ter.TesSUCCESS
 	}
 	return ter.TecNO_AUTH
+}
+
+func pseudoAccountAuthExempt(view state.LedgerView, account [20]byte, rules *amendment.Rules) (bool, ter.Result) {
+	if rules == nil || (!rules.Enabled(amendment.FeatureSingleAssetVault) && !rules.Enabled(amendment.FeatureMPTokensV2)) {
+		return false, ter.TesSUCCESS
+	}
+	accountRaw, err := view.Read(keylet.Account(account))
+	if err != nil {
+		return false, ter.TefINTERNAL
+	}
+	if accountRaw == nil {
+		return false, ter.TesSUCCESS
+	}
+	accountRoot, err := state.ParseAccountRoot(accountRaw)
+	if err != nil {
+		return false, ter.TefINTERNAL
+	}
+	return accountRoot.IsPseudoAccount(), ter.TesSUCCESS
 }
 
 func RequireAssetAuthAt(view state.LedgerView, asset tx.Asset, account [20]byte, authType AuthType, parentCloseTime uint32) ter.Result {

--- a/internal/tx/mptutil/mpt_test.go
+++ b/internal/tx/mptutil/mpt_test.go
@@ -119,6 +119,26 @@ func TestPseudoAccountImplicitAuthorizationRequiresAmendment(t *testing.T) {
 	require.Equal(t, ter.TesSUCCESS, RequireAuth(view, id, pseudo, false))
 }
 
+func TestFixCleanup330AuthorizesPseudoAccountBeforeHoldingCheck(t *testing.T) {
+	view := newMPTTestView()
+	var issuer, pseudo [20]byte
+	issuer[19] = 1
+	pseudo[19] = 2
+	id := keylet.MakeMPTID(1, issuer)
+	putTestIssuance(t, view, id, entry.LsfMPTRequireAuth, nil)
+	putTestAccount(t, view, issuer, 0, [32]byte{})
+	putTestAccount(t, view, pseudo, 0, [32]byte{1})
+
+	view.rules = amendment.NewRules([][32]byte{amendment.FeatureSingleAssetVault})
+	require.Equal(t, ter.TecNO_AUTH, RequireAuthAt(view, id, pseudo, true, 0))
+
+	view.rules = amendment.NewRules([][32]byte{
+		amendment.FeatureSingleAssetVault,
+		amendment.FeatureFixCleanup3_3_0,
+	})
+	require.Equal(t, ter.TesSUCCESS, RequireAuthAt(view, id, pseudo, true, 0))
+}
+
 func TestIOUTransferCheckPropagatesTrustLineReadError(t *testing.T) {
 	view := newMPTTestView()
 	var issuer, from, to [20]byte
@@ -655,6 +675,20 @@ func TestPseudoFreezeChecksMPT(t *testing.T) {
 	view = newView()
 	putTestIssuance(t, view, id, entry.LsfMPTLocked, nil)
 	require.Equal(t, ter.TesSUCCESS, CheckWithdrawFreeze(view, pseudo, source, issuer, asset))
+
+	view = newView()
+	vaultPseudo := [20]byte{5}
+	underlyingIssuer := [20]byte{6}
+	underlyingID := keylet.MakeMPTID(2, underlyingIssuer)
+	shareID := keylet.MakeMPTID(3, vaultPseudo)
+	vaultID := [32]byte{7}
+	putTestAccount(t, view, vaultPseudo, 0, vaultID)
+	putTestAccount(t, view, underlyingIssuer, 0, [32]byte{})
+	putTestIssuance(t, view, underlyingID, entry.LsfMPTLocked, nil)
+	putTestIssuance(t, view, shareID, 0, nil)
+	putTestVault(t, view, vaultID, issuer, vaultPseudo, shareID, underlyingID)
+	shareAsset := tx.Asset{MPTIssuanceID: EncodeID(shareID)}
+	require.Equal(t, ter.TecINTERNAL, CheckDepositFreeze(view, source, pseudo, shareAsset))
 }
 
 func putTestAccount(t *testing.T, view *mptTestView, account [20]byte, flags uint32, vaultID [32]byte) {

--- a/internal/tx/mptutil/mpt_test.go
+++ b/internal/tx/mptutil/mpt_test.go
@@ -545,6 +545,118 @@ func TestSendTransferRateOverflowReturnsTefException(t *testing.T) {
 	require.Zero(t, gross)
 }
 
+func TestPseudoFreezeChecksIOU(t *testing.T) {
+	issuer := [20]byte{1}
+	source := [20]byte{2}
+	pseudo := [20]byte{3}
+	destination := [20]byte{4}
+	asset := tx.Asset{Currency: "USD", Issuer: state.EncodeAccountIDSafe(issuer)}
+
+	newView := func() *mptTestView {
+		view := newMPTTestView()
+		putTestAccount(t, view, issuer, 0, [32]byte{})
+		return view
+	}
+	putLine := func(t *testing.T, view *mptTestView, account [20]byte, flags uint32) {
+		t.Helper()
+		raw, err := state.SerializeRippleState(&state.RippleState{
+			Balance:   state.NewIssuedAmountFromValue(1, 0, "USD", asset.Issuer),
+			LowLimit:  state.NewIssuedAmountFromValue(100, 0, "USD", asset.Issuer),
+			HighLimit: state.NewIssuedAmountFromValue(100, 0, "USD", state.EncodeAccountIDSafe(account)),
+			Flags:     flags,
+		})
+		require.NoError(t, err)
+		require.NoError(t, view.Insert(keylet.Line(account, issuer, "USD"), raw))
+	}
+
+	t.Run("deposit global freeze", func(t *testing.T) {
+		view := newView()
+		putTestAccount(t, view, issuer, state.LsfGlobalFreeze, [32]byte{})
+		require.Equal(t, ter.TecFROZEN, CheckDepositFreeze(view, source, pseudo, asset))
+	})
+	t.Run("issuer deposit bypasses source freeze", func(t *testing.T) {
+		view := newView()
+		putLine(t, view, source, state.LsfLowFreeze)
+		require.Equal(t, ter.TesSUCCESS, CheckDepositFreeze(view, issuer, pseudo, asset))
+	})
+	t.Run("deposit checks source and pseudo", func(t *testing.T) {
+		view := newView()
+		putLine(t, view, source, state.LsfLowFreeze)
+		require.Equal(t, ter.TecFROZEN, CheckDepositFreeze(view, source, pseudo, asset))
+		view = newView()
+		putLine(t, view, pseudo, state.LsfLowFreeze)
+		require.Equal(t, ter.TecFROZEN, CheckDepositFreeze(view, source, pseudo, asset))
+	})
+	t.Run("withdraw matrix", func(t *testing.T) {
+		view := newView()
+		putLine(t, view, pseudo, state.LsfLowFreeze)
+		require.Equal(t, ter.TecFROZEN, CheckWithdrawFreeze(view, pseudo, source, source, asset))
+
+		view = newView()
+		putLine(t, view, source, state.LsfLowFreeze)
+		require.Equal(t, ter.TesSUCCESS, CheckWithdrawFreeze(view, pseudo, source, source, asset))
+		require.Equal(t, ter.TecFROZEN, CheckWithdrawFreeze(view, pseudo, source, destination, asset))
+
+		view = newView()
+		putLine(t, view, destination, state.LsfLowDeepFreeze)
+		require.Equal(t, ter.TecFROZEN, CheckWithdrawFreeze(view, pseudo, source, destination, asset))
+
+		view = newView()
+		putTestAccount(t, view, issuer, state.LsfGlobalFreeze, [32]byte{})
+		require.Equal(t, ter.TecFROZEN, CheckWithdrawFreeze(view, pseudo, source, source, asset))
+		require.Equal(t, ter.TesSUCCESS, CheckWithdrawFreeze(view, pseudo, source, issuer, asset))
+	})
+}
+
+func TestPseudoFreezeChecksMPT(t *testing.T) {
+	issuer := [20]byte{1}
+	source := [20]byte{2}
+	pseudo := [20]byte{3}
+	destination := [20]byte{4}
+	id := keylet.MakeMPTID(1, issuer)
+	asset := tx.Asset{MPTIssuanceID: EncodeID(id)}
+
+	newView := func() *mptTestView {
+		view := newMPTTestView()
+		putTestAccount(t, view, issuer, 0, [32]byte{})
+		putTestIssuance(t, view, id, 0, nil)
+		return view
+	}
+	putLock := func(t *testing.T, view *mptTestView, account [20]byte) {
+		t.Helper()
+		putTestHolding(t, view, id, account, entry.LsfMPTLocked)
+	}
+
+	view := newView()
+	putTestIssuance(t, view, id, entry.LsfMPTLocked, nil)
+	require.Equal(t, ter.TecLOCKED, CheckDepositFreeze(view, source, pseudo, asset))
+
+	view = newView()
+	putLock(t, view, source)
+	require.Equal(t, ter.TecLOCKED, CheckDepositFreeze(view, source, pseudo, asset))
+
+	view = newView()
+	putLock(t, view, pseudo)
+	require.Equal(t, ter.TecLOCKED, CheckDepositFreeze(view, source, pseudo, asset))
+
+	view = newView()
+	putLock(t, view, pseudo)
+	require.Equal(t, ter.TecLOCKED, CheckWithdrawFreeze(view, pseudo, source, source, asset))
+
+	view = newView()
+	putLock(t, view, source)
+	require.Equal(t, ter.TecLOCKED, CheckWithdrawFreeze(view, pseudo, source, source, asset))
+	require.Equal(t, ter.TecLOCKED, CheckWithdrawFreeze(view, pseudo, source, destination, asset))
+
+	view = newView()
+	putLock(t, view, destination)
+	require.Equal(t, ter.TecLOCKED, CheckWithdrawFreeze(view, pseudo, source, destination, asset))
+
+	view = newView()
+	putTestIssuance(t, view, id, entry.LsfMPTLocked, nil)
+	require.Equal(t, ter.TesSUCCESS, CheckWithdrawFreeze(view, pseudo, source, issuer, asset))
+}
+
 func putTestAccount(t *testing.T, view *mptTestView, account [20]byte, flags uint32, vaultID [32]byte) {
 	t.Helper()
 	raw, err := state.SerializeAccountRoot(&state.AccountRoot{

--- a/internal/tx/vault/vault_deposit.go
+++ b/internal/tx/vault/vault_deposit.go
@@ -128,12 +128,18 @@ func (v *VaultDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.
 		return ter.TefINTERNAL
 	}
 
-	if res := checkFrozen(view, asset, accountID); res != ter.TesSUCCESS {
-		return res
-	}
-	shareAsset := tx.Asset{MPTIssuanceID: hex.EncodeToString(vd.ShareMPTID[:])}
-	if res := checkFrozen(view, shareAsset, accountID); res != ter.TesSUCCESS {
-		return res
+	if config.RequireRules().Enabled(amendment.FeatureFixCleanup3_3_0) {
+		if res := mptutil.CheckDepositFreeze(view, accountID, vd.Account, asset); res != ter.TesSUCCESS {
+			return res
+		}
+	} else {
+		if res := checkFrozen(view, asset, accountID); res != ter.TesSUCCESS {
+			return res
+		}
+		shareAsset := tx.Asset{MPTIssuanceID: hex.EncodeToString(vd.ShareMPTID[:])}
+		if res := checkFrozen(view, shareAsset, accountID); res != ter.TesSUCCESS {
+			return res
+		}
 	}
 
 	// Private vault: a non-owner needs domain authorization.

--- a/internal/tx/vault/vault_deposit_audit_test.go
+++ b/internal/tx/vault/vault_deposit_audit_test.go
@@ -185,6 +185,43 @@ func TestVaultDepositPreclaim_DispatchesMPTRequireAuth(t *testing.T) {
 	}
 }
 
+func TestVaultDepositPreclaim_FixCleanup330ChecksPseudoMPTFreeze(t *testing.T) {
+	view, deposit, mptID, depositor := vaultDepositFixture(t, entry.LsfMPTCanTransfer, true)
+	var pseudo [20]byte
+	copy(pseudo[:], vaultDepositTestID(0x44, 20))
+
+	putToken := func(account [20]byte, flags uint32) {
+		t.Helper()
+		data, err := state.SerializeMPToken(&state.MPTokenData{
+			Account:           account,
+			MPTokenIssuanceID: mptID,
+			MPTAmount:         1_000,
+			Flags:             flags,
+		})
+		vaultDepositPut(t, view, keylet.MPTokenByID(mptID, account), vaultDepositEncoded(t, data, err))
+	}
+	putToken(depositor, 0)
+	putToken(pseudo, entry.LsfMPTLocked)
+
+	fixOff := amendment.NewRulesBuilder().
+		FromPreset(amendment.PresetAllSupported).
+		Disable(amendment.FeatureFixCleanup3_3_0).
+		Build()
+	view.rules = fixOff
+	if result := deposit.Preclaim(view, tx.EngineConfig{Rules: fixOff}); result != ter.TesSUCCESS {
+		t.Fatalf("fixCleanup3_3_0 OFF: got %v, want tesSUCCESS", result)
+	}
+
+	fixOn := amendment.NewRulesBuilder().
+		FromPreset(amendment.PresetAllSupported).
+		Enable(amendment.FeatureFixCleanup3_3_0).
+		Build()
+	view.rules = fixOn
+	if result := deposit.Preclaim(view, tx.EngineConfig{Rules: fixOn}); result != ter.TecLOCKED {
+		t.Fatalf("fixCleanup3_3_0 ON: got %v, want tecLOCKED", result)
+	}
+}
+
 func TestVaultDepositPreclaim_IOUUsesFullBalance(t *testing.T) {
 	view := newVaultDepositView()
 	var issuer, depositor, owner, pseudo [20]byte

--- a/internal/tx/vault/vault_withdraw.go
+++ b/internal/tx/vault/vault_withdraw.go
@@ -190,11 +190,17 @@ func (v *VaultWithdraw) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter
 	if res := requireAuth(view, asset, dstID, authType, config.ParentCloseTime); res != ter.TesSUCCESS {
 		return res
 	}
-	if res := checkFrozen(view, asset, dstID); res != ter.TesSUCCESS {
-		return res
-	}
-	if res := checkVaultShareFrozen(view, accountID, vd); res != ter.TesSUCCESS {
-		return res
+	if config.RequireRules().Enabled(amendment.FeatureFixCleanup3_3_0) {
+		if res := mptutil.CheckWithdrawFreeze(view, vd.Account, accountID, dstID, asset); res != ter.TesSUCCESS {
+			return res
+		}
+	} else {
+		if res := checkFrozen(view, asset, dstID); res != ter.TesSUCCESS {
+			return res
+		}
+		if res := checkVaultShareFrozen(view, accountID, vd); res != ter.TesSUCCESS {
+			return res
+		}
 	}
 
 	return ter.TesSUCCESS

--- a/internal/tx/vault/vault_withdraw_preclaim_test.go
+++ b/internal/tx/vault/vault_withdraw_preclaim_test.go
@@ -467,8 +467,8 @@ func TestVaultWithdraw_ShareInheritsVaultHoldingFreeze(t *testing.T) {
 	if err != nil {
 		t.Fatalf("serialize frozen line: %v", err)
 	}
-	rules := amendment.NewRules([][32]byte{amendment.FeatureSingleAssetVault})
-	view := roView{rules: rules, data: map[[32]byte][]byte{
+	baseRules := amendment.NewRules([][32]byte{amendment.FeatureSingleAssetVault})
+	view := roView{rules: baseRules, data: map[[32]byte][]byte{
 		keylet.VaultByID(vaultID).Key: mustVault(t, &vaultData{
 			WithdrawalPolicy: VaultStrategyFirstComeFirstServe,
 			Owner:            submitterID,
@@ -498,8 +498,16 @@ func TestVaultWithdraw_ShareInheritsVaultHoldingFreeze(t *testing.T) {
 		strings.ToUpper(hex.EncodeToString(vaultID[:])),
 		state.NewIssuedAmountFromValue(1, 0, "USD", issuerAddr),
 	)
-	if got := withdraw.Preclaim(view, tx.EngineConfig{Rules: rules}); got != ter.TecLOCKED {
-		t.Fatalf("got %v, want tecLOCKED", got)
+	if got := withdraw.Preclaim(view, tx.EngineConfig{Rules: baseRules}); got != ter.TecLOCKED {
+		t.Fatalf("pre-fix got %v, want tecLOCKED", got)
+	}
+	fixRules := amendment.NewRules([][32]byte{
+		amendment.FeatureSingleAssetVault,
+		amendment.FeatureFixCleanup3_3_0,
+	})
+	view.rules = fixRules
+	if got := withdraw.Preclaim(view, tx.EngineConfig{Rules: fixRules}); got != ter.TecFROZEN {
+		t.Fatalf("fixCleanup3_3_0 got %v, want tecFROZEN", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- unify IOU and MPT deposit/withdraw freeze and authorization checks across AMM, Vault, and LoanBroker pseudo-accounts
- reject pseudo-account targets for gated CredentialCreate and DepositPreauth authorize creation while preserving legacy precedence
- cover issuer redemption, self recovery, deep freeze, holder locks, authorization, target precedence, metadata, and rollback behavior

## Stack

1. **#1382 — this PR**
2. #1383 — Permissioned DEX cleanup
3. #1385 — AMM results and deletion invariants

## Verification

- `just build`
- `GOCACHE=/tmp/goxrpl-stack-cache just build-nocgo`
- `GOCACHE=/tmp/goxrpl-stack-cache just vet`
- `just lint` (0 issues)
- `GOCACHE=/tmp/goxrpl-stack-cache just test-tx`
- `GOCACHE=/tmp/goxrpl-stack-cache just test-integration`
- `GOCACHE=/tmp/goxrpl-stack-cache just test`
- conformance audit against clean local rippled `3.3.0` (`00a178fb92ca49521b937ae1a99d863765ea8a90`)

Fixes #1382
