### PR TITLE
fix: close v3.3.0 final parity gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,11 @@ jobs:
         run: ./scripts/setup-mpt-crypto.sh test ./amendment/... ./crypto/mptcrypto/... ./internal/tx/mpt/... ./internal/testing/mpt/...
 
   consensus-smoke:
-    name: Consensus smoke (2 rippled + 1 goxrpl)
+    name: Consensus smoke (rippled ${{ matrix.rippled-version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        rippled-version: ["3.3.0", "3.2.0"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -232,7 +236,7 @@ jobs:
         run: bash scripts/consensus-smoke/smoke.sh
         env:
           GOXRPL_IMAGE: goxrpl:latest
-          RIPPLED_IMAGE: xrpllabsofficial/xrpld:3.2.0
+          RIPPLED_IMAGE: xrpllabsofficial/xrpld:${{ matrix.rippled-version }}
           PAYMENT_COUNT: "3"
           MIN_SEQ_EMPTY: "15"
           BOOT_TIMEOUT: "240"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,15 @@ jobs:
       - name: Build and test native backend
         run: ./scripts/setup-mpt-crypto.sh test ./amendment/... ./crypto/mptcrypto/... ./internal/tx/mpt/... ./internal/testing/mpt/...
 
+  peer-interop:
+    name: Peer interop (rippled 3.3.0)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup
+      - name: Run live handshake and manifest interop
+        run: PEERTLS_DOCKER_INTEROP=1 go test -tags docker -timeout 5m -v -run 'Test(Handshake|Manifest)_Interop_RippledDocker' ./internal/peermanagement/
+
   consensus-smoke:
     name: Consensus smoke (rippled ${{ matrix.rippled-version }})
     strategy:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,7 +101,7 @@ jobs:
         run: bash scripts/consensus-smoke/smoke.sh
         env:
           GOXRPL_IMAGE: goxrpl:latest
-          RIPPLED_IMAGE: xrpllabsofficial/xrpld:3.2.0
+          RIPPLED_IMAGE: xrpllabsofficial/xrpld:3.3.0
           PAYMENT_COUNT: "25"
           MIN_SEQ_EMPTY: "40"
           BOOT_TIMEOUT: "360"

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -70,11 +70,13 @@ removing a line brings that suite back into scope.
 
 As of this writing the out-of-scope suites fall into two groups:
 
-- **Not implemented yet** — `Vault`, `Batch`, `EscrowToken`, `XChain`, `XChainSim`,
-  `Delegate`, `Credentials`. **Vault** and the **XChain** bridge ship as
-  *registered stubs by design*: they parse and register but are not active
-  (the `XChainBridge` amendment is `SupportedNo`). This is an intentional scope
-  boundary for the current release, not a regression.
+- **Not implemented yet** — `EscrowToken`, `XChain`, and `XChainSim`. The
+  **XChain** bridge ships as a registered fail-closed stub: it parses and
+  registers but is not active (`XChainBridge` is `SupportedNo`).
+- **Implemented features with incomplete legacy-fixture coverage** — `Vault`,
+  `Batch`, `Delegate`, and `Credentials`. Their production implementations and
+  focused suites are active, but the imported conformance corpus and runner do
+  not yet represent all released variants.
 - **Partially implemented / known gaps** — several `NFTokenBurn*` and `NFToken*`
   variants, `Regression`, `ThinBook`, `Transaction_ordering`, and `ledger/BookDirs`.
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -14,11 +14,11 @@ behavior is deliberately mirrored, the Go code cites the rippled source file it
 follows (e.g. `Transactor.cpp`, `applySteps.h`), so a reviewer can check the port
 against the original.
 
-The local `rippled/` tree is the working reference. Its transaction logic lives
-under `rippled/src/xrpld/app/tx/detail/`, ledger objects under
-`rippled/src/xrpld/ledger/detail/`, protocol definitions under
-`rippled/src/libxrpl/protocol/`, and the upstream unit tests — which the Go
-conformance suites mirror — under `rippled/src/test/app/`.
+The local `rippled-worktrees/<version>-oracle/` tree is the working reference.
+Its transaction logic lives under `src/xrpld/app/tx/detail/`, ledger objects
+under `src/xrpld/ledger/detail/`, protocol definitions under
+`src/libxrpl/protocol/`, and the upstream unit tests — which the Go conformance
+suites mirror — under `src/test/app/`.
 
 ## The conformance suite
 
@@ -70,15 +70,13 @@ removing a line brings that suite back into scope.
 
 As of this writing the out-of-scope suites fall into two groups:
 
-- **Not implemented yet** — `EscrowToken`, `XChain`, and `XChainSim`. The
+- **Not implemented yet** — `XChain` and `XChainSim`. The
   **XChain** bridge ships as a registered fail-closed stub: it parses and
   registers but is not active (`XChainBridge` is `SupportedNo`).
 - **Implemented features with incomplete legacy-fixture coverage** — `Vault`,
-  `Batch`, `Delegate`, and `Credentials`. Their production implementations and
+  `Batch`, and `Delegate`. Their production implementations and
   focused suites are active, but the imported conformance corpus and runner do
   not yet represent all released variants.
-- **Partially implemented / known gaps** — several `NFTokenBurn*` and `NFToken*`
-  variants, `Regression`, `ThinBook`, `Transaction_ordering`, and `ledger/BookDirs`.
 
 A generated, always-current pass/fail snapshot is produced separately — see
 [conformance-status.md](conformance-status.md) (regenerate with `just docs-gen`)

--- a/docs/v3.3.0.md
+++ b/docs/v3.3.0.md
@@ -1,0 +1,153 @@
+# rippled 3.3.0 parity audit
+
+This document records the final-tag audit for goXRPL's `v3.3.0` branch. The
+behavioral oracle is rippled tag `3.3.0`, peeled commit
+`00a178fb92ca49521b937ae1a99d863765ea8a90`.
+
+## Oracle provenance
+
+- Local oracle: `rippled-worktrees/v3.3.0-oracle`
+- Tag object: `32a8a5d561d157aa54d7a90d50e4e765607692b1`
+- Peeled commit: `00a178fb92ca49521b937ae1a99d863765ea8a90`
+- GitHub signature verification: valid, signed by `asalikhov@ripple.com`
+- Local worktree: detached at the exact tag commit and clean during the audit
+
+The local keyring does not contain the signer's public key, so local
+`git verify-tag` cannot establish trust independently. The tag object and
+peeled commit were therefore cross-checked locally and against GitHub's valid
+signature record.
+
+## Compared release points
+
+The final commit was compared with all three tracker baselines:
+
+| Baseline | Commit | Commits to final | Files reported by compare |
+| --- | --- | ---: | ---: |
+| rippled 3.2.0 | `3c43f4614f87965298773279ff5b85d4c56c637b` | 194 | 300+ |
+| rippled 3.3.0-rc1 | `18e311e1e245bcc1813363bd1771b94931585d80` | 42 | 109 |
+| public RC2 staging | `982bf36dd8f162a504182a0c78d2c8b19d99c4cd` | 21 | 48 |
+
+The 3.2.0 comparison exceeds GitHub's 300-file response limit. Protocol-bearing
+surfaces were independently inventoried from the complete 3.2.0 and 3.3.0
+source trees rather than inferred from that truncated response.
+
+The final deltas fall into these implementation-relevant groups:
+
+- Sponsor schema and accounting: `SponsorshipSet` uses final
+  `FeeAmountDelta` and `RemainingOwnerCountDelta` fields and delta semantics,
+  not the RC2 absolute fields.
+- Validator manifests: separate configurable trusted and untrusted cache
+  limits, pre-decode admission, relay, persistence, and validator-list
+  integration include the 3.2.1 carry-forward changes.
+- Peer wire: `TMPing` reserves protobuf tags 3 and 4, pongs contain only the
+  type and optional sequence, and the complete uncompressed ping frame is
+  limited to 1 KiB.
+- Validation and consensus: validation fields must arrive in strictly
+  increasing canonical order, and close-time adjustment uses the weighted
+  lower median including the local node's unit vote.
+- RPC: `account_tx` supports the released delegate filter and pagination
+  interaction; `amm_info` rejects invalid asset types.
+- Protocol/schema cleanup: the final SField delta, transaction and ledger
+  templates, flags, TERs, amendment retirement, MPT behavior, credential and
+  delegation checks, and path/payment-channel fixes are reflected in the
+  integrated child changes.
+- Reverted RC2 behavior: the temporary 256 KiB per-node and 1 MiB aggregate
+  `TMLedgerData` limits are not treated as final-tag requirements. The released
+  64 MiB message ceiling and existing resource controls remain authoritative.
+- Non-protocol release work: build, packaging, configuration, documentation,
+  and test infrastructure changes do not alter goXRPL ledger behavior.
+
+## Protocol inventory
+
+The final rippled SField macro contains 373 fields, compared with 338 in
+3.2.0. There are 36 literal additions and one removal (`MutableFlags`), for the
+released net increase of 35.
+
+The additions are:
+
+`AmountCommitment`, `AuditorEncryptedAmount`, `AuditorEncryptedBalance`,
+`AuditorEncryptionKey`, `BalanceCommitment`, `BlindingFactor`,
+`ConfidentialBalanceInbox`, `ConfidentialBalanceSpending`,
+`ConfidentialBalanceVersion`, `ConfidentialOutstandingAmount`,
+`CounterpartySponsor`, `DestinationEncryptedAmount`, `FeeAmount`,
+`FeeAmountDelta`, `HighSponsor`, `HolderEncryptedAmount`,
+`HolderEncryptionKey`, `ImmutableFlags`, `IssuerEncryptedAmount`,
+`IssuerEncryptedBalance`, `IssuerEncryptionKey`, `LowSponsor`, `MaxFee`,
+`ObjectID`, `RemainingOwnerCount`, `RemainingOwnerCountDelta`,
+`SenderEncryptedAmount`, `Sponsee`, `SponseeNode`, `Sponsor`, `SponsorFlags`,
+`SponsorSignature`, `SponsoredOwnerCount`, `SponsoringAccountCount`,
+`SponsoringOwnerCount`, and `ZKProof`.
+
+The generated Go definitions contain every final oracle field with matching
+type, ordinal, and metadata. The broader inventory also found exact matches for:
+
+- 82 concrete transaction type IDs and templates;
+- 31 concrete ledger-entry type IDs and templates;
+- 197 TER names and numeric values;
+- universal and ledger-specific flag values;
+- final signing preimages used by transactions, Batch, validations,
+  proposals, manifests, ledger replay, and confidential transfers; and
+- the audited fee and protocol constants.
+
+The Go definition file additionally contains codec sentinels, decoded
+`hash`/`index` fields, and RPC-only funded fields. These are not serialized
+SFields and do not change protocol encoding.
+
+## Amendment and compatibility exceptions
+
+The final oracle amendment registry was compared entry by entry. The following
+existing goXRPL exceptions are intentionally fail-closed and require maintainer
+approval as part of this release gate:
+
+- `XChainBridge` remains `SupportedNo`. The transaction shapes are registered,
+  but their ledger mutation methods are explicit hard-failure stubs. Advertising
+  oracle-level support before implementing the cross-chain state machine would
+  permit enabled transactions to reach `tefINTERNAL`.
+- `ConfidentialTransfer` is `SupportedYes` only in builds containing the native
+  MPT proof backend. Production Docker and native-backend CI builds include and
+  verify that backend. A build without it remains `SupportedNo` so it cannot
+  vote for or advertise cryptographic behavior it cannot validate.
+- `InvariantsV1_1`, `fixNFTokenNegOffer`, `fixNFTokenDirV1`, and
+  `NonFungibleTokensV1` remain registered for historical-ledger compatibility,
+  although they no longer appear in the final rippled feature macro.
+- The legacy credential hash prefix remains available to goXRPL callers. It is
+  not used as a final rippled signing prefix and does not change any audited
+  serialized preimage.
+
+All other final oracle amendment names, IDs, support states, defaults, and
+retired states match.
+
+## Integrated child ledger
+
+All implementation dependencies under #1365 were closed before this audit.
+The integrated branch contains:
+
+| Area | Issues | Integrated evidence |
+| --- | --- | --- |
+| Sponsor | #1366, #1368, #1370 | #1617 and final delta commits |
+| BatchV1_1 | #1369, #1373 | #1619 and #1623 |
+| Confidential MPT | #1371, #1372, #1374, #1375 | #1625-#1628 |
+| DynamicMPT | #1376 | #1600 |
+| Lending staging | #1377 | #1633 |
+| `fixCleanup3_3_0` | #1378-#1386 | integrated cleanup PRs through #1647 |
+| Manifest finalization | #1595 | #1614 |
+| RPC finalization | #1596 | #1630 |
+| Amendment retirement | #1388 | #1652 |
+
+## Verification matrix
+
+The release gate covers:
+
+- focused off/on and integrated feature suites for Sponsor, BatchV1_1,
+  ConfidentialTransfer, PermissionDelegationV1_1, DynamicMPT, Lending staging,
+  and `fixCleanup3_3_0`;
+- transaction, integration, ledger, TxQ, RPC, consensus, peer, manifest,
+  codec, crypto, storage, and conformance suites;
+- full and no-CGO builds, vet, strict/advisory lint, generated documentation,
+  race-sensitive packages, and diff hygiene;
+- live handshake and manifest interoperability with rippled 3.3.0; and
+- consensus smoke against rippled 3.3.0 plus rippled 3.2.0 mixed-version
+  coverage.
+
+The exact commands and final results are recorded on the pull request and its
+CI checks so they remain tied to the reviewed commit.

--- a/docs/v3.3.0.md
+++ b/docs/v3.3.0.md
@@ -93,20 +93,26 @@ The Go definition file additionally contains codec sentinels, decoded
 `hash`/`index` fields, and RPC-only funded fields. These are not serialized
 SFields and do not change protocol encoding.
 
-## Amendment and compatibility exceptions
+## Amendment and compatibility notes
 
-The final oracle amendment registry was compared entry by entry. The following
-existing goXRPL exceptions are intentionally fail-closed and require maintainer
-approval as part of this release gate:
+The final oracle amendment registry was compared entry by entry.
+
+`ConfidentialTransfer` is part of the v3.3.0 release surface. All five
+confidential MPT transaction types and their associated ledger behavior are
+implemented, and the production image requires the pinned native `mpt-crypto`
+backend used by rippled 3.3.0. Its build fails unless that backend initializes,
+and CI exercises the native implementation on Linux and macOS. Untagged and
+no-CGO library builds retain a fail-closed backend so those build targets remain
+portable; that artifact-level capability distinction is not a missing protocol
+feature or a v3.3.0 parity exception.
+
+The following existing goXRPL exceptions remain fail-closed and require
+maintainer approval as part of this release gate:
 
 - `XChainBridge` remains `SupportedNo`. The transaction shapes are registered,
   but their ledger mutation methods are explicit hard-failure stubs. Advertising
   oracle-level support before implementing the cross-chain state machine would
   permit enabled transactions to reach `tefINTERNAL`.
-- `ConfidentialTransfer` is `SupportedYes` only in builds containing the native
-  MPT proof backend. Production Docker and native-backend CI builds include and
-  verify that backend. A build without it remains `SupportedNo` so it cannot
-  vote for or advertise cryptographic behavior it cannot validate.
 - `InvariantsV1_1`, `fixNFTokenNegOffer`, `fixNFTokenDirV1`, and
   `NonFungibleTokensV1` remain registered for historical-ledger compatibility,
   although they no longer appear in the final rippled feature macro.
@@ -115,7 +121,7 @@ approval as part of this release gate:
   serialized preimage.
 
 All other final oracle amendment names, IDs, support states, defaults, and
-retired states match.
+retired states match the production release artifact.
 
 ## Integrated child ledger
 

--- a/docs/v3.3.0.md
+++ b/docs/v3.3.0.md
@@ -149,11 +149,13 @@ The release gate covers:
   and `fixCleanup3_3_0`;
 - transaction, integration, ledger, TxQ, RPC, consensus, peer, manifest,
   codec, crypto, storage, and conformance suites;
-- full and no-CGO builds, vet, strict/advisory lint, generated documentation,
+- full and no-CGO builds, vet, strict lint, generated documentation,
   race-sensitive packages, and diff hygiene;
 - live handshake and manifest interoperability with rippled 3.3.0; and
 - consensus smoke against rippled 3.3.0 plus rippled 3.2.0 mixed-version
   coverage.
+
+Advisory lint also runs in CI as a non-blocking signal.
 
 The exact commands and final results are recorded on the pull request and its
 CI checks so they remain tied to the reviewed commit.

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -74,7 +74,7 @@ type Adaptor struct {
 	// operating mode for server_info.state_accounting.
 	stateAcct *stateAccounting
 
-	// Close-time offset, adjusted each round toward the network average.
+	// Close-time offset, adjusted each round toward the network median.
 	// Atomic ns so the Now() hot path avoids lock contention.
 	closeOffsetNs atomic.Int64
 

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -959,23 +960,44 @@ func (a *Adaptor) PrevCloseTimeResolution() time.Duration {
 	return 30 * time.Second // protocol default
 }
 
-// AdjustCloseTime weight-averages raw close times and applies quarter-step
-// damping toward the network's view of time. Arithmetic is in whole seconds:
-// NetClock is second-granular and a ns replace would never decay toward zero.
+// AdjustCloseTime selects the weighted lower median of raw close times and
+// applies quarter-step damping toward the network's view of time.
 func (a *Adaptor) AdjustCloseTime(rawCloseTimes consensus.CloseTimes) {
 	if rawCloseTimes.Self.IsZero() {
 		return
 	}
 
 	selfSecs := rawCloseTimes.Self.Unix()
-	totalSecs := selfSecs
-	count := int64(1)
-	for t, v := range rawCloseTimes.Peers {
-		count += int64(v)
-		totalSecs += t.Unix() * int64(v)
+	weights := make(map[int64]int64, len(rawCloseTimes.Peers)+1)
+	times := make([]int64, 0, len(rawCloseTimes.Peers)+1)
+	for peerTime, weight := range rawCloseTimes.Peers {
+		peerSecs := peerTime.Unix()
+		if _, present := weights[peerSecs]; !present {
+			times = append(times, peerSecs)
+		}
+		weights[peerSecs] += int64(weight)
 	}
-	avgSecs := (totalSecs + count/2) / count
-	bySecs := avgSecs - selfSecs
+	if _, present := weights[selfSecs]; !present {
+		times = append(times, selfSecs)
+	}
+	weights[selfSecs]++
+	sort.Slice(times, func(i, j int) bool { return times[i] < times[j] })
+
+	totalWeight := int64(0)
+	for _, weight := range weights {
+		totalWeight += weight
+	}
+	halfWeight := (totalWeight + 1) / 2
+	var tally int64
+	medianSecs := selfSecs
+	for _, closeTime := range times {
+		tally += weights[closeTime]
+		if tally >= halfWeight {
+			medianSecs = closeTime
+			break
+		}
+	}
+	bySecs := medianSecs - selfSecs
 
 	currentSecs := int64(time.Duration(a.closeOffsetNs.Load()) / time.Second)
 	if bySecs == 0 && currentSecs == 0 {

--- a/internal/consensus/adaptor/adaptor_close_time_test.go
+++ b/internal/consensus/adaptor/adaptor_close_time_test.go
@@ -14,10 +14,7 @@ import (
 func TestAdjustCloseTime_DampingMatchesRippled(t *testing.T) {
 	const second = int64(time.Second)
 
-	// self is fixed; peer close times are constructed to produce the
-	// target `by` (avg_secs - self_secs). With 1 peer the average is
-	// the midpoint, so a single peer at self + 2*by yields the desired
-	// `by`.
+	// A peer bin with weight two determines the median over itself and self.
 	self := time.Unix(1_700_000_000, 0)
 
 	tests := []struct {
@@ -87,10 +84,10 @@ func TestAdjustCloseTime_DampingMatchesRippled(t *testing.T) {
 			a := newTestAdaptor(t)
 			a.closeOffsetNs.Store(tc.initialNs)
 
-			peer := self.Add(time.Duration(2*tc.bySecs) * time.Second)
+			peer := self.Add(time.Duration(tc.bySecs) * time.Second)
 			a.AdjustCloseTime(consensus.CloseTimes{
 				Self:  self,
-				Peers: map[time.Time]int{peer: 1},
+				Peers: map[time.Time]int{peer: 2},
 			})
 
 			gotNs := a.closeOffsetNs.Load()
@@ -98,6 +95,50 @@ func TestAdjustCloseTime_DampingMatchesRippled(t *testing.T) {
 			if gotNs != wantNs {
 				t.Fatalf("closeOffsetNs = %dns (%ds), want %dns (%ds)",
 					gotNs, gotNs/second, wantNs, tc.wantNewSec)
+			}
+		})
+	}
+}
+
+func TestAdjustCloseTime_WeightedLowerMedian(t *testing.T) {
+	self := time.Unix(1_700_000_000, 0)
+	tests := []struct {
+		name  string
+		peers map[time.Time]int
+		want  time.Duration
+	}{
+		{
+			name: "self participates in median",
+			peers: map[time.Time]int{
+				self.Add(-20 * time.Second): 1,
+				self.Add(20 * time.Second):  1,
+			},
+			want: 0,
+		},
+		{
+			name: "weighted peer bin wins",
+			peers: map[time.Time]int{
+				self.Add(-8 * time.Second): 3,
+				self.Add(30 * time.Second): 1,
+			},
+			want: -2 * time.Second,
+		},
+		{
+			name: "even split chooses earlier bin",
+			peers: map[time.Time]int{
+				self.Add(-8 * time.Second): 1,
+				self.Add(8 * time.Second):  2,
+			},
+			want: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			a := newTestAdaptor(t)
+			a.AdjustCloseTime(consensus.CloseTimes{Self: self, Peers: test.peers})
+			if got := time.Duration(a.closeOffsetNs.Load()); got != test.want {
+				t.Fatalf("close offset = %s, want %s", got, test.want)
 			}
 		})
 	}

--- a/internal/consensus/adaptor/adaptor_close_time_test.go
+++ b/internal/consensus/adaptor/adaptor_close_time_test.go
@@ -20,7 +20,7 @@ func TestAdjustCloseTime_DampingMatchesRippled(t *testing.T) {
 	tests := []struct {
 		name       string
 		initialNs  int64 // pre-existing closeOffsetNs
-		bySecs     int64 // desired (avg - self) in seconds
+		bySecs     int64 // desired (median - self) in seconds
 		wantNewSec int64 // expected post-store offset, in seconds
 	}{
 		{

--- a/internal/consensus/adaptor/finalization_conformance_test.go
+++ b/internal/consensus/adaptor/finalization_conformance_test.go
@@ -60,7 +60,7 @@ func TestSTValidationPreservesSignedAmountPresence(t *testing.T) {
 				wire:      appendFieldHeader(nil, typeAmount, fieldBaseFeeDrops),
 			}
 			amount.wire = binary.BigEndian.AppendUint64(amount.wire, test.raw)
-			fields = append(fields, amount)
+			fields = insertValidationWireField(fields, amount)
 
 			blob, _, _ := signValidationWireFields(t, identity, fields)
 			validation, err := parseSTValidation(blob)

--- a/internal/consensus/adaptor/stvalidation.go
+++ b/internal/consensus/adaptor/stvalidation.go
@@ -188,6 +188,8 @@ func parseSTValidation(data []byte) (*consensus.Validation, error) {
 	var signingFields []validationSigningField
 	var present uint32
 	seen := make(map[uint32]struct{}, len(validationTemplate))
+	var previousKey uint32
+	havePrevious := false
 
 	pos := 0
 	for pos < len(data) {
@@ -206,6 +208,11 @@ func parseSTValidation(data []byte) (*consensus.Validation, error) {
 		if _, duplicate := seen[key]; duplicate {
 			return nil, fmt.Errorf("%w: %s", errDuplicateField, spec.name)
 		}
+		if havePrevious && key <= previousKey {
+			return nil, fmt.Errorf("%w: %s", errNonCanonicalFieldID, spec.name)
+		}
+		previousKey = key
+		havePrevious = true
 
 		// Determine field data length and advance pos past it.
 		// For VL-encoded fields, skipFieldData reads past the VL prefix and data,

--- a/internal/consensus/adaptor/stvalidation_template_test.go
+++ b/internal/consensus/adaptor/stvalidation_template_test.go
@@ -1,7 +1,6 @@
 package adaptor
 
 import (
-	"bytes"
 	"encoding/binary"
 	"sort"
 	"testing"
@@ -70,6 +69,14 @@ func validationWireFieldIndex(t *testing.T, fields []validationWireField, key ui
 	}
 	t.Fatalf("validation field 0x%x not found", key)
 	return -1
+}
+
+func insertValidationWireField(fields []validationWireField, field validationWireField) []validationWireField {
+	index := sort.Search(len(fields), func(i int) bool { return fields[i].key > field.key })
+	fields = append(fields, validationWireField{})
+	copy(fields[index+1:], fields[index:])
+	fields[index] = field
+	return fields
 }
 
 func signValidationWireFields(
@@ -167,27 +174,15 @@ func TestParseSTValidation_RejectsDuplicateTemplateFields(t *testing.T) {
 }
 
 func TestParseSTValidation_TemplateShape(t *testing.T) {
-	t.Run("out of order is canonicalized", func(t *testing.T) {
+	t.Run("out of order is rejected", func(t *testing.T) {
 		identity, fields := signedValidationFixture(t)
 		signingTime := validationWireFieldIndex(t, fields, validationFieldKey(typeUINT32, fieldSigningTime))
 		ledgerHash := validationWireFieldIndex(t, fields, validationFieldKey(typeHash256, fieldLedgerHash))
 		fields[signingTime], fields[ledgerHash] = fields[ledgerHash], fields[signingTime]
 
 		blob, _, _ := signValidationWireFields(t, identity, fields)
-		validation, err := parseSTValidation(blob)
-		require.NoError(t, err)
-		assert.NoError(t, VerifyValidation(validation))
-
-		canonical, err := CanonicalSTValidation(validation)
-		require.NoError(t, err)
-		assert.False(t, bytes.Equal(blob, canonical))
-		canonicalFields := decodeValidationWireFields(t, canonical)
-		assert.True(t, sort.SliceIsSorted(canonicalFields, func(i, j int) bool {
-			return canonicalFields[i].key < canonicalFields[j].key
-		}))
-		reparsed, err := parseSTValidation(canonical)
-		require.NoError(t, err)
-		assert.NoError(t, VerifyValidation(reparsed))
+		_, err := parseSTValidation(blob)
+		assert.ErrorIs(t, err, errNonCanonicalFieldID)
 	})
 
 	t.Run("unexpected field", func(t *testing.T) {
@@ -381,14 +376,14 @@ func TestParseSTValidation_ValidatesAmounts(t *testing.T) {
 		{
 			name:   "truncated MPT",
 			amount: mptAmount()[:32],
-			target: errShortData,
+			target: errUnexpectedField,
 		},
 	}
 
 	for _, test := range invalid {
 		t.Run(test.name, func(t *testing.T) {
 			identity, fields := signedValidationFixture(t)
-			fields = append(fields, amountField(test.amount))
+			fields = insertValidationWireField(fields, amountField(test.amount))
 
 			blob, _, _ := signValidationWireFields(t, identity, fields)
 			_, err := parseSTValidation(blob)
@@ -421,7 +416,7 @@ func TestParseSTValidation_ValidatesAmounts(t *testing.T) {
 	for _, test := range valid {
 		t.Run(test.name, func(t *testing.T) {
 			identity, fields := signedValidationFixture(t)
-			fields = append(fields, amountField(test.amount))
+			fields = insertValidationWireField(fields, amountField(test.amount))
 
 			blob, _, _ := signValidationWireFields(t, identity, fields)
 			validation, err := parseSTValidation(blob)

--- a/internal/consensus/rcl/engine_accept.go
+++ b/internal/consensus/rcl/engine_accept.go
@@ -351,8 +351,9 @@ func (e *Engine) commitAcceptedLedgerLocked(work ledgerAcceptWork, newLedger con
 		Timestamp:   e.adaptor.Now(),
 	})
 
-	// Adjust our clock toward the network's close-time average.
-	if e.mode == consensus.ModeProposing || e.mode == consensus.ModeObserving {
+	// Adjust our clock toward the network's close-time median unless consensus
+	// moved on without us.
+	if !consensusFail && (e.mode == consensus.ModeProposing || e.mode == consensus.ModeObserving) {
 		e.adaptor.AdjustCloseTime(e.state.CloseTimes)
 	}
 

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -135,6 +135,7 @@ type mockAdaptor struct {
 	modeChanges          []consensus.Mode
 	phaseChanges         []consensus.Phase
 	switchedLedgers      []consensus.Ledger
+	adjustCloseTimeCalls int
 
 	// Time
 	now time.Time
@@ -662,7 +663,11 @@ func (a *mockAdaptor) PrevCloseTimeResolution() time.Duration {
 	return time.Second
 }
 
-func (a *mockAdaptor) AdjustCloseTime(rawCloseTimes consensus.CloseTimes) {}
+func (a *mockAdaptor) AdjustCloseTime(consensus.CloseTimes) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.adjustCloseTimeCalls++
+}
 
 func (a *mockAdaptor) OnConsensusReached(ledger consensus.Ledger, validations []*consensus.Validation, roundTime time.Duration) {
 }
@@ -3995,8 +4000,8 @@ func TestSendValidation_RestartFloorSurvivesIdleExpiry(t *testing.T) {
 	}
 }
 
-// TestAcceptLedger_ConsensusFailSuppressesValidation pins the
-// rippled-faithful emission gate at RCLConsensus.cpp:479,591-594:
+// TestAcceptLedger_ConsensusFailSuppressesValidationAndClockAdjustment pins
+// rippled's consensus-failure gates for validation and close-time adjustment.
 //
 //	bool const consensusFail = result.state == ConsensusState::MovedOn;
 //	if (validating_ && !consensusFail && canValidateSeq(...)) validate(...)
@@ -4010,17 +4015,18 @@ func TestSendValidation_RestartFloorSurvivesIdleExpiry(t *testing.T) {
 // suppress-paths. The previous over-broad rule `result != Success`
 // silently bowed goxrpl out of every timed-out round and turned a
 // recoverable stall into permanent quorum starvation (#451).
-func TestAcceptLedger_ConsensusFailSuppressesValidation(t *testing.T) {
+func TestAcceptLedger_ConsensusFailSuppressesValidationAndClockAdjustment(t *testing.T) {
 	cases := []struct {
-		name   string
-		result consensus.Result
-		want   int // emissions expected
+		name       string
+		result     consensus.Result
+		wantEmit   int
+		wantAdjust int
 	}{
-		{"Success_emits", consensus.ResultSuccess, 1},
-		{"Timeout_emits", consensus.ResultTimeout, 1},
-		{"Abandoned_emits", consensus.ResultAbandoned, 1},
-		{"MovedOn_suppressed", consensus.ResultMovedOn, 0},
-		{"Fail_suppressed", consensus.ResultFail, 0},
+		{"Success_emits", consensus.ResultSuccess, 1, 1},
+		{"Timeout_emits", consensus.ResultTimeout, 1, 1},
+		{"Abandoned_emits", consensus.ResultAbandoned, 1, 1},
+		{"MovedOn_suppressed", consensus.ResultMovedOn, 0, 0},
+		{"Fail_suppressed", consensus.ResultFail, 0, 0},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -4055,13 +4061,18 @@ func TestAcceptLedger_ConsensusFailSuppressesValidation(t *testing.T) {
 			engine.mu.Unlock()
 
 			adaptor.mu.RLock()
-			got := len(adaptor.validationsBroadcast)
+			gotEmit := len(adaptor.validationsBroadcast)
+			gotAdjust := adaptor.adjustCloseTimeCalls
 			adaptor.mu.RUnlock()
 
-			if got != tc.want {
+			if gotEmit != tc.wantEmit {
 				t.Fatalf("result=%v: want %d emissions, got %d "+
 					"(consensusFail gate did not match rippled "+
-					"RCLConsensus.cpp:587-594)", tc.result, tc.want, got)
+					"RCLConsensus.cpp:587-594)", tc.result, tc.wantEmit, gotEmit)
+			}
+			if gotAdjust != tc.wantAdjust {
+				t.Fatalf("result=%v: want %d close-time adjustments, got %d",
+					tc.result, tc.wantAdjust, gotAdjust)
 			}
 		})
 	}

--- a/internal/peermanagement/inbound_budget_test.go
+++ b/internal/peermanagement/inbound_budget_test.go
@@ -20,6 +20,24 @@ func readBudgetUsed(budget *readBudget) int64 {
 	return budget.used
 }
 
+func TestInboundPingBudgetFollowsWireSize(t *testing.T) {
+	small := message.Header{
+		MessageType:      message.TypePing,
+		PayloadSize:      8,
+		UncompressedSize: 8,
+	}
+	require.Zero(t, inboundFrameReservation(small))
+
+	large := message.Header{
+		MessageType:      message.TypePing,
+		PayloadSize:      64*1024 + 1,
+		Compressed:       true,
+		UncompressedSize: 1,
+		Algorithm:        message.AlgorithmLZ4,
+	}
+	require.Equal(t, int64(64*1024+2), inboundFrameReservation(large))
+}
+
 func TestInboundBulkBudgetFollowsMessageThroughConsumer(t *testing.T) {
 	payload := protowire.AppendTag(nil, 100, protowire.BytesType)
 	payload = protowire.AppendBytes(payload, bytes.Repeat([]byte{0x4c}, 32*1024))

--- a/internal/peermanagement/manifest_interop_test.go
+++ b/internal/peermanagement/manifest_interop_test.go
@@ -229,6 +229,9 @@ func TestManifest_Interop_RippledDocker(t *testing.T) {
 	defaultWitness := newManifestInteropPeer(t, node.addr, defaultLimit)
 	lowerWitness := newManifestInteropPeer(t, node.addr, lowerLimit)
 	higherWitness := newManifestInteropPeer(t, node.addr, higherLimit)
+	for _, peer := range []*manifestInteropPeer{source, defaultWitness, lowerWitness, higherWitness} {
+		require.NotEmpty(t, receiveManifests(t, peer).List)
+	}
 
 	serialized := make([][]byte, 0, manifestInteropBatchCount)
 	for i := range manifestInteropBatchCount {
@@ -281,15 +284,24 @@ func TestManifest_Interop_RippledDocker(t *testing.T) {
 	defaultWitness.stop()
 	reconnected := newManifestInteropPeer(t, node.addr, defaultLimit)
 	snapshot := receiveManifests(t, reconnected)
-	require.Len(t, snapshot.List, manifestInteropBatchCount+1)
+	want := make(map[string]struct{}, manifestInteropBatchCount+1)
+	for _, item := range serialized {
+		want[string(item)] = struct{}{}
+	}
+	want[string(revoked)] = struct{}{}
 	var revokedCount int
 	for _, item := range snapshot.List {
+		if _, ok := want[string(item.STObject)]; !ok {
+			continue
+		}
+		delete(want, string(item.STObject))
 		parsed, err := manifest.Deserialize(item.STObject)
 		require.NoError(t, err)
 		if parsed.Revoked() {
 			revokedCount++
 		}
 	}
+	require.Zero(t, len(want), "%d synthetic manifests missing from reconnect snapshot", len(want))
 	require.Equal(t, 1, revokedCount)
 }
 

--- a/internal/peermanagement/message/codec.go
+++ b/internal/peermanagement/message/codec.go
@@ -15,6 +15,7 @@ const (
 	smallMsgMax  = 64 * 1024        // 64 KiB
 	mediumMsgMax = 1 * 1024 * 1024  // 1 MiB
 	largeMsgMax  = 16 * 1024 * 1024 // 16 MiB
+	maxPingSize  = 1024
 )
 
 // MaxPayloadSizeForType returns the largest payload a peer may claim
@@ -32,7 +33,7 @@ func IsKnownMessageType(t MessageType) bool {
 
 func payloadSizeLimit(t MessageType) uint32 {
 	switch t {
-	case TypePing, TypeSquelch:
+	case TypeSquelch:
 		return 2048
 	case TypeEndpoints,
 		TypeStatusChange,
@@ -306,6 +307,10 @@ func validateHeaderClaims(header Header) error {
 	if header.PayloadSize > MaxMessageSize || header.UncompressedSize > MaxMessageSize {
 		return fmt.Errorf("%w: exceeds protocol max %d bytes",
 			ErrMessageTooLarge, MaxMessageSize)
+	}
+	if header.MessageType == TypePing && uint64(header.UncompressedSize)+uint64(header.HeaderSize()) > maxPingSize {
+		return fmt.Errorf("%w: uncompressed ping with header exceeds %d bytes",
+			ErrMessageTooLarge, maxPingSize)
 	}
 
 	// Cap both the on-wire and uncompressed claims per message type

--- a/internal/peermanagement/message/codec_test.go
+++ b/internal/peermanagement/message/codec_test.go
@@ -161,10 +161,11 @@ func TestHeaderClaimBoundariesAreSymmetric(t *testing.T) {
 		uncompressedSize uint32
 		wantErr          bool
 	}{
-		{"ping exact", 2048, TypePing, AlgorithmNone, 0, false},
-		{"ping over", 2049, TypePing, AlgorithmNone, 0, true},
-		{"ping compressed wire over", 2049, TypePing, AlgorithmLZ4, 100, true},
-		{"ping compressed claim over", 100, TypePing, AlgorithmLZ4, 2049, true},
+		{"ping exact", maxPingSize - HeaderSizeUncompressed, TypePing, AlgorithmNone, 0, false},
+		{"ping over", maxPingSize - HeaderSizeUncompressed + 1, TypePing, AlgorithmNone, 0, true},
+		{"ping compressed exact", 100, TypePing, AlgorithmLZ4, maxPingSize - HeaderSizeCompressed, false},
+		{"ping compressed claim over", 100, TypePing, AlgorithmLZ4, maxPingSize - HeaderSizeCompressed + 1, true},
+		{"ping compressed wire above limit", maxPingSize + 1, TypePing, AlgorithmLZ4, 1, false},
 		{"proof exact", largeMsgMax, TypeProofPathResponse, AlgorithmLZ4, largeMsgMax, false},
 		{"proof over", 100, TypeProofPathResponse, AlgorithmLZ4, largeMsgMax + 1, true},
 		{"replay above proof", 100, TypeReplayDeltaResponse, AlgorithmLZ4, largeMsgMax + 1, false},
@@ -209,14 +210,14 @@ func TestHeaderClaimBoundariesAreSymmetric(t *testing.T) {
 }
 
 func TestBuildWireMessagePingBoundary(t *testing.T) {
-	frame, err := BuildWireMessage(TypePing, make([]byte, 2048))
+	frame, err := BuildWireMessage(TypePing, make([]byte, maxPingSize-HeaderSizeUncompressed))
 	if err != nil {
 		t.Fatalf("BuildWireMessage exact boundary: %v", err)
 	}
 	if _, err := ReadHeader(bytes.NewReader(frame)); err != nil {
 		t.Fatalf("ReadHeader exact boundary: %v", err)
 	}
-	if _, err := BuildWireMessage(TypePing, make([]byte, 2049)); !errors.Is(err, ErrMessageTooLarge) {
+	if _, err := BuildWireMessage(TypePing, make([]byte, maxPingSize-HeaderSizeUncompressed+1)); !errors.Is(err, ErrMessageTooLarge) {
 		t.Fatalf("BuildWireMessage over boundary error = %v, want ErrMessageTooLarge", err)
 	}
 }
@@ -464,7 +465,7 @@ func TestReadFrameCaps(t *testing.T) {
 		{"validatorlist_20mib_ok", TypeValidatorList, 20 * mib, false},
 		{"unknown_20mib_ok", MessageType(9999), 20 * mib, false},
 		// Request-shaped types keep their stricter hardening caps.
-		{"ping_20mib_rejected", TypePing, 20 * mib, true},
+		{"ping_20mib_claim_rejected", TypePing, 20 * mib, true},
 		{"getledger_20mib_rejected", TypeGetLedger, 20 * mib, true},
 		// The protocol ceiling is hard even for the most permissive type.
 		{"ledgerdata_over_ceiling_rejected", TypeLedgerData, MaxMessageSize + 1, true},

--- a/internal/peermanagement/message/messages.go
+++ b/internal/peermanagement/message/messages.go
@@ -272,27 +272,15 @@ func (l *LedgerData) HasError() bool {
 
 // Ping represents a ping/pong message for keepalive and latency measurement.
 type Ping struct {
-	PType       PingType `json:"type"`
-	Seq         uint32   `json:"seq,omitempty"`
-	SeqSet      bool     `json:"-"`
-	PingTime    uint64   `json:"ping_time,omitempty"`
-	PingTimeSet bool     `json:"-"`
-	NetTime     uint64   `json:"net_time,omitempty"`
-	NetTimeSet  bool     `json:"-"`
+	PType  PingType `json:"type"`
+	Seq    uint32   `json:"seq,omitempty"`
+	SeqSet bool     `json:"-"`
 }
 
 func (p *Ping) Type() MessageType { return TypePing }
 
 func (p *Ping) HasSeq() bool {
 	return p != nil && (p.SeqSet || p.Seq != 0)
-}
-
-func (p *Ping) HasPingTime() bool {
-	return p != nil && (p.PingTimeSet || p.PingTime != 0)
-}
-
-func (p *Ping) HasNetTime() bool {
-	return p != nil && (p.NetTimeSet || p.NetTime != 0)
 }
 
 // Squelch represents a squelch message for reduce-relay.

--- a/internal/peermanagement/message/outbound_compression_test.go
+++ b/internal/peermanagement/message/outbound_compression_test.go
@@ -31,7 +31,7 @@ func TestCompressFrameIfWorthwhilePolicy(t *testing.T) {
 		{
 			name:     "ineligible",
 			msgType:  TypePing,
-			payload:  bytes.Repeat([]byte{'A'}, 1024),
+			payload:  bytes.Repeat([]byte{'A'}, maxPingSize-HeaderSizeUncompressed),
 			compress: false,
 		},
 	}

--- a/internal/peermanagement/message/serialize_proto.go
+++ b/internal/peermanagement/message/serialize_proto.go
@@ -177,24 +177,14 @@ var codecs = map[MessageType]msgCodec{
 			if m.HasSeq() {
 				out.Seq = pb.Uint32(m.Seq)
 			}
-			if m.HasPingTime() {
-				out.PingTime = pb.Uint64(m.PingTime)
-			}
-			if m.HasNetTime() {
-				out.NetTime = pb.Uint64(m.NetTime)
-			}
 			return out, nil
 		},
 		decode: func(pmsg pb.Message) (Message, error) {
 			p := pmsg.(*proto.TMPing)
 			return &Ping{
-				PType:       PingType(p.GetType()),
-				Seq:         p.GetSeq(),
-				SeqSet:      p.Seq != nil,
-				PingTime:    p.GetPingTime(),
-				PingTimeSet: p.PingTime != nil,
-				NetTime:     p.GetNetTime(),
-				NetTimeSet:  p.NetTime != nil,
+				PType:  PingType(p.GetType()),
+				Seq:    p.GetSeq(),
+				SeqSet: p.Seq != nil,
 			}, nil
 		},
 	},

--- a/internal/peermanagement/message/serialize_test.go
+++ b/internal/peermanagement/message/serialize_test.go
@@ -12,9 +12,9 @@ import (
 
 func TestPingRoundtrip(t *testing.T) {
 	tests := []*Ping{
-		{PType: PingTypePing, Seq: 1, PingTime: 1000},
-		{PType: PingTypePong, Seq: 2, PingTime: 2000, NetTime: 3000},
-		{PType: PingTypePing, Seq: 0, PingTime: 0},
+		{PType: PingTypePing, Seq: 1},
+		{PType: PingTypePong, Seq: 2},
+		{PType: PingTypePing},
 	}
 
 	for i, original := range tests {
@@ -35,12 +35,6 @@ func TestPingRoundtrip(t *testing.T) {
 		}
 		if decoded.Seq != original.Seq {
 			t.Errorf("Test %d: Seq = %d, want %d", i, decoded.Seq, original.Seq)
-		}
-		if decoded.PingTime != original.PingTime {
-			t.Errorf("Test %d: PingTime = %d, want %d", i, decoded.PingTime, original.PingTime)
-		}
-		if decoded.NetTime != original.NetTime {
-			t.Errorf("Test %d: NetTime = %d, want %d", i, decoded.NetTime, original.NetTime)
 		}
 	}
 }
@@ -932,8 +926,8 @@ func TestPingOptionalScalarPresence(t *testing.T) {
 		set  bool
 	}{
 		{name: "absent", ping: &Ping{PType: PingTypePing}},
-		{name: "explicit zero", ping: &Ping{PType: PingTypePing, SeqSet: true, PingTimeSet: true, NetTimeSet: true}, set: true},
-		{name: "nonzero", ping: &Ping{PType: PingTypePong, Seq: 1, PingTime: 2, NetTime: 3}, set: true},
+		{name: "explicit zero", ping: &Ping{PType: PingTypePing, SeqSet: true}, set: true},
+		{name: "nonzero", ping: &Ping{PType: PingTypePong, Seq: 1}, set: true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -946,8 +940,8 @@ func TestPingOptionalScalarPresence(t *testing.T) {
 				t.Fatal(err)
 			}
 			ping := decoded.(*Ping)
-			if ping.SeqSet != test.set || ping.PingTimeSet != test.set || ping.NetTimeSet != test.set {
-				t.Fatalf("scalar presence = %v/%v/%v, want %v", ping.SeqSet, ping.PingTimeSet, ping.NetTimeSet, test.set)
+			if ping.SeqSet != test.set {
+				t.Fatalf("seq presence = %v, want %v", ping.SeqSet, test.set)
 			}
 		})
 	}

--- a/internal/peermanagement/overlay_message.go
+++ b/internal/peermanagement/overlay_message.go
@@ -614,8 +614,11 @@ func (o *Overlay) handlePing(evt Event) bool {
 	switch ping.PType {
 	case message.PingTypePing:
 		o.selectMessageCharge(&evt, resource.FeeModerateBurdenPeer(), "ping request")
-		pong := *ping
-		pong.PType = message.PingTypePong
+		pong := message.Ping{PType: message.PingTypePong}
+		if ping.HasSeq() {
+			pong.Seq = ping.Seq
+			pong.SeqSet = true
+		}
 		wireMsg, err := message.EncodeFrame(&pong)
 		if err != nil {
 			return false

--- a/internal/peermanagement/overlay_ping_test.go
+++ b/internal/peermanagement/overlay_ping_test.go
@@ -10,39 +10,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOverlayHandlePingPongEchoesOptionalFields(t *testing.T) {
+func TestOverlayHandlePingPongCopiesOnlySequence(t *testing.T) {
 	peer := newTestPeer(t, 7)
 	o := newTestOverlayWithPeers(map[PeerID]*Peer{7: peer})
 
 	tests := []struct {
-		name string
-		ping *message.Ping
+		name    string
+		payload []byte
+		seq     uint32
+		seqSet  bool
 	}{
-		{name: "absent", ping: &message.Ping{PType: message.PingTypePing}},
+		{name: "absent", payload: []byte{0x08, 0x00}},
 		{
-			name: "explicit zero",
-			ping: &message.Ping{
-				PType:       message.PingTypePing,
-				SeqSet:      true,
-				PingTimeSet: true,
-				NetTimeSet:  true,
-			},
+			name:    "explicit zero",
+			payload: []byte{0x08, 0x00, 0x10, 0x00},
+			seqSet:  true,
 		},
 		{
-			name: "nonzero",
-			ping: &message.Ping{
-				PType:    message.PingTypePing,
-				Seq:      11,
-				PingTime: 22,
-				NetTime:  33,
-			},
+			name:    "legacy unknown fields",
+			payload: []byte{0x08, 0x00, 0x10, 0x0b, 0x18, 0x16, 0x20, 0x21},
+			seq:     11,
+			seqSet:  true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			payload, err := message.Encode(tt.ping)
-			require.NoError(t, err)
-			require.True(t, o.handlePing(Event{PeerID: 7, Payload: payload}))
+			require.True(t, o.handlePing(Event{PeerID: 7, Payload: tt.payload}))
 
 			frame := requireOutboundFrame(t, peer)
 			header, replyPayload, err := readTestFrame(bytes.NewReader(frame))
@@ -53,12 +46,15 @@ func TestOverlayHandlePingPongEchoesOptionalFields(t *testing.T) {
 			pong := decoded.(*message.Ping)
 
 			assert.Equal(t, message.PingTypePong, pong.PType)
-			assert.Equal(t, tt.ping.Seq, pong.Seq)
-			assert.Equal(t, tt.ping.HasSeq(), pong.HasSeq())
-			assert.Equal(t, tt.ping.PingTime, pong.PingTime)
-			assert.Equal(t, tt.ping.HasPingTime(), pong.HasPingTime())
-			assert.Equal(t, tt.ping.NetTime, pong.NetTime)
-			assert.Equal(t, tt.ping.HasNetTime(), pong.HasNetTime())
+			assert.Equal(t, tt.seq, pong.Seq)
+			assert.Equal(t, tt.seqSet, pong.HasSeq())
+			expectedPayload, err := message.Encode(&message.Ping{
+				PType:  message.PingTypePong,
+				Seq:    tt.seq,
+				SeqSet: tt.seqSet,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, expectedPayload, replyPayload)
 		})
 	}
 }

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -341,12 +341,15 @@ func (p *Peer) manifestFrameExceedsLimit(header message.Header) bool {
 	return header.PayloadSize > limit || header.UncompressedSize > limit
 }
 
-func isInboundBulkMessageType(msgType message.MessageType) bool {
-	return !message.IsKnownMessageType(msgType) || message.MaxPayloadSizeForType(msgType) > 64*1024
+func isInboundBulkFrame(header message.Header) bool {
+	if header.MessageType == message.TypePing {
+		return header.PayloadSize > 64*1024
+	}
+	return !message.IsKnownMessageType(header.MessageType) || message.MaxPayloadSizeForType(header.MessageType) > 64*1024
 }
 
 func inboundFrameReservation(header message.Header) int64 {
-	if !isInboundBulkMessageType(header.MessageType) {
+	if !isInboundBulkFrame(header) {
 		return 0
 	}
 	size := int64(header.PayloadSize)

--- a/internal/peermanagement/proto/xrpl.pb.go
+++ b/internal/peermanagement/proto/xrpl.pb.go
@@ -2297,9 +2297,7 @@ func (x *TMLedgerData) GetError() TMReplyError {
 type TMPing struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Type          *TMPingPingType        `protobuf:"varint,1,req,name=type,enum=protocol.TMPingPingType" json:"type,omitempty"`
-	Seq           *uint32                `protobuf:"varint,2,opt,name=seq" json:"seq,omitempty"`           // detect stale replies, ensure other side is reading
-	PingTime      *uint64                `protobuf:"varint,3,opt,name=pingTime" json:"pingTime,omitempty"` // know when we think we sent the ping
-	NetTime       *uint64                `protobuf:"varint,4,opt,name=netTime" json:"netTime,omitempty"`
+	Seq           *uint32                `protobuf:"varint,2,opt,name=seq" json:"seq,omitempty"` // detect stale replies, ensure other side is reading
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2344,20 +2342,6 @@ func (x *TMPing) GetType() TMPingPingType {
 func (x *TMPing) GetSeq() uint32 {
 	if x != nil && x.Seq != nil {
 		return *x.Seq
-	}
-	return 0
-}
-
-func (x *TMPing) GetPingTime() uint64 {
-	if x != nil && x.PingTime != nil {
-		return *x.PingTime
-	}
-	return 0
-}
-
-func (x *TMPing) GetNetTime() uint64 {
-	if x != nil && x.NetTime != nil {
-		return *x.NetTime
 	}
 	return 0
 }
@@ -2918,17 +2902,15 @@ const file_internal_peermanagement_proto_xrpl_proto_rawDesc = "" +
 	"\x04type\x18\x03 \x02(\x0e2\x1a.protocol.TMLedgerInfoTypeR\x04type\x12,\n" +
 	"\x05nodes\x18\x04 \x03(\v2\x16.protocol.TMLedgerNodeR\x05nodes\x12$\n" +
 	"\rrequestCookie\x18\x05 \x01(\rR\rrequestCookie\x12,\n" +
-	"\x05error\x18\x06 \x01(\x0e2\x16.protocol.TMReplyErrorR\x05error\"\xa3\x01\n" +
+	"\x05error\x18\x06 \x01(\x0e2\x16.protocol.TMReplyErrorR\x05error\"y\n" +
 	"\x06TMPing\x12-\n" +
 	"\x04type\x18\x01 \x02(\x0e2\x19.protocol.TMPing.pingTypeR\x04type\x12\x10\n" +
-	"\x03seq\x18\x02 \x01(\rR\x03seq\x12\x1a\n" +
-	"\bpingTime\x18\x03 \x01(\x04R\bpingTime\x12\x18\n" +
-	"\anetTime\x18\x04 \x01(\x04R\anetTime\"\"\n" +
+	"\x03seq\x18\x02 \x01(\rR\x03seq\"\"\n" +
 	"\bpingType\x12\n" +
 	"\n" +
 	"\x06ptPING\x10\x00\x12\n" +
 	"\n" +
-	"\x06ptPONG\x10\x01\"y\n" +
+	"\x06ptPONG\x10\x01J\x04\b\x03\x10\x04J\x04\b\x04\x10\x05\"y\n" +
 	"\tTMSquelch\x12\x18\n" +
 	"\asquelch\x18\x01 \x02(\bR\asquelch\x12(\n" +
 	"\x0fvalidatorPubKey\x18\x02 \x02(\fR\x0fvalidatorPubKey\x12(\n" +

--- a/internal/peermanagement/proto/xrpl.proto
+++ b/internal/peermanagement/proto/xrpl.proto
@@ -293,14 +293,15 @@ message TMLedgerData {
 }
 
 message TMPing {
+  // Previously used - don't reuse.
+  reserved 3, 4;
+
   enum pingType {
     ptPING = 0;  // we want a reply
     ptPONG = 1;  // this is a reply
   }
   required pingType type = 1;
-  optional uint32 seq = 2;       // detect stale replies, ensure other side is reading
-  optional uint64 pingTime = 3;  // know when we think we sent the ping
-  optional uint64 netTime = 4;
+  optional uint32 seq = 2;  // detect stale replies, ensure other side is reading
 }
 
 message TMSquelch {

--- a/internal/peermanagement/proto/xrpl_proto_test.go
+++ b/internal/peermanagement/proto/xrpl_proto_test.go
@@ -16,7 +16,7 @@ func TestSchemaProvenance(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	const expected = "d52b004814cbe9d243fd132166c18da7923ddf5608827277bf5928457ee4bbe5"
+	const expected = "f920a631f343959b5a582e7089d06c678001d2c5a5ccd07acc6c7d2a994ddbcf"
 	if actual := fmt.Sprintf("%x", sha256.Sum256(schema)); actual != expected {
 		t.Fatalf("xrpl.proto SHA256 = %s, want %s", actual, expected)
 	}
@@ -42,8 +42,8 @@ func TestSchemaDescriptorShape(t *testing.T) {
 	}
 
 	messages, required, optional, repeated := descriptorCounts(file.Messages())
-	if messages != 30 || required != 48 || optional != 43 || repeated != 14 {
-		t.Fatalf("descriptor counts = messages:%d required:%d optional:%d repeated:%d, want 30/48/43/14", messages, required, optional, repeated)
+	if messages != 30 || required != 48 || optional != 41 || repeated != 14 {
+		t.Fatalf("descriptor counts = messages:%d required:%d optional:%d repeated:%d, want 30/48/41/14", messages, required, optional, repeated)
 	}
 
 	endpoints := file.Messages().ByName("TMEndpoints")
@@ -53,6 +53,10 @@ func TestSchemaDescriptorShape(t *testing.T) {
 	objects := file.Messages().ByName("TMGetObjectByHash")
 	if objects == nil || !objects.ReservedRanges().Has(3) {
 		t.Fatal("TMGetObjectByHash must reserve field 3")
+	}
+	ping := file.Messages().ByName("TMPing")
+	if ping == nil || !ping.ReservedRanges().Has(3) || !ping.ReservedRanges().Has(4) {
+		t.Fatal("TMPing must reserve fields 3 and 4")
 	}
 	if file.Messages().ByName("TMLink") == nil {
 		t.Fatal("TMLink descriptor is missing")

--- a/internal/tx/engine/confidential_preflight_test.go
+++ b/internal/tx/engine/confidential_preflight_test.go
@@ -67,3 +67,34 @@ func TestConfidentialMPTConvertPreflightPrecedence(t *testing.T) {
 		t.Fatalf("Batch delegated Convert preflight = %v, want temINVALID_INNER_BATCH", got)
 	}
 }
+
+func TestConfidentialMPTPreflightAmendmentGate(t *testing.T) {
+	newBase := func(transactionType txcore.Type) txcore.BaseTx {
+		base := *txcore.NewBaseTx(transactionType, precedenceSourceAddr)
+		base.Fee = "100"
+		base.Sequence = u32(5)
+		return base
+	}
+
+	tests := []struct {
+		name        string
+		transaction txcore.Transaction
+	}{
+		{"Convert", &mpt.ConfidentialMPTConvert{BaseTx: newBase(txcore.TypeConfidentialMPTConvert)}},
+		{"MergeInbox", &mpt.ConfidentialMPTMergeInbox{BaseTx: newBase(txcore.TypeConfidentialMPTMergeInbox)}},
+		{"ConvertBack", &mpt.ConfidentialMPTConvertBack{BaseTx: newBase(txcore.TypeConfidentialMPTConvertBack)}},
+		{"Send", &mpt.ConfidentialMPTSend{BaseTx: newBase(txcore.TypeConfidentialMPTSend)}},
+		{"Clawback", &mpt.ConfidentialMPTClawback{BaseTx: newBase(txcore.TypeConfidentialMPTClawback)}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := preflightEngine(confidentialPreflightRules(false)).preflight(test.transaction); got != ter.TemDISABLED {
+				t.Fatalf("disabled preflight = %v, want temDISABLED", got)
+			}
+			if got := preflightEngine(confidentialPreflightRules(true)).preflight(test.transaction); got != ter.TemINVALID {
+				t.Fatalf("enabled preflight = %v, want temINVALID", got)
+			}
+		})
+	}
+}

--- a/protocol/lending.go
+++ b/protocol/lending.go
@@ -1,6 +1,6 @@
 package protocol
 
-// Lending (XLS-66) protocol constants, mirroring rippled 3.1.0
+// Lending (XLS-66) protocol constants, mirroring rippled 3.3.0
 // include/xrpl/protocol/Protocol.h. Rates are expressed in bips (basis points,
 // 1/10000) or tenth-bips (1/100000); a management fee rate of 10% is stored as
 // 10000 tenth-bips.

--- a/scripts/conformance-out-of-scope.txt
+++ b/scripts/conformance-out-of-scope.txt
@@ -4,9 +4,11 @@
 #
 # To bring a suite into scope, remove or comment out the line.
 
-# Not implemented yet
+# Implemented with incomplete legacy-fixture coverage
 app/Batch
 app/Delegate
 app/Vault
+
+# Not implemented yet
 app/XChain
 app/XChainSim

--- a/scripts/consensus-smoke/README.md
+++ b/scripts/consensus-smoke/README.md
@@ -46,7 +46,7 @@ containers up after a failure for inspection.
 | env var          | default                            | meaning                                       |
 |------------------|------------------------------------|-----------------------------------------------|
 | `GOXRPL_IMAGE`   | `goxrpl:latest`                    | image for goxrpl-0                            |
-| `RIPPLED_IMAGE`  | `xrpllabsofficial/xrpld:3.2.0`    | image for rippled-0,1                         |
+| `RIPPLED_IMAGE`  | `xrpllabsofficial/xrpld:3.3.0`    | image for rippled-0,1                         |
 | `MIN_SEQ_EMPTY`  | `15`                               | seq target for phase 1 (empty ledger)         |
 | `PAYMENT_COUNT`  | `5`                                | number of payments to submit in phase 2       |
 | `BOOT_TIMEOUT`   | `180`                              | seconds to wait for phase 1 to validate       |

--- a/scripts/consensus-smoke/configs/goxrpl-0.toml
+++ b/scripts/consensus-smoke/configs/goxrpl-0.toml
@@ -28,10 +28,6 @@ beta_rpc_api = 0
 # validate the same ledger for the network to advance. Any consensus
 # divergence between goxrpl and rippled wedges validation, which is the
 # regression signal we want from this per-PR smoke.
-#
-# Until #418 (cold-bootstrap fork at seq=6/7) lands, this smoke is expected
-# to fail — that's the entire point: it becomes the gate that closes when
-# the consensus work is complete.
 validation_seed = "sn8KuG4fs84rowCsqTuz6AtqEkmJ7"
 validators_file = "/etc/goxrpl/validators.toml"
 

--- a/scripts/consensus-smoke/docker-compose.yml
+++ b/scripts/consensus-smoke/docker-compose.yml
@@ -4,10 +4,6 @@ name: goxrpl-consensus-smoke
 # (ceil(0.8 * 3)), so every node must validate the same ledger for the
 # network to advance. This is the regression gate for cross-implementation
 # consensus and tx-execution determinism.
-#
-# Until #418 (cold-bootstrap fork at seq=6/7) is fixed, this smoke is
-# expected to fail at phase 1 because the network wedges at seq=5. That's
-# the point: the smoke closes when the consensus work is complete.
 
 services:
   rippled-0:

--- a/scripts/consensus-smoke/docker-compose.yml
+++ b/scripts/consensus-smoke/docker-compose.yml
@@ -11,7 +11,7 @@ name: goxrpl-consensus-smoke
 
 services:
   rippled-0:
-    image: ${RIPPLED_IMAGE:-xrpllabsofficial/xrpld:3.2.0}
+    image: ${RIPPLED_IMAGE:-xrpllabsofficial/xrpld:3.3.0}
     hostname: rippled-0
     ports:
       - "5005"
@@ -28,7 +28,7 @@ services:
       start_period: 5s
 
   rippled-1:
-    image: ${RIPPLED_IMAGE:-xrpllabsofficial/xrpld:3.2.0}
+    image: ${RIPPLED_IMAGE:-xrpllabsofficial/xrpld:3.3.0}
     hostname: rippled-1
     ports:
       - "5005"

--- a/scripts/consensus-smoke/smoke.sh
+++ b/scripts/consensus-smoke/smoke.sh
@@ -18,7 +18,7 @@
 #
 # Knobs (env vars):
 #   GOXRPL_IMAGE        image to use for goxrpl-0 (default: goxrpl:latest)
-#   RIPPLED_IMAGE       image to use for rippled-0,1 (default: xrpllabsofficial/xrpld:3.2.0)
+#   RIPPLED_IMAGE       image to use for rippled-0,1 (default: xrpllabsofficial/xrpld:3.3.0)
 #   MIN_SEQ_EMPTY       minimum validated seq for the empty-ledger phase (default 15)
 #   (phase 2 no longer takes a MIN_SEQ_TX — it waits for one submitted
 #    payment to land in a validated ledger, then asserts hash agreement at
@@ -35,7 +35,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
 
 GOXRPL_IMAGE="${GOXRPL_IMAGE:-goxrpl:latest}"
-RIPPLED_IMAGE="${RIPPLED_IMAGE:-xrpllabsofficial/xrpld:3.2.0}"
+RIPPLED_IMAGE="${RIPPLED_IMAGE:-xrpllabsofficial/xrpld:3.3.0}"
 MIN_SEQ_EMPTY="${MIN_SEQ_EMPTY:-15}"
 MIN_SEQ_TX="${MIN_SEQ_TX:-12}"
 PAYMENT_COUNT="${PAYMENT_COUNT:-5}"


### PR DESCRIPTION
## Summary
- audit the integrated `v3.3.0` branch against the signed rippled `3.3.0` tag at `00a178fb92ca49521b937ae1a99d863765ea8a90` and record the final protocol inventory in `docs/v3.3.0.md`
- align the released `TMPing` schema, pong payload, and 1 KiB uncompressed frame limit with the final oracle
- reject non-canonical validation field ordering and use rippled's weighted lower median for close-time adjustment
- verify Confidential Transfer as part of the v3.3.0 release surface: all five transaction types are implemented, the production image requires the pinned native `mpt-crypto` backend, and native Linux/macOS CI covers it
- run consensus smoke against rippled 3.3.0 plus the retained 3.2.0 mixed-version leg
- document the existing fail-closed XChain support boundary for maintainer approval

## Test plan
- [x] `go test -p 1 ./...`
- [x] `just build-all`
- [x] `just build-nocgo`
- [x] `just vet`
- [x] `golangci-lint run`
- [x] `just docs-check`
- [x] `git diff --check`
- [x] `go test -race ./internal/peermanagement/message`
- [x] pinned `mpt-crypto` 1.0.2 upstream suite, static-link check, and tagged Go Confidential Transfer suites
- [ ] `just conformance --list-fail` (local external fixture corpus unavailable; CI owns the recorded corpus gate)
- [ ] race-enabled consensus/engine packages (local linker exhausted the host volume; CI owns the full race gate)
- [ ] live rippled 3.3.0 handshake, manifest, and consensus interop (local Docker daemon is stopped; CI owns Docker interop)

Fixes #1387
