### PR TITLE
perf(consensus): pipeline catch-up replay acquisition

### DIFF
--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -57,6 +57,22 @@ type FastSyncMetrics struct {
 	CompletionRecheckRejectedUnavailable uint64
 	TargetSuperseded                     uint64
 	ObsoleteAcquisitionCompleted         uint64
+	ReplayPipelineRequested              uint64
+	ReplayPipelineReady                  uint64
+	ReplayPipelineApplied                uint64
+	ReplayPipelineDiscarded              uint64
+	ReplayPipelineRetried                uint64
+	ReplayPipelineFallbacks              uint64
+	ReplayPipelineAcquireUs              uint64
+	ReplayPipelineReadyWaitUs            uint64
+	ReplayPipelineApplyUs                uint64
+	ReplayPipelinePersistUs              uint64
+	ReplayPipelineWindow                 uint32
+	ReplayPipelineDepth                  uint32
+	ReplayPipelineReadyDepth             uint32
+	ReplayPipelineHeadSeq                uint32
+	ReplayPipelineTargetSeq              uint32
+	ReplayPipelineHeadBlockedUs          uint64
 }
 
 type peerBootstrapAcknowledger interface {
@@ -274,10 +290,21 @@ type Router struct {
 	completionRecheckRejectedUnavailable atomic.Uint64
 	targetSuperseded                     atomic.Uint64
 	obsoleteAcquisitionCompleted         atomic.Uint64
+	replayPipelineRequested              atomic.Uint64
+	replayPipelineReady                  atomic.Uint64
+	replayPipelineApplied                atomic.Uint64
+	replayPipelineDiscarded              atomic.Uint64
+	replayPipelineRetried                atomic.Uint64
+	replayPipelineFallbacks              atomic.Uint64
+	replayPipelineAcquireUs              atomic.Uint64
+	replayPipelineReadyWaitUs            atomic.Uint64
+	replayPipelineApplyUs                atomic.Uint64
+	replayPipelinePersistUs              atomic.Uint64
 
 	acquisitionMu     sync.Mutex
 	consensusRecovery consensusRecovery
 	lastHandoffSeq    uint32
+	standardReplay    standardReplayPipeline
 
 	// historyMu guards history, the single backward history-backfill target: the
 	// next ledger a jump-adopt skipped (rippled Reason::HISTORY). The walk is
@@ -639,6 +666,7 @@ func (r *Router) StopAcquisitions() (legacy, replay int) {
 	if r.replayer != nil {
 		replay = r.replayer.Stop()
 	}
+	r.cancelStandardReplayPipelineLocked()
 	r.consensusRecovery = consensusRecovery{}
 	r.lastHandoffSeq = 0
 	r.acquisitionMu.Unlock()

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -171,12 +171,10 @@ const maxConcurrentSpeculativeCatchup = maxConcurrentCatchup - 1
 // newer trusted targets remain queued and are armed when it completes.
 const maxConcurrentProvisionalFullStateCatchup = 1
 
-// maxForwardDeltaGap bounds how far behind the tip the router walks forward one
-// ledger at a time (replay-delta against the held parent) before it prefers a
-// single full-state jump-adopt. Within the gap a same-branch serial walk (O(txs)
-// per hop) outruns the network's close cadence and converges; beyond it a cold
-// or far-behind start jumps straight to the validated tip. Mirrors rippled
-// reserving InboundLedger full-state acquisition for the cold/forked case.
+// maxForwardDeltaGap bounds how far behind the tip the router walks forward
+// before it prefers a single full-state jump-adopt. Within the gap a proven
+// same-branch walk replays transactions against each accepted predecessor;
+// beyond it a cold or far-behind start jumps straight to the validated tip.
 const maxForwardDeltaGap = 128
 
 const catchupLinkageGracePeriod = 2 * time.Second
@@ -283,6 +281,16 @@ func (r *Router) catchupInFlight() int {
 	return r.fetchTracker.CountReason(inbound.ReasonConsensus) + r.replayer.Count()
 }
 
+func (r *Router) protectedCatchupInFlight() int {
+	active := r.replayer.Count()
+	for _, candidate := range r.fetchTracker.Active() {
+		if candidate.Reason() == inbound.ReasonConsensus && !candidate.TransactionOnly() {
+			active++
+		}
+	}
+	return active
+}
+
 // recordCatchupTarget raises the single consensus catch-up target or refreshes
 // its preferred peer when another peer advertises the same ledger.
 func (r *Router) recordCatchupTarget(seq uint32, hash [32]byte, peerID uint64) {
@@ -375,14 +383,13 @@ func (r *Router) bestCatchupTarget() (seq uint32, hash [32]byte, peerID uint64) 
 	return r.catchup.seq, r.catchup.hash, r.catchup.peerID
 }
 
-// armCatchupTowardTarget arms one catch-up acquisition while under the
-// maxConcurrentCatchup cap and the tip is still ahead of closed. Two strategies,
-// mirroring rippled's LedgerMaster::doAdvance forward walk vs InboundLedger
-// full-state acquisition:
+// armCatchupTowardTarget arms catch-up work while the tip is still ahead of
+// closed. Two strategies mirror rippled's forward replay and full-state
+// acquisition:
 //
 //   - Forward-delta step: closed+1 is a known clean child of closed and the tip
-//     is within maxForwardDeltaGap → acquire closed+1 (parent is local, so the
-//     replay-delta path is selected); completion re-arms the serial walk.
+//     is within maxForwardDeltaGap. Replay-capable peers use the delta protocol;
+//     standard peers acquire a bounded window and apply it in ledger order.
 //   - Jump-adopt: otherwise (cold/far/forked) acquire the far validated tip
 //     directly; the legacy full-state path plus completeInboundLedger's gap>1
 //     branch jumps the working ledger forward.
@@ -457,6 +464,12 @@ func (r *Router) armPendingConsensusLedger() bool {
 				recovery.anchorSeq = 0
 			}
 			r.acquisitionMu.Unlock()
+		}
+		if replay && parent != nil {
+			if _, replayPeerFound := r.resolveReplayPeer(parent.Sequence()+1, 0); !replayPeerFound &&
+				r.tryArmStandardReplayPipeline(svc, parent, seq, hash, 0) {
+				return true
+			}
 		}
 
 		r.acquisitionMu.Lock()
@@ -594,9 +607,6 @@ func (r *Router) armCatchupTowardTargetWithPeer(peerHint uint64) {
 	if svc == nil {
 		return
 	}
-	if r.catchupInFlight() >= maxConcurrentSpeculativeCatchup {
-		return
-	}
 	r.catchupMu.Lock()
 	target := r.catchup
 	r.catchupMu.Unlock()
@@ -607,12 +617,16 @@ func (r *Router) armCatchupTowardTargetWithPeer(peerHint uint64) {
 	if tSeq == 0 {
 		return
 	}
+	r.reconcileStandardReplayTarget(tSeq, tHash)
 	closed := svc.GetClosedLedgerIndex()
 	if tSeq <= closed {
 		if target.source != catchupSourceQuorum {
 			return
 		}
 		if held, err := svc.GetLedgerByHash(tHash); err == nil && held != nil {
+			return
+		}
+		if r.protectedCatchupInFlight() >= maxConcurrentSpeculativeCatchup {
 			return
 		}
 		peer, found := r.resolveAcquisitionPeer(tSeq, peerHint)
@@ -625,6 +639,17 @@ func (r *Router) armCatchupTowardTargetWithPeer(peerHint uint64) {
 	if target.source == catchupSourcePeer &&
 		!svc.NeedsInitialSync() && !svc.IsFastLoadProvisional() &&
 		!aheadByMoreThan(tSeq, closed, 1) {
+		return
+	}
+	closedLedger := svc.GetClosedLedger()
+	if closedLedger != nil && tSeq-closed <= maxForwardDeltaGap &&
+		r.recoveryAnchorReachesTarget(closedLedger.Sequence(), closedLedger.Hash(), tHash) {
+		if _, replayPeerFound := r.resolveReplayPeer(closedLedger.Sequence()+1, peerHint); !replayPeerFound &&
+			r.tryArmStandardReplayPipeline(svc, closedLedger, tSeq, tHash, peerHint) {
+			return
+		}
+	}
+	if r.protectedCatchupInFlight() >= maxConcurrentSpeculativeCatchup {
 		return
 	}
 
@@ -824,7 +849,7 @@ func (r *Router) canAdmitCatchupLocked(hash [32]byte, limit int) bool {
 	if r.isAcquiring(hash) {
 		return true
 	}
-	return r.catchupInFlight() < limit
+	return r.protectedCatchupInFlight() < limit
 }
 
 func (r *Router) startLedgerAcquisitionLocked(seq uint32, hash [32]byte, peerID uint64) {
@@ -929,12 +954,12 @@ func (r *Router) startLedgerAcquisitionLegacy(seq uint32, hash [32]byte, peerID 
 // go-xrpl's optional replay-delta extension. Completion locally replays the
 // transactions against the already-held parent and verifies both target roots.
 // Caller holds acquisitionMu.
-func (r *Router) startLedgerReplayAcquisitionLegacyLocked(seq uint32, hash [32]byte, peerID uint64) {
+func (r *Router) startLedgerReplayAcquisitionLegacyLocked(seq uint32, hash [32]byte, peerID uint64) (*inbound.Ledger, bool) {
 	if seq != 0 && r.belowFloor(seq) {
-		return
+		return nil, false
 	}
 	if r.replayer.Has(hash) {
-		return
+		return nil, false
 	}
 
 	opts := append(r.acquisitionOpts(), inbound.WithTransactionOnly())
@@ -942,7 +967,7 @@ func (r *Router) startLedgerReplayAcquisitionLegacyLocked(seq uint32, hash [32]b
 		return inbound.New(hash, seq, peerID, r.logger, opts...)
 	})
 	if !created {
-		return
+		return il, false
 	}
 
 	r.logger.Info("starting ledger replay acquisition (standard tx-only)",
@@ -961,6 +986,7 @@ func (r *Router) startLedgerReplayAcquisitionLegacyLocked(seq uint32, hash [32]b
 	if !requested {
 		r.requestLedgerBase(il, 0, "failed to request replay ledger base from peer")
 	}
+	return il, true
 }
 
 func (r *Router) startLedgerAcquisitionLegacyLocked(seq uint32, hash [32]byte, peerID uint64) {
@@ -1071,17 +1097,24 @@ func (r *Router) requestConsensusLedger(id consensus.LedgerID) error {
 
 	r.acquisitionMu.Lock()
 	r.consensusRecovery.targetHash = hash
-	if step := r.consensusRecovery.stepHash; step != ([32]byte{}) && r.isAcquiring(step) {
+	step := r.consensusRecovery.stepHash
+	pipelineStep := r.standardReplayOwnsLocked(step)
+	if step != ([32]byte{}) && r.isAcquiring(step) && !pipelineStep {
 		r.acquisitionMu.Unlock()
 		return nil
 	}
-	if r.isAcquiring(hash) {
+	pipelineTarget := r.standardReplayOwnsLocked(hash)
+	if r.isAcquiring(hash) && !pipelineTarget {
 		r.consensusRecovery.stepHash = hash
 		r.acquisitionMu.Unlock()
 		return nil
 	}
-	r.consensusRecovery.stepHash = [32]byte{}
+	if !pipelineTarget {
+		r.consensusRecovery.stepHash = [32]byte{}
+	}
 	r.acquisitionMu.Unlock()
+	seq, _ := r.lookupSeqForHash(hash)
+	r.reconcileStandardReplayTarget(seq, hash)
 	r.armConsensusCatchup()
 	return nil
 }
@@ -1186,6 +1219,18 @@ func (r *Router) onLedgerFullyValidated(seq uint32, hash [32]byte) {
 	}
 	for _, replayHash := range r.replayer.AbandonOtherAtSequence(seq, hash) {
 		removed[replayHash] = struct{}{}
+	}
+	pipelineConflict := r.standardReplay.active &&
+		((seq == r.standardReplay.anchorSeq && hash != r.standardReplay.anchorHash) ||
+			(seq == r.standardReplay.targetSeq && hash != r.standardReplay.targetHash))
+	if entry := r.standardReplay.entries[seq]; entry != nil && entry.hash != hash {
+		pipelineConflict = true
+	}
+	if pipelineConflict {
+		for _, pipelineEntry := range r.standardReplay.entries {
+			removed[pipelineEntry.hash] = struct{}{}
+		}
+		legacy = append(legacy, r.cancelStandardReplayPipelineLocked()...)
 	}
 	if _, ok := removed[r.consensusRecovery.stepHash]; ok {
 		r.consensusRecovery.stepHash = [32]byte{}
@@ -1345,6 +1390,24 @@ func (r *Router) FetchInfo() map[string]any {
 
 // FastSyncMetrics returns the current bounded outcome counters.
 func (r *Router) FastSyncMetrics() FastSyncMetrics {
+	r.acquisitionMu.Lock()
+	depth := len(r.standardReplay.entries)
+	readyDepth := 0
+	for _, entry := range r.standardReplay.entries {
+		if !entry.readyAt.IsZero() {
+			readyDepth++
+		}
+	}
+	headSeq := uint32(0)
+	blockedUs := uint64(0)
+	if r.standardReplay.active {
+		headSeq = r.standardReplay.anchorSeq + 1
+		if !r.standardReplay.headBlockedAt.IsZero() {
+			blockedUs = durationMicros(time.Since(r.standardReplay.headBlockedAt))
+		}
+	}
+	targetSeq := r.standardReplay.targetSeq
+	r.acquisitionMu.Unlock()
 	return FastSyncMetrics{
 		CompletionRecheckAccepted:            r.completionRecheckAccepted.Load(),
 		CompletionRecheckRejectedNoEvidence:  r.completionRecheckRejectedNoEvidence.Load(),
@@ -1352,6 +1415,22 @@ func (r *Router) FastSyncMetrics() FastSyncMetrics {
 		CompletionRecheckRejectedUnavailable: r.completionRecheckRejectedUnavailable.Load(),
 		TargetSuperseded:                     r.targetSuperseded.Load(),
 		ObsoleteAcquisitionCompleted:         r.obsoleteAcquisitionCompleted.Load(),
+		ReplayPipelineRequested:              r.replayPipelineRequested.Load(),
+		ReplayPipelineReady:                  r.replayPipelineReady.Load(),
+		ReplayPipelineApplied:                r.replayPipelineApplied.Load(),
+		ReplayPipelineDiscarded:              r.replayPipelineDiscarded.Load(),
+		ReplayPipelineRetried:                r.replayPipelineRetried.Load(),
+		ReplayPipelineFallbacks:              r.replayPipelineFallbacks.Load(),
+		ReplayPipelineAcquireUs:              r.replayPipelineAcquireUs.Load(),
+		ReplayPipelineReadyWaitUs:            r.replayPipelineReadyWaitUs.Load(),
+		ReplayPipelineApplyUs:                r.replayPipelineApplyUs.Load(),
+		ReplayPipelinePersistUs:              r.replayPipelinePersistUs.Load(),
+		ReplayPipelineWindow:                 standardReplayPipelineWindow,
+		ReplayPipelineDepth:                  uint32(depth),
+		ReplayPipelineReadyDepth:             uint32(readyDepth),
+		ReplayPipelineHeadSeq:                headSeq,
+		ReplayPipelineTargetSeq:              targetSeq,
+		ReplayPipelineHeadBlockedUs:          blockedUs,
 	}
 }
 
@@ -1371,7 +1450,11 @@ func (r *Router) recordCompletionRecheck(result validationRecheckResult) {
 // ClearFetchInfo resets the acquisition counters and recent-failure history,
 // backing fetch_info's `clear` param.
 func (r *Router) ClearFetchInfo() {
-	r.retireLegacyAcquisitions(r.fetchTracker.Clear())
+	r.acquisitionMu.Lock()
+	ledgers := r.fetchTracker.Clear()
+	r.cancelStandardReplayPipelineLocked()
+	r.acquisitionMu.Unlock()
+	r.retireLegacyAcquisitions(ledgers)
 }
 
 func (r *Router) retireLegacyAcquisitions(ledgers []*inbound.Ledger) {
@@ -1641,26 +1724,9 @@ func (r *Router) handleReplayDeltaResponse(msg *peermanagement.InboundMessage) {
 // adoptVerifiedLedger stores a ledger reconstructed from a verified replay
 // delta until consensus selects it as the canonical frontier.
 func (r *Router) adoptVerifiedLedger(l *ledger.Ledger) error {
-	svc := r.adaptor.LedgerService()
-	if svc == nil {
-		return errors.New("no ledger service")
-	}
-	hdr := l.Header()
-	stateMap, err := l.StateMapSnapshot()
+	hdr, initialCandidate, err := r.storeVerifiedLedger(l)
 	if err != nil {
-		return fmt.Errorf("snapshot state map: %w", err)
-	}
-	// Pass the verified tx map through so the stored ledger carries
-	// real transactions — without this, tx/tx_history/account_tx RPCs
-	// can't answer for replay-delta ledgers and we can't
-	// re-serve the replay-delta to other peers.
-	txMap, err := l.TxMapSnapshot()
-	if err != nil {
-		return fmt.Errorf("snapshot tx map: %w", err)
-	}
-	initialCandidate, err := svc.BootstrapLedgerWithState(r.lifecycleContext(), &hdr, stateMap, txMap)
-	if err != nil {
-		return fmt.Errorf("store replay-delta ledger: %w", err)
+		return err
 	}
 	r.logger.Info("acquired ledger via replay delta",
 		"seq", hdr.LedgerIndex,
@@ -1669,6 +1735,31 @@ func (r *Router) adoptVerifiedLedger(l *ledger.Ledger) error {
 	)
 	r.completeStoredConsensusRecovery(hdr.LedgerIndex, hdr.Hash, hdr.ParentHash, initialCandidate)
 	return nil
+}
+
+func (r *Router) storeVerifiedLedger(l *ledger.Ledger) (header.LedgerHeader, bool, error) {
+	svc := r.adaptor.LedgerService()
+	if svc == nil {
+		return header.LedgerHeader{}, false, errors.New("no ledger service")
+	}
+	hdr := l.Header()
+	stateMap, err := l.StateMapSnapshot()
+	if err != nil {
+		return header.LedgerHeader{}, false, fmt.Errorf("snapshot state map: %w", err)
+	}
+	// Pass the verified tx map through so the stored ledger carries
+	// real transactions — without this, tx/tx_history/account_tx RPCs
+	// can't answer for replay-delta ledgers and we can't
+	// re-serve the replay-delta to other peers.
+	txMap, err := l.TxMapSnapshot()
+	if err != nil {
+		return header.LedgerHeader{}, false, fmt.Errorf("snapshot tx map: %w", err)
+	}
+	initialCandidate, err := svc.BootstrapLedgerWithState(r.lifecycleContext(), &hdr, stateMap, txMap)
+	if err != nil {
+		return header.LedgerHeader{}, false, fmt.Errorf("store replay-delta ledger: %w", err)
+	}
+	return hdr, initialCandidate, nil
 }
 
 func (r *Router) completeStoredConsensusRecovery(seq uint32, hash, parentHash [32]byte, initialCandidate bool) bool {
@@ -2679,6 +2770,9 @@ func (r *Router) failInboundAcquisitionWithSnapshot(il *inbound.Ledger, snapshot
 		"hash", fmt.Sprintf("%x", hash[:8]),
 		"timeouts", il.Timeouts(),
 	)
+	if reason == inbound.ReasonConsensus && il.TransactionOnly() && r.failStandardReplayPipelineEntry(il) {
+		return
+	}
 	if reason == inbound.ReasonConsensus {
 		r.markFailedCatchupAcquisition(hash)
 		r.failConsensusRecoveryStep(hash)
@@ -2810,6 +2904,9 @@ func (r *Router) completeInboundLedgerReady(il *inbound.Ledger) {
 	// parent, verify the derived roots against the peer header, then feed the
 	// same adoption path as the optional replay-delta protocol.
 	if il.TransactionOnly() {
+		if r.completeStandardReplayPipelineEntry(il, h, txMap, peerID) {
+			return
+		}
 		r.completeStandardTransactionReplay(h, txMap, peerID)
 		return
 	}

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -1050,9 +1050,43 @@ func (r *Router) canAdmitProvisionalFullStateLocked(hash [32]byte) bool {
 }
 
 func (r *Router) fallbackReplayAcquisition(seq uint32, hash [32]byte, peerID uint64) {
+	r.fallbackReplayAcquisitionForTarget(seq, hash, peerID, standardReplayTarget{})
+}
+
+func (r *Router) fallbackStandardReplayAcquisition(
+	seq uint32,
+	hash [32]byte,
+	peerID uint64,
+	expected standardReplayTarget,
+) {
+	r.fallbackReplayAcquisitionForTarget(seq, hash, peerID, expected)
+}
+
+func (r *Router) fallbackReplayAcquisitionForTarget(
+	seq uint32,
+	hash [32]byte,
+	peerID uint64,
+	expected standardReplayTarget,
+) {
 	r.acquisitionMu.Lock()
 
 	target := r.consensusRecovery.targetHash
+	if expected.hash != ([32]byte{}) {
+		if target != ([32]byte{}) {
+			if target != expected.hash {
+				r.acquisitionMu.Unlock()
+				return
+			}
+		} else {
+			r.catchupMu.Lock()
+			current := r.catchup.seq == expected.seq && r.catchup.hash == expected.hash
+			r.catchupMu.Unlock()
+			if !current {
+				r.acquisitionMu.Unlock()
+				return
+			}
+		}
+	}
 	if target != ([32]byte{}) && r.consensusRecovery.stepHash != hash && target != hash {
 		r.acquisitionMu.Unlock()
 		return
@@ -2890,26 +2924,37 @@ func (r *Router) completeInboundLedgerReady(il *inbound.Ledger) {
 		}
 		return
 	}
-	if !r.fetchTracker.RemoveExpectedWithSnapshot(il, il.Snapshot(), true) {
-		r.retireAcquisitionStore(r.lifecycleContext(), il)
-		return
-	}
 	peerID := il.PeerID()
-	r.acquisitionMu.Lock()
-	recoveryTarget := r.consensusRecovery.targetHash == h.Hash
-	r.acquisitionMu.Unlock()
 
 	// A forward child fetched from a standard rippled peer contains only its
 	// header and transaction SHAMap. Rebuild the state from the locally-held
 	// parent, verify the derived roots against the peer header, then feed the
 	// same adoption path as the optional replay-delta protocol.
 	if il.TransactionOnly() {
-		if r.completeStandardReplayPipelineEntry(il, h, txMap, peerID) {
+		r.acquisitionMu.Lock()
+		if !r.fetchTracker.RemoveExpectedWithSnapshot(il, il.Snapshot(), true) {
+			r.acquisitionMu.Unlock()
+			r.retireAcquisitionStore(r.lifecycleContext(), il)
+			return
+		}
+		handled, startDrain := r.completeStandardReplayPipelineEntryLocked(il, h, txMap, peerID)
+		r.acquisitionMu.Unlock()
+		if handled {
+			if startDrain {
+				r.drainStandardReplayPipeline()
+			}
 			return
 		}
 		r.completeStandardTransactionReplay(h, txMap, peerID)
 		return
 	}
+	if !r.fetchTracker.RemoveExpectedWithSnapshot(il, il.Snapshot(), true) {
+		r.retireAcquisitionStore(r.lifecycleContext(), il)
+		return
+	}
+	r.acquisitionMu.Lock()
+	recoveryTarget := r.consensusRecovery.targetHash == h.Hash
+	r.acquisitionMu.Unlock()
 
 	// A history backfill installs validated sequence history below the closed tip,
 	// then advances the backward walk to its parent. It never touches operating

--- a/internal/consensus/adaptor/router_catchup_fallback_test.go
+++ b/internal/consensus/adaptor/router_catchup_fallback_test.go
@@ -23,14 +23,7 @@ func storeRecoveryLedger(t *testing.T, svc *service.Service, l *ledger.Ledger) {
 	require.NoError(t, svc.StoreLedgerWithState(t.Context(), &h, stateMap, txMap))
 }
 
-func retireLegacyRecoveryStep(t *testing.T, r *Router, hash [32]byte) {
-	t.Helper()
-	il := r.fetchTracker.Find(hash)
-	require.NotNil(t, il)
-	require.True(t, r.fetchTracker.DiscardExpected(il))
-}
-
-func TestConsensusRecoveryLegacyFallbackWalksFromMovingAnchor(t *testing.T) {
+func TestConsensusRecoveryLegacyFallbackPipelinesProvenSuccessors(t *testing.T) {
 	r, _, sender, svc := makeRouter(t)
 	_, err := svc.AcceptLedger(context.Background())
 	require.NoError(t, err)
@@ -68,37 +61,17 @@ func TestConsensusRecoveryLegacyFallbackWalksFromMovingAnchor(t *testing.T) {
 		anchorHash: anchorHash,
 		anchorSeq:  anchorSeq,
 	}, r.consensusRecovery)
-	require.Equal(t, []legacyBaseCall{{peerID: 7, hash: child1Hash, seq: child1Seq}}, sender.legacyCalls())
-	require.Empty(t, sender.replayCalls())
-	require.Nil(t, r.fetchTracker.Find(targetHash))
-	childAcquisition := r.fetchTracker.Find(child1Hash)
-	require.NotNil(t, childAcquisition)
-	require.True(t, childAcquisition.TransactionOnly())
-
-	retireLegacyRecoveryStep(t, r, child1Hash)
-	storeRecoveryLedger(t, svc, child1)
-	r.completeStoredConsensusRecovery(child1Seq, child1Hash, anchorHash, false)
-	require.Equal(t, consensusRecovery{
-		targetHash: targetHash,
-		stepHash:   child2Hash,
-		anchorHash: child1Hash,
-		anchorSeq:  child1Seq,
-	}, r.consensusRecovery)
-
-	retireLegacyRecoveryStep(t, r, child2Hash)
-	storeRecoveryLedger(t, svc, child2)
-	r.completeStoredConsensusRecovery(child2Seq, child2Hash, child1Hash, false)
-	require.Equal(t, consensusRecovery{
-		targetHash: targetHash,
-		stepHash:   targetHash,
-		anchorHash: child2Hash,
-		anchorSeq:  child2Seq,
-	}, r.consensusRecovery)
 	require.Equal(t, []legacyBaseCall{
 		{peerID: 7, hash: child1Hash, seq: child1Seq},
 		{peerID: 7, hash: child2Hash, seq: child2Seq},
 		{peerID: 7, hash: targetHash, seq: targetSeq},
 	}, sender.legacyCalls())
+	require.Empty(t, sender.replayCalls())
+	for _, hash := range [][32]byte{child1Hash, child2Hash, targetHash} {
+		acquisition := r.fetchTracker.Find(hash)
+		require.NotNil(t, acquisition)
+		require.True(t, acquisition.TransactionOnly())
+	}
 }
 
 func TestConsensusRecoveryReplayIssueFailureFallsBackToNextChild(t *testing.T) {

--- a/internal/consensus/adaptor/router_replay_pipeline.go
+++ b/internal/consensus/adaptor/router_replay_pipeline.go
@@ -26,6 +26,11 @@ type standardReplayPipeline struct {
 	headBlockedAt time.Time
 }
 
+type standardReplayTarget struct {
+	seq  uint32
+	hash [32]byte
+}
+
 type standardReplayEntry struct {
 	generation  uint64
 	seq         uint32
@@ -280,22 +285,20 @@ func (r *Router) standardReplayOwnsLocked(hash [32]byte) bool {
 	return false
 }
 
-func (r *Router) completeStandardReplayPipelineEntry(
+func (r *Router) completeStandardReplayPipelineEntryLocked(
 	il *inbound.Ledger,
 	h *header.LedgerHeader,
 	txMap *shamap.SHAMap,
 	peerID uint64,
-) bool {
+) (bool, bool) {
 	if il == nil || h == nil {
-		return false
+		return false, false
 	}
 	now := time.Now()
-	r.acquisitionMu.Lock()
 	entry := r.standardReplay.entries[h.LedgerIndex]
 	if !r.standardReplay.active || entry == nil || entry.hash != h.Hash ||
 		entry.generation != r.standardReplay.generation || entry.acquisition != il {
-		r.acquisitionMu.Unlock()
-		return false
+		return false, false
 	}
 	entry.header = *h
 	entry.txMap = txMap
@@ -310,12 +313,7 @@ func (r *Router) completeStandardReplayPipelineEntry(
 		r.standardReplay.applying = true
 	}
 	r.updateStandardReplayHeadBlockLocked(now)
-	r.acquisitionMu.Unlock()
-
-	if startDrain {
-		r.drainStandardReplayPipeline()
-	}
-	return true
+	return true, startDrain
 }
 
 func (r *Router) failStandardReplayPipelineEntry(il *inbound.Ledger) bool {
@@ -383,12 +381,12 @@ func (r *Router) drainStandardReplayPipeline() {
 		}
 		generation := r.standardReplay.generation
 		if entry.failed {
-			retired, current := r.discardStandardReplayHeadLocked(entry, generation)
+			retired, target, current := r.discardStandardReplayHeadLocked(entry, generation)
 			r.acquisitionMu.Unlock()
 			r.retireLegacyAcquisitions(retired)
 			if current {
 				r.replayPipelineFallbacks.Add(1)
-				r.startLedgerAcquisitionLegacy(entry.seq, entry.hash, entry.peerID)
+				r.fallbackStandardReplayAcquisition(entry.seq, entry.hash, entry.peerID, target)
 			}
 			return
 		}
@@ -396,14 +394,15 @@ func (r *Router) drainStandardReplayPipeline() {
 		r.acquisitionMu.Unlock()
 
 		applyStarted := time.Now()
-		hdr, initialCandidate, persistDuration, err := r.applyStandardReplayEntry(&copyEntry)
+		hdr, initialCandidate, persistDuration, err := r.applyStandardReplayEntry(&copyEntry, entry, generation)
 		applyDuration := time.Since(applyStarted) - persistDuration
 		if applyDuration < 0 {
 			applyDuration = 0
 		}
 		if err != nil {
 			r.acquisitionMu.Lock()
-			retired, current := r.discardStandardReplayHeadLocked(entry, generation)
+			retired, target, current := r.discardStandardReplayHeadLocked(entry, generation)
+			continueDrain := !current && r.standardReplay.active
 			r.acquisitionMu.Unlock()
 			r.retireLegacyAcquisitions(retired)
 			if current {
@@ -413,7 +412,10 @@ func (r *Router) drainStandardReplayPipeline() {
 					"hash", fmt.Sprintf("%x", entry.hash[:8]),
 					"error", err,
 				)
-				r.startLedgerAcquisitionLegacy(entry.seq, entry.hash, entry.peerID)
+				r.fallbackStandardReplayAcquisition(entry.seq, entry.hash, entry.peerID, target)
+			}
+			if continueDrain {
+				continue
 			}
 			return
 		}
@@ -459,19 +461,29 @@ func (r *Router) drainStandardReplayPipeline() {
 func (r *Router) discardStandardReplayHeadLocked(
 	entry *standardReplayEntry,
 	generation uint64,
-) ([]*inbound.Ledger, bool) {
+) ([]*inbound.Ledger, standardReplayTarget, bool) {
+	target := standardReplayTarget{
+		seq:  r.standardReplay.targetSeq,
+		hash: r.standardReplay.targetHash,
+	}
 	if !r.standardReplay.active || r.standardReplay.generation != generation ||
 		r.standardReplay.entries[entry.seq] != entry || r.standardReplay.anchorSeq+1 != entry.seq {
-		r.standardReplay.applying = false
-		return nil, false
+		if !r.standardReplay.active {
+			r.standardReplay.applying = false
+		}
+		return nil, standardReplayTarget{}, false
 	}
 	retired := r.cancelStandardReplayPipelineLocked()
+	if r.consensusRecovery.targetHash != ([32]byte{}) {
+		r.consensusRecovery.stepHash = entry.hash
+	}
 	r.standardReplay.applying = false
-	return retired, true
+	return retired, target, true
 }
 
 func (r *Router) applyStandardReplayEntry(
-	entry *standardReplayEntry,
+	entry, activeEntry *standardReplayEntry,
+	generation uint64,
 ) (header.LedgerHeader, bool, time.Duration, error) {
 	if entry == nil {
 		return header.LedgerHeader{}, false, 0, errors.New("nil standard replay pipeline entry")
@@ -535,9 +547,17 @@ func (r *Router) applyStandardReplayEntry(
 		return header.LedgerHeader{}, false, 0, err
 	}
 
+	r.acquisitionMu.Lock()
+	current := r.standardReplay.active && r.standardReplay.generation == generation &&
+		r.standardReplay.entries[activeEntry.seq] == activeEntry && r.standardReplay.anchorSeq+1 == activeEntry.seq
+	if !current {
+		r.acquisitionMu.Unlock()
+		return header.LedgerHeader{}, false, 0, errors.New("standard replay pipeline entry was superseded")
+	}
 	persistStarted := time.Now()
 	storedHeader, initialCandidate, err := r.storeVerifiedLedger(derived)
 	persistDuration := time.Since(persistStarted)
+	r.acquisitionMu.Unlock()
 	if err != nil {
 		return header.LedgerHeader{}, false, persistDuration, err
 	}

--- a/internal/consensus/adaptor/router_replay_pipeline.go
+++ b/internal/consensus/adaptor/router_replay_pipeline.go
@@ -1,0 +1,552 @@
+package adaptor
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service"
+	"github.com/LeJamon/go-xrpl/shamap"
+)
+
+const standardReplayPipelineWindow = 8
+
+type standardReplayPipeline struct {
+	generation    uint64
+	active        bool
+	applying      bool
+	anchorSeq     uint32
+	anchorHash    [32]byte
+	targetSeq     uint32
+	targetHash    [32]byte
+	entries       map[uint32]*standardReplayEntry
+	headBlockedAt time.Time
+}
+
+type standardReplayEntry struct {
+	generation  uint64
+	seq         uint32
+	hash        [32]byte
+	parentHash  [32]byte
+	peerID      uint64
+	requestedAt time.Time
+	readyAt     time.Time
+	header      header.LedgerHeader
+	txMap       *shamap.SHAMap
+	acquisition *inbound.Ledger
+	failed      bool
+}
+
+type standardReplayLink struct {
+	seq        uint32
+	hash       [32]byte
+	parentHash [32]byte
+}
+
+func (r *Router) standardReplayLinks(
+	anchor *ledger.Ledger,
+	targetSeq uint32,
+	targetHash [32]byte,
+) ([]standardReplayLink, bool) {
+	if anchor == nil || targetSeq <= anchor.Sequence() || targetHash == ([32]byte{}) {
+		return nil, false
+	}
+
+	links := make([]standardReplayLink, 0, standardReplayPipelineWindow)
+	parentHash := anchor.Hash()
+	for seq := anchor.Sequence() + 1; seq <= targetSeq; seq++ {
+		entry, ok := r.lookupSeqHash(seq)
+		if !ok || entry.hash == ([32]byte{}) || !entry.haveParent || entry.parentHash != parentHash {
+			return nil, false
+		}
+		if seq == targetSeq && entry.hash != targetHash {
+			return nil, false
+		}
+		if len(links) < standardReplayPipelineWindow {
+			links = append(links, standardReplayLink{
+				seq:        seq,
+				hash:       entry.hash,
+				parentHash: parentHash,
+			})
+		}
+		parentHash = entry.hash
+	}
+	return links, len(links) > 0
+}
+
+func (r *Router) standardReplayBase(
+	svc *service.Service,
+	fallback *ledger.Ledger,
+	targetSeq uint32,
+	targetHash [32]byte,
+) *ledger.Ledger {
+	if svc == nil {
+		return fallback
+	}
+
+	r.acquisitionMu.Lock()
+	active := r.standardReplay.active
+	anchorSeq := r.standardReplay.anchorSeq
+	anchorHash := r.standardReplay.anchorHash
+	currentTargetSeq := r.standardReplay.targetSeq
+	currentTargetHash := r.standardReplay.targetHash
+	r.acquisitionMu.Unlock()
+
+	if !active {
+		return fallback
+	}
+	compatible := targetSeq == currentTargetSeq && targetHash == currentTargetHash
+	if !compatible && targetSeq > anchorSeq {
+		compatible = r.recoveryAnchorReachesTarget(anchorSeq, anchorHash, targetHash)
+	}
+	if !compatible {
+		r.cancelStandardReplayPipeline()
+		return fallback
+	}
+	anchor, err := svc.GetLedgerByHash(anchorHash)
+	if err != nil || anchor == nil || anchor.Sequence() != anchorSeq {
+		r.cancelStandardReplayPipeline()
+		return fallback
+	}
+	return anchor
+}
+
+func (r *Router) reconcileStandardReplayTarget(targetSeq uint32, targetHash [32]byte) {
+	r.acquisitionMu.Lock()
+	active := r.standardReplay.active
+	anchorSeq := r.standardReplay.anchorSeq
+	anchorHash := r.standardReplay.anchorHash
+	currentTargetSeq := r.standardReplay.targetSeq
+	currentTargetHash := r.standardReplay.targetHash
+	r.acquisitionMu.Unlock()
+	if !active {
+		return
+	}
+	compatible := targetSeq == currentTargetSeq && targetHash == currentTargetHash
+	if !compatible && targetSeq > anchorSeq {
+		compatible = r.recoveryAnchorReachesTarget(anchorSeq, anchorHash, targetHash)
+	}
+	if !compatible {
+		r.cancelStandardReplayPipeline()
+	}
+}
+
+func (r *Router) tryArmStandardReplayPipeline(
+	svc *service.Service,
+	anchor *ledger.Ledger,
+	targetSeq uint32,
+	targetHash [32]byte,
+	peerHint uint64,
+) bool {
+	anchor = r.standardReplayBase(svc, anchor, targetSeq, targetHash)
+	links, proven := r.standardReplayLinks(anchor, targetSeq, targetHash)
+	if !proven {
+		r.cancelStandardReplayPipeline()
+		return false
+	}
+
+	r.acquisitionMu.Lock()
+	initial := !r.standardReplay.active
+	if initial && len(links) < 2 {
+		r.acquisitionMu.Unlock()
+		return false
+	}
+	if !initial && (r.standardReplay.anchorSeq != anchor.Sequence() || r.standardReplay.anchorHash != anchor.Hash()) {
+		r.acquisitionMu.Unlock()
+		r.cancelStandardReplayPipeline()
+		return false
+	}
+	if initial {
+		r.standardReplay.generation++
+		r.standardReplay.active = true
+		r.standardReplay.anchorSeq = anchor.Sequence()
+		r.standardReplay.anchorHash = anchor.Hash()
+		r.standardReplay.entries = make(map[uint32]*standardReplayEntry, standardReplayPipelineWindow)
+	}
+	r.standardReplay.targetSeq = targetSeq
+	r.standardReplay.targetHash = targetHash
+
+	desired := make(map[uint32]standardReplayLink, len(links))
+	for _, link := range links {
+		desired[link.seq] = link
+	}
+	retired := r.pruneStandardReplayEntriesLocked(desired, targetSeq)
+
+	now := time.Now()
+	for _, link := range links {
+		if existing := r.standardReplay.entries[link.seq]; existing != nil {
+			continue
+		}
+		peerID, ok := r.resolveAcquisitionPeer(link.seq, peerHint)
+		if !ok {
+			break
+		}
+		il, created := r.startLedgerReplayAcquisitionLegacyLocked(link.seq, link.hash, peerID)
+		if il == nil || !il.TransactionOnly() {
+			break
+		}
+		r.standardReplay.entries[link.seq] = &standardReplayEntry{
+			generation:  r.standardReplay.generation,
+			seq:         link.seq,
+			hash:        link.hash,
+			parentHash:  link.parentHash,
+			peerID:      peerID,
+			requestedAt: now,
+			acquisition: il,
+		}
+		if created {
+			r.replayPipelineRequested.Add(1)
+		}
+	}
+
+	if r.consensusRecovery.targetHash == targetHash {
+		if head := r.standardReplay.entries[r.standardReplay.anchorSeq+1]; head != nil {
+			r.consensusRecovery.stepHash = head.hash
+		}
+	}
+	armed := len(r.standardReplay.entries) > 0
+	if !armed {
+		retired = append(retired, r.cancelStandardReplayPipelineLocked()...)
+	}
+	r.acquisitionMu.Unlock()
+	r.retireLegacyAcquisitions(retired)
+	return armed
+}
+
+func (r *Router) pruneStandardReplayEntriesLocked(
+	desired map[uint32]standardReplayLink,
+	targetSeq uint32,
+) []*inbound.Ledger {
+	var retired []*inbound.Ledger
+	for seq, entry := range r.standardReplay.entries {
+		link, keep := desired[seq]
+		keep = keep && seq <= targetSeq && entry.hash == link.hash && entry.parentHash == link.parentHash
+		if keep {
+			continue
+		}
+		if entry.acquisition != nil && r.fetchTracker.DiscardExpected(entry.acquisition) {
+			retired = append(retired, entry.acquisition)
+		}
+		delete(r.standardReplay.entries, seq)
+		r.replayPipelineDiscarded.Add(1)
+		if r.consensusRecovery.stepHash == entry.hash {
+			r.consensusRecovery.stepHash = [32]byte{}
+		}
+	}
+	return retired
+}
+
+func (r *Router) cancelStandardReplayPipeline() {
+	r.acquisitionMu.Lock()
+	retired := r.cancelStandardReplayPipelineLocked()
+	r.acquisitionMu.Unlock()
+	r.retireLegacyAcquisitions(retired)
+}
+
+func (r *Router) cancelStandardReplayPipelineLocked() []*inbound.Ledger {
+	if !r.standardReplay.active && len(r.standardReplay.entries) == 0 {
+		return nil
+	}
+	var retired []*inbound.Ledger
+	for _, entry := range r.standardReplay.entries {
+		if entry.acquisition != nil && r.fetchTracker.DiscardExpected(entry.acquisition) {
+			retired = append(retired, entry.acquisition)
+		}
+		if r.consensusRecovery.stepHash == entry.hash {
+			r.consensusRecovery.stepHash = [32]byte{}
+		}
+		r.replayPipelineDiscarded.Add(1)
+	}
+	r.standardReplay.generation++
+	r.standardReplay.active = false
+	r.standardReplay.anchorSeq = 0
+	r.standardReplay.anchorHash = [32]byte{}
+	r.standardReplay.targetSeq = 0
+	r.standardReplay.targetHash = [32]byte{}
+	r.standardReplay.entries = nil
+	r.standardReplay.headBlockedAt = time.Time{}
+	return retired
+}
+
+func (r *Router) standardReplayOwnsLocked(hash [32]byte) bool {
+	for _, entry := range r.standardReplay.entries {
+		if entry.hash == hash {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Router) completeStandardReplayPipelineEntry(
+	il *inbound.Ledger,
+	h *header.LedgerHeader,
+	txMap *shamap.SHAMap,
+	peerID uint64,
+) bool {
+	if il == nil || h == nil {
+		return false
+	}
+	now := time.Now()
+	r.acquisitionMu.Lock()
+	entry := r.standardReplay.entries[h.LedgerIndex]
+	if !r.standardReplay.active || entry == nil || entry.hash != h.Hash ||
+		entry.generation != r.standardReplay.generation || entry.acquisition != il {
+		r.acquisitionMu.Unlock()
+		return false
+	}
+	entry.header = *h
+	entry.txMap = txMap
+	entry.peerID = peerID
+	entry.readyAt = now
+	entry.acquisition = nil
+	r.replayPipelineReady.Add(1)
+	r.replayPipelineRetried.Add(uint64(il.Timeouts()))
+	r.replayPipelineAcquireUs.Add(durationMicros(now.Sub(entry.requestedAt)))
+	startDrain := !r.standardReplay.applying
+	if startDrain {
+		r.standardReplay.applying = true
+	}
+	r.updateStandardReplayHeadBlockLocked(now)
+	r.acquisitionMu.Unlock()
+
+	if startDrain {
+		r.drainStandardReplayPipeline()
+	}
+	return true
+}
+
+func (r *Router) failStandardReplayPipelineEntry(il *inbound.Ledger) bool {
+	if il == nil {
+		return false
+	}
+	now := time.Now()
+	r.acquisitionMu.Lock()
+	entry := r.standardReplay.entries[il.Seq()]
+	if !r.standardReplay.active || entry == nil || entry.hash != il.Hash() || entry.acquisition != il {
+		r.acquisitionMu.Unlock()
+		return false
+	}
+	entry.failed = true
+	entry.acquisition = nil
+	entry.peerID = il.PeerID()
+	r.replayPipelineRetried.Add(uint64(il.Timeouts()))
+	startDrain := !r.standardReplay.applying
+	if startDrain {
+		r.standardReplay.applying = true
+	}
+	r.updateStandardReplayHeadBlockLocked(now)
+	r.acquisitionMu.Unlock()
+	if startDrain {
+		r.drainStandardReplayPipeline()
+	}
+	return true
+}
+
+func (r *Router) updateStandardReplayHeadBlockLocked(now time.Time) {
+	if !r.standardReplay.active {
+		r.standardReplay.headBlockedAt = time.Time{}
+		return
+	}
+	head := r.standardReplay.entries[r.standardReplay.anchorSeq+1]
+	if head != nil && (!head.readyAt.IsZero() || head.failed) {
+		r.standardReplay.headBlockedAt = time.Time{}
+		return
+	}
+	for seq, entry := range r.standardReplay.entries {
+		if seq > r.standardReplay.anchorSeq+1 && (!entry.readyAt.IsZero() || entry.failed) {
+			if r.standardReplay.headBlockedAt.IsZero() {
+				r.standardReplay.headBlockedAt = now
+			}
+			return
+		}
+	}
+	r.standardReplay.headBlockedAt = time.Time{}
+}
+
+func (r *Router) drainStandardReplayPipeline() {
+	for {
+		r.acquisitionMu.Lock()
+		if !r.standardReplay.active {
+			r.standardReplay.applying = false
+			r.acquisitionMu.Unlock()
+			return
+		}
+		entry := r.standardReplay.entries[r.standardReplay.anchorSeq+1]
+		if entry == nil || (entry.readyAt.IsZero() && !entry.failed) {
+			r.standardReplay.applying = false
+			r.updateStandardReplayHeadBlockLocked(time.Now())
+			r.acquisitionMu.Unlock()
+			return
+		}
+		generation := r.standardReplay.generation
+		if entry.failed {
+			retired, current := r.discardStandardReplayHeadLocked(entry, generation)
+			r.acquisitionMu.Unlock()
+			r.retireLegacyAcquisitions(retired)
+			if current {
+				r.replayPipelineFallbacks.Add(1)
+				r.startLedgerAcquisitionLegacy(entry.seq, entry.hash, entry.peerID)
+			}
+			return
+		}
+		copyEntry := *entry
+		r.acquisitionMu.Unlock()
+
+		applyStarted := time.Now()
+		hdr, initialCandidate, persistDuration, err := r.applyStandardReplayEntry(&copyEntry)
+		applyDuration := time.Since(applyStarted) - persistDuration
+		if applyDuration < 0 {
+			applyDuration = 0
+		}
+		if err != nil {
+			r.acquisitionMu.Lock()
+			retired, current := r.discardStandardReplayHeadLocked(entry, generation)
+			r.acquisitionMu.Unlock()
+			r.retireLegacyAcquisitions(retired)
+			if current {
+				r.replayPipelineFallbacks.Add(1)
+				r.logger.Error("standard transaction replay pipeline apply failed; falling back to full-state acquisition",
+					"seq", entry.seq,
+					"hash", fmt.Sprintf("%x", entry.hash[:8]),
+					"error", err,
+				)
+				r.startLedgerAcquisitionLegacy(entry.seq, entry.hash, entry.peerID)
+			}
+			return
+		}
+
+		r.acquisitionMu.Lock()
+		current := r.standardReplay.active && r.standardReplay.generation == generation &&
+			r.standardReplay.entries[entry.seq] == entry && r.standardReplay.anchorSeq+1 == entry.seq
+		if !current {
+			if r.standardReplay.active {
+				r.acquisitionMu.Unlock()
+				continue
+			}
+			r.standardReplay.applying = false
+			r.acquisitionMu.Unlock()
+			return
+		}
+		delete(r.standardReplay.entries, entry.seq)
+		r.standardReplay.anchorSeq = entry.seq
+		r.standardReplay.anchorHash = entry.hash
+		r.replayPipelineApplied.Add(1)
+		r.replayPipelineApplyUs.Add(durationMicros(applyDuration))
+		r.replayPipelinePersistUs.Add(durationMicros(persistDuration))
+		r.replayPipelineReadyWaitUs.Add(durationMicros(applyStarted.Sub(entry.readyAt)))
+		if entry.seq == r.standardReplay.targetSeq && entry.hash == r.standardReplay.targetHash {
+			r.standardReplay.active = false
+			r.standardReplay.entries = nil
+			r.standardReplay.headBlockedAt = time.Time{}
+		}
+		r.acquisitionMu.Unlock()
+
+		r.logger.Info("applied standard transaction replay pipeline entry",
+			"seq", entry.seq,
+			"hash", fmt.Sprintf("%x", entry.hash[:8]),
+			"acquire_us", durationMicros(entry.readyAt.Sub(entry.requestedAt)),
+			"ready_wait_us", durationMicros(applyStarted.Sub(entry.readyAt)),
+			"apply_us", durationMicros(applyDuration),
+			"persist_us", durationMicros(persistDuration),
+		)
+		r.completeStoredConsensusRecovery(hdr.LedgerIndex, hdr.Hash, hdr.ParentHash, initialCandidate)
+	}
+}
+
+func (r *Router) discardStandardReplayHeadLocked(
+	entry *standardReplayEntry,
+	generation uint64,
+) ([]*inbound.Ledger, bool) {
+	if !r.standardReplay.active || r.standardReplay.generation != generation ||
+		r.standardReplay.entries[entry.seq] != entry || r.standardReplay.anchorSeq+1 != entry.seq {
+		r.standardReplay.applying = false
+		return nil, false
+	}
+	retired := r.cancelStandardReplayPipelineLocked()
+	r.standardReplay.applying = false
+	return retired, true
+}
+
+func (r *Router) applyStandardReplayEntry(
+	entry *standardReplayEntry,
+) (header.LedgerHeader, bool, time.Duration, error) {
+	if entry == nil {
+		return header.LedgerHeader{}, false, 0, errors.New("nil standard replay pipeline entry")
+	}
+	h := entry.header
+	if h.Hash != entry.hash {
+		return header.LedgerHeader{}, false, 0, errors.New("prepared ledger hash changed")
+	}
+	if h.LedgerIndex != entry.seq {
+		return header.LedgerHeader{}, false, 0, fmt.Errorf("prepared ledger sequence %d does not match expected %d", h.LedgerIndex, entry.seq)
+	}
+	if h.ParentHash != entry.parentHash {
+		return header.LedgerHeader{}, false, 0, errors.New("prepared ledger no longer attaches to the accepted predecessor")
+	}
+
+	svc := r.adaptor.LedgerService()
+	if svc == nil {
+		return header.LedgerHeader{}, false, 0, errors.New("no ledger service")
+	}
+	parent, err := svc.GetLedgerByHash(entry.parentHash)
+	if err != nil || parent == nil {
+		if err == nil {
+			err = errors.New("accepted replay predecessor is unavailable")
+		}
+		return header.LedgerHeader{}, false, 0, err
+	}
+	if parent.Sequence()+1 != entry.seq {
+		return header.LedgerHeader{}, false, 0, fmt.Errorf("replay predecessor sequence %d is not before %d", parent.Sequence(), entry.seq)
+	}
+
+	stateMap, err := parent.StateMapSnapshot()
+	if err != nil {
+		return header.LedgerHeader{}, false, 0, fmt.Errorf("snapshot replay predecessor state: %w", err)
+	}
+	txMap := entry.txMap
+	if txMap == nil {
+		if h.TxHash != ([32]byte{}) {
+			return header.LedgerHeader{}, false, 0, errors.New("missing transaction map for non-empty transaction root")
+		}
+		txMap = shamap.New(shamap.TypeTransaction)
+	} else {
+		txHash, hashErr := txMap.Hash()
+		if hashErr != nil {
+			return header.LedgerHeader{}, false, 0, fmt.Errorf("hash prepared transaction map: %w", hashErr)
+		}
+		if txHash != h.TxHash {
+			return header.LedgerHeader{}, false, 0, errors.New("prepared transaction map root changed")
+		}
+	}
+
+	target, err := ledger.NewFromHeader(h, stateMap, txMap, parent.Fees())
+	if err != nil {
+		return header.LedgerHeader{}, false, 0, fmt.Errorf("construct transaction-only replay target: %w", err)
+	}
+	replay, err := inbound.NewStoredLedgerReplay(parent, target, r.logger)
+	if err != nil {
+		return header.LedgerHeader{}, false, 0, fmt.Errorf("prepare transaction-only replay: %w", err)
+	}
+	derived, err := replay.Apply(r.adaptor.EngineConfigForReplay(parent))
+	if err != nil {
+		return header.LedgerHeader{}, false, 0, err
+	}
+
+	persistStarted := time.Now()
+	storedHeader, initialCandidate, err := r.storeVerifiedLedger(derived)
+	persistDuration := time.Since(persistStarted)
+	if err != nil {
+		return header.LedgerHeader{}, false, persistDuration, err
+	}
+	return storedHeader, initialCandidate, persistDuration, nil
+}
+
+func durationMicros(d time.Duration) uint64 {
+	if d <= 0 {
+		return 0
+	}
+	return uint64(d.Microseconds())
+}

--- a/internal/consensus/adaptor/router_replay_pipeline_test.go
+++ b/internal/consensus/adaptor/router_replay_pipeline_test.go
@@ -246,3 +246,86 @@ func TestStandardReplayPipelineFallsBackWhenHeadFails(t *testing.T) {
 	assert.Equal(t, uint64(7), metrics.ReplayPipelineRetried)
 	assert.GreaterOrEqual(t, metrics.ReplayPipelineDiscarded, uint64(len(links)))
 }
+
+func TestStandardReplayPipelineFallbackRespectsProtectedLimit(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	_, err := svc.AcceptLedger(context.Background())
+	require.NoError(t, err)
+	links := buildStandardReplayTestChain(t, r, svc.GetClosedLedger(), 3)
+	armStandardReplayTestPipeline(t, r, a, sender, links)
+
+	r.acquisitionMu.Lock()
+	for i := range maxConcurrentCatchup {
+		hash := [32]byte{0xf0, byte(i + 1)}
+		r.startLedgerAcquisitionLegacyLocked(links[len(links)-1].seq+uint32(i)+1, hash, 7)
+	}
+	r.acquisitionMu.Unlock()
+	require.Equal(t, maxConcurrentCatchup, r.protectedCatchupInFlight())
+
+	head := r.fetchTracker.Find(links[0].hash)
+	require.NotNil(t, head)
+	now := time.Now()
+	for range 6 {
+		now = now.Add(4 * time.Second)
+		require.Equal(t, inbound.TimerEscalate, head.OnTimer(now))
+	}
+	now = now.Add(4 * time.Second)
+	require.Equal(t, inbound.TimerFailed, head.OnTimer(now))
+	r.failInboundAcquisition(head)
+
+	assert.Nil(t, r.fetchTracker.Find(links[0].hash))
+	assert.Equal(t, maxConcurrentCatchup, r.protectedCatchupInFlight())
+}
+
+func TestStandardReplayPipelineDoesNotFallbackAfterGossipTargetAdvances(t *testing.T) {
+	r, _, sender, svc := makeRouter(t)
+	_, err := svc.AcceptLedger(context.Background())
+	require.NoError(t, err)
+	links := buildStandardReplayTestChain(t, r, svc.GetClosedLedger(), 3)
+	sender.mu.Lock()
+	sender.peerSupportsReplay = false
+	sender.mu.Unlock()
+	trackCatchupPeer(r, 7, links[len(links)-1].seq)
+	r.recordCatchupTarget(links[len(links)-1].seq, links[len(links)-1].hash, 7)
+	r.armCatchupTowardTarget()
+	require.True(t, r.standardReplay.active)
+	require.Equal(t, [32]byte{}, r.consensusRecovery.targetHash)
+
+	head := r.fetchTracker.Find(links[0].hash)
+	require.NotNil(t, head)
+	r.recordCatchupTarget(links[len(links)-1].seq+1, [32]byte{0xee}, 8)
+	now := time.Now()
+	for range 6 {
+		now = now.Add(4 * time.Second)
+		require.Equal(t, inbound.TimerEscalate, head.OnTimer(now))
+	}
+	now = now.Add(4 * time.Second)
+	require.Equal(t, inbound.TimerFailed, head.OnTimer(now))
+	r.failInboundAcquisition(head)
+
+	assert.Nil(t, r.fetchTracker.Find(links[0].hash))
+	assert.Zero(t, r.protectedCatchupInFlight())
+}
+
+func TestStandardReplayPipelineStaleFailureKeepsReplacementDrain(t *testing.T) {
+	r, _, _, _ := makeRouter(t)
+	replacement := &standardReplayEntry{generation: 2, seq: 11, hash: [32]byte{0x11}}
+	r.standardReplay = standardReplayPipeline{
+		generation: 2,
+		active:     true,
+		applying:   true,
+		anchorSeq:  10,
+		entries:    map[uint32]*standardReplayEntry{replacement.seq: replacement},
+	}
+	stale := &standardReplayEntry{generation: 1, seq: 10, hash: [32]byte{0x10}}
+
+	r.acquisitionMu.Lock()
+	retired, _, current := r.discardStandardReplayHeadLocked(stale, stale.generation)
+	r.acquisitionMu.Unlock()
+
+	assert.Empty(t, retired)
+	assert.False(t, current)
+	assert.True(t, r.standardReplay.active)
+	assert.True(t, r.standardReplay.applying)
+	assert.Same(t, replacement, r.standardReplay.entries[replacement.seq])
+}

--- a/internal/consensus/adaptor/router_replay_pipeline_test.go
+++ b/internal/consensus/adaptor/router_replay_pipeline_test.go
@@ -1,0 +1,248 @@
+package adaptor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type standardReplayTestLink struct {
+	response *message.ReplayDeltaResponse
+	ledger   *ledger.Ledger
+	hash     [32]byte
+	seq      uint32
+}
+
+func buildStandardReplayTestChain(t *testing.T, r *Router, parent *ledger.Ledger, count int) []standardReplayTestLink {
+	t.Helper()
+	links := make([]standardReplayTestLink, 0, count)
+	for range count {
+		response, child, hash, seq := buildSuccessorAgainstParent(t, parent)
+		r.recordSeqHash(seq, hash, parent.Hash(), true)
+		links = append(links, standardReplayTestLink{response: response, ledger: child, hash: hash, seq: seq})
+		parent = child
+	}
+	return links
+}
+
+func buildAlternativeReplaySuccessor(t *testing.T, parent *ledger.Ledger, salt time.Duration) standardReplayTestLink {
+	t.Helper()
+	closeTime := time.Date(2026, 2, 3, 4, 5, 6, 0, time.UTC).
+		Add(time.Duration(parent.Sequence()) * time.Second).
+		Add(salt)
+	child, err := ledger.NewOpen(parent, closeTime)
+	require.NoError(t, err)
+	require.NoError(t, child.Close(closeTime, 0))
+	h := child.Header()
+	return standardReplayTestLink{
+		response: &message.ReplayDeltaResponse{
+			LedgerHash:   h.Hash[:],
+			LedgerHeader: header.AddRaw(h, false),
+		},
+		ledger: child,
+		hash:   h.Hash,
+		seq:    h.LedgerIndex,
+	}
+}
+
+func completeStandardReplayTestLink(t *testing.T, r *Router, link standardReplayTestLink) {
+	t.Helper()
+	il := r.fetchTracker.Find(link.hash)
+	require.NotNil(t, il)
+	require.True(t, il.TransactionOnly())
+	require.NoError(t, il.GotBase([]message.LedgerNode{
+		{NodeData: link.response.LedgerHeader},
+		{NodeData: []byte{1}},
+	}))
+	require.True(t, il.IsComplete())
+	r.completeInboundLedger(il)
+}
+
+func armStandardReplayTestPipeline(
+	t *testing.T,
+	r *Router,
+	a *Adaptor,
+	sender *recordingSender,
+	links []standardReplayTestLink,
+) {
+	t.Helper()
+	require.NotEmpty(t, links)
+	sender.mu.Lock()
+	sender.peerSupportsReplay = false
+	sender.mu.Unlock()
+	trackCatchupPeer(r, 7, links[len(links)-1].seq)
+	require.NoError(t, a.RequestLedger(consensus.LedgerID(links[len(links)-1].hash)))
+}
+
+func TestStandardReplayPipelineAppliesReadySuccessorsInOrder(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	_, err := svc.AcceptLedger(context.Background())
+	require.NoError(t, err)
+	links := buildStandardReplayTestChain(t, r, svc.GetClosedLedger(), 3)
+	armStandardReplayTestPipeline(t, r, a, sender, links)
+	require.Len(t, sender.legacyCalls(), 3)
+	require.NoError(t, a.RequestLedger(consensus.LedgerID(links[len(links)-1].hash)))
+	assert.Equal(t, links[0].hash, r.consensusRecovery.stepHash)
+
+	completeStandardReplayTestLink(t, r, links[2])
+	completeStandardReplayTestLink(t, r, links[1])
+	for _, link := range links {
+		stored, _ := svc.GetLedgerByHash(link.hash)
+		assert.Nil(t, stored)
+	}
+	metrics := r.FastSyncMetrics()
+	assert.Equal(t, uint32(2), metrics.ReplayPipelineReadyDepth)
+	assert.Equal(t, links[0].seq, metrics.ReplayPipelineHeadSeq)
+	assert.False(t, r.standardReplay.headBlockedAt.IsZero())
+
+	completeStandardReplayTestLink(t, r, links[0])
+	for _, link := range links {
+		stored, lookupErr := svc.GetLedgerByHash(link.hash)
+		require.NoError(t, lookupErr)
+		require.NotNil(t, stored)
+		assert.Equal(t, link.seq, stored.Sequence())
+	}
+	metrics = r.FastSyncMetrics()
+	assert.Equal(t, uint64(3), metrics.ReplayPipelineReady)
+	assert.Equal(t, uint64(3), metrics.ReplayPipelineApplied)
+	assert.Zero(t, metrics.ReplayPipelineDepth)
+	assert.Zero(t, metrics.ReplayPipelineReadyDepth)
+}
+
+func TestStandardReplayPipelineBoundsAndRefillsWindow(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	_, err := svc.AcceptLedger(context.Background())
+	require.NoError(t, err)
+	links := buildStandardReplayTestChain(t, r, svc.GetClosedLedger(), standardReplayPipelineWindow+2)
+	armStandardReplayTestPipeline(t, r, a, sender, links)
+
+	require.Len(t, sender.legacyCalls(), standardReplayPipelineWindow)
+	assert.Nil(t, r.fetchTracker.Find(links[standardReplayPipelineWindow].hash))
+	metrics := r.FastSyncMetrics()
+	assert.Equal(t, uint32(standardReplayPipelineWindow), metrics.ReplayPipelineDepth)
+	assert.Equal(t, uint32(standardReplayPipelineWindow), metrics.ReplayPipelineWindow)
+
+	completeStandardReplayTestLink(t, r, links[0])
+	require.Len(t, sender.legacyCalls(), standardReplayPipelineWindow+1)
+	require.NotNil(t, r.fetchTracker.Find(links[standardReplayPipelineWindow].hash))
+	metrics = r.FastSyncMetrics()
+	assert.Equal(t, uint64(standardReplayPipelineWindow+1), metrics.ReplayPipelineRequested)
+	assert.Equal(t, uint32(standardReplayPipelineWindow), metrics.ReplayPipelineDepth)
+}
+
+func TestStandardReplayPipelineCancelsSupersededFork(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	_, err := svc.AcceptLedger(context.Background())
+	require.NoError(t, err)
+	closed := svc.GetClosedLedger()
+	oldLinks := buildStandardReplayTestChain(t, r, closed, 3)
+	armStandardReplayTestPipeline(t, r, a, sender, oldLinks)
+	stale := r.fetchTracker.Find(oldLinks[0].hash)
+	require.NotNil(t, stale)
+
+	newLinks := make([]standardReplayTestLink, 0, 3)
+	parent := closed
+	for i := 1; i <= 3; i++ {
+		link := buildAlternativeReplaySuccessor(t, parent, time.Duration(i)*time.Minute)
+		r.recordSeqHash(link.seq, link.hash, parent.Hash(), true)
+		newLinks = append(newLinks, link)
+		parent = link.ledger
+	}
+	trackCatchupPeer(r, 7, newLinks[len(newLinks)-1].seq)
+	require.NoError(t, a.RequestLedger(consensus.LedgerID(newLinks[len(newLinks)-1].hash)))
+
+	for _, link := range oldLinks {
+		assert.Nil(t, r.fetchTracker.Find(link.hash))
+	}
+	for _, link := range newLinks {
+		require.NotNil(t, r.fetchTracker.Find(link.hash))
+	}
+	require.NoError(t, stale.GotBase([]message.LedgerNode{
+		{NodeData: oldLinks[0].response.LedgerHeader},
+		{NodeData: []byte{1}},
+	}))
+	r.completeInboundLedger(stale)
+	stored, _ := svc.GetLedgerByHash(oldLinks[0].hash)
+	assert.Nil(t, stored)
+	assert.GreaterOrEqual(t, r.FastSyncMetrics().ReplayPipelineDiscarded, uint64(len(oldLinks)))
+}
+
+func TestStandardReplayPipelineLeavesFullStateSlotAvailable(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	_, err := svc.AcceptLedger(context.Background())
+	require.NoError(t, err)
+	links := buildStandardReplayTestChain(t, r, svc.GetClosedLedger(), standardReplayPipelineWindow)
+	armStandardReplayTestPipeline(t, r, a, sender, links)
+
+	fullStateHash := [32]byte{0xfa, 0x57}
+	r.acquisitionMu.Lock()
+	require.True(t, r.canAdmitCatchupLocked(fullStateHash, maxConcurrentCatchup))
+	r.startLedgerAcquisitionLegacyLocked(links[len(links)-1].seq+1, fullStateHash, 7)
+	r.acquisitionMu.Unlock()
+	fullState := r.fetchTracker.Find(fullStateHash)
+	require.NotNil(t, fullState)
+	assert.False(t, fullState.TransactionOnly())
+}
+
+func TestStandardReplayPipelineDoesNotClaimFullStateAcquisition(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	_, err := svc.AcceptLedger(context.Background())
+	require.NoError(t, err)
+	links := buildStandardReplayTestChain(t, r, svc.GetClosedLedger(), 3)
+	sender.mu.Lock()
+	sender.peerSupportsReplay = false
+	sender.mu.Unlock()
+	trackCatchupPeer(r, 7, links[len(links)-1].seq)
+
+	r.acquisitionMu.Lock()
+	r.startLedgerAcquisitionLegacyLocked(links[0].seq, links[0].hash, 7)
+	r.acquisitionMu.Unlock()
+	require.NoError(t, a.RequestLedger(consensus.LedgerID(links[len(links)-1].hash)))
+
+	head := r.fetchTracker.Find(links[0].hash)
+	require.NotNil(t, head)
+	assert.False(t, head.TransactionOnly())
+	assert.False(t, r.standardReplay.active)
+	for _, link := range links[1:] {
+		assert.Nil(t, r.fetchTracker.Find(link.hash))
+	}
+}
+
+func TestStandardReplayPipelineFallsBackWhenHeadFails(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	_, err := svc.AcceptLedger(context.Background())
+	require.NoError(t, err)
+	links := buildStandardReplayTestChain(t, r, svc.GetClosedLedger(), 3)
+	armStandardReplayTestPipeline(t, r, a, sender, links)
+
+	head := r.fetchTracker.Find(links[0].hash)
+	require.NotNil(t, head)
+	now := time.Now()
+	for range 6 {
+		now = now.Add(4 * time.Second)
+		require.Equal(t, inbound.TimerEscalate, head.OnTimer(now))
+		r.escalateAcquisition(head, now)
+	}
+	now = now.Add(4 * time.Second)
+	require.Equal(t, inbound.TimerFailed, head.OnTimer(now))
+	r.failInboundAcquisition(head)
+
+	fallback := r.fetchTracker.Find(links[0].hash)
+	require.NotNil(t, fallback)
+	assert.False(t, fallback.TransactionOnly())
+	for _, link := range links[1:] {
+		assert.Nil(t, r.fetchTracker.Find(link.hash))
+	}
+	metrics := r.FastSyncMetrics()
+	assert.Equal(t, uint64(1), metrics.ReplayPipelineFallbacks)
+	assert.Equal(t, uint64(7), metrics.ReplayPipelineRetried)
+	assert.GreaterOrEqual(t, metrics.ReplayPipelineDiscarded, uint64(len(links)))
+}

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -771,6 +771,22 @@ func (r *nodeRuntime) configureConsensus() error {
 					CompletionRecheckRejectedUnavailable: snapshot.CompletionRecheckRejectedUnavailable,
 					TargetSuperseded:                     snapshot.TargetSuperseded,
 					ObsoleteAcquisitionCompleted:         snapshot.ObsoleteAcquisitionCompleted,
+					ReplayPipelineRequested:              snapshot.ReplayPipelineRequested,
+					ReplayPipelineReady:                  snapshot.ReplayPipelineReady,
+					ReplayPipelineApplied:                snapshot.ReplayPipelineApplied,
+					ReplayPipelineDiscarded:              snapshot.ReplayPipelineDiscarded,
+					ReplayPipelineRetried:                snapshot.ReplayPipelineRetried,
+					ReplayPipelineFallbacks:              snapshot.ReplayPipelineFallbacks,
+					ReplayPipelineAcquireUs:              snapshot.ReplayPipelineAcquireUs,
+					ReplayPipelineReadyWaitUs:            snapshot.ReplayPipelineReadyWaitUs,
+					ReplayPipelineApplyUs:                snapshot.ReplayPipelineApplyUs,
+					ReplayPipelinePersistUs:              snapshot.ReplayPipelinePersistUs,
+					ReplayPipelineWindow:                 snapshot.ReplayPipelineWindow,
+					ReplayPipelineDepth:                  snapshot.ReplayPipelineDepth,
+					ReplayPipelineReadyDepth:             snapshot.ReplayPipelineReadyDepth,
+					ReplayPipelineHeadSeq:                snapshot.ReplayPipelineHeadSeq,
+					ReplayPipelineTargetSeq:              snapshot.ReplayPipelineTargetSeq,
+					ReplayPipelineHeadBlockedUs:          snapshot.ReplayPipelineHeadBlockedUs,
 				}
 			}
 		}

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -238,6 +238,22 @@ func addServerDiagnostics(info map[string]any, services *types.ServiceGraph) {
 			"completion_recheck_rejected_quorum_unavailable": strconv.FormatUint(metrics.CompletionRecheckRejectedUnavailable, 10),
 			"target_superseded":                              strconv.FormatUint(metrics.TargetSuperseded, 10),
 			"obsolete_acquisition_completed":                 strconv.FormatUint(metrics.ObsoleteAcquisitionCompleted, 10),
+			"replay_pipeline_requested":                      strconv.FormatUint(metrics.ReplayPipelineRequested, 10),
+			"replay_pipeline_ready":                          strconv.FormatUint(metrics.ReplayPipelineReady, 10),
+			"replay_pipeline_applied":                        strconv.FormatUint(metrics.ReplayPipelineApplied, 10),
+			"replay_pipeline_discarded":                      strconv.FormatUint(metrics.ReplayPipelineDiscarded, 10),
+			"replay_pipeline_retried":                        strconv.FormatUint(metrics.ReplayPipelineRetried, 10),
+			"replay_pipeline_fallbacks":                      strconv.FormatUint(metrics.ReplayPipelineFallbacks, 10),
+			"replay_pipeline_acquire_us":                     strconv.FormatUint(metrics.ReplayPipelineAcquireUs, 10),
+			"replay_pipeline_ready_wait_us":                  strconv.FormatUint(metrics.ReplayPipelineReadyWaitUs, 10),
+			"replay_pipeline_apply_us":                       strconv.FormatUint(metrics.ReplayPipelineApplyUs, 10),
+			"replay_pipeline_persist_us":                     strconv.FormatUint(metrics.ReplayPipelinePersistUs, 10),
+			"replay_pipeline_window":                         strconv.FormatUint(uint64(metrics.ReplayPipelineWindow), 10),
+			"replay_pipeline_depth":                          strconv.FormatUint(uint64(metrics.ReplayPipelineDepth), 10),
+			"replay_pipeline_ready_depth":                    strconv.FormatUint(uint64(metrics.ReplayPipelineReadyDepth), 10),
+			"replay_pipeline_head_seq":                       strconv.FormatUint(uint64(metrics.ReplayPipelineHeadSeq), 10),
+			"replay_pipeline_target_seq":                     strconv.FormatUint(uint64(metrics.ReplayPipelineTargetSeq), 10),
+			"replay_pipeline_head_blocked_us":                strconv.FormatUint(metrics.ReplayPipelineHeadBlockedUs, 10),
 		}
 	}
 	info["counters"] = counters

--- a/internal/rpc/server_diagnostics_test.go
+++ b/internal/rpc/server_diagnostics_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
@@ -51,6 +52,22 @@ func TestServerDiagnosticsWireShape(t *testing.T) {
 			CompletionRecheckRejectedUnavailable: 1,
 			TargetSuperseded:                     13,
 			ObsoleteAcquisitionCompleted:         5,
+			ReplayPipelineRequested:              21,
+			ReplayPipelineReady:                  22,
+			ReplayPipelineApplied:                23,
+			ReplayPipelineDiscarded:              24,
+			ReplayPipelineRetried:                25,
+			ReplayPipelineFallbacks:              26,
+			ReplayPipelineAcquireUs:              27,
+			ReplayPipelineReadyWaitUs:            28,
+			ReplayPipelineApplyUs:                29,
+			ReplayPipelinePersistUs:              30,
+			ReplayPipelineWindow:                 31,
+			ReplayPipelineDepth:                  32,
+			ReplayPipelineReadyDepth:             33,
+			ReplayPipelineHeadSeq:                34,
+			ReplayPipelineTargetSeq:              35,
+			ReplayPipelineHeadBlockedUs:          36,
 		}
 	}
 
@@ -93,13 +110,32 @@ func TestServerDiagnosticsWireShape(t *testing.T) {
 				t.Fatalf("subscriptions = %#v", subscriptions)
 			}
 			fastSync := counters["fast_sync"].(map[string]any)
-			if fastSync["completion_recheck_accepted"] != "8" ||
-				fastSync["completion_recheck_rejected_no_evidence"] != "3" ||
-				fastSync["completion_recheck_rejected_below_quorum"] != "2" ||
-				fastSync["completion_recheck_rejected_quorum_unavailable"] != "1" ||
-				fastSync["target_superseded"] != "13" ||
-				fastSync["obsolete_acquisition_completed"] != "5" {
-				t.Fatalf("fast_sync = %#v", fastSync)
+			wantFastSync := map[string]any{
+				"completion_recheck_accepted":                    "8",
+				"completion_recheck_rejected_no_evidence":        "3",
+				"completion_recheck_rejected_below_quorum":       "2",
+				"completion_recheck_rejected_quorum_unavailable": "1",
+				"target_superseded":                              "13",
+				"obsolete_acquisition_completed":                 "5",
+				"replay_pipeline_requested":                      "21",
+				"replay_pipeline_ready":                          "22",
+				"replay_pipeline_applied":                        "23",
+				"replay_pipeline_discarded":                      "24",
+				"replay_pipeline_retried":                        "25",
+				"replay_pipeline_fallbacks":                      "26",
+				"replay_pipeline_acquire_us":                     "27",
+				"replay_pipeline_ready_wait_us":                  "28",
+				"replay_pipeline_apply_us":                       "29",
+				"replay_pipeline_persist_us":                     "30",
+				"replay_pipeline_window":                         "31",
+				"replay_pipeline_depth":                          "32",
+				"replay_pipeline_ready_depth":                    "33",
+				"replay_pipeline_head_seq":                       "34",
+				"replay_pipeline_target_seq":                     "35",
+				"replay_pipeline_head_blocked_us":                "36",
+			}
+			if !reflect.DeepEqual(fastSync, wantFastSync) {
+				t.Fatalf("fast_sync = %#v, want %#v", fastSync, wantFastSync)
 			}
 			activities := body["current_activities"].(map[string]any)
 			if len(activities["jobs"].([]map[string]any)) != 0 {

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -1286,6 +1286,22 @@ type FastSyncMetrics struct {
 	CompletionRecheckRejectedUnavailable uint64
 	TargetSuperseded                     uint64
 	ObsoleteAcquisitionCompleted         uint64
+	ReplayPipelineRequested              uint64
+	ReplayPipelineReady                  uint64
+	ReplayPipelineApplied                uint64
+	ReplayPipelineDiscarded              uint64
+	ReplayPipelineRetried                uint64
+	ReplayPipelineFallbacks              uint64
+	ReplayPipelineAcquireUs              uint64
+	ReplayPipelineReadyWaitUs            uint64
+	ReplayPipelineApplyUs                uint64
+	ReplayPipelinePersistUs              uint64
+	ReplayPipelineWindow                 uint32
+	ReplayPipelineDepth                  uint32
+	ReplayPipelineReadyDepth             uint32
+	ReplayPipelineHeadSeq                uint32
+	ReplayPipelineTargetSeq              uint32
+	ReplayPipelineHeadBlockedUs          uint64
 }
 
 // SubmitResult contains the result of submitting a transaction.


### PR DESCRIPTION
## Summary

- prefetch up to eight proven successor headers and transaction SHAMaps through the existing standard inbound-ledger tracker
- buffer completed transaction-only acquisitions by sequence and replay/persist them strictly from the accepted head
- cancel stale descendants on target/fork changes, preserve the full-state recovery budget, and fall back to full-state acquisition when the ordered head exhausts its retry budget or fails verification
- expose pipeline outcome, timing, depth, head, and target metrics through `server_info`

## Rippled parity

This follows rippled v3.3.0's online replay model: `LedgerReplayer` creates the delta acquisitions concurrently, while `LedgerReplayTask::tryAdvance` consumes them in sequence order. The Go path continues to use the existing inbound-ledger header and transaction-SHAMap verification, then rechecks sequence, parent hash, transaction root, derived account root, and final ledger hash before storage.

The optional go-xrpl replay-delta extension remains unchanged. This pipeline only replaces the serial standard transaction-only fallback when the complete successor ancestry is already proven; unknown linkage retains the existing serial/full-state behavior.

## Safety and bounds

- fixed eight-entry window, refilled only after ordered consumption
- tracker identity plus pipeline generation rejects late or superseded completions
- prepared descendants cannot advance consensus, confirm fast-load, or enable proposing
- transaction-only prefetches do not consume the protected full-state/wrong-ledger slot
- existing peer selection, retry budgets, acquisition persistence scopes, and full-state fallback remain in force

## Verification

- `just test`
- `go test ./internal/consensus/... ./internal/rpc/... ./internal/node/... -count=1`
- `go test -race ./internal/consensus/adaptor -run 'TestStandardReplayPipeline|TestConsensusRecovery' -count=1`
- `just lint`
- `just vet`
- `just build`

The deterministic coverage includes out-of-order completion with ordered application, bounded refill, target/fork supersession, full-state slot protection, acquisition-domain ownership, and timeout-driven full-state fallback.

Live Testnet throughput validation was not available in the local test environment. The new independent counters and phase timings are included so the 0.83 ledger/s baseline, resource pressure, and gap-reduction rate can be measured during review/deployment.

Base branch: `fix/testnet-catchup-handoff` (the standard transaction-only catch-up path profiled in the issue is introduced by that branch and is not yet on `main`).

Fixes #1658
