### PR TITLE
refactor: consolidate trust-line freeze helpers

### DIFF
--- a/internal/tx/check/check_cash.go
+++ b/internal/tx/check/check_cash.go
@@ -684,12 +684,8 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 			}
 		}
 
-		// Check if issuer froze destination's trust line
-		// Reference: CashCheck.cpp L240-246
-		// isFrozen(view, dstId, currency, issuerId) checks:
-		// 1. Global freeze on issuer
-		// 2. Issuer's freeze flag on the trust line
-		frozen, err := isIssuerFrozenForAccount(ctx.View, accountID, issuerID, sendMax.Currency)
+		// Check the issuer's global and destination trust-line freezes.
+		frozen, err := tx.IsIOUFrozen(ctx.View, accountID, issuerID, sendMax.Currency)
 		if err != nil {
 			return ter.TefINTERNAL
 		}
@@ -887,25 +883,6 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 	}
 
 	return ter.TesSUCCESS
-}
-
-// isIssuerFrozenForAccount reports rippled's isFrozen(view, account, currency,
-// issuer) for an IOU: the issuer's global freeze, or — when account != issuer —
-// the issuer-side individual freeze of the trust line. It delegates to the
-// shared freeze primitives rather than re-reading and re-deriving the freeze
-// flags. The account == issuer corner short-circuits identically: the
-// shared IsTrustlineFrozen reads the self-self line (absent) and returns false,
-// so only the global freeze applies.
-// Reference: rippled/src/xrpld/ledger/detail/View.cpp isFrozen().
-func isIssuerFrozenForAccount(view tx.LedgerView, accountID, issuerID [20]byte, currency string) (bool, error) {
-	issuer, err := tx.ReadAccountRoot(view, issuerID)
-	if err != nil {
-		return false, err
-	}
-	if issuer != nil && issuer.Flags&state.LsfGlobalFreeze != 0 {
-		return true, nil
-	}
-	return isTrustLineFrozenByIssuer(view, accountID, issuerID, currency)
 }
 
 // createTrustLineForCheckCash creates a trust line between the check casher

--- a/internal/tx/check/check_cash.go
+++ b/internal/tx/check/check_cash.go
@@ -684,7 +684,6 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 			}
 		}
 
-		// Check the issuer's global and destination trust-line freezes.
 		frozen, err := tx.IsIOUFrozen(ctx.View, accountID, issuerID, sendMax.Currency)
 		if err != nil {
 			return ter.TefINTERNAL

--- a/internal/tx/check/check_create.go
+++ b/internal/tx/check/check_create.go
@@ -176,30 +176,10 @@ func (c *CheckCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 			return ter.TefINTERNAL
 		}
 
-		// Check global freeze on issuer
-		// Reference: CreateCheck.cpp L117-125
-		issuerKey := keylet.Account(issuerID)
-		issuerData, err := ctx.View.Read(issuerKey)
-		if err != nil {
-			return ter.TefINTERNAL
-		}
-		if issuerData != nil {
-			issuerAccount, err := state.ParseAccountRoot(issuerData)
-			if err != nil {
-				return ter.TefINTERNAL
-			}
-			if issuerAccount.Flags&state.LsfGlobalFreeze != 0 {
-				return ter.TecFROZEN
-			}
-		}
-
 		accountID := ctx.AccountID
 
-		// Check source trust line freeze (if source is not issuer): the issuer's
-		// freeze of the source side blocks the source from sending. This is the
-		// shared issuer-side individual freeze check.
-		// Reference: CreateCheck.cpp L131-145
-		frozen, err := isTrustLineFrozenByIssuer(ctx.View, accountID, issuerID, c.SendMax.Currency)
+		// Check the issuer's global and source trust-line freezes.
+		frozen, err := tx.IsIOUFrozen(ctx.View, accountID, issuerID, c.SendMax.Currency)
 		if err != nil {
 			return ter.TefINTERNAL
 		}
@@ -210,7 +190,7 @@ func (c *CheckCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 		// Check destination trust line freeze (if dest is not issuer): check if
 		// the destination froze their own side (not issuer freeze).
 		// Reference: CreateCheck.cpp L146-159
-		frozen, err = isTrustLineFrozenBySelf(ctx.View, destID, issuerID, c.SendMax.Currency)
+		frozen, err = tx.IsTrustlineFrozenBy(ctx.View, destID, issuerID, c.SendMax.Currency)
 		if err != nil {
 			return ter.TefINTERNAL
 		}
@@ -300,37 +280,4 @@ func (c *CheckCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 	}
 
 	return ter.TesSUCCESS
-}
-
-// isTrustLineFrozenBySelf reports whether the trust line between account and
-// issuer is frozen on the account's own side. Returns false when account ==
-// issuer, the line does not exist, or the line cannot be read or parsed.
-func isTrustLineFrozenByIssuer(view tx.LedgerView, accountID, issuerID [20]byte, currency string) (bool, error) {
-	if accountID == issuerID {
-		return false, nil
-	}
-	tl, err := tx.ReadRippleState(view, accountID, issuerID, currency)
-	if err != nil || tl == nil {
-		return false, err
-	}
-	freezeFlag := state.LsfLowFreeze
-	if keylet.IsLowAccount(accountID, issuerID) {
-		freezeFlag = state.LsfHighFreeze
-	}
-	return tl.Flags&freezeFlag != 0, nil
-}
-
-func isTrustLineFrozenBySelf(view tx.LedgerView, accountID, issuerID [20]byte, currency string) (bool, error) {
-	if accountID == issuerID {
-		return false, nil
-	}
-	tl, err := tx.ReadRippleState(view, accountID, issuerID, currency)
-	if err != nil || tl == nil {
-		return false, err
-	}
-	freezeFlag := state.LsfLowFreeze
-	if !keylet.IsLowAccount(accountID, issuerID) {
-		freezeFlag = state.LsfHighFreeze
-	}
-	return tl.Flags&freezeFlag != 0, nil
 }

--- a/internal/tx/check/check_create.go
+++ b/internal/tx/check/check_create.go
@@ -178,7 +178,6 @@ func (c *CheckCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 
 		accountID := ctx.AccountID
 
-		// Check the issuer's global and source trust-line freezes.
 		frozen, err := tx.IsIOUFrozen(ctx.View, accountID, issuerID, c.SendMax.Currency)
 		if err != nil {
 			return ter.TefINTERNAL

--- a/internal/tx/check/handler_integrity_test.go
+++ b/internal/tx/check/handler_integrity_test.go
@@ -18,17 +18,17 @@ func TestCheckCreateFreezeReadFailuresAreInternal(t *testing.T) {
 	lineKey := keylet.Line(sourceID, issuerID, "USD")
 	view.readErrors[lineKey.Key] = errors.New("storage failure")
 
-	if frozen, err := isTrustLineFrozenByIssuer(view, sourceID, issuerID, "USD"); err == nil || frozen {
+	if frozen, err := tx.IsTrustlineFrozenBy(view, issuerID, sourceID, "USD"); err == nil || frozen {
 		t.Fatalf("issuer freeze lookup = (%v, %v), want (false, error)", frozen, err)
 	}
 	delete(view.readErrors, lineKey.Key)
-	if frozen, err := isTrustLineFrozenByIssuer(view, sourceID, issuerID, "USD"); err != nil || frozen {
+	if frozen, err := tx.IsTrustlineFrozenBy(view, issuerID, sourceID, "USD"); err != nil || frozen {
 		t.Fatalf("missing issuer line = (%v, %v), want (false, nil)", frozen, err)
 	}
 
 	lineKey = keylet.Line(destinationID, issuerID, "USD")
 	view.readErrors[lineKey.Key] = errors.New("storage failure")
-	if frozen, err := isTrustLineFrozenBySelf(view, destinationID, issuerID, "USD"); err == nil || frozen {
+	if frozen, err := tx.IsTrustlineFrozenBy(view, destinationID, issuerID, "USD"); err == nil || frozen {
 		t.Fatalf("self freeze lookup = (%v, %v), want (false, error)", frozen, err)
 	}
 }

--- a/internal/tx/escrow/integrity_test.go
+++ b/internal/tx/escrow/integrity_test.go
@@ -174,6 +174,8 @@ func TestIOUStateHelpersFailClosed(t *testing.T) {
 
 	delete(view.readErrors, lineKey.Key)
 	require.NoError(t, view.Insert(lineKey, []byte{0xff}))
+	_, result = isIOUFrozen(view, holderID, issuerID, "USD")
+	require.Equal(t, ter.TefINTERNAL, result)
 	_, result = isIOUDeepFrozen(view, holderID, issuerID, "USD")
 	require.Equal(t, ter.TefINTERNAL, result)
 }

--- a/internal/tx/escrow/token_helpers.go
+++ b/internal/tx/escrow/token_helpers.go
@@ -853,25 +853,11 @@ func isIOUFrozen(
 	if issuer.Flags&state.LsfGlobalFreeze != 0 {
 		return true, ter.TesSUCCESS
 	}
-	if accountID == issuerID {
-		return false, ter.TesSUCCESS
-	}
-
-	data, err := view.Read(keylet.Line(accountID, issuerID, currency))
+	frozen, err := tx.IsTrustlineFrozenBy(view, issuerID, accountID, currency)
 	if err != nil {
 		return false, ter.TefINTERNAL
 	}
-	if data == nil {
-		return false, ter.TesSUCCESS
-	}
-	line, err := state.ParseRippleState(data)
-	if err != nil {
-		return false, ter.TefINTERNAL
-	}
-	if state.CompareAccountIDs(issuerID, accountID) > 0 {
-		return line.Flags&state.LsfHighFreeze != 0, ter.TesSUCCESS
-	}
-	return line.Flags&state.LsfLowFreeze != 0, ter.TesSUCCESS
+	return frozen, ter.TesSUCCESS
 }
 
 func isIOUDeepFrozen(

--- a/internal/tx/mptutil/mpt.go
+++ b/internal/tx/mptutil/mpt.go
@@ -193,7 +193,7 @@ func IsAssetFrozen(view state.LedgerView, asset tx.Asset, account [20]byte) bool
 		id, err := DecodeID(asset.MPTIssuanceID)
 		return err == nil && IsFrozen(view, id, account)
 	}
-	return isIOUFrozen(view, account, asset)
+	return tx.IsFrozen(view, account, asset)
 }
 
 // CheckDepositFreeze applies the freeze rules for sending an asset from a
@@ -296,7 +296,7 @@ func checkGlobalFrozen(view state.LedgerView, asset tx.Asset) ter.Result {
 		}
 		return ter.TesSUCCESS
 	}
-	if isIOUGlobalFrozen(view, asset.Issuer) {
+	if tx.IsGlobalFrozen(view, asset.Issuer) {
 		return ter.TecFROZEN
 	}
 	return ter.TesSUCCESS
@@ -313,7 +313,7 @@ func checkIndividualFrozen(view state.LedgerView, account [20]byte, asset tx.Ass
 		}
 		return ter.TesSUCCESS
 	}
-	if isIOUIndividualFrozen(view, account, asset) {
+	if tx.IsIndividualFrozen(view, account, asset) {
 		return ter.TecFROZEN
 	}
 	return ter.TesSUCCESS
@@ -338,41 +338,6 @@ func checkDeepFrozen(view state.LedgerView, account [20]byte, asset tx.Asset) te
 		return ter.TecFROZEN
 	}
 	return ter.TesSUCCESS
-}
-
-func isIOUGlobalFrozen(view state.LedgerView, issuerAddress string) bool {
-	issuer, err := state.DecodeAccountID(issuerAddress)
-	if err != nil {
-		return false
-	}
-	raw, err := view.Read(keylet.Account(issuer))
-	if err != nil || raw == nil {
-		return false
-	}
-	account, err := state.ParseAccountRoot(raw)
-	return err == nil && account.Flags&state.LsfGlobalFreeze != 0
-}
-
-func isIOUIndividualFrozen(view state.LedgerView, account [20]byte, asset tx.Asset) bool {
-	if asset.IsNative() || asset.Currency == "XRP" {
-		return false
-	}
-	issuer, err := state.DecodeAccountID(asset.Issuer)
-	if err != nil || account == issuer {
-		return false
-	}
-	raw, err := view.Read(keylet.Line(account, issuer, asset.Currency))
-	if err != nil || raw == nil {
-		return false
-	}
-	line, err := state.ParseRippleState(raw)
-	if err != nil {
-		return false
-	}
-	if state.CompareAccountIDs(issuer, account) > 0 {
-		return line.Flags&state.LsfHighFreeze != 0
-	}
-	return line.Flags&state.LsfLowFreeze != 0
 }
 
 func isIOUDeepFrozen(view state.LedgerView, account, issuer [20]byte, currency string) bool {
@@ -401,7 +366,7 @@ func isAnyAssetFrozen(view state.LedgerView, asset tx.Asset, accounts [][20]byte
 		return false
 	}
 	for _, account := range accounts {
-		if isIOUFrozen(view, account, asset) {
+		if tx.IsFrozen(view, account, asset) {
 			return true
 		}
 	}
@@ -604,38 +569,6 @@ func requireAssetAuthWithTypeAt(view state.LedgerView, asset tx.Asset, account [
 		return ter.TecNO_AUTH
 	}
 	return ter.TesSUCCESS
-}
-
-func isIOUFrozen(view state.LedgerView, account [20]byte, asset tx.Asset) bool {
-	if asset.IsNative() {
-		return false
-	}
-	issuer, err := state.DecodeAccountID(asset.Issuer)
-	if err != nil {
-		return false
-	}
-	issuerRaw, err := view.Read(keylet.Account(issuer))
-	if err == nil && issuerRaw != nil {
-		if issuerAccount, parseErr := state.ParseAccountRoot(issuerRaw); parseErr == nil &&
-			issuerAccount.Flags&state.LsfGlobalFreeze != 0 {
-			return true
-		}
-	}
-	if account == issuer {
-		return false
-	}
-	lineRaw, err := view.Read(keylet.Line(account, issuer, asset.Currency))
-	if err != nil || lineRaw == nil {
-		return false
-	}
-	line, err := state.ParseRippleState(lineRaw)
-	if err != nil {
-		return false
-	}
-	if state.CompareAccountIDs(issuer, account) > 0 {
-		return line.Flags&state.LsfHighFreeze != 0
-	}
-	return line.Flags&state.LsfLowFreeze != 0
 }
 
 func ValidDomain(view state.LedgerView, domainIDHex string, account [20]byte, parentCloseTime uint32) ter.Result {

--- a/internal/tx/payment/amm_liquidity.go
+++ b/internal/tx/payment/amm_liquidity.go
@@ -354,24 +354,8 @@ func ammAccountHoldsFromPayment(view *PaymentSandbox, ammAccountID [20]byte, iss
 // Checks both global freeze on the issuer and individual freeze on the trust line.
 // Reference: rippled View.cpp isFrozen(view, account, currency, issuer)
 func isTrustLineFrozenForAMM(view *PaymentSandbox, ammAccountID, issuerID [20]byte, trustLine *state.RippleState) bool {
-	// Check global freeze on the issuer
-	issuerData, err := view.Read(keylet.Account(issuerID))
-	if err == nil && issuerData != nil {
-		issuerAcct, err := state.ParseAccountRoot(issuerData)
-		if err == nil && (issuerAcct.Flags&state.LsfGlobalFreeze) != 0 {
-			return true
-		}
-	}
-
-	// Check individual freeze on the trust line.
-	// The issuer's freeze flag is on their side of the trust line.
-	// Reference: rippled View.cpp isFrozen():
-	//   (issuer > account) ? lsfHighFreeze : lsfLowFreeze
-	issuerIsHigh := state.CompareAccountIDs(issuerID, ammAccountID) > 0
-	if issuerIsHigh {
-		return (trustLine.Flags & state.LsfHighFreeze) != 0
-	}
-	return (trustLine.Flags & state.LsfLowFreeze) != 0
+	return tx.IsGlobalFrozen(view, state.EncodeAccountIDSafe(issuerID)) ||
+		tx.IsRippleStateFrozenBy(trustLine, issuerID, ammAccountID)
 }
 
 // trustLineBalanceFor extracts the balance from a trust line for a given account.

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -549,54 +549,6 @@ func (s *BookStep) isOfferOwnerAuthorized(
 	return (line.Flags & authFlag) != 0
 }
 
-// isFrozen checks if an account's trust line for the given currency/issuer is frozen.
-// Returns true if:
-//   - The issuer has GlobalFreeze set on their AccountRoot, OR
-//   - The issuer has individually frozen the account's trust line (lsfHighFreeze/lsfLowFreeze)
-//
-// XRP cannot be frozen, so this always returns false for XRP.
-// Reference: rippled View.cpp isFrozen(view, account, currency, issuer)
-func (s *BookStep) isFrozen(sb *PaymentSandbox, account [20]byte, currency string, issuer [20]byte) bool {
-	// XRP cannot be frozen
-	if currency == "" || currency == "XRP" {
-		return false
-	}
-
-	// Check global freeze on the issuer
-	issuerData, err := sb.Read(keylet.Account(issuer))
-	if err == nil && issuerData != nil {
-		issuerAcct, err := state.ParseAccountRoot(issuerData)
-		if err == nil && (issuerAcct.Flags&state.LsfGlobalFreeze) != 0 {
-			return true
-		}
-	}
-
-	// If the account IS the issuer, no individual freeze to check
-	if issuer == account {
-		return false
-	}
-
-	// Check individual freeze on the trust line
-	// The issuer's freeze flag depends on which side (high/low) the issuer is on
-	// Reference: rippled View.cpp isFrozen():
-	//   (issuer > account) ? lsfHighFreeze : lsfLowFreeze
-	lineKey := keylet.Line(account, issuer, currency)
-	lineData, err := sb.Read(lineKey)
-	if err != nil || lineData == nil {
-		return false
-	}
-	rs, err := state.ParseRippleState(lineData)
-	if err != nil {
-		return false
-	}
-
-	issuerIsHigh := state.CompareAccountIDs(issuer, account) > 0
-	if issuerIsHigh {
-		return (rs.Flags & state.LsfHighFreeze) != 0
-	}
-	return (rs.Flags & state.LsfLowFreeze) != 0
-}
-
 // isDeepFrozen checks if an account's trust line for the given currency/issuer
 // has either the high or low deep freeze flag set.
 // Deep freeze is more restrictive than regular freeze — it prevents both
@@ -727,7 +679,7 @@ func (s *BookStep) getOfferFundedAmount(sb *PaymentSandbox, offer *state.LedgerO
 	//     if (isFrozen(...) || isDeepFrozen(...)) return false;
 	//   }
 	if offerOwner != issuer {
-		if s.isFrozen(sb, offerOwner, currency, issuer) ||
+		if tx.IsFrozen(sb, offerOwner, tx.Asset{Currency: currency, Issuer: state.EncodeAccountIDSafe(issuer)}) ||
 			s.isDeepFrozen(sb, offerOwner, currency, issuer) {
 			return ZeroIOUEitherAmount(currency, state.EncodeAccountIDSafe(issuer))
 		}

--- a/internal/tx/payment/step_direct.go
+++ b/internal/tx/payment/step_direct.go
@@ -816,19 +816,9 @@ func checkFreeze(view *PaymentSandbox, src, dst [20]byte, currency string) ter.R
 			return ter.TefINTERNAL
 		}
 
-		// 3. Check individual freeze
-		// Reference: rippled StepChecks.h:53 — (dst > src) ? lsfHighFreeze : lsfLowFreeze
-		// If src is low (dst is high), check lsfHighFreeze (dst's side)
-		// If src is high (dst is low), check lsfLowFreeze (dst's side)
-		srcIsLow := state.CompareAccountIDs(src, dst) < 0
-		if srcIsLow {
-			if (rs.Flags & state.LsfHighFreeze) != 0 {
-				return ter.TerNO_LINE
-			}
-		} else {
-			if (rs.Flags & state.LsfLowFreeze) != 0 {
-				return ter.TerNO_LINE
-			}
+		// 3. Check individual freeze on the destination's side.
+		if tx.IsRippleStateFrozenBy(rs, dst, src) {
+			return ter.TerNO_LINE
 		}
 
 		// 4. Check deep freeze — either side having deep freeze blocks the line

--- a/internal/tx/payment/step_direct.go
+++ b/internal/tx/payment/step_direct.go
@@ -816,7 +816,6 @@ func checkFreeze(view *PaymentSandbox, src, dst [20]byte, currency string) ter.R
 			return ter.TefINTERNAL
 		}
 
-		// 3. Check individual freeze on the destination's side.
 		if tx.IsRippleStateFrozenBy(rs, dst, src) {
 			return ter.TerNO_LINE
 		}

--- a/internal/tx/utils.go
+++ b/internal/tx/utils.go
@@ -31,7 +31,7 @@ func FormatUint64Hex(v uint64) string {
 // that must distinguish the two route err != nil to TefINTERNAL and nil data to
 // their own not-found code; callers that legitimately treat both the same can
 // test (root == nil) after checking err.
-func ReadAccountRoot(view LedgerView, accountID [20]byte) (*state.AccountRoot, error) {
+func ReadAccountRoot(view state.LedgerView, accountID [20]byte) (*state.AccountRoot, error) {
 	data, err := view.Read(keylet.Account(accountID))
 	if err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func ReadAccountRoot(view LedgerView, accountID [20]byte) (*state.AccountRoot, e
 // contract: an absent line returns (nil, nil), while a storage or parse failure
 // returns (nil, err). Callers that treat "absent" and "error" the same can test
 // (rs == nil) after checking err.
-func ReadRippleState(view LedgerView, accountID, issuerID [20]byte, currency string) (*state.RippleState, error) {
+func ReadRippleState(view state.LedgerView, accountID, issuerID [20]byte, currency string) (*state.RippleState, error) {
 	data, err := view.Read(keylet.Line(accountID, issuerID, currency))
 	if err != nil {
 		return nil, err
@@ -58,34 +58,44 @@ func ReadRippleState(view LedgerView, accountID, issuerID [20]byte, currency str
 	return state.ParseRippleState(data)
 }
 
-// IsTrustlineFrozen checks if a specific trustline is frozen.
-func IsTrustlineFrozen(view LedgerView, accountID, issuerID [20]byte, currency string) bool {
-	trustLineKey := keylet.Line(accountID, issuerID, currency)
-	trustLineData, err := view.Read(trustLineKey)
-	if err != nil || trustLineData == nil {
+// IsRippleStateFrozenBy reports whether freezer set its regular-freeze flag on
+// an already-parsed trust line with counterparty.
+func IsRippleStateFrozenBy(line *state.RippleState, freezerID, counterpartyID [20]byte) bool {
+	if line == nil || freezerID == counterpartyID {
 		return false
 	}
-
-	rs, err := state.ParseRippleState(trustLineData)
-	if err != nil {
-		return false
+	if state.CompareAccountIDs(freezerID, counterpartyID) > 0 {
+		return line.Flags&state.LsfHighFreeze != 0
 	}
+	return line.Flags&state.LsfLowFreeze != 0
+}
 
-	// Check if the ISSUER has frozen this trust line.
-	// Reference: rippled View.cpp isFrozen() - checks the issuer's freeze flag:
-	//   (issuer > account) ? lsfHighFreeze : lsfLowFreeze
-	issuerIsHigh := state.CompareAccountIDs(issuerID, accountID) > 0
-	if issuerIsHigh {
-		return (rs.Flags & state.LsfHighFreeze) != 0
+// IsTrustlineFrozenBy reports whether freezer set its regular-freeze flag on
+// the trust line with counterparty. A missing line is not frozen; read and
+// parse errors are returned to callers that must preserve ledger-integrity
+// failures.
+func IsTrustlineFrozenBy(view state.LedgerView, freezerID, counterpartyID [20]byte, currency string) (bool, error) {
+	if currency == "" || currency == "XRP" || freezerID == counterpartyID {
+		return false, nil
 	}
-	return (rs.Flags & state.LsfLowFreeze) != 0
+	line, err := ReadRippleState(view, freezerID, counterpartyID, currency)
+	if err != nil || line == nil {
+		return false, err
+	}
+	return IsRippleStateFrozenBy(line, freezerID, counterpartyID), nil
+}
+
+// IsTrustlineFrozen reports whether issuer individually froze account's trust
+// line. Read and parse failures retain the historical false result.
+func IsTrustlineFrozen(view state.LedgerView, accountID, issuerID [20]byte, currency string) bool {
+	frozen, _ := IsTrustlineFrozenBy(view, issuerID, accountID, currency)
+	return frozen
 }
 
 // IsIndividualFrozen checks if a specific account is individually frozen for an asset.
 // This checks if the issuer has frozen the account's side of the trustline.
 // Reference: rippled ledger/View.cpp isIndividualFrozen
-func IsIndividualFrozen(view LedgerView, accountID [20]byte, asset Asset) bool {
-	// XRP cannot be frozen
+func IsIndividualFrozen(view state.LedgerView, accountID [20]byte, asset Asset) bool {
 	if asset.Currency == "" || asset.Currency == "XRP" {
 		return false
 	}
@@ -95,31 +105,24 @@ func IsIndividualFrozen(view LedgerView, accountID [20]byte, asset Asset) bool {
 		return false
 	}
 
-	// If account is issuer, not frozen
-	if accountID == issuerID {
-		return false
-	}
+	return IsTrustlineFrozen(view, accountID, issuerID, asset.Currency)
+}
 
-	trustLineKey := keylet.Line(accountID, issuerID, asset.Currency)
-	trustLineData, err := view.Read(trustLineKey)
-	if err != nil || trustLineData == nil {
-		return false
+// IsIOUFrozen reports whether issuer globally froze its currency or
+// individually froze account's trust line. Missing ledger entries are not
+// frozen; read and parse errors are returned.
+func IsIOUFrozen(view state.LedgerView, accountID, issuerID [20]byte, currency string) (bool, error) {
+	if currency == "" || currency == "XRP" {
+		return false, nil
 	}
-
-	rs, err := state.ParseRippleState(trustLineData)
+	issuer, err := ReadAccountRoot(view, issuerID)
 	if err != nil {
-		return false
+		return false, err
 	}
-
-	// Check if the issuer has frozen the trust line.
-	// Reference: rippled View.cpp isFrozen() line 264:
-	//   sle->isFlag((issuer > account) ? lsfHighFreeze : lsfLowFreeze)
-	// The freeze flag is on the ISSUER's side of the trust line.
-	issuerIsHigh := state.CompareAccountIDs(issuerID, accountID) > 0
-	if issuerIsHigh {
-		return (rs.Flags & state.LsfHighFreeze) != 0
+	if issuer != nil && issuer.Flags&state.LsfGlobalFreeze != 0 {
+		return true, nil
 	}
-	return (rs.Flags & state.LsfLowFreeze) != 0
+	return IsTrustlineFrozenBy(view, issuerID, accountID, currency)
 }
 
 // HasExpired reports whether an optional expiration has passed relative to the
@@ -145,7 +148,7 @@ func HasExpiredField(expiration uint32, parentCloseTime uint32) bool {
 // individual freeze); deep freeze is not consulted. XRP is never frozen.
 // Reference: rippled ledger/View.cpp isFrozen(view, account, currency, issuer)
 // and the inline Issue overload in View.h.
-func IsFrozen(view LedgerView, accountID [20]byte, asset Asset) bool {
+func IsFrozen(view state.LedgerView, accountID [20]byte, asset Asset) bool {
 	if asset.Currency == "" || asset.Currency == "XRP" {
 		return false
 	}
@@ -289,7 +292,7 @@ func decodeAssetMPTID(a Asset) ([24]byte, bool) {
 
 // IsGlobalFrozen checks if an issuer has globally frozen assets.
 // Reference: rippled ledger/View.h isGlobalFrozen()
-func IsGlobalFrozen(view LedgerView, issuerAddress string) bool {
+func IsGlobalFrozen(view state.LedgerView, issuerAddress string) bool {
 	if issuerAddress == "" {
 		return false
 	}

--- a/internal/tx/utils_freeze_test.go
+++ b/internal/tx/utils_freeze_test.go
@@ -1,0 +1,194 @@
+package tx
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+type freezeTestView struct {
+	*mockBaseView
+	readErrors map[[32]byte]error
+}
+
+func newFreezeTestView() *freezeTestView {
+	return &freezeTestView{
+		mockBaseView: newMockBaseView(),
+		readErrors:   make(map[[32]byte]error),
+	}
+}
+
+func (v *freezeTestView) Read(k keylet.Keylet) ([]byte, error) {
+	if err := v.readErrors[k.Key]; err != nil {
+		return nil, err
+	}
+	return v.mockBaseView.Read(k)
+}
+
+func freezeAccountID(value byte) [20]byte {
+	var id [20]byte
+	id[0] = value
+	return id
+}
+
+func putFreezeLine(t *testing.T, view *freezeTestView, lowID, highID [20]byte, flags uint32) {
+	t.Helper()
+	lowAddress := state.EncodeAccountIDSafe(lowID)
+	highAddress := state.EncodeAccountIDSafe(highID)
+	raw, err := state.SerializeRippleState(&state.RippleState{
+		Balance:   state.NewIssuedAmountFromValue(0, -100, "USD", lowAddress),
+		LowLimit:  state.NewIssuedAmountFromValue(0, -100, "USD", lowAddress),
+		HighLimit: state.NewIssuedAmountFromValue(0, -100, "USD", highAddress),
+		Flags:     flags,
+	})
+	if err != nil {
+		t.Fatalf("serialize trust line: %v", err)
+	}
+	view.data[keylet.Line(lowID, highID, "USD").Key] = raw
+}
+
+func putFreezeAccount(t *testing.T, view *freezeTestView, accountID [20]byte, flags uint32) {
+	t.Helper()
+	raw, err := state.SerializeAccountRoot(&state.AccountRoot{
+		Account:  state.EncodeAccountIDSafe(accountID),
+		Balance:  1_000_000_000,
+		Sequence: 1,
+		Flags:    flags,
+	})
+	if err != nil {
+		t.Fatalf("serialize account root: %v", err)
+	}
+	view.data[keylet.Account(accountID).Key] = raw
+}
+
+func TestIsRippleStateFrozenBy(t *testing.T) {
+	lowID := freezeAccountID(1)
+	highID := freezeAccountID(2)
+
+	tests := []struct {
+		name           string
+		line           *state.RippleState
+		freezerID      [20]byte
+		counterpartyID [20]byte
+		want           bool
+	}{
+		{"low side", &state.RippleState{Flags: state.LsfLowFreeze}, lowID, highID, true},
+		{"low ignores high flag", &state.RippleState{Flags: state.LsfHighFreeze}, lowID, highID, false},
+		{"high side", &state.RippleState{Flags: state.LsfHighFreeze}, highID, lowID, true},
+		{"high ignores low flag", &state.RippleState{Flags: state.LsfLowFreeze}, highID, lowID, false},
+		{"nil line", nil, lowID, highID, false},
+		{"self", &state.RippleState{Flags: state.LsfLowFreeze | state.LsfHighFreeze}, lowID, lowID, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := IsRippleStateFrozenBy(test.line, test.freezerID, test.counterpartyID); got != test.want {
+				t.Fatalf("IsRippleStateFrozenBy() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestIsTrustlineFrozenByContracts(t *testing.T) {
+	lowID := freezeAccountID(1)
+	highID := freezeAccountID(2)
+	view := newFreezeTestView()
+	putFreezeLine(t, view, lowID, highID, state.LsfHighFreeze)
+
+	frozen, err := IsTrustlineFrozenBy(view, highID, lowID, "USD")
+	if err != nil || !frozen {
+		t.Fatalf("high-side freeze = (%v, %v), want (true, nil)", frozen, err)
+	}
+	frozen, err = IsTrustlineFrozenBy(view, lowID, highID, "USD")
+	if err != nil || frozen {
+		t.Fatalf("low-side freeze = (%v, %v), want (false, nil)", frozen, err)
+	}
+
+	for _, test := range []struct {
+		name      string
+		accountID [20]byte
+		peerID    [20]byte
+		currency  string
+	}{
+		{"missing", highID, lowID, "EUR"},
+		{"XRP", highID, lowID, "XRP"},
+		{"self", highID, highID, "USD"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			frozen, err := IsTrustlineFrozenBy(view, test.accountID, test.peerID, test.currency)
+			if err != nil || frozen {
+				t.Fatalf("freeze lookup = (%v, %v), want (false, nil)", frozen, err)
+			}
+		})
+	}
+
+	lineKey := keylet.Line(lowID, highID, "USD")
+	readErr := errors.New("read failed")
+	view.readErrors[lineKey.Key] = readErr
+	if frozen, err := IsTrustlineFrozenBy(view, highID, lowID, "USD"); !errors.Is(err, readErr) || frozen {
+		t.Fatalf("read failure = (%v, %v), want (false, read error)", frozen, err)
+	}
+	if IsTrustlineFrozen(view, lowID, highID, "USD") {
+		t.Fatal("boolean wrapper reported frozen after read failure")
+	}
+
+	delete(view.readErrors, lineKey.Key)
+	view.data[lineKey.Key] = []byte{0xff}
+	if frozen, err := IsTrustlineFrozenBy(view, highID, lowID, "USD"); err == nil || frozen {
+		t.Fatalf("parse failure = (%v, %v), want (false, error)", frozen, err)
+	}
+	if IsTrustlineFrozen(view, lowID, highID, "USD") {
+		t.Fatal("boolean wrapper reported frozen after parse failure")
+	}
+}
+
+func TestIsIOUFrozenContracts(t *testing.T) {
+	accountID := freezeAccountID(1)
+	issuerID := freezeAccountID(2)
+	issuerAddress := state.EncodeAccountIDSafe(issuerID)
+	asset := Asset{Currency: "USD", Issuer: issuerAddress}
+	view := newFreezeTestView()
+
+	putFreezeAccount(t, view, issuerID, state.LsfGlobalFreeze)
+	frozen, err := IsIOUFrozen(view, issuerID, issuerID, "USD")
+	if err != nil || !frozen {
+		t.Fatalf("self-issued global freeze = (%v, %v), want (true, nil)", frozen, err)
+	}
+	if IsIndividualFrozen(view, issuerID, asset) {
+		t.Fatal("self-issued asset reported individually frozen")
+	}
+	if !IsFrozen(view, issuerID, asset) {
+		t.Fatal("self-issued asset did not retain global freeze")
+	}
+
+	putFreezeAccount(t, view, issuerID, 0)
+	putFreezeLine(t, view, accountID, issuerID, state.LsfHighFreeze)
+	frozen, err = IsIOUFrozen(view, accountID, issuerID, "USD")
+	if err != nil || !frozen {
+		t.Fatalf("individual freeze = (%v, %v), want (true, nil)", frozen, err)
+	}
+	if !IsIndividualFrozen(view, accountID, asset) {
+		t.Fatal("asset did not report issuer-side individual freeze")
+	}
+
+	accountKey := keylet.Account(issuerID)
+	readErr := errors.New("read failed")
+	view.readErrors[accountKey.Key] = readErr
+	if frozen, err := IsIOUFrozen(view, accountID, issuerID, "USD"); !errors.Is(err, readErr) || frozen {
+		t.Fatalf("global read failure = (%v, %v), want (false, read error)", frozen, err)
+	}
+	if !IsFrozen(view, accountID, asset) {
+		t.Fatal("boolean full helper failed to check the trust line after a global-freeze read failure")
+	}
+
+	delete(view.readErrors, accountKey.Key)
+	view.data[accountKey.Key] = []byte{0xff}
+	if frozen, err := IsIOUFrozen(view, accountID, issuerID, "USD"); err == nil || frozen {
+		t.Fatalf("global parse failure = (%v, %v), want (false, error)", frozen, err)
+	}
+	if !IsFrozen(view, accountID, asset) {
+		t.Fatal("boolean full helper failed to check the trust line after a global-freeze parse failure")
+	}
+}


### PR DESCRIPTION
## Summary

- centralize trust-line freeze-side selection and error-aware IOU freeze checks
- migrate Check, Payment/AMM, Escrow, and MPT callers while preserving their existing TER and fail-open behavior
- add focused coverage for high/low flags, self-issued assets, and ledger read/parse failures

## Test plan

- [x] `go test ./internal/tx ./internal/tx/check ./internal/tx/payment ./internal/tx/escrow ./internal/tx/mptutil ./internal/tx/vault`
- [x] focused Check, Payment, AMM, and Escrow integration tests
- [x] `just test-tx`
- [x] `just test-integration`
- [x] `go test ./internal/testing/nft/... ./internal/testing/mpt/...`
- [x] `just vet`
- [x] `just lint`
- [x] `just build`
- [x] `just build-nocgo`

Fixes #324
