### PR TITLE
feat(fast-load): persist verified SHAMap checkpoint

### DIFF
--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -466,8 +466,10 @@ func (r *Router) armPendingConsensusLedger() bool {
 			r.acquisitionMu.Unlock()
 			return true
 		}
+		acquisitionSeq := seq
 		acquisitionHash := hash
 		if replay {
+			acquisitionSeq = nextSeq
 			acquisitionHash = nextHash
 		}
 		if r.isAcquiring(acquisitionHash) {
@@ -488,10 +490,10 @@ func (r *Router) armPendingConsensusLedger() bool {
 			}
 		}
 
-		peerID, _ := r.selectAcquisitionPeer(seq)
-		r.startLedgerAcquisitionLegacyLocked(seq, hash, peerID)
-		if r.fetchTracker.Find(hash) != nil {
-			r.consensusRecovery.stepHash = hash
+		peerID, _ := r.selectAcquisitionPeer(acquisitionSeq)
+		r.startLedgerAcquisitionLegacyLocked(acquisitionSeq, acquisitionHash, peerID)
+		if r.fetchTracker.Find(acquisitionHash) != nil {
+			r.consensusRecovery.stepHash = acquisitionHash
 		}
 		r.acquisitionMu.Unlock()
 		return true
@@ -942,24 +944,42 @@ func (r *Router) startLedgerAcquisitionLegacyLocked(seq uint32, hash [32]byte, p
 
 func (r *Router) fallbackReplayAcquisition(seq uint32, hash [32]byte, peerID uint64) {
 	r.acquisitionMu.Lock()
-	defer r.acquisitionMu.Unlock()
 
 	target := r.consensusRecovery.targetHash
 	if target != ([32]byte{}) && r.consensusRecovery.stepHash != hash && target != hash {
+		r.acquisitionMu.Unlock()
 		return
 	}
-	if target != ([32]byte{}) && r.consensusRecovery.stepHash == hash {
-		seq, _ = r.lookupSeqForHash(target)
-		hash = target
-		r.consensusRecovery.stepHash = [32]byte{}
+	if target != ([32]byte{}) && target != hash {
+		targetSeq, known := r.lookupSeqForHash(target)
+		if !known {
+			r.consensusRecovery.stepHash = [32]byte{}
+			r.acquisitionMu.Unlock()
+			r.armConsensusCatchup()
+			return
+		}
+		nextSeq, nextHash, _, replay, _ := r.recoveryForwardStep(
+			r.adaptor.LedgerService(),
+			targetSeq,
+			target,
+			r.consensusRecovery,
+		)
+		if !replay || nextSeq != seq || nextHash != hash {
+			r.consensusRecovery.stepHash = [32]byte{}
+			r.acquisitionMu.Unlock()
+			r.armConsensusCatchup()
+			return
+		}
 	}
 	if !r.canAdmitCatchupLocked(hash, maxConcurrentCatchup) {
+		r.acquisitionMu.Unlock()
 		return
 	}
 	r.startLedgerAcquisitionLegacyLocked(seq, hash, peerID)
 	if target != ([32]byte{}) && r.fetchTracker.Find(hash) != nil {
 		r.consensusRecovery.stepHash = hash
 	}
+	r.acquisitionMu.Unlock()
 }
 
 func (r *Router) requestConsensusLedger(id consensus.LedgerID) error {

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
@@ -491,7 +492,11 @@ func (r *Router) armPendingConsensusLedger() bool {
 		}
 
 		peerID, _ := r.selectAcquisitionPeer(acquisitionSeq)
-		r.startLedgerAcquisitionLegacyLocked(acquisitionSeq, acquisitionHash, peerID)
+		if replay && parent != nil {
+			r.startLedgerReplayAcquisitionLegacyLocked(acquisitionSeq, acquisitionHash, peerID)
+		} else {
+			r.startLedgerAcquisitionLegacyLocked(acquisitionSeq, acquisitionHash, peerID)
+		}
 		if r.fetchTracker.Find(acquisitionHash) != nil {
 			r.consensusRecovery.stepHash = acquisitionHash
 		}
@@ -780,8 +785,10 @@ func (r *Router) refreshCatchupAcquisitionPeer(il *inbound.Ledger, peerID uint64
 // strategy for the given target. When we have the parent ledger locally
 // and the peer advertises ledger-replay, the bandwidth-efficient
 // replay-delta protocol is preferred (one request returns header + every
-// tx blob); otherwise we fall back to the legacy mtGET_LEDGER
-// header+state walk.
+// tx blob). When the peer does not support that extension, standard
+// mtGET_LEDGER fetches only the header + transaction SHAMap and the same local
+// replay verifier derives the child state. A full header+state walk is reserved
+// for targets whose parent is not held locally.
 //
 // This is currently the only driver of startReplayDeltaAcquisition: it
 // handles a single target ledger per call. The Replayer coordinator
@@ -843,7 +850,12 @@ func (r *Router) startLedgerAcquisitionLocked(seq uint32, hash [32]byte, peerID 
 		if err := r.startReplayDeltaAcquisition(seq, hash, peerID, parent); err == nil {
 			return
 		}
-		// Fall through to the legacy path on issue failure.
+		// Fall through to standard-protocol transaction-only replay on issue
+		// failure. The peer need not implement the optional replay extension.
+	}
+	if parent != nil {
+		r.startLedgerReplayAcquisitionLegacyLocked(seq, hash, peerID)
+		return
 	}
 	r.startLedgerAcquisitionLegacyLocked(seq, hash, peerID)
 }
@@ -903,6 +915,46 @@ func (r *Router) startLedgerAcquisitionLegacy(seq uint32, hash [32]byte, peerID 
 	r.acquisitionMu.Lock()
 	defer r.acquisitionMu.Unlock()
 	r.startLedgerAcquisitionLegacyLocked(seq, hash, peerID)
+}
+
+// startLedgerReplayAcquisitionLegacyLocked uses the standard mtGET_LEDGER
+// protocol to fetch only a successor ledger's header and transaction SHAMap.
+// This is the interoperable fast path for rippled peers, which do not advertise
+// go-xrpl's optional replay-delta extension. Completion locally replays the
+// transactions against the already-held parent and verifies both target roots.
+// Caller holds acquisitionMu.
+func (r *Router) startLedgerReplayAcquisitionLegacyLocked(seq uint32, hash [32]byte, peerID uint64) {
+	if seq != 0 && r.belowFloor(seq) {
+		return
+	}
+	if r.replayer.Has(hash) {
+		return
+	}
+
+	opts := append(r.acquisitionOpts(), inbound.WithTransactionOnly())
+	il, created := r.fetchTracker.GetOrCreate(hash, func() *inbound.Ledger {
+		return inbound.New(hash, seq, peerID, r.logger, opts...)
+	})
+	if !created {
+		return
+	}
+
+	r.logger.Info("starting ledger replay acquisition (standard tx-only)",
+		"seq", seq,
+		"hash", fmt.Sprintf("%x", hash[:8]),
+		"peer", peerID,
+	)
+
+	r.seedAcquisitionPeers(il)
+	requested := false
+	for _, candidate := range il.Peers() {
+		if r.requestLedgerBaseFromPeer(il, candidate, "failed to request replay ledger base from peer") {
+			requested = true
+		}
+	}
+	if !requested {
+		r.requestLedgerBase(il, 0, "failed to request replay ledger base from peer")
+	}
 }
 
 func (r *Router) startLedgerAcquisitionLegacyLocked(seq uint32, hash [32]byte, peerID uint64) {
@@ -2724,6 +2776,15 @@ func (r *Router) completeInboundLedgerReady(il *inbound.Ledger) {
 	recoveryTarget := r.consensusRecovery.targetHash == h.Hash
 	r.acquisitionMu.Unlock()
 
+	// A forward child fetched from a standard rippled peer contains only its
+	// header and transaction SHAMap. Rebuild the state from the locally-held
+	// parent, verify the derived roots against the peer header, then feed the
+	// same adoption path as the optional replay-delta protocol.
+	if il.TransactionOnly() {
+		r.completeStandardTransactionReplay(h, txMap, peerID)
+		return
+	}
+
 	// A history backfill installs validated sequence history below the closed tip,
 	// then advances the backward walk to its parent. It never touches operating
 	// mode or the consensus engine.
@@ -2775,4 +2836,93 @@ func (r *Router) completeInboundLedgerReady(il *inbound.Ledger) {
 		"initial_candidate", initialCandidate,
 	)
 	r.completeStoredConsensusRecovery(h.LedgerIndex, h.Hash, h.ParentHash, initialCandidate)
+}
+
+// completeStandardTransactionReplay turns a transaction-only mtGET_LEDGER
+// acquisition into a verified successor ledger. This keeps forward catch-up
+// interoperable with stock rippled peers: no custom handshake feature is
+// required, and the target account-state tree is never downloaded.
+func (r *Router) completeStandardTransactionReplay(
+	h *header.LedgerHeader,
+	txMap *shamap.SHAMap,
+	peerID uint64,
+) {
+	if h == nil {
+		return
+	}
+	svc := r.adaptor.LedgerService()
+	if svc == nil {
+		return
+	}
+	fallback := func(err error) {
+		r.logger.Warn("standard transaction replay failed; falling back to full-state acquisition",
+			"seq", h.LedgerIndex,
+			"hash", fmt.Sprintf("%x", h.Hash[:8]),
+			"peer", peerID,
+			"error", err,
+		)
+		r.startLedgerAcquisitionLegacy(h.LedgerIndex, h.Hash, peerID)
+	}
+
+	parent, err := svc.GetLedgerByHash(h.ParentHash)
+	if err != nil || parent == nil {
+		if err == nil {
+			err = errors.New("locally-held replay parent is unavailable")
+		}
+		fallback(err)
+		return
+	}
+	if parent.Sequence()+1 != h.LedgerIndex {
+		fallback(fmt.Errorf("replay parent sequence %d is not predecessor of %d", parent.Sequence(), h.LedgerIndex))
+		return
+	}
+
+	stateMap, err := parent.StateMapSnapshot()
+	if err != nil {
+		fallback(fmt.Errorf("snapshot replay parent state: %w", err))
+		return
+	}
+	if txMap == nil {
+		if h.TxHash != ([32]byte{}) {
+			fallback(errors.New("missing transaction map for non-empty transaction root"))
+			return
+		}
+		txMap = shamap.New(shamap.TypeTransaction)
+	}
+
+	// NewStoredLedgerReplay only needs a header and verified transaction map
+	// from target. Carrying the parent's state snapshot here is intentional:
+	// ReplayDelta.Apply replaces it with the derived child state and checks the
+	// resulting AccountHash before adoption.
+	target, err := ledger.NewFromHeader(*h, stateMap, txMap, parent.Fees())
+	if err != nil {
+		fallback(fmt.Errorf("construct transaction-only replay target: %w", err))
+		return
+	}
+	replay, err := inbound.NewStoredLedgerReplay(parent, target, r.logger)
+	if err != nil {
+		fallback(fmt.Errorf("prepare standard transaction replay: %w", err))
+		return
+	}
+	derived, err := replay.Apply(r.adaptor.EngineConfigForReplay(parent))
+	if err != nil {
+		// The transaction SHAMap root was proven against the canonical header;
+		// failure here means local transaction-engine divergence, not bad peer
+		// data. Preserve the full-state fallback as a safe recovery path.
+		r.logger.Error("ENGINE DIVERGENCE: standard transaction replay apply failed",
+			"seq", h.LedgerIndex,
+			"hash", fmt.Sprintf("%x", h.Hash[:8]),
+			"error", err,
+		)
+		fallback(err)
+		return
+	}
+	r.logger.Info("acquired ledger via standard transaction replay",
+		"seq", h.LedgerIndex,
+		"hash", fmt.Sprintf("%x", h.Hash[:8]),
+		"peer", peerID,
+	)
+	if err := r.adoptVerifiedLedger(derived); err != nil {
+		r.logger.Warn("failed to store standard transaction replay ledger", "error", err)
+	}
 }

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -165,6 +165,12 @@ const maxConcurrentCatchup = 3
 // requested by consensus wrong-ledger recovery.
 const maxConcurrentSpeculativeCatchup = maxConcurrentCatchup - 1
 
+// A provisional fast-loaded ledger has a cold in-memory full-below cache. A
+// second full-state acquisition would duplicate the same durable SHAMap scan
+// and compete for storage bandwidth. Keep one pinned full-state jump in flight;
+// newer trusted targets remain queued and are armed when it completes.
+const maxConcurrentProvisionalFullStateCatchup = 1
+
 // maxForwardDeltaGap bounds how far behind the tip the router walks forward one
 // ledger at a time (replay-delta against the held parent) before it prefers a
 // single full-state jump-adopt. Within the gap a same-branch serial walk (O(txs)
@@ -967,6 +973,9 @@ func (r *Router) startLedgerAcquisitionLegacyLocked(seq uint32, hash [32]byte, p
 	if r.replayer.Has(hash) {
 		return
 	}
+	if !r.canAdmitProvisionalFullStateLocked(hash) {
+		return
+	}
 
 	il, created := r.fetchTracker.GetOrCreate(hash, func() *inbound.Ledger {
 		return inbound.New(hash, seq, peerID, r.logger, r.acquisitionOpts()...)
@@ -992,6 +1001,26 @@ func (r *Router) startLedgerAcquisitionLegacyLocked(seq uint32, hash [32]byte, p
 	if !requested {
 		r.requestLedgerBase(il, 0, "failed to request ledger base from peer")
 	}
+}
+
+// canAdmitProvisionalFullStateLocked prevents competing full-state walks only
+// while confirming a fast-loaded ledger. Transaction-only replay acquisitions
+// remain unaffected. Caller holds acquisitionMu.
+func (r *Router) canAdmitProvisionalFullStateLocked(hash [32]byte) bool {
+	svc := r.adaptor.LedgerService()
+	if svc == nil || !svc.IsFastLoadProvisional() {
+		return true
+	}
+	if existing := r.fetchTracker.Find(hash); existing != nil {
+		return true
+	}
+	active := 0
+	for _, candidate := range r.fetchTracker.Active() {
+		if candidate.Reason() == inbound.ReasonConsensus && !candidate.TransactionOnly() {
+			active++
+		}
+	}
+	return active < maxConcurrentProvisionalFullStateCatchup
 }
 
 func (r *Router) fallbackReplayAcquisition(seq uint32, hash [32]byte, peerID uint64) {

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -856,8 +856,6 @@ func (r *Router) startLedgerAcquisitionLocked(seq uint32, hash [32]byte, peerID 
 		if err := r.startReplayDeltaAcquisition(seq, hash, peerID, parent); err == nil {
 			return
 		}
-		// Fall through to standard-protocol transaction-only replay on issue
-		// failure. The peer need not implement the optional replay extension.
 	}
 	if parent != nil {
 		r.startLedgerReplayAcquisitionLegacyLocked(seq, hash, peerID)
@@ -923,11 +921,6 @@ func (r *Router) startLedgerAcquisitionLegacy(seq uint32, hash [32]byte, peerID 
 	r.startLedgerAcquisitionLegacyLocked(seq, hash, peerID)
 }
 
-// startLedgerReplayAcquisitionLegacyLocked uses the standard mtGET_LEDGER
-// protocol to fetch only a successor ledger's header and transaction SHAMap.
-// This is the interoperable fast path for rippled peers, which do not advertise
-// go-xrpl's optional replay-delta extension. Completion locally replays the
-// transactions against the already-held parent and verifies both target roots.
 // Caller holds acquisitionMu.
 func (r *Router) startLedgerReplayAcquisitionLegacyLocked(seq uint32, hash [32]byte, peerID uint64) {
 	if seq != 0 && r.belowFloor(seq) {
@@ -1003,9 +996,7 @@ func (r *Router) startLedgerAcquisitionLegacyLocked(seq uint32, hash [32]byte, p
 	}
 }
 
-// canAdmitProvisionalFullStateLocked prevents competing full-state walks only
-// while confirming a fast-loaded ledger. Transaction-only replay acquisitions
-// remain unaffected. Caller holds acquisitionMu.
+// Caller holds acquisitionMu.
 func (r *Router) canAdmitProvisionalFullStateLocked(hash [32]byte) bool {
 	svc := r.adaptor.LedgerService()
 	if svc == nil || !svc.IsFastLoadProvisional() {
@@ -2867,10 +2858,6 @@ func (r *Router) completeInboundLedgerReady(il *inbound.Ledger) {
 	r.completeStoredConsensusRecovery(h.LedgerIndex, h.Hash, h.ParentHash, initialCandidate)
 }
 
-// completeStandardTransactionReplay turns a transaction-only mtGET_LEDGER
-// acquisition into a verified successor ledger. This keeps forward catch-up
-// interoperable with stock rippled peers: no custom handshake feature is
-// required, and the target account-state tree is never downloaded.
 func (r *Router) completeStandardTransactionReplay(
 	h *header.LedgerHeader,
 	txMap *shamap.SHAMap,

--- a/internal/consensus/adaptor/router_catchup_fallback_test.go
+++ b/internal/consensus/adaptor/router_catchup_fallback_test.go
@@ -1,0 +1,240 @@
+package adaptor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/require"
+)
+
+func storeRecoveryLedger(t *testing.T, svc *service.Service, l *ledger.Ledger) {
+	t.Helper()
+	stateMap, err := l.StateMapSnapshot()
+	require.NoError(t, err)
+	txMap, err := l.TxMapSnapshot()
+	require.NoError(t, err)
+	h := l.Header()
+	require.NoError(t, svc.StoreLedgerWithState(t.Context(), &h, stateMap, txMap))
+}
+
+func retireLegacyRecoveryStep(t *testing.T, r *Router, hash [32]byte) {
+	t.Helper()
+	il := r.fetchTracker.Find(hash)
+	require.NotNil(t, il)
+	require.True(t, r.fetchTracker.DiscardExpected(il))
+}
+
+func TestConsensusRecoveryLegacyFallbackWalksFromMovingAnchor(t *testing.T) {
+	r, _, sender, svc := makeRouter(t)
+	_, err := svc.AcceptLedger(context.Background())
+	require.NoError(t, err)
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+
+	_, anchor, anchorHash, anchorSeq := buildSuccessorAgainstParent(t, closed)
+	_, child1, child1Hash, child1Seq := buildSuccessorAgainstParent(t, anchor)
+	_, child2, child2Hash, child2Seq := buildSuccessorAgainstParent(t, child1)
+	_, _, targetHash, targetSeq := buildSuccessorAgainstParent(t, child2)
+	for _, link := range []struct {
+		seq    uint32
+		hash   [32]byte
+		parent [32]byte
+	}{
+		{anchorSeq, anchorHash, closed.Hash()},
+		{child1Seq, child1Hash, anchorHash},
+		{child2Seq, child2Hash, child1Hash},
+		{targetSeq, targetHash, child2Hash},
+	} {
+		r.recordSeqHash(link.seq, link.hash, link.parent, true)
+	}
+	storeRecoveryLedger(t, svc, anchor)
+	trackCatchupPeer(r, 7, targetSeq)
+	sender.mu.Lock()
+	sender.peerSupportsReplay = false
+	sender.mu.Unlock()
+
+	r.consensusRecovery = consensusRecovery{targetHash: targetHash, stepHash: anchorHash}
+	r.completeStoredConsensusRecovery(anchorSeq, anchorHash, closed.Hash(), false)
+
+	require.Equal(t, consensusRecovery{
+		targetHash: targetHash,
+		stepHash:   child1Hash,
+		anchorHash: anchorHash,
+		anchorSeq:  anchorSeq,
+	}, r.consensusRecovery)
+	require.Equal(t, []legacyBaseCall{{peerID: 7, hash: child1Hash, seq: child1Seq}}, sender.legacyCalls())
+	require.Empty(t, sender.replayCalls())
+	require.Nil(t, r.fetchTracker.Find(targetHash))
+
+	retireLegacyRecoveryStep(t, r, child1Hash)
+	storeRecoveryLedger(t, svc, child1)
+	r.completeStoredConsensusRecovery(child1Seq, child1Hash, anchorHash, false)
+	require.Equal(t, consensusRecovery{
+		targetHash: targetHash,
+		stepHash:   child2Hash,
+		anchorHash: child1Hash,
+		anchorSeq:  child1Seq,
+	}, r.consensusRecovery)
+
+	retireLegacyRecoveryStep(t, r, child2Hash)
+	storeRecoveryLedger(t, svc, child2)
+	r.completeStoredConsensusRecovery(child2Seq, child2Hash, child1Hash, false)
+	require.Equal(t, consensusRecovery{
+		targetHash: targetHash,
+		stepHash:   targetHash,
+		anchorHash: child2Hash,
+		anchorSeq:  child2Seq,
+	}, r.consensusRecovery)
+	require.Equal(t, []legacyBaseCall{
+		{peerID: 7, hash: child1Hash, seq: child1Seq},
+		{peerID: 7, hash: child2Hash, seq: child2Seq},
+		{peerID: 7, hash: targetHash, seq: targetSeq},
+	}, sender.legacyCalls())
+}
+
+func TestConsensusRecoveryReplayIssueFailureFallsBackToNextChild(t *testing.T) {
+	r, _, sender, svc := makeRouter(t)
+	_, err := svc.AcceptLedger(context.Background())
+	require.NoError(t, err)
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+
+	_, anchor, anchorHash, anchorSeq := buildSuccessorAgainstParent(t, closed)
+	_, child, childHash, childSeq := buildSuccessorAgainstParent(t, anchor)
+	_, _, targetHash, targetSeq := buildSuccessorAgainstParent(t, child)
+	r.recordSeqHash(anchorSeq, anchorHash, closed.Hash(), true)
+	r.recordSeqHash(childSeq, childHash, anchorHash, true)
+	r.recordSeqHash(targetSeq, targetHash, childHash, true)
+	storeRecoveryLedger(t, svc, anchor)
+	trackCatchupPeer(r, 7, targetSeq)
+	sender.mu.Lock()
+	sender.replayDeltaErr = errors.New("replay request failed")
+	sender.mu.Unlock()
+	r.consensusRecovery = consensusRecovery{
+		targetHash: targetHash,
+		anchorHash: anchorHash,
+		anchorSeq:  anchorSeq,
+	}
+
+	require.True(t, r.armPendingConsensusLedger())
+	require.Equal(t, []replayDeltaCall{{peerID: 7, hash: childHash}}, sender.replayCalls())
+	require.Equal(t, []legacyBaseCall{{peerID: 7, hash: childHash, seq: childSeq}}, sender.legacyCalls())
+	require.Equal(t, childHash, r.consensusRecovery.stepHash)
+	require.Zero(t, r.replayer.Count())
+	require.NotNil(t, r.fetchTracker.Find(childHash))
+	require.Nil(t, r.fetchTracker.Find(targetHash))
+}
+
+func TestConsensusRecoveryReplayFailureKeepsChildOfMovingTarget(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	_, err := svc.AcceptLedger(context.Background())
+	require.NoError(t, err)
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+
+	_, anchor, anchorHash, anchorSeq := buildSuccessorAgainstParent(t, closed)
+	_, child, childHash, childSeq := buildSuccessorAgainstParent(t, anchor)
+	_, oldTarget, oldTargetHash, oldTargetSeq := buildSuccessorAgainstParent(t, child)
+	_, _, newTargetHash, newTargetSeq := buildSuccessorAgainstParent(t, oldTarget)
+	for _, link := range []struct {
+		seq    uint32
+		hash   [32]byte
+		parent [32]byte
+	}{
+		{anchorSeq, anchorHash, closed.Hash()},
+		{childSeq, childHash, anchorHash},
+		{oldTargetSeq, oldTargetHash, childHash},
+		{newTargetSeq, newTargetHash, oldTargetHash},
+	} {
+		r.recordSeqHash(link.seq, link.hash, link.parent, true)
+	}
+	storeRecoveryLedger(t, svc, anchor)
+	trackCatchupPeer(r, 7, newTargetSeq)
+	r.consensusRecovery = consensusRecovery{
+		targetHash: oldTargetHash,
+		anchorHash: anchorHash,
+		anchorSeq:  anchorSeq,
+	}
+	require.True(t, r.armPendingConsensusLedger())
+	require.Equal(t, childHash, r.consensusRecovery.stepHash)
+	require.NoError(t, a.RequestLedger(consensus.LedgerID(newTargetHash)))
+
+	bad := &message.ReplayDeltaResponse{LedgerHash: childHash[:], Error: message.ReplyErrorNoLedger}
+	payload, err := message.Encode(bad)
+	require.NoError(t, err)
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  7,
+		Type:    message.TypeReplayDeltaResponse,
+		Payload: payload,
+	})
+
+	require.Equal(t, []legacyBaseCall{{peerID: 7, hash: childHash, seq: childSeq}}, sender.legacyCalls())
+	require.Equal(t, consensusRecovery{
+		targetHash: newTargetHash,
+		stepHash:   childHash,
+		anchorHash: anchorHash,
+		anchorSeq:  anchorSeq,
+	}, r.consensusRecovery)
+	require.Nil(t, r.fetchTracker.Find(newTargetHash))
+}
+
+func TestConsensusRecoveryLegacyFallbackRequiresCompleteAncestry(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		recordTarget bool
+		parentHash   [32]byte
+	}{
+		{name: "missing ancestry"},
+		{name: "broken linkage", recordTarget: true, parentHash: [32]byte{0xFF}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, _, sender, svc := makeRouter(t)
+			_, err := svc.AcceptLedger(context.Background())
+			require.NoError(t, err)
+			closed := svc.GetClosedLedger()
+			require.NotNil(t, closed)
+
+			_, anchor, anchorHash, anchorSeq := buildSuccessorAgainstParent(t, closed)
+			_, child, childHash, childSeq := buildSuccessorAgainstParent(t, anchor)
+			_, _, targetHash, targetSeq := buildSuccessorAgainstParent(t, child)
+			r.recordSeqHash(anchorSeq, anchorHash, closed.Hash(), true)
+			r.recordSeqHash(childSeq, childHash, tc.parentHash, true)
+			if tc.recordTarget {
+				r.recordSeqHash(targetSeq, targetHash, childHash, true)
+			}
+			storeRecoveryLedger(t, svc, anchor)
+			trackCatchupPeer(r, 7, targetSeq)
+			sender.mu.Lock()
+			sender.peerSupportsReplay = false
+			sender.mu.Unlock()
+			r.consensusRecovery = consensusRecovery{
+				targetHash: targetHash,
+				anchorHash: anchorHash,
+				anchorSeq:  anchorSeq,
+			}
+
+			require.True(t, r.armPendingConsensusLedger())
+			expectedSeq := uint32(0)
+			expectedRecovery := consensusRecovery{
+				targetHash: targetHash,
+				stepHash:   targetHash,
+				anchorHash: anchorHash,
+				anchorSeq:  anchorSeq,
+			}
+			if tc.recordTarget {
+				expectedSeq = targetSeq
+				expectedRecovery.anchorHash = [32]byte{}
+				expectedRecovery.anchorSeq = 0
+			}
+			require.Equal(t, []legacyBaseCall{{peerID: 7, hash: targetHash, seq: expectedSeq}}, sender.legacyCalls())
+			require.Equal(t, expectedRecovery, r.consensusRecovery)
+			require.Nil(t, r.fetchTracker.Find(childHash))
+		})
+	}
+}

--- a/internal/consensus/adaptor/router_catchup_fallback_test.go
+++ b/internal/consensus/adaptor/router_catchup_fallback_test.go
@@ -71,6 +71,9 @@ func TestConsensusRecoveryLegacyFallbackWalksFromMovingAnchor(t *testing.T) {
 	require.Equal(t, []legacyBaseCall{{peerID: 7, hash: child1Hash, seq: child1Seq}}, sender.legacyCalls())
 	require.Empty(t, sender.replayCalls())
 	require.Nil(t, r.fetchTracker.Find(targetHash))
+	childAcquisition := r.fetchTracker.Find(child1Hash)
+	require.NotNil(t, childAcquisition)
+	require.True(t, childAcquisition.TransactionOnly())
 
 	retireLegacyRecoveryStep(t, r, child1Hash)
 	storeRecoveryLedger(t, svc, child1)
@@ -128,6 +131,7 @@ func TestConsensusRecoveryReplayIssueFailureFallsBackToNextChild(t *testing.T) {
 	require.Equal(t, childHash, r.consensusRecovery.stepHash)
 	require.Zero(t, r.replayer.Count())
 	require.NotNil(t, r.fetchTracker.Find(childHash))
+	require.True(t, r.fetchTracker.Find(childHash).TransactionOnly())
 	require.Nil(t, r.fetchTracker.Find(targetHash))
 }
 

--- a/internal/consensus/adaptor/router_catchup_forward_test.go
+++ b/internal/consensus/adaptor/router_catchup_forward_test.go
@@ -284,6 +284,42 @@ func TestRouter_ProvisionalWarmStartFarGapJumpAdopts(t *testing.T) {
 	assert.True(t, svc.IsFastLoadProvisional())
 }
 
+func TestRouter_ProvisionalWarmStartAllowsOnlyOneFullStateAcquisition(t *testing.T) {
+	r, sender, svc := makeProvisionalWarmRouter(t)
+	closed := svc.GetClosedLedgerIndex()
+	targetSeq := closed + maxForwardDeltaGap + 1
+	trackCatchupPeer(r, 7, targetSeq+1)
+
+	firstHash := [32]byte{0xF1}
+	secondHash := [32]byte{0xF2}
+	require.True(t, r.startLedgerAcquisition(targetSeq, firstHash, 7))
+	assert.False(t, r.startLedgerAcquisition(targetSeq+1, secondHash, 7))
+
+	assert.NotNil(t, r.fetchTracker.Find(firstHash))
+	assert.Nil(t, r.fetchTracker.Find(secondHash))
+	require.Len(t, sender.legacyCalls(), 1)
+	assert.Equal(t, firstHash, sender.legacyCalls()[0].hash)
+}
+
+func TestRouter_ProvisionalWarmStartStillAllowsTransactionOnlyReplay(t *testing.T) {
+	r, sender, svc := makeProvisionalWarmRouter(t)
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	trackCatchupPeer(r, 7, closed.Sequence()+maxForwardDeltaGap+1)
+
+	fullHash := [32]byte{0xF1}
+	require.True(t, r.startLedgerAcquisition(closed.Sequence()+maxForwardDeltaGap+1, fullHash, 7))
+
+	nextHash := [32]byte{0xB1}
+	require.True(t, r.startLedgerAcquisition(closed.Sequence()+1, nextHash, 7))
+
+	assert.NotNil(t, r.fetchTracker.Find(fullHash))
+	assert.True(t, r.isAcquiring(nextHash))
+	require.Len(t, sender.legacyCalls(), 1)
+	require.Len(t, sender.replayCalls(), 1)
+	assert.Equal(t, nextHash, sender.replayCalls()[0].hash)
+}
+
 func TestRouter_ProvisionalWarmStartRecentForkJumpAdopts(t *testing.T) {
 	r, sender, svc := makeProvisionalWarmRouter(t)
 	closed := svc.GetClosedLedger()

--- a/internal/consensus/adaptor/router_replay_delta_test.go
+++ b/internal/consensus/adaptor/router_replay_delta_test.go
@@ -31,6 +31,7 @@ type recordingSender struct {
 	noopSender
 	mu               sync.Mutex
 	replayDeltaCalls []replayDeltaCall
+	replayDeltaErr   error
 	legacyBaseCalls  []legacyBaseCall
 	legacyBaseErr    error
 	legacyBaseErrs   map[uint64]error
@@ -63,7 +64,7 @@ func (s *recordingSender) RequestReplayDelta(peerID uint64, hash [32]byte) error
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.replayDeltaCalls = append(s.replayDeltaCalls, replayDeltaCall{peerID: peerID, hash: hash})
-	return nil
+	return s.replayDeltaErr
 }
 
 func (s *recordingSender) RequestLedgerBaseFromPeer(peerID uint64, hash [32]byte, seq uint32, indirect bool) error {

--- a/internal/consensus/adaptor/router_replay_delta_test.go
+++ b/internal/consensus/adaptor/router_replay_delta_test.go
@@ -338,10 +338,6 @@ func TestRouter_NoParent_FallsBackToLegacy(t *testing.T) {
 	assert.Equal(t, 0, r.replayer.Count(), "no replay-delta acquisition when no parent is available")
 }
 
-// TestRouter_PeerDoesNotSupportReplay_UsesStandardTransactionReplay verifies that
-// when the peer did NOT advertise the ledger-replay protocol feature
-// during handshake, the router uses standard mtGET_LEDGER but marks the
-// acquisition transaction-only so it does not download the child's state tree.
 func TestRouter_PeerDoesNotSupportReplay_UsesStandardTransactionReplay(t *testing.T) {
 	r, _, rs, svc := makeRouter(t)
 	parent := svc.GetClosedLedger()

--- a/internal/consensus/adaptor/router_replay_delta_test.go
+++ b/internal/consensus/adaptor/router_replay_delta_test.go
@@ -338,13 +338,11 @@ func TestRouter_NoParent_FallsBackToLegacy(t *testing.T) {
 	assert.Equal(t, 0, r.replayer.Count(), "no replay-delta acquisition when no parent is available")
 }
 
-// TestRouter_PeerDoesNotSupportReplay_FallsBackToLegacy verifies that
+// TestRouter_PeerDoesNotSupportReplay_UsesStandardTransactionReplay verifies that
 // when the peer did NOT advertise the ledger-replay protocol feature
-// during handshake, the router takes the legacy mtGET_LEDGER path even
-// if we have a local parent. Mirrors the policy behind
-// LedgerDeltaAcquire::trigger skipping peers without
-// ProtocolFeature::LedgerReplay.
-func TestRouter_PeerDoesNotSupportReplay_FallsBackToLegacy(t *testing.T) {
+// during handshake, the router uses standard mtGET_LEDGER but marks the
+// acquisition transaction-only so it does not download the child's state tree.
+func TestRouter_PeerDoesNotSupportReplay_UsesStandardTransactionReplay(t *testing.T) {
 	r, _, rs, svc := makeRouter(t)
 	parent := svc.GetClosedLedger()
 	require.NotNil(t, parent)
@@ -363,7 +361,41 @@ func TestRouter_PeerDoesNotSupportReplay_FallsBackToLegacy(t *testing.T) {
 	assert.Equal(t, target, calls[0].hash)
 	assert.Equal(t, uint64(11), calls[0].peerID)
 	assert.Equal(t, 0, r.replayer.Count(), "replay-delta must not be armed")
-	assert.NotNil(t, r.fetchTracker.Find(target), "legacy acquisition must be armed")
+	il := r.fetchTracker.Find(target)
+	require.NotNil(t, il, "standard acquisition must be armed")
+	assert.True(t, il.TransactionOnly(), "held parent must select the tx-only standard fast path")
+}
+
+func TestRouter_StandardTransactionReplay_EmptySuccessor(t *testing.T) {
+	r, _, rs, svc := makeRouter(t)
+	resp, targetHash, targetSeq := buildEmptyClosedSuccessorResponse(t, svc)
+
+	rs.mu.Lock()
+	rs.peerSupportsReplay = false
+	rs.mu.Unlock()
+	r.startLedgerAcquisition(targetSeq, targetHash, 11)
+	il := r.fetchTracker.Find(targetHash)
+	require.NotNil(t, il)
+	require.True(t, il.TransactionOnly())
+
+	// Stock rippled's liBASE reply contains header + state root. The tx root is
+	// absent for an empty transaction tree; transaction-only mode deliberately
+	// ignores the state root and completes immediately.
+	require.NoError(t, il.GotBase([]message.LedgerNode{
+		{NodeData: resp.LedgerHeader},
+		{NodeData: []byte{0x01}},
+	}))
+	require.True(t, il.IsComplete())
+	r.completeInboundLedger(il)
+
+	require.Nil(t, r.fetchTracker.Find(targetHash))
+	require.Zero(t, r.replayer.Count())
+	held, err := svc.GetLedgerByHash(targetHash)
+	require.NoError(t, err)
+	require.NotNil(t, held, "verified standard transaction replay must be stored")
+	assert.Equal(t, targetSeq, held.Sequence())
+	assert.Empty(t, rs.replayCalls())
+	assert.Len(t, rs.legacyCalls(), 1, "only the standard base request should be sent")
 }
 
 // TestRouter_ReplayDeltaResponse_Routed verifies that an inbound

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -191,9 +191,10 @@ type Engine struct {
 	// expired round waits at the close-time gate; reset each startRoundLocked.
 	roundExpiredReported bool
 
-	// lastSignTime is the monotonic floor for emitted validation SignTime: a
-	// regressing adaptor clock (NTP step, VM pause) is bumped to
-	// lastSignTime+1s so peers never see non-monotonic validations.
+	// lastSignTime is the whole-second, wire-canonical monotonic floor for
+	// emitted validation SignTime: a regressing adaptor clock (NTP step, VM
+	// pause) is bumped to lastSignTime+1s so peers never see non-monotonic
+	// validations.
 	// Protected by e.mu.
 	lastSignTime time.Time
 

--- a/internal/consensus/rcl/engine_accept.go
+++ b/internal/consensus/rcl/engine_accept.go
@@ -627,10 +627,13 @@ func (e *Engine) sendValidation(ledger consensus.Ledger) {
 
 	full := e.mode == consensus.ModeProposing
 
-	// SignTime under a monotonic floor: a regressing adaptor clock would emit
-	// a stale SignTime peers reject, so bump to lastSignTime+1s. SeenTime
-	// mirrors SignTime.
-	signTime := e.adaptor.Now()
+	// SignTime is a UINT32 count of XRPL epoch seconds on the wire. Normalize
+	// before signing and tracking so a validation relayed back by a peer is
+	// identical to the local copy; retaining adaptor-clock nanoseconds locally
+	// would make the tracker misclassify that echo as a conflicting validation.
+	// Keep the normalized time under a monotonic floor: a regressing adaptor
+	// clock is bumped to lastSignTime+1s so peers never see stale SignTimes.
+	signTime := time.Unix(e.adaptor.Now().Unix(), 0).UTC()
 	if !e.lastSignTime.IsZero() && !signTime.After(e.lastSignTime) {
 		signTime = e.lastSignTime.Add(1 * time.Second)
 	}

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -2790,6 +2790,56 @@ func TestSendValidation_ClockRegressionPreservesMonotonic(t *testing.T) {
 	}
 }
 
+// A locally generated validation is tracked before it is serialized. Since
+// sfSigningTime has whole-second precision, the local copy must use the same
+// precision or its peer-relayed echo looks like a same-sequence conflict.
+func TestSendValidation_PeerEchoIsNotConflicting(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.validator = true
+	adaptor.opMode = consensus.OpModeFull
+
+	engine := NewEngine(adaptor, DefaultConfig())
+	if err := engine.Start(t.Context()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer engine.Stop()
+
+	engine.StartRound(consensus.RoundID{
+		Seq:        100,
+		ParentHash: consensus.LedgerID{1},
+	}, true)
+
+	adaptor.mu.Lock()
+	adaptor.validationsBroadcast = nil
+	adaptor.now = time.Unix(1_700_000_000, 987_654_321).UTC()
+	adaptor.mu.Unlock()
+
+	engine.mu.Lock()
+	engine.sendValidation(&mockLedger{id: consensus.LedgerID{0xA1}, seq: 101})
+	engine.mu.Unlock()
+
+	adaptor.mu.RLock()
+	if len(adaptor.validationsBroadcast) != 1 {
+		adaptor.mu.RUnlock()
+		t.Fatalf("want one validation, got %d", len(adaptor.validationsBroadcast))
+	}
+	emitted := adaptor.validationsBroadcast[0]
+	adaptor.mu.RUnlock()
+
+	if emitted.SignTime.Nanosecond() != 0 {
+		t.Fatalf("SignTime must match whole-second wire precision, got %v", emitted.SignTime)
+	}
+
+	// Model the precision of sfSigningTime after serialize/parse and feed the
+	// echoed validation through the same tracker used by the engine.
+	echo := *emitted
+	echo.SignTime = time.Unix(emitted.SignTime.Unix(), 0).UTC()
+	echo.SeenTime = adaptor.Now()
+	if status := engine.validationTracker.AddStatus(&echo); status != ValStatusBadSeq {
+		t.Fatalf("peer echo status: want %v, got %v", ValStatusBadSeq, status)
+	}
+}
+
 // TestSendValidation_ClockMonotonic_NormalCase confirms the monotonic floor
 // does NOT inject an artificial step when the adaptor clock advances
 // normally. With a 3-second forward step, the second SignTime should be

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -2830,8 +2830,6 @@ func TestSendValidation_PeerEchoIsNotConflicting(t *testing.T) {
 		t.Fatalf("SignTime must match whole-second wire precision, got %v", emitted.SignTime)
 	}
 
-	// Model the precision of sfSigningTime after serialize/parse and feed the
-	// echoed validation through the same tracker used by the engine.
 	echo := *emitted
 	echo.SignTime = time.Unix(emitted.SignTime.Unix(), 0).UTC()
 	echo.SeenTime = adaptor.Now()

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -176,6 +176,15 @@ type Ledger struct {
 	// fetchPackRequested records that the router escalated this stalled
 	// acquisition to a fetch-pack (at most once). Guarded by mu.
 	fetchPackRequested bool
+
+	// transactionOnly is used by forward catch-up when the parent ledger is
+	// already held locally but the peer does not support the optional
+	// ledger-replay extension. Standard mtGET_LEDGER can still provide the
+	// target header and transaction SHAMap; the router replays those
+	// transactions against the held parent and verifies AccountHash before
+	// adoption. In this mode the peer's account-state SHAMap is deliberately
+	// ignored, avoiding a full-state download for every child ledger.
+	transactionOnly bool
 }
 
 // Option configures an acquisition at construction.
@@ -205,6 +214,16 @@ func WithFamily(family shamap.Family) Option {
 func WithHeaderAdmission(admit func(uint32) error) Option {
 	return func(l *Ledger) {
 		l.headerAdmission = admit
+	}
+}
+
+// WithTransactionOnly configures a standard-protocol acquisition to fetch the
+// target header and transaction SHAMap without walking its account-state
+// SHAMap. The result must be replayed against a locally-held parent and its
+// derived AccountHash verified before it is trusted.
+func WithTransactionOnly() Option {
+	return func(l *Ledger) {
+		l.transactionOnly = true
 	}
 }
 
@@ -269,6 +288,12 @@ func (l *Ledger) newSyncMap(t shamap.Type) (*shamap.SHAMap, error) {
 // Reason returns why this acquisition was started.
 func (l *Ledger) Reason() Reason {
 	return l.reason
+}
+
+// TransactionOnly reports whether this acquisition contains only the target
+// header and transaction SHAMap for local replay.
+func (l *Ledger) TransactionOnly() bool {
+	return l.transactionOnly
 }
 
 // State returns the current acquisition state.
@@ -628,7 +653,12 @@ func (l *Ledger) GotBaseUsefulContext(ctx context.Context, nodes []message.Ledge
 		)
 	}
 
-	if l.stateMap == nil && len(nodes) >= 2 && len(nodes[1].NodeData) > 0 {
+	if l.transactionOnly {
+		// The parent state is already local. Do not attach or persist the target
+		// state root: the replay engine derives the target state and verifies it
+		// against h.AccountHash before the router adopts the ledger.
+		l.haveState = true
+	} else if l.stateMap == nil && len(nodes) >= 2 && len(nodes[1].NodeData) > 0 {
 		sm, createErr := l.newSyncMap(shamap.TypeState)
 		if createErr != nil {
 			return useful, fmt.Errorf("create state map: %w", createErr)
@@ -664,7 +694,7 @@ func (l *Ledger) GotBaseUsefulContext(ctx context.Context, nodes []message.Ledge
 		useful++
 	}
 
-	if l.stateMap == nil || (h.TxHash != ([32]byte{}) && l.txMap == nil) {
+	if (!l.transactionOnly && l.stateMap == nil) || (h.TxHash != ([32]byte{}) && l.txMap == nil) {
 		return useful, nil
 	}
 	l.state = StateWantState

--- a/internal/ledger/inbound/tracker_test.go
+++ b/internal/ledger/inbound/tracker_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap"
 	"github.com/LeJamon/go-xrpl/shamap/backend"
+	"github.com/stretchr/testify/require"
 )
 
 type trackerBlockingFamily struct {
@@ -584,6 +585,48 @@ func TestInbound_FullAcquisitionWithTransactions(t *testing.T) {
 	if _, has := entry["needed_transaction_hashes"]; has {
 		t.Errorf("needed_transaction_hashes must be absent once tx acquired, got %#v", entry["needed_transaction_hashes"])
 	}
+}
+
+// TestInbound_TransactionOnlyAcquisition proves the standard-protocol replay
+// path ignores the target account-state tree and completes after fetching only
+// the header and transaction SHAMap. The router later replays this result
+// against its locally-held parent and verifies the derived AccountHash.
+func TestInbound_TransactionOnlyAcquisition(t *testing.T) {
+	t.Parallel()
+	stateRootHash, stateRoot, _ := buildSourceMap(t, shamap.TypeState)
+	txRootHash, txRoot, txWire := buildSourceMap(t, shamap.TypeTransaction)
+
+	hdr, hash := encodeHeader(header.LedgerHeader{
+		LedgerIndex: 701,
+		AccountHash: stateRootHash,
+		TxHash:      txRootHash,
+	})
+	il := New(hash, 701, 7, discardLogger(), WithTransactionOnly())
+	require.NoError(t, il.GotBase([]message.LedgerNode{
+		{NodeData: hdr},
+		{NodeData: stateRoot},
+		{NodeData: txRoot},
+	}))
+	require.True(t, il.TransactionOnly())
+	require.Nil(t, il.stateMap, "transaction-only acquisition must not construct the target state tree")
+	require.True(t, il.Snapshot().HaveState, "local replay supplies state after acquisition")
+	require.False(t, il.IsComplete(), "non-empty transaction tree is still outstanding")
+
+	requests, complete, err := il.CollectMissingAddedRequestsContext(t.Context(), []uint64{7})
+	require.NoError(t, err)
+	require.False(t, complete)
+	require.NotEmpty(t, requests)
+	for _, request := range requests {
+		require.True(t, request.Transaction, "transaction-only mode must never request state nodes")
+	}
+
+	require.NoError(t, il.GotTransactionNodes(txWire))
+	il.CollectMissingRequest(false)
+	require.True(t, il.IsComplete())
+	_, gotState, gotTx, err := il.Result()
+	require.NoError(t, err)
+	require.Nil(t, gotState)
+	require.NotNil(t, gotTx)
 }
 
 // TestInbound_EmptyTxTreeImmediatelyComplete confirms a ledger with no

--- a/internal/ledger/inbound/tracker_test.go
+++ b/internal/ledger/inbound/tracker_test.go
@@ -587,10 +587,6 @@ func TestInbound_FullAcquisitionWithTransactions(t *testing.T) {
 	}
 }
 
-// TestInbound_TransactionOnlyAcquisition proves the standard-protocol replay
-// path ignores the target account-state tree and completes after fetching only
-// the header and transaction SHAMap. The router later replays this result
-// against its locally-held parent and verifies the derived AccountHash.
 func TestInbound_TransactionOnlyAcquisition(t *testing.T) {
 	t.Parallel()
 	stateRootHash, stateRoot, _ := buildSourceMap(t, shamap.TypeState)

--- a/internal/ledger/service/fast_load.go
+++ b/internal/ledger/service/fast_load.go
@@ -56,13 +56,36 @@ func (s *Service) loadLatestLedger(ctx context.Context) (*ledger.Ledger, error) 
 	if !storedHeaderMatchesInfo(h, info) {
 		return nil, fmt.Errorf("ledger %d header does not match persisted metadata", info.Sequence)
 	}
-	if err := s.verifyStoredSHAMap(ctx, h.AccountHash, shamap.TypeState); err != nil {
-		return nil, fmt.Errorf("ledger %d state tree: %w", info.Sequence, err)
+	accepted, checkpointErr := s.acceptFastLoadCheckpoint(ctx, s.startupFastLoadCheckpoint, h)
+	if checkpointErr != nil {
+		s.logger.Warn("Fast-load checkpoint rejected; using strict traversal",
+			"sequence", h.LedgerIndex,
+			"err", checkpointErr,
+		)
 	}
-	if h.TxHash != ([32]byte{}) {
-		if err := s.verifyStoredSHAMap(ctx, h.TxHash, shamap.TypeTransaction); err != nil {
-			return nil, fmt.Errorf("ledger %d transaction tree: %w", info.Sequence, err)
+	if !accepted {
+		stateMetrics, err := s.verifyStoredSHAMapMeasured(ctx, h.AccountHash, shamap.TypeState)
+		if err != nil {
+			return nil, fmt.Errorf("ledger %d state tree: %w", info.Sequence, err)
 		}
+		metrics := stateMetrics
+		if h.TxHash != ([32]byte{}) {
+			txMetrics, err := s.verifyStoredSHAMapMeasured(ctx, h.TxHash, shamap.TypeTransaction)
+			if err != nil {
+				return nil, fmt.Errorf("ledger %d transaction tree: %w", info.Sequence, err)
+			}
+			metrics.nodes += txMetrics.nodes
+			metrics.elapsed += txMetrics.elapsed
+		}
+		s.fastLoadStrictNodes.Store(metrics.nodes)
+		s.fastLoadStrictElapsed.Store(uint64(metrics.elapsed))
+		s.markFastLoadCheckpointEligible()
+		s.logger.Info("Fast-load strict traversal completed",
+			"sequence", h.LedgerIndex,
+			"checkpoint_fallback", s.startupFastLoadCheckpoint != nil,
+			"nodes_checked", metrics.nodes,
+			"elapsed", metrics.elapsed.String(),
+		)
 	}
 	if err := loaded.SetValidated(); err != nil {
 		return nil, fmt.Errorf("mark newest ledger %d validated: %w", info.Sequence, err)
@@ -210,10 +233,29 @@ func mergeFeeSettings(fees drops.Fees, settings *state.FeeSettings) drops.Fees {
 }
 
 func (s *Service) verifyStoredSHAMap(ctx context.Context, root [32]byte, mapType shamap.Type) error {
+	_, err := s.verifyStoredSHAMapMeasured(ctx, root, mapType)
+	return err
+}
+
+type storedSHAMapVerificationMetrics struct {
+	nodes   uint64
+	elapsed time.Duration
+}
+
+func (s *Service) verifyStoredSHAMapMeasured(
+	ctx context.Context,
+	root [32]byte,
+	mapType shamap.Type,
+) (storedSHAMapVerificationMetrics, error) {
 	startedAt := time.Now()
 	ticker := time.NewTicker(storedSHAMapVerificationLogInterval)
 	defer ticker.Stop()
-	return s.verifyStoredSHAMapWithTicks(ctx, root, mapType, startedAt, time.Now, ticker.C)
+	var metrics storedSHAMapVerificationMetrics
+	err := s.verifyStoredSHAMapWithTicksReport(
+		ctx, root, mapType, startedAt, time.Now, ticker.C,
+		func(result storedSHAMapVerificationMetrics) { metrics = result },
+	)
+	return metrics, err
 }
 
 func (s *Service) verifyStoredSHAMapWithTicks(
@@ -224,9 +266,31 @@ func (s *Service) verifyStoredSHAMapWithTicks(
 	now func() time.Time,
 	ticks <-chan time.Time,
 ) (err error) {
+	return s.verifyStoredSHAMapWithTicksReport(ctx, root, mapType, startedAt, now, ticks, nil)
+}
+
+func (s *Service) verifyStoredSHAMapWithTicksReport(
+	ctx context.Context,
+	root [32]byte,
+	mapType shamap.Type,
+	startedAt time.Time,
+	now func() time.Time,
+	ticks <-chan time.Time,
+	report func(storedSHAMapVerificationMetrics),
+) (err error) {
 	progress := newStoredSHAMapVerificationProgress(s.logger, s.nodeStore, root, mapType, startedAt)
 	defer func() {
-		progress.finish(now(), err)
+		finishedAt := now()
+		progress.finish(finishedAt, err)
+		if err == nil && report != nil {
+			elapsed := finishedAt.Sub(startedAt)
+			if elapsed < 0 {
+				elapsed = 0
+			}
+			report(storedSHAMapVerificationMetrics{
+				nodes: progress.nodesChecked.Load(), elapsed: elapsed,
+			})
+		}
 	}()
 
 	if root == ([32]byte{}) {

--- a/internal/ledger/service/fast_load.go
+++ b/internal/ledger/service/fast_load.go
@@ -233,6 +233,14 @@ func (s *Service) verifyStoredSHAMapWithTicks(
 		return fmt.Errorf("zero root")
 	}
 
+	// The strict startup walk proves these durable subtrees complete. Retain
+	// shallow proofs and publish them only after the whole traversal succeeds,
+	// so the first inbound-ledger missing-node walk can skip the shared stored
+	// state instead of reading it all again. A concurrent generation reset makes
+	// Insert reject these old-generation proofs.
+	proofs := newStoredSHAMapProofs(s.shamapFamily)
+	proofs.record(storedSHAMapNode{hash: root})
+
 	fetch := s.storedSHAMapVerificationFetch()
 	rootNode, _, err := s.loadStoredSHAMapNodeWithFetch(
 		ctx,
@@ -270,8 +278,9 @@ func (s *Service) verifyStoredSHAMapWithTicks(
 		workers*storedSHAMapFrontierTasksPerWorker,
 		mapType,
 		fetch,
-		func() {
+		func(node storedSHAMapNode) {
 			progress.nodesChecked.Add(1)
+			proofs.record(node)
 		},
 	)
 	for _, count := range outstanding {
@@ -286,6 +295,7 @@ func (s *Service) verifyStoredSHAMapWithTicks(
 	startedWorkers := min(workers, len(frontier))
 	progress.configureWorkers(workers, startedWorkers, len(frontier))
 	if len(frontier) == 0 {
+		proofs.publish()
 		return nil
 	}
 
@@ -331,8 +341,9 @@ func (s *Service) verifyStoredSHAMapWithTicks(
 					[]storedSHAMapNode{task.node},
 					mapType,
 					fetch,
-					func([32]byte, *nodestore.Node) error {
+					func(node storedSHAMapNode, _ *nodestore.Node) error {
 						unreportedNodes++
+						proofs.record(node)
 						if unreportedNodes == storedSHAMapNodeCountBatch {
 							progress.nodesChecked.Add(unreportedNodes)
 							unreportedNodes = 0
@@ -371,13 +382,63 @@ func (s *Service) verifyStoredSHAMapWithTicks(
 			}
 			select {
 			case <-workersDone:
-				return context.Cause(walkCtx)
+				err = context.Cause(walkCtx)
+				if err == nil {
+					proofs.publish()
+				}
+				return err
 			default:
 			}
 			progress.report(tick)
 		case <-workersDone:
-			return context.Cause(walkCtx)
+			err = context.Cause(walkCtx)
+			if err == nil {
+				proofs.publish()
+			}
+			return err
 		}
+	}
+}
+
+type storedSHAMapProofs struct {
+	cache      *shamap.FullBelowCache
+	generation uint32
+	mu         sync.Mutex
+	hashes     [][32]byte
+}
+
+func newStoredSHAMapProofs(family shamap.Family) *storedSHAMapProofs {
+	proofs := &storedSHAMapProofs{}
+	provider, ok := family.(interface {
+		FullBelowCache() *shamap.FullBelowCache
+	})
+	if !ok || provider.FullBelowCache() == nil {
+		return proofs
+	}
+	proofs.cache = provider.FullBelowCache()
+	proofs.generation = proofs.cache.Generation()
+	return proofs
+}
+
+func (p *storedSHAMapProofs) record(node storedSHAMapNode) {
+	if p.cache == nil || node.depth > shamap.FullBelowCacheMaxDepth {
+		return
+	}
+	p.mu.Lock()
+	p.hashes = append(p.hashes, node.hash)
+	p.mu.Unlock()
+}
+
+func (p *storedSHAMapProofs) publish() {
+	if p.cache == nil {
+		return
+	}
+	p.mu.Lock()
+	hashes := p.hashes
+	p.hashes = nil
+	p.mu.Unlock()
+	for _, hash := range hashes {
+		p.cache.Insert(p.generation, hash)
 	}
 }
 
@@ -427,7 +488,7 @@ func (s *Service) buildStoredSHAMapFrontier(
 	target int,
 	mapType shamap.Type,
 	fetch storedSHAMapFetch,
-	visit func(),
+	visit func(storedSHAMapNode),
 ) ([]storedSHAMapTask, []uint32, error) {
 	splitRootBranches := target > storedSHAMapFrontierTasksPerWorker
 	target = max(target, len(branches))
@@ -463,7 +524,7 @@ func (s *Service) buildStoredSHAMapFrontier(
 			return frontier, outstanding, err
 		}
 		if visit != nil {
-			visit()
+			visit(task.node)
 		}
 		outstanding[task.branch]--
 		for _, child := range children {
@@ -501,7 +562,12 @@ func (s *Service) walkStoredSHAMapWithFetch(
 		[]storedSHAMapNode{{hash: root}},
 		mapType,
 		fetch,
-		visit,
+		func(node storedSHAMapNode, stored *nodestore.Node) error {
+			if visit == nil {
+				return nil
+			}
+			return visit(node.hash, stored)
+		},
 	)
 }
 
@@ -510,7 +576,7 @@ func (s *Service) walkStoredSHAMapNodesWithFetch(
 	stack []storedSHAMapNode,
 	mapType shamap.Type,
 	fetch storedSHAMapFetch,
-	visit func([32]byte, *nodestore.Node) error,
+	visit func(storedSHAMapNode, *nodestore.Node) error,
 ) error {
 	for len(stack) > 0 {
 		if err := ctx.Err(); err != nil {
@@ -527,7 +593,7 @@ func (s *Service) walkStoredSHAMapNodesWithFetch(
 			return err
 		}
 		if visit != nil {
-			if err := visit(pending.hash, stored); err != nil {
+			if err := visit(pending, stored); err != nil {
 				return err
 			}
 		}

--- a/internal/ledger/service/fast_load_checkpoint.go
+++ b/internal/ledger/service/fast_load_checkpoint.go
@@ -1,0 +1,528 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/crypto/sha512half"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/LeJamon/go-xrpl/storage/nodestore"
+	"github.com/LeJamon/go-xrpl/storage/relationaldb"
+)
+
+const (
+	fastLoadCheckpointVersion   = uint16(2)
+	fastLoadCheckpointTombstone = byte(0)
+	fastLoadCheckpointActive    = byte(1)
+	fastLoadCheckpointFixedSize = 8 + 2 + 1 + 4 + 32 + 32 + 32 + 32 + 32 + 8 + 8 + 4 + 4 + 32
+
+	fastLoadCheckpointIneligible  uint32 = 0
+	fastLoadCheckpointEligible           = 1
+	fastLoadCheckpointInvalidated        = 2
+)
+
+var (
+	fastLoadCheckpointMagic = [8]byte{'g', 'o', 'X', 'R', 'P', 'L', 'f', 'c'}
+	fastLoadCheckpointKey   = nodestore.Hash256(sha512half.Sum([]byte("go-xrpl fast-load checkpoint v1")))
+)
+
+type fastLoadCheckpoint struct {
+	sequence             uint32
+	ledgerHash           [32]byte
+	stateRoot            [32]byte
+	txRoot               [32]byte
+	nodeStoreFingerprint [32]byte
+	schemaFingerprint    [32]byte
+	strictNodes          uint64
+	strictElapsed        uint64
+	stateProofs          [][32]byte
+	txProofs             [][32]byte
+}
+
+func maxFastLoadProofs() int {
+	total := 0
+	level := 1
+	for depth := 0; depth <= shamap.FullBelowCacheMaxDepth; depth++ {
+		total += level
+		level *= shamap.BranchFactor
+	}
+	return total
+}
+
+func maxFastLoadCheckpointSize() int {
+	return fastLoadCheckpointFixedSize + 2*maxFastLoadProofs()*32
+}
+
+func encodeFastLoadCheckpoint(checkpoint *fastLoadCheckpoint) []byte {
+	if checkpoint == nil {
+		return finishFastLoadCheckpointEncoding(appendFastLoadCheckpointHeader(nil, fastLoadCheckpointTombstone))
+	}
+	data := appendFastLoadCheckpointHeader(
+		make([]byte, 0, fastLoadCheckpointFixedSize+(len(checkpoint.stateProofs)+len(checkpoint.txProofs))*32),
+		fastLoadCheckpointActive,
+	)
+	data = binary.BigEndian.AppendUint32(data, checkpoint.sequence)
+	data = append(data, checkpoint.ledgerHash[:]...)
+	data = append(data, checkpoint.stateRoot[:]...)
+	data = append(data, checkpoint.txRoot[:]...)
+	data = append(data, checkpoint.nodeStoreFingerprint[:]...)
+	data = append(data, checkpoint.schemaFingerprint[:]...)
+	data = binary.BigEndian.AppendUint64(data, checkpoint.strictNodes)
+	data = binary.BigEndian.AppendUint64(data, checkpoint.strictElapsed)
+	data = binary.BigEndian.AppendUint32(data, uint32(len(checkpoint.stateProofs)))
+	data = binary.BigEndian.AppendUint32(data, uint32(len(checkpoint.txProofs)))
+	for _, hash := range checkpoint.stateProofs {
+		data = append(data, hash[:]...)
+	}
+	for _, hash := range checkpoint.txProofs {
+		data = append(data, hash[:]...)
+	}
+	return finishFastLoadCheckpointEncoding(data)
+}
+
+func appendFastLoadCheckpointHeader(data []byte, status byte) []byte {
+	data = append(data, fastLoadCheckpointMagic[:]...)
+	data = binary.BigEndian.AppendUint16(data, fastLoadCheckpointVersion)
+	return append(data, status)
+}
+
+func finishFastLoadCheckpointEncoding(data []byte) []byte {
+	checksum := sha512half.Sum(data)
+	return append(data, checksum[:]...)
+}
+
+func decodeFastLoadCheckpoint(data []byte) (*fastLoadCheckpoint, bool, error) {
+	if len(data) > maxFastLoadCheckpointSize() {
+		return nil, false, fmt.Errorf("checkpoint is oversized: %d bytes", len(data))
+	}
+	const headerSize = 8 + 2 + 1
+	if len(data) < headerSize+32 {
+		return nil, false, errors.New("checkpoint is truncated")
+	}
+	payload := data[:len(data)-32]
+	wantChecksum := sha512half.Sum(payload)
+	if !bytes.Equal(data[len(data)-32:], wantChecksum[:]) {
+		return nil, false, errors.New("checkpoint checksum mismatch")
+	}
+	if !bytes.Equal(payload[:8], fastLoadCheckpointMagic[:]) {
+		return nil, false, errors.New("checkpoint magic mismatch")
+	}
+	if version := binary.BigEndian.Uint16(payload[8:10]); version != fastLoadCheckpointVersion {
+		return nil, false, fmt.Errorf("unsupported checkpoint version %d", version)
+	}
+	status := payload[10]
+	if status == fastLoadCheckpointTombstone {
+		if len(payload) != headerSize {
+			return nil, false, errors.New("malformed checkpoint tombstone")
+		}
+		return nil, true, nil
+	}
+	if status != fastLoadCheckpointActive {
+		return nil, false, fmt.Errorf("unknown checkpoint status %d", status)
+	}
+	if len(data) < fastLoadCheckpointFixedSize {
+		return nil, false, errors.New("active checkpoint is truncated")
+	}
+	offset := headerSize
+	checkpoint := &fastLoadCheckpoint{sequence: binary.BigEndian.Uint32(payload[offset : offset+4])}
+	offset += 4
+	copy(checkpoint.ledgerHash[:], payload[offset:offset+32])
+	offset += 32
+	copy(checkpoint.stateRoot[:], payload[offset:offset+32])
+	offset += 32
+	copy(checkpoint.txRoot[:], payload[offset:offset+32])
+	offset += 32
+	copy(checkpoint.nodeStoreFingerprint[:], payload[offset:offset+32])
+	offset += 32
+	copy(checkpoint.schemaFingerprint[:], payload[offset:offset+32])
+	offset += 32
+	checkpoint.strictNodes = binary.BigEndian.Uint64(payload[offset : offset+8])
+	offset += 8
+	checkpoint.strictElapsed = binary.BigEndian.Uint64(payload[offset : offset+8])
+	offset += 8
+	if checkpoint.strictElapsed > math.MaxInt64 {
+		return nil, false, errors.New("checkpoint strict traversal duration overflows")
+	}
+	stateCount := binary.BigEndian.Uint32(payload[offset : offset+4])
+	offset += 4
+	txCount := binary.BigEndian.Uint32(payload[offset : offset+4])
+	offset += 4
+	maxProofs := uint32(maxFastLoadProofs())
+	if stateCount == 0 || stateCount > maxProofs || txCount > maxProofs {
+		return nil, false, fmt.Errorf("invalid checkpoint proof counts state=%d transaction=%d", stateCount, txCount)
+	}
+	proofBytes := uint64(stateCount+txCount) * 32
+	if proofBytes != uint64(len(payload)-offset) {
+		return nil, false, errors.New("checkpoint proof data length mismatch")
+	}
+	checkpoint.stateProofs = make([][32]byte, stateCount)
+	checkpoint.txProofs = make([][32]byte, txCount)
+	seen := make(map[[32]byte]struct{}, int(stateCount+txCount))
+	readProofs := func(proofs [][32]byte) error {
+		for i := range proofs {
+			copy(proofs[i][:], payload[offset:offset+32])
+			offset += 32
+			if proofs[i] == ([32]byte{}) {
+				return errors.New("checkpoint contains a zero proof hash")
+			}
+			if _, duplicate := seen[proofs[i]]; duplicate {
+				return fmt.Errorf("checkpoint contains duplicate proof hash %x", proofs[i][:8])
+			}
+			seen[proofs[i]] = struct{}{}
+		}
+		return nil
+	}
+	if err := readProofs(checkpoint.stateProofs); err != nil {
+		return nil, false, err
+	}
+	if err := readProofs(checkpoint.txProofs); err != nil {
+		return nil, false, err
+	}
+	if checkpoint.sequence == 0 || checkpoint.ledgerHash == ([32]byte{}) || checkpoint.stateRoot == ([32]byte{}) ||
+		checkpoint.nodeStoreFingerprint == ([32]byte{}) || checkpoint.schemaFingerprint == ([32]byte{}) {
+		return nil, false, errors.New("checkpoint contains empty ledger identity")
+	}
+	if checkpoint.stateProofs[0] != checkpoint.stateRoot {
+		return nil, false, errors.New("checkpoint state proof does not start at its root")
+	}
+	if checkpoint.txRoot == ([32]byte{}) {
+		if len(checkpoint.txProofs) != 0 {
+			return nil, false, errors.New("zero transaction root has proof data")
+		}
+	} else if len(checkpoint.txProofs) == 0 || checkpoint.txProofs[0] != checkpoint.txRoot {
+		return nil, false, errors.New("checkpoint transaction proof does not start at its root")
+	}
+	return checkpoint, false, nil
+}
+
+func (s *Service) consumeFastLoadCheckpoint(ctx context.Context) (*fastLoadCheckpoint, error) {
+	if s.nodeStore == nil {
+		return nil, nil
+	}
+	node, fetchErr := s.nodeStore.Fetch(ctx, fastLoadCheckpointKey)
+	if node == nil && fetchErr == nil {
+		s.logger.Info("Fast-load checkpoint unavailable", "reason", "missing")
+		return nil, nil
+	}
+	var checkpoint *fastLoadCheckpoint
+	var tombstone bool
+	var decodeErr error
+	if fetchErr == nil {
+		if node.Type != nodestore.NodeLedger || node.Hash != fastLoadCheckpointKey {
+			decodeErr = errors.New("checkpoint has invalid NodeStore metadata")
+		} else {
+			checkpoint, tombstone, decodeErr = decodeFastLoadCheckpoint(node.Data)
+			if decodeErr == nil && checkpoint != nil && node.LedgerSeq != checkpoint.sequence {
+				decodeErr = errors.New("checkpoint sequence does not match NodeStore metadata")
+			}
+		}
+	}
+	if fetchErr == nil && decodeErr == nil && tombstone {
+		s.logger.Info("Fast-load checkpoint unavailable", "reason", "tombstone")
+		return nil, nil
+	}
+	durable, ok := s.nodeStore.(nodestore.DurableDatabase)
+	if !ok {
+		return nil, errors.New("consume fast-load checkpoint: NodeStore has no durable checkpoint capability")
+	}
+	tombstoneData := encodeFastLoadCheckpoint(nil)
+	if err := durable.StoreDurable(context.WithoutCancel(ctx), &nodestore.Node{
+		Type: nodestore.NodeLedger, Hash: fastLoadCheckpointKey, Data: tombstoneData,
+	}); err != nil {
+		return nil, fmt.Errorf("consume fast-load checkpoint: %w", err)
+	}
+	if fetchErr != nil {
+		s.logger.Warn("Fast-load checkpoint unreadable and consumed", "err", fetchErr)
+		return nil, nil
+	}
+	if decodeErr != nil {
+		s.logger.Warn("Fast-load checkpoint rejected and consumed", "err", decodeErr)
+		return nil, nil
+	}
+	s.logger.Info("Fast-load checkpoint consumed", "sequence", checkpoint.sequence)
+	return checkpoint, nil
+}
+
+func (s *Service) collectFastLoadProofs(
+	ctx context.Context,
+	root [32]byte,
+	mapType shamap.Type,
+) ([][32]byte, error) {
+	if root == ([32]byte{}) {
+		if mapType == shamap.TypeTransaction {
+			return nil, nil
+		}
+		return nil, errors.New("zero state root")
+	}
+	queue := []storedSHAMapNode{{hash: root}}
+	proofs := make([][32]byte, 0, min(maxFastLoadProofs(), 256))
+	seen := make(map[[32]byte]struct{})
+	fetch := s.storedSHAMapVerificationFetch()
+	for len(queue) != 0 {
+		pending := queue[0]
+		queue = queue[1:]
+		if _, duplicate := seen[pending.hash]; duplicate {
+			return nil, fmt.Errorf("reachable shallow graph contains duplicate node %x", pending.hash[:8])
+		}
+		seen[pending.hash] = struct{}{}
+		node, _, err := s.loadStoredSHAMapNodeWithFetch(ctx, pending, mapType, fetch)
+		if err != nil {
+			return nil, err
+		}
+		proofs = append(proofs, pending.hash)
+		if pending.depth == shamap.FullBelowCacheMaxDepth {
+			continue
+		}
+		inner, ok := node.(shamap.InnerNodeReader)
+		if !ok {
+			continue
+		}
+		for branch := range shamap.BranchFactor {
+			if inner.IsEmptyBranch(branch) {
+				continue
+			}
+			child, err := inner.ChildHash(branch)
+			if err != nil {
+				return nil, err
+			}
+			queue = append(queue, storedSHAMapNode{hash: child, depth: pending.depth + 1})
+		}
+	}
+	return proofs, nil
+}
+
+func (s *Service) acceptFastLoadCheckpoint(
+	ctx context.Context,
+	checkpoint *fastLoadCheckpoint,
+	h header.LedgerHeader,
+) (bool, error) {
+	if checkpoint == nil {
+		return false, nil
+	}
+	if checkpoint.sequence != h.LedgerIndex || checkpoint.ledgerHash != h.Hash ||
+		checkpoint.stateRoot != h.AccountHash || checkpoint.txRoot != h.TxHash {
+		return false, errors.New("checkpoint ledger identity does not match durable tip")
+	}
+	durable, schema, err := s.fastLoadDurability()
+	if err != nil {
+		return false, err
+	}
+	accepted := false
+	err = durable.WithDurableSnapshot(ctx, func(nodeFingerprint [32]byte) error {
+		if nodeFingerprint != checkpoint.nodeStoreFingerprint {
+			return errors.New("checkpoint NodeStore identity or mutation generation mismatch")
+		}
+		schemaFingerprint, err := schema.SchemaFingerprint(ctx)
+		if err != nil {
+			return fmt.Errorf("fingerprint relational database: %w", err)
+		}
+		if schemaFingerprint != checkpoint.schemaFingerprint {
+			return errors.New("checkpoint relational identity or schema mismatch")
+		}
+		stateProofs, err := s.collectFastLoadProofs(ctx, h.AccountHash, shamap.TypeState)
+		if err != nil {
+			return fmt.Errorf("revalidate checkpoint state proof: %w", err)
+		}
+		if !equalFastLoadProofs(stateProofs, checkpoint.stateProofs) {
+			return errors.New("checkpoint state proof mismatch")
+		}
+		txProofs, err := s.collectFastLoadProofs(ctx, h.TxHash, shamap.TypeTransaction)
+		if err != nil {
+			return fmt.Errorf("revalidate checkpoint transaction proof: %w", err)
+		}
+		if !equalFastLoadProofs(txProofs, checkpoint.txProofs) {
+			return errors.New("checkpoint transaction proof mismatch")
+		}
+		provider, ok := s.shamapFamily.(interface {
+			FullBelowCache() *shamap.FullBelowCache
+		})
+		if !ok || provider.FullBelowCache() == nil {
+			return errors.New("SHAMap family has no shared full-below cache")
+		}
+		cache := provider.FullBelowCache()
+		generation := cache.Generation()
+		for _, hash := range stateProofs {
+			cache.Insert(generation, hash)
+		}
+		for _, hash := range txProofs {
+			cache.Insert(generation, hash)
+		}
+		s.fastLoadStrictNodes.Store(checkpoint.strictNodes)
+		s.fastLoadStrictElapsed.Store(checkpoint.strictElapsed)
+		s.markFastLoadCheckpointEligible()
+		s.logger.Info("Fast-load checkpoint accepted",
+			"sequence", h.LedgerIndex,
+			"strict_traversals_saved", 1+boolInt(h.TxHash != ([32]byte{})),
+			"strict_nodes_saved", checkpoint.strictNodes,
+			"strict_elapsed_saved", time.Duration(checkpoint.strictElapsed).String(),
+			"shallow_nodes_read", len(stateProofs)+len(txProofs),
+		)
+		accepted = true
+		return nil
+	})
+	return accepted, err
+}
+
+func equalFastLoadProofs(left, right [][32]byte) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func boolInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+// InvalidateFastLoadCheckpointEligibility prevents shutdown from publishing a
+// proof across a destructive NodeStore mutation.
+func (s *Service) InvalidateFastLoadCheckpointEligibility() {
+	s.fastLoadCheckpointState.Store(fastLoadCheckpointInvalidated)
+}
+
+func (s *Service) markFastLoadCheckpointEligible() {
+	s.fastLoadCheckpointState.CompareAndSwap(fastLoadCheckpointIneligible, fastLoadCheckpointEligible)
+}
+
+// PrepareFastLoadCheckpoint publishes a one-use checkpoint for the next clean
+// start. The service must already be stopped so persistence and validation tips
+// cannot move while the durable state is checked.
+func (s *Service) PrepareFastLoadCheckpoint(ctx context.Context) (bool, error) {
+	if !s.config.FastLoad || s.nodeStore == nil || s.shamapFamily == nil || s.relationalDB == nil {
+		s.logger.Info("Fast-load checkpoint not prepared", "reason", "checkpointing is not configured")
+		return false, nil
+	}
+	s.lifecycleMu.Lock()
+	stopped := s.lifecycleState == serviceStopped
+	s.lifecycleMu.Unlock()
+	if !stopped {
+		return false, errors.New("prepare fast-load checkpoint before ledger service stopped")
+	}
+	if s.fastLoadCheckpointState.Load() != fastLoadCheckpointEligible {
+		s.logger.Info("Fast-load checkpoint not prepared", "reason", "run is not eligible")
+		return false, nil
+	}
+	if err := s.nodeStore.Sync(ctx); err != nil {
+		return false, fmt.Errorf("sync NodeStore before fast-load checkpoint: %w", err)
+	}
+	s.mu.RLock()
+	validated := s.validatedLedger
+	s.mu.RUnlock()
+	if validated == nil || !validated.IsValidated() || !s.hasCompleteLedger(validated) {
+		return false, errors.New("latest validated ledger is not durably complete")
+	}
+	h := validated.Header()
+	info, err := s.relationalDB.Ledger().GetNewestLedgerInfo(ctx)
+	if err != nil {
+		return false, fmt.Errorf("load newest relational ledger for checkpoint: %w", err)
+	}
+	tip, err := s.nodeStore.Fetch(ctx, validatedTipKey)
+	if err != nil {
+		return false, fmt.Errorf("fetch durable validated tip for checkpoint: %w", err)
+	}
+	if tip == nil || tip.Type != nodestore.NodeLedger || tip.LedgerSeq != h.LedgerIndex ||
+		len(tip.Data) != 32 || !bytes.Equal(tip.Data, h.Hash[:]) {
+		return false, errors.New("durable validated tip does not match latest validated ledger")
+	}
+	storedHeader, err := s.nodeStore.Fetch(ctx, nodestore.Hash256(h.Hash))
+	if err != nil {
+		return false, fmt.Errorf("fetch durable ledger header for checkpoint: %w", err)
+	}
+	if storedHeader == nil || storedHeader.Type != nodestore.NodeLedger ||
+		storedHeader.LedgerSeq != h.LedgerIndex || !bytes.Equal(storedHeader.Data, validated.SerializeHeader()) {
+		return false, errors.New("durable ledger header does not match latest validated ledger")
+	}
+	durableHeader, err := header.DeserializeHeader(storedHeader.Data, true)
+	if err != nil || durableHeader == nil {
+		return false, errors.New("durable validated header is malformed")
+	}
+	if !storedHeaderMatchesInfo(*durableHeader, info) {
+		return false, errors.New("newest relational ledger does not match durable validated header")
+	}
+	h = *durableHeader
+	durable, schema, err := s.fastLoadDurability()
+	if err != nil {
+		s.logger.Info("Fast-load checkpoint not prepared", "reason", "durable fingerprint unavailable", "err", err)
+		return false, nil
+	}
+	prepared := false
+	err = durable.WithDurableSnapshot(ctx, func(nodeFingerprint [32]byte) error {
+		if s.fastLoadCheckpointState.Load() != fastLoadCheckpointEligible {
+			s.logger.Info("Fast-load checkpoint not prepared", "reason", "run was invalidated during preparation")
+			return nil
+		}
+		schemaFingerprint, err := schema.SchemaFingerprint(ctx)
+		if err != nil {
+			return fmt.Errorf("fingerprint relational database: %w", err)
+		}
+		stateProofs, err := s.collectFastLoadProofs(ctx, h.AccountHash, shamap.TypeState)
+		if err != nil {
+			return fmt.Errorf("collect checkpoint state proof: %w", err)
+		}
+		txProofs, err := s.collectFastLoadProofs(ctx, h.TxHash, shamap.TypeTransaction)
+		if err != nil {
+			return fmt.Errorf("collect checkpoint transaction proof: %w", err)
+		}
+		if s.fastLoadCheckpointState.Load() != fastLoadCheckpointEligible {
+			s.logger.Info("Fast-load checkpoint not prepared", "reason", "run was invalidated during preparation")
+			return nil
+		}
+		currentSchemaFingerprint, err := schema.SchemaFingerprint(ctx)
+		if err != nil {
+			return fmt.Errorf("recheck relational fingerprint: %w", err)
+		}
+		if currentSchemaFingerprint != schemaFingerprint {
+			return errors.New("relational identity changed during checkpoint preparation")
+		}
+		checkpoint := &fastLoadCheckpoint{
+			sequence: h.LedgerIndex, ledgerHash: h.Hash,
+			stateRoot: h.AccountHash, txRoot: h.TxHash,
+			nodeStoreFingerprint: nodeFingerprint, schemaFingerprint: schemaFingerprint,
+			strictNodes: s.fastLoadStrictNodes.Load(), strictElapsed: s.fastLoadStrictElapsed.Load(),
+			stateProofs: stateProofs, txProofs: txProofs,
+		}
+		if err := durable.StoreDurable(ctx, &nodestore.Node{
+			Type: nodestore.NodeLedger, Hash: fastLoadCheckpointKey,
+			Data: encodeFastLoadCheckpoint(checkpoint), LedgerSeq: h.LedgerIndex,
+		}); err != nil {
+			return fmt.Errorf("durably store fast-load checkpoint: %w", err)
+		}
+		s.logger.Info("Fast-load checkpoint prepared",
+			"sequence", h.LedgerIndex,
+			"state_proofs", len(stateProofs),
+			"transaction_proofs", len(txProofs),
+			"shallow_nodes", len(stateProofs)+len(txProofs),
+			"strict_nodes", checkpoint.strictNodes,
+			"strict_elapsed", time.Duration(checkpoint.strictElapsed).String(),
+		)
+		prepared = true
+		return nil
+	})
+	return prepared, err
+}
+
+func (s *Service) fastLoadDurability() (nodestore.DurableDatabase, relationaldb.SchemaFingerprinter, error) {
+	durable, ok := s.nodeStore.(nodestore.DurableDatabase)
+	if !ok {
+		return nil, nil, errors.New("NodeStore has no durable checkpoint capability")
+	}
+	schema, ok := s.relationalDB.(relationaldb.SchemaFingerprinter)
+	if !ok {
+		return nil, nil, errors.New("relational database has no schema fingerprint capability")
+	}
+	return durable, schema, nil
+}

--- a/internal/ledger/service/fast_load_checkpoint_test.go
+++ b/internal/ledger/service/fast_load_checkpoint_test.go
@@ -84,7 +84,7 @@ func TestService_FastLoadCheckpointCapturesStrictTraversalMetrics(t *testing.T) 
 	svc, _, root, expectedNodes, _ := newStoredVerificationFixture(t, shamap.BranchFactor)
 	metrics, err := svc.verifyStoredSHAMapMeasured(t.Context(), root, shamap.TypeState)
 	require.NoError(t, err)
-	require.Equal(t, uint64(expectedNodes), metrics.nodes)
+	require.Equal(t, expectedNodes, metrics.nodes)
 	require.Positive(t, metrics.elapsed)
 }
 
@@ -200,6 +200,46 @@ func TestService_FastLoadCheckpointConsumeSyncFailureAbortsStartup(t *testing.T)
 	svc := newFastLoadCheckpointService(t, db, newTestRepositories(t, ctx), false)
 	err := svc.Start()
 	require.ErrorContains(t, err, "consume fast-load checkpoint")
+}
+
+func TestService_FastLoadCheckpointPreservedWhenStartupCannotUseIt(t *testing.T) {
+	tests := []struct {
+		name     string
+		fastLoad bool
+		mode     StartupMode
+	}{
+		{name: "fast load disabled", mode: StartupNormal},
+		{name: "network startup", fastLoad: true, mode: StartupNetwork},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			db := newTestNodeStore(t, 100_000)
+			t.Cleanup(func() { require.NoError(t, db.Close()) })
+			checkpoint := testFastLoadCheckpoint()
+			require.NoError(t, db.Store(ctx, &nodestore.Node{
+				Type: nodestore.NodeLedger, Hash: fastLoadCheckpointKey,
+				Data: encodeFastLoadCheckpoint(checkpoint), LedgerSeq: checkpoint.sequence,
+			}))
+			svc, err := New(Config{
+				Standalone: true, Startup: StartupConfig{Mode: test.mode},
+				GenesisConfig: genesis.DefaultConfig(), NodeStore: db,
+				SHAMapFamily: backend.New(db), RelationalDB: newTestRepositories(t, ctx),
+				FastLoad: test.fastLoad,
+			})
+			require.NoError(t, err)
+			require.NoError(t, svc.Start())
+			svc.Stop()
+
+			stored, err := db.Fetch(ctx, fastLoadCheckpointKey)
+			require.NoError(t, err)
+			require.NotNil(t, stored)
+			got, tombstone, err := decodeFastLoadCheckpoint(stored.Data)
+			require.NoError(t, err)
+			require.False(t, tombstone)
+			require.Equal(t, checkpoint, got)
+		})
+	}
 }
 
 func TestService_FastLoadCheckpointConsumeWaitsAfterCancellation(t *testing.T) {

--- a/internal/ledger/service/fast_load_checkpoint_test.go
+++ b/internal/ledger/service/fast_load_checkpoint_test.go
@@ -1,0 +1,609 @@
+package service
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/LeJamon/go-xrpl/shamap/backend"
+	"github.com/LeJamon/go-xrpl/storage/nodestore"
+	"github.com/LeJamon/go-xrpl/storage/relationaldb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFastLoadCheckpointEncodingRejectsMalformedData(t *testing.T) {
+	checkpoint := testFastLoadCheckpoint()
+	valid := encodeFastLoadCheckpoint(checkpoint)
+	activeOffset := 8 + 2 + 1
+	stateRootOffset := activeOffset + 4 + 32
+	strictMetricsOffset := stateRootOffset + 32 + 32 + 32 + 32
+	stateCountOffset := strictMetricsOffset + 16
+	proofOffset := stateCountOffset + 8
+
+	rechecksum := func(data []byte) []byte {
+		return finishFastLoadCheckpointEncoding(data[:len(data)-32])
+	}
+	tests := map[string][]byte{
+		"truncated": valid[:20],
+		"oversized": make([]byte, maxFastLoadCheckpointSize()+1),
+		"checksum": func() []byte {
+			data := append([]byte(nil), valid...)
+			data[len(data)-1] ^= 1
+			return data
+		}(),
+		"version": func() []byte {
+			data := append([]byte(nil), valid...)
+			binary.BigEndian.PutUint16(data[8:10], fastLoadCheckpointVersion+1)
+			return rechecksum(data)
+		}(),
+		"zero sequence": func() []byte {
+			data := append([]byte(nil), valid...)
+			clear(data[activeOffset : activeOffset+4])
+			return rechecksum(data)
+		}(),
+		"root mismatch": func() []byte {
+			data := append([]byte(nil), valid...)
+			data[stateRootOffset] ^= 1
+			return rechecksum(data)
+		}(),
+		"proof length": func() []byte {
+			data := append([]byte(nil), valid...)
+			binary.BigEndian.PutUint32(data[stateCountOffset:stateCountOffset+4], 2)
+			return rechecksum(data)
+		}(),
+		"duplicate proof": func() []byte {
+			data := append([]byte(nil), valid...)
+			binary.BigEndian.PutUint32(data[stateCountOffset:stateCountOffset+4], 2)
+			data = append(data[:proofOffset+32], append([]byte(nil), data[proofOffset:]...)...)
+			copy(data[proofOffset+32:proofOffset+64], data[proofOffset:proofOffset+32])
+			return rechecksum(data)
+		}(),
+	}
+	for name, data := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := decodeFastLoadCheckpoint(data)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestFastLoadCheckpointTombstoneRoundTrip(t *testing.T) {
+	checkpoint, tombstone, err := decodeFastLoadCheckpoint(encodeFastLoadCheckpoint(nil))
+	require.NoError(t, err)
+	require.True(t, tombstone)
+	require.Nil(t, checkpoint)
+}
+
+func TestService_FastLoadCheckpointCapturesStrictTraversalMetrics(t *testing.T) {
+	svc, _, root, expectedNodes, _ := newStoredVerificationFixture(t, shamap.BranchFactor)
+	metrics, err := svc.verifyStoredSHAMapMeasured(t.Context(), root, shamap.TypeState)
+	require.NoError(t, err)
+	require.Equal(t, uint64(expectedNodes), metrics.nodes)
+	require.Positive(t, metrics.elapsed)
+}
+
+func TestService_FastLoadCheckpointCleanRestartAndOneUse(t *testing.T) {
+	ctx := context.Background()
+	base := newTestNodeStore(t, 100_000)
+	t.Cleanup(func() { require.NoError(t, base.Close()) })
+	tracked := &checkpointTrackingDatabase{Database: base, uncached: base}
+	repositories := newTestRepositories(t, ctx)
+
+	writer := newFastLoadCheckpointService(t, tracked, repositories, true)
+	require.NoError(t, writer.Start())
+	for i := range 32 {
+		var key [32]byte
+		key[0] = 0xee
+		key[4] = byte(i)
+		data := make([]byte, 12)
+		data[11] = byte(i + 1)
+		require.NoError(t, writer.openLedger.Insert(keylet.Keylet{Key: key}, data))
+	}
+	rawTx, _ := validRelationalTestTransaction(t, 1)
+	txBlob, txHash := makeTxMetaBlobForTest(t, rawTx, 0)
+	require.NoError(t, writer.openLedger.AddTransactionWithMeta(txHash, txBlob))
+	_, err := writer.AcceptLedger(ctx)
+	require.NoError(t, err)
+	writer.FlushPersists()
+	want := writer.GetValidatedLedger()
+	require.NotNil(t, want)
+	writer.Stop()
+	writer.fastLoadStrictNodes.Store(27_807_179)
+	writer.fastLoadStrictElapsed.Store(uint64(28*time.Minute + 44*time.Second))
+	prepared, err := writer.PrepareFastLoadCheckpoint(ctx)
+	require.NoError(t, err)
+	require.True(t, prepared)
+
+	stored, err := tracked.Fetch(ctx, fastLoadCheckpointKey)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	checkpoint, tombstone, err := decodeFastLoadCheckpoint(stored.Data)
+	require.NoError(t, err)
+	require.False(t, tombstone)
+	require.NotEmpty(t, checkpoint.stateProofs)
+	require.NotEmpty(t, checkpoint.txProofs)
+	require.Equal(t, uint64(27_807_179), checkpoint.strictNodes)
+	require.Equal(t, uint64(28*time.Minute+44*time.Second), checkpoint.strictElapsed)
+	tracked.resetUncachedReads()
+	reader := newFastLoadCheckpointService(t, tracked, repositories, false)
+	require.NoError(t, reader.Start())
+	require.True(t, reader.IsFastLoadProvisional())
+	require.Equal(t, want.Hash(), reader.GetValidatedLedger().Hash())
+	require.Equal(t, checkpoint.strictNodes, reader.fastLoadStrictNodes.Load())
+	require.Equal(t, checkpoint.strictElapsed, reader.fastLoadStrictElapsed.Load())
+	require.Equal(t, len(checkpoint.stateProofs)+len(checkpoint.txProofs), tracked.uncachedReads())
+	cache := reader.shamapFamily.(interface {
+		FullBelowCache() *shamap.FullBelowCache
+	}).FullBelowCache()
+	generation := cache.Generation()
+	require.True(t, cache.Has(generation, checkpoint.stateRoot))
+	require.True(t, cache.Has(generation, checkpoint.txRoot))
+	reader.Stop()
+
+	consumed, err := tracked.Fetch(ctx, fastLoadCheckpointKey)
+	require.NoError(t, err)
+	_, tombstone, err = decodeFastLoadCheckpoint(consumed.Data)
+	require.NoError(t, err)
+	require.True(t, tombstone)
+
+	tracked.resetUncachedReads()
+	secondRestart := newFastLoadCheckpointService(t, tracked, repositories, false)
+	require.NoError(t, secondRestart.Start())
+	require.Greater(t, tracked.uncachedReads(), len(checkpoint.stateProofs)+len(checkpoint.txProofs))
+	secondRestart.Stop()
+}
+
+func TestService_FastLoadCheckpointZeroTransactionRoot(t *testing.T) {
+	ctx := context.Background()
+	db := newTestNodeStore(t, 100_000)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	repositories := newTestRepositories(t, ctx)
+
+	writer := newFastLoadCheckpointService(t, db, repositories, true)
+	require.NoError(t, writer.Start())
+	_, err := writer.AcceptLedger(ctx)
+	require.NoError(t, err)
+	writer.FlushPersists()
+	writer.Stop()
+	prepared, err := writer.PrepareFastLoadCheckpoint(ctx)
+	require.NoError(t, err)
+	require.True(t, prepared)
+	stored, err := db.Fetch(ctx, fastLoadCheckpointKey)
+	require.NoError(t, err)
+	checkpoint, _, err := decodeFastLoadCheckpoint(stored.Data)
+	require.NoError(t, err)
+	require.Equal(t, [32]byte{}, checkpoint.txRoot)
+	require.Empty(t, checkpoint.txProofs)
+
+	reader := newFastLoadCheckpointService(t, db, repositories, false)
+	require.NoError(t, reader.Start())
+	require.True(t, reader.IsFastLoadProvisional())
+	reader.Stop()
+}
+
+func TestService_FastLoadCheckpointConsumeSyncFailureAbortsStartup(t *testing.T) {
+	ctx := context.Background()
+	base := newTestNodeStore(t, 100_000)
+	t.Cleanup(func() { require.NoError(t, base.Close()) })
+	checkpoint := testFastLoadCheckpoint()
+	require.NoError(t, base.Store(ctx, &nodestore.Node{
+		Type: nodestore.NodeLedger, Hash: fastLoadCheckpointKey,
+		Data: encodeFastLoadCheckpoint(checkpoint), LedgerSeq: checkpoint.sequence,
+	}))
+	db := &checkpointTrackingDatabase{Database: base, syncErr: errors.New("injected sync failure")}
+	svc := newFastLoadCheckpointService(t, db, newTestRepositories(t, ctx), false)
+	err := svc.Start()
+	require.ErrorContains(t, err, "consume fast-load checkpoint")
+}
+
+func TestService_FastLoadCheckpointConsumeWaitsAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	base := newTestNodeStore(t, 100_000)
+	t.Cleanup(func() { require.NoError(t, base.Close()) })
+	checkpoint := testFastLoadCheckpoint()
+	require.NoError(t, base.Store(context.Background(), &nodestore.Node{
+		Type: nodestore.NodeLedger, Hash: fastLoadCheckpointKey,
+		Data: encodeFastLoadCheckpoint(checkpoint), LedgerSeq: checkpoint.sequence,
+	}))
+	db := &checkpointTrackingDatabase{
+		Database: base, uncached: base, blockOnSyncCall: 1,
+		syncStarted: make(chan struct{}, 1), syncRelease: make(chan struct{}, 1),
+	}
+	svc := newFastLoadCheckpointService(t, db, newTestRepositories(t, context.Background()), false)
+	type result struct {
+		checkpoint *fastLoadCheckpoint
+		err        error
+	}
+	done := make(chan result, 1)
+	go func() {
+		got, err := svc.consumeFastLoadCheckpoint(ctx)
+		done <- result{checkpoint: got, err: err}
+	}()
+	<-db.syncStarted
+	cancel()
+	select {
+	case got := <-done:
+		t.Fatalf("consume returned before tombstone flush completed: %v", got.err)
+	case <-time.After(25 * time.Millisecond):
+	}
+	db.syncRelease <- struct{}{}
+	got := <-done
+	require.NoError(t, got.err)
+	require.NotNil(t, got.checkpoint)
+	stored, err := base.Fetch(context.Background(), fastLoadCheckpointKey)
+	require.NoError(t, err)
+	_, tombstone, err := decodeFastLoadCheckpoint(stored.Data)
+	require.NoError(t, err)
+	require.True(t, tombstone)
+	second, err := svc.consumeFastLoadCheckpoint(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, second)
+}
+
+func TestService_FastLoadCheckpointMismatchFallsBackToStrictTraversal(t *testing.T) {
+	ctx := context.Background()
+	tests := map[string]func(*fastLoadCheckpoint){
+		"root": func(checkpoint *fastLoadCheckpoint) {
+			checkpoint.stateRoot = [32]byte{0xfa}
+			checkpoint.stateProofs[0] = checkpoint.stateRoot
+		},
+		"proof": func(checkpoint *fastLoadCheckpoint) {
+			checkpoint.stateProofs = append(checkpoint.stateProofs, [32]byte{0xfb})
+		},
+		"NodeStore fingerprint": func(checkpoint *fastLoadCheckpoint) {
+			checkpoint.nodeStoreFingerprint[0] ^= 1
+		},
+		"relational schema fingerprint": func(checkpoint *fastLoadCheckpoint) {
+			checkpoint.schemaFingerprint[0] ^= 1
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			db := newTestNodeStore(t, 100_000)
+			t.Cleanup(func() { require.NoError(t, db.Close()) })
+			repositories := newTestRepositories(t, ctx)
+			writer := durableCheckpointServiceWithRepositories(t, ctx, db, repositories)
+			prepared, prepareErr := writer.PrepareFastLoadCheckpoint(ctx)
+			require.NoError(t, prepareErr)
+			require.True(t, prepared)
+			stored, err := db.Fetch(ctx, fastLoadCheckpointKey)
+			require.NoError(t, err)
+			checkpoint, _, err := decodeFastLoadCheckpoint(stored.Data)
+			require.NoError(t, err)
+			mutate(checkpoint)
+			require.NoError(t, db.Store(ctx, &nodestore.Node{
+				Type: nodestore.NodeLedger, Hash: fastLoadCheckpointKey,
+				Data: encodeFastLoadCheckpoint(checkpoint), LedgerSeq: checkpoint.sequence,
+			}))
+			require.NoError(t, db.Sync(ctx))
+
+			reader := newFastLoadCheckpointService(t, db, repositories, false)
+			require.NoError(t, reader.Start())
+			require.True(t, reader.IsFastLoadProvisional())
+			require.Equal(t, checkpoint.sequence, reader.GetValidatedLedgerIndex())
+			reader.Stop()
+		})
+	}
+}
+
+func TestService_FastLoadCheckpointManagedMutationFallsBackToStrictTraversal(t *testing.T) {
+	ctx := context.Background()
+	base := newTestNodeStore(t, 100_000)
+	t.Cleanup(func() { require.NoError(t, base.Close()) })
+	tracked := &checkpointTrackingDatabase{Database: base, uncached: base}
+	repositories := newTestRepositories(t, ctx)
+	writer := newFastLoadCheckpointService(t, tracked, repositories, true)
+	require.NoError(t, writer.Start())
+	for i := range 32 {
+		var key [32]byte
+		key[0] = 0xee
+		key[4] = byte(i)
+		data := make([]byte, 12)
+		data[11] = byte(i + 1)
+		require.NoError(t, writer.openLedger.Insert(keylet.Keylet{Key: key}, data))
+	}
+	_, err := writer.AcceptLedger(ctx)
+	require.NoError(t, err)
+	writer.FlushPersists()
+	writer.Stop()
+	prepared, err := writer.PrepareFastLoadCheckpoint(ctx)
+	require.NoError(t, err)
+	require.True(t, prepared)
+	stored, err := base.Fetch(ctx, fastLoadCheckpointKey)
+	require.NoError(t, err)
+	checkpoint, _, err := decodeFastLoadCheckpoint(stored.Data)
+	require.NoError(t, err)
+
+	deleted, err := base.DeleteBefore(ctx, 1, 1)
+	require.NoError(t, err)
+	require.Zero(t, deleted)
+	tracked.resetUncachedReads()
+	reader := newFastLoadCheckpointService(t, tracked, repositories, false)
+	require.NoError(t, reader.Start())
+	require.Greater(t, tracked.uncachedReads(), len(checkpoint.stateProofs)+len(checkpoint.txProofs))
+	reader.Stop()
+}
+
+func TestService_FastLoadCheckpointPreparationOrderingAndFailures(t *testing.T) {
+	ctx := context.Background()
+	t.Run("store then sync", func(t *testing.T) {
+		base := newTestNodeStore(t, 100_000)
+		t.Cleanup(func() { require.NoError(t, base.Close()) })
+		db := &checkpointTrackingDatabase{Database: base, uncached: base}
+		svc := durableCheckpointService(t, ctx, db)
+		db.resetOperations()
+		prepared, err := svc.PrepareFastLoadCheckpoint(ctx)
+		require.NoError(t, err)
+		require.True(t, prepared)
+		require.Equal(t, []string{"sync", "checkpoint-store", "sync"}, db.operations())
+	})
+
+	t.Run("store failure", func(t *testing.T) {
+		base := newTestNodeStore(t, 100_000)
+		t.Cleanup(func() { require.NoError(t, base.Close()) })
+		db := &checkpointTrackingDatabase{Database: base, uncached: base}
+		svc := durableCheckpointService(t, ctx, db)
+		db.checkpointStoreErr = errors.New("injected store failure")
+		_, err := svc.PrepareFastLoadCheckpoint(ctx)
+		require.ErrorContains(t, err, "durably store fast-load checkpoint")
+	})
+
+	t.Run("cancellation after store waits for durable publication", func(t *testing.T) {
+		base := newTestNodeStore(t, 100_000)
+		t.Cleanup(func() { require.NoError(t, base.Close()) })
+		db := &checkpointTrackingDatabase{Database: base, uncached: base}
+		svc := durableCheckpointService(t, ctx, db)
+		db.resetOperations()
+		prepareCtx, cancelPrepare := context.WithCancel(ctx)
+		db.cancelOnActiveStore = cancelPrepare
+		prepared, err := svc.PrepareFastLoadCheckpoint(prepareCtx)
+		require.NoError(t, err)
+		require.True(t, prepared)
+		stored, fetchErr := db.Fetch(ctx, fastLoadCheckpointKey)
+		require.NoError(t, fetchErr)
+		checkpoint, tombstone, decodeErr := decodeFastLoadCheckpoint(stored.Data)
+		require.NoError(t, decodeErr)
+		require.False(t, tombstone)
+		require.NotNil(t, checkpoint)
+	})
+
+	t.Run("blocking flush does not return on cancellation", func(t *testing.T) {
+		base := newTestNodeStore(t, 100_000)
+		t.Cleanup(func() { require.NoError(t, base.Close()) })
+		db := &checkpointTrackingDatabase{Database: base, uncached: base}
+		svc := durableCheckpointService(t, ctx, db)
+		db.resetOperations()
+		db.mu.Lock()
+		db.blockOnSyncCall = 2
+		db.syncStarted = make(chan struct{}, 1)
+		db.syncRelease = make(chan struct{}, 1)
+		db.mu.Unlock()
+		prepareCtx, cancelPrepare := context.WithCancel(ctx)
+		type result struct {
+			prepared bool
+			err      error
+		}
+		done := make(chan result, 1)
+		go func() {
+			prepared, err := svc.PrepareFastLoadCheckpoint(prepareCtx)
+			done <- result{prepared: prepared, err: err}
+		}()
+		<-db.syncStarted
+		cancelPrepare()
+		select {
+		case got := <-done:
+			t.Fatalf("prepare returned before active flush completed: %v", got.err)
+		case <-time.After(25 * time.Millisecond):
+		}
+		db.syncRelease <- struct{}{}
+		got := <-done
+		require.NoError(t, got.err)
+		require.True(t, got.prepared)
+	})
+}
+
+func TestService_FastLoadCheckpointRefusesInvalidTipAndPrune(t *testing.T) {
+	ctx := context.Background()
+	t.Run("tip mismatch", func(t *testing.T) {
+		base := newTestNodeStore(t, 100_000)
+		t.Cleanup(func() { require.NoError(t, base.Close()) })
+		db := &checkpointTrackingDatabase{Database: base, uncached: base}
+		svc := durableCheckpointService(t, ctx, db)
+		require.NoError(t, base.Store(ctx, &nodestore.Node{
+			Type: nodestore.NodeLedger, Hash: validatedTipKey,
+			Data: make([]byte, 32), LedgerSeq: svc.GetValidatedLedgerIndex(),
+		}))
+		_, err := svc.PrepareFastLoadCheckpoint(ctx)
+		require.ErrorContains(t, err, "durable validated tip")
+	})
+
+	t.Run("prune invalidation", func(t *testing.T) {
+		base := newTestNodeStore(t, 100_000)
+		t.Cleanup(func() { require.NoError(t, base.Close()) })
+		db := &checkpointTrackingDatabase{Database: base, uncached: base}
+		svc := durableCheckpointService(t, ctx, db)
+		svc.InvalidateFastLoadCheckpointEligibility()
+		svc.markFastLoadCheckpointEligible()
+		prepared, err := svc.PrepareFastLoadCheckpoint(ctx)
+		require.NoError(t, err)
+		require.False(t, prepared)
+		stored, err := db.Fetch(ctx, fastLoadCheckpointKey)
+		require.NoError(t, err)
+		require.Nil(t, stored)
+	})
+}
+
+func testFastLoadCheckpoint() *fastLoadCheckpoint {
+	return &fastLoadCheckpoint{
+		sequence: 10, ledgerHash: [32]byte{1}, stateRoot: [32]byte{2},
+		txRoot: [32]byte{3}, stateProofs: [][32]byte{{2}}, txProofs: [][32]byte{{3}},
+		nodeStoreFingerprint: [32]byte{4}, schemaFingerprint: [32]byte{5},
+		strictNodes: 27_807_179, strictElapsed: uint64(28*time.Minute + 44*time.Second),
+	}
+}
+
+func newFastLoadCheckpointService(
+	t *testing.T,
+	db nodestore.Database,
+	repositories relationaldb.RepositoryManager,
+	standalone bool,
+) *Service {
+	t.Helper()
+	svc, err := New(Config{
+		Standalone: standalone, GenesisConfig: genesis.DefaultConfig(),
+		NodeStore: db, SHAMapFamily: backend.New(db), RelationalDB: repositories, FastLoad: true,
+	})
+	require.NoError(t, err)
+	return svc
+}
+
+type uncachedNodeReader interface {
+	FetchDataUncached(context.Context, nodestore.Hash256) ([]byte, error)
+}
+
+type checkpointTrackingDatabase struct {
+	nodestore.Database
+	uncached            uncachedNodeReader
+	mu                  sync.Mutex
+	reads               int
+	ops                 []string
+	syncErr             error
+	checkpointStoreErr  error
+	cancelOnActiveStore context.CancelFunc
+	syncCalls           int
+	blockOnSyncCall     int
+	syncStarted         chan struct{}
+	syncRelease         chan struct{}
+}
+
+func (d *checkpointTrackingDatabase) FetchDataUncached(ctx context.Context, hash nodestore.Hash256) ([]byte, error) {
+	d.mu.Lock()
+	d.reads++
+	d.mu.Unlock()
+	return d.uncached.FetchDataUncached(ctx, hash)
+}
+
+func (d *checkpointTrackingDatabase) Store(ctx context.Context, node *nodestore.Node) error {
+	if node.Hash == fastLoadCheckpointKey {
+		d.mu.Lock()
+		d.ops = append(d.ops, "checkpoint-store")
+		err := d.checkpointStoreErr
+		cancel := d.cancelOnActiveStore
+		d.mu.Unlock()
+		if err != nil {
+			return err
+		}
+		storeErr := d.Database.Store(ctx, node)
+		if storeErr == nil && node.LedgerSeq != 0 && cancel != nil {
+			cancel()
+		}
+		return storeErr
+	}
+	return d.Database.Store(ctx, node)
+}
+
+func (d *checkpointTrackingDatabase) Sync(ctx context.Context) error {
+	d.mu.Lock()
+	d.ops = append(d.ops, "sync")
+	d.syncCalls++
+	call := d.syncCalls
+	fail := d.syncErr
+	block := call == d.blockOnSyncCall
+	started := d.syncStarted
+	release := d.syncRelease
+	d.mu.Unlock()
+	if fail != nil {
+		return fail
+	}
+	if block {
+		started <- struct{}{}
+		<-release
+	}
+	return d.Database.Sync(ctx)
+}
+
+func (d *checkpointTrackingDatabase) StoreDurable(ctx context.Context, node *nodestore.Node) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := d.Store(ctx, node); err != nil {
+		return err
+	}
+	return d.Sync(context.Background())
+}
+
+func (d *checkpointTrackingDatabase) DurableFingerprint(ctx context.Context) ([32]byte, error) {
+	durable, ok := d.Database.(nodestore.DurableDatabase)
+	if !ok {
+		return [32]byte{}, errors.New("missing durable database capability")
+	}
+	return durable.DurableFingerprint(ctx)
+}
+
+func (d *checkpointTrackingDatabase) WithDurableSnapshot(
+	ctx context.Context,
+	fn func([32]byte) error,
+) error {
+	durable, ok := d.Database.(nodestore.DurableDatabase)
+	if !ok {
+		return errors.New("missing durable database capability")
+	}
+	return durable.WithDurableSnapshot(ctx, fn)
+}
+
+func (d *checkpointTrackingDatabase) uncachedReads() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.reads
+}
+
+func (d *checkpointTrackingDatabase) resetUncachedReads() {
+	d.mu.Lock()
+	d.reads = 0
+	d.mu.Unlock()
+}
+
+func (d *checkpointTrackingDatabase) resetOperations() {
+	d.mu.Lock()
+	d.ops = nil
+	d.syncCalls = 0
+	d.mu.Unlock()
+}
+
+func (d *checkpointTrackingDatabase) operations() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]string(nil), d.ops...)
+}
+
+func durableCheckpointService(t *testing.T, ctx context.Context, db nodestore.Database) *Service {
+	t.Helper()
+	repositories := newTestRepositories(t, ctx)
+	return durableCheckpointServiceWithRepositories(t, ctx, db, repositories)
+}
+
+func durableCheckpointServiceWithRepositories(
+	t *testing.T,
+	ctx context.Context,
+	db nodestore.Database,
+	repositories relationaldb.RepositoryManager,
+) *Service {
+	t.Helper()
+	svc, err := New(Config{
+		Standalone: true, GenesisConfig: genesis.DefaultConfig(),
+		NodeStore: db, SHAMapFamily: backend.New(db), RelationalDB: repositories, FastLoad: true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	_, err = svc.AcceptLedger(ctx)
+	require.NoError(t, err)
+	svc.FlushPersists()
+	svc.Stop()
+	return svc
+}

--- a/internal/ledger/service/fast_load_test.go
+++ b/internal/ledger/service/fast_load_test.go
@@ -785,6 +785,63 @@ func TestService_VerifyStoredSHAMapUsesUncachedReads(t *testing.T) {
 	require.Equal(t, before.Reads+expectedNodes, after.Reads)
 }
 
+func TestService_VerifyStoredSHAMapSeedsFullBelowCache(t *testing.T) {
+	svc, _, root, _, _ := newStoredVerificationFixture(t, shamap.BranchFactor)
+	provider, ok := svc.shamapFamily.(interface {
+		FullBelowCache() *shamap.FullBelowCache
+	})
+	require.True(t, ok)
+	cache := provider.FullBelowCache()
+	cache.Bump()
+	generation := cache.Generation()
+
+	rootNode, _, err := svc.loadStoredSHAMapNode(
+		t.Context(),
+		storedSHAMapNode{hash: root},
+		shamap.TypeState,
+	)
+	require.NoError(t, err)
+	inner, ok := rootNode.(shamap.InnerNodeReader)
+	require.True(t, ok)
+	child, err := inner.ChildHash(0)
+	require.NoError(t, err)
+	require.False(t, cache.Has(generation, root))
+	require.False(t, cache.Has(generation, child))
+
+	require.NoError(t, svc.verifyStoredSHAMap(t.Context(), root, shamap.TypeState))
+
+	require.True(t, cache.Has(generation, root))
+	require.True(t, cache.Has(generation, child))
+}
+
+func TestService_VerifyStoredSHAMapDoesNotSeedFailedProofs(t *testing.T) {
+	svc, db, root, _, _ := newStoredVerificationFixture(t, 1)
+	provider, ok := svc.shamapFamily.(interface {
+		FullBelowCache() *shamap.FullBelowCache
+	})
+	require.True(t, ok)
+	cache := provider.FullBelowCache()
+	cache.Bump()
+	generation := cache.Generation()
+
+	raw := db.(interface {
+		FetchDataUncached(context.Context, nodestore.Hash256) ([]byte, error)
+	})
+	tracked := &uncachedTrackingDatabase{Database: db}
+	tracked.rewrite = func(hash nodestore.Hash256, data []byte) ([]byte, error) {
+		if hash == nodestore.Hash256(root) {
+			return data, nil
+		}
+		return raw.FetchDataUncached(t.Context(), nodestore.Hash256(root))
+	}
+	svc.nodeStore = tracked
+
+	err := svc.verifyStoredSHAMap(t.Context(), root, shamap.TypeState)
+	require.ErrorContains(t, err, "invalid content hash")
+	require.False(t, cache.Has(generation, root))
+	require.Zero(t, cache.Size())
+}
+
 func TestService_VerifyStoredSHAMapFallsBackToFetch(t *testing.T) {
 	svc, db, root, expectedNodes, _ := newStoredVerificationFixture(t, shamap.BranchFactor)
 	tracked := &fallbackTrackingDatabase{Database: db}

--- a/internal/ledger/service/persistence.go
+++ b/internal/ledger/service/persistence.go
@@ -77,6 +77,9 @@ func (s *Service) persistValidatedLedgerAtToken(
 
 	if l.IsValidated() {
 		s.recordValidatedPersistence(seq, token, persistErr == nil)
+		if persistErr == nil && s.nodeStore != nil && s.shamapFamily != nil {
+			s.markFastLoadCheckpointEligible()
+		}
 	}
 	return persistErr
 }

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/amendment"
@@ -186,6 +187,11 @@ type Service struct {
 	heldAdoptions map[uint32]*pendingAdopt
 
 	networkLedgerState networkLedgerState
+
+	startupFastLoadCheckpoint *fastLoadCheckpoint
+	fastLoadCheckpointState   atomic.Uint32
+	fastLoadStrictNodes       atomic.Uint64
+	fastLoadStrictElapsed     atomic.Uint64
 
 	// startupReplay is the one-shot replay staged for the first close and is
 	// guarded by mu together with the closed/open ledger frontier.
@@ -475,6 +481,14 @@ func (s *Service) Start() (err error) {
 		if err != nil {
 			s.lifecycleState = serviceFailed
 		}
+	}()
+	checkpoint, err := s.consumeFastLoadCheckpoint(context.Background())
+	if err != nil {
+		return err
+	}
+	s.startupFastLoadCheckpoint = checkpoint
+	defer func() {
+		s.startupFastLoadCheckpoint = nil
 	}()
 
 	s.mu.Lock()

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -482,11 +482,12 @@ func (s *Service) Start() (err error) {
 			s.lifecycleState = serviceFailed
 		}
 	}()
-	checkpoint, err := s.consumeFastLoadCheckpoint(context.Background())
-	if err != nil {
-		return err
+	if s.config.FastLoad && s.config.Startup.Mode == StartupNormal {
+		s.startupFastLoadCheckpoint, err = s.consumeFastLoadCheckpoint(context.Background())
+		if err != nil {
+			return err
+		}
 	}
-	s.startupFastLoadCheckpoint = checkpoint
 	defer func() {
 		s.startupFastLoadCheckpoint = nil
 	}()

--- a/internal/node/lifecycle_test.go
+++ b/internal/node/lifecycle_test.go
@@ -359,6 +359,44 @@ func TestNodeRuntimeShutdownBoundsBlockingStoreClose(t *testing.T) {
 	close(release)
 }
 
+func TestNodeRuntimeShutdownLeavesStoresOpenWhileCheckpointFlushIsRunning(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var nodeStoreClosed atomic.Bool
+	var repositoryClosed atomic.Bool
+	runtime := &nodeRuntime{
+		prepareFastLoadCheckpoint: func(context.Context) (bool, error) {
+			close(started)
+			<-release
+			return true, nil
+		},
+		nodeStore: &shutdownProbeDB{close: func() error {
+			nodeStoreClosed.Store(true)
+			return nil
+		}},
+		repo: &shutdownProbeRepository{close: func() error {
+			repositoryClosed.Store(true)
+			return nil
+		}},
+		serverLog: xrpllog.Discard(),
+	}
+	result := make(chan error, 1)
+	go func() { result <- runtime.shutdownWithin(50 * time.Millisecond) }()
+	<-started
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("shutdown error = %v, want deadline exceeded", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("shutdown exceeded its total budget")
+	}
+	if nodeStoreClosed.Load() || repositoryClosed.Load() {
+		t.Fatal("storage closed while checkpoint flush was still running")
+	}
+	close(release)
+}
+
 func TestNodeRuntimeShutdownLeavesStoresOpenWhileTransportHandlerIsRunning(t *testing.T) {
 	runtimeCtx, cancelRuntime := context.WithCancel(context.Background())
 	defer cancelRuntime()

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -69,12 +69,13 @@ type nodeRuntime struct {
 	transports    *boundRPCTransports
 	watchdog      *watchdog.Watchdog
 
-	networkID      uint32
-	retentionFloor func() uint32
-	shutdownCh     chan struct{}
-	shutdowner     types.Shutdowner
-	stopSampler    func()
-	stopWatchdog   func()
+	networkID                 uint32
+	retentionFloor            func() uint32
+	prepareFastLoadCheckpoint func(context.Context) (bool, error)
+	shutdownCh                chan struct{}
+	shutdowner                types.Shutdowner
+	stopSampler               func()
+	stopWatchdog              func()
 }
 
 func newNodeRuntime(
@@ -338,7 +339,10 @@ func (r *nodeRuntime) configureMaintenance() error {
 				r.rotator.SetStateRefresh(
 					r.ledger.RefreshValidatedState,
 					r.nodeFamily.SetMinimumLedgerSeq,
-					r.nodeFamily.BeginPrune,
+					func() func() {
+						r.ledger.InvalidateFastLoadCheckpointEligibility()
+						return r.nodeFamily.BeginPrune()
+					},
 				)
 				if err := context.Cause(ctx); err != nil {
 					return err
@@ -1312,6 +1316,34 @@ func (r *nodeRuntime) shutdownWithin(timeout time.Duration) error {
 	if !serviceStopped {
 		errs = append(errs, errors.New("shutdown incomplete: stores left open because ledger service did not stop"))
 		return errors.Join(errs...)
+	}
+	prepareCheckpoint := r.prepareFastLoadCheckpoint
+	if prepareCheckpoint == nil && r.ledger != nil {
+		prepareCheckpoint = r.ledger.PrepareFastLoadCheckpoint
+	}
+	if len(errs) == 0 && prepareCheckpoint != nil {
+		checkpointCtx, cancelCheckpoint := context.WithTimeout(ctx, storeShutdownGrace)
+		var prepared bool
+		completed, err := runShutdownPhase(checkpointCtx, "prepare fast-load checkpoint", func() error {
+			var prepareErr error
+			prepared, prepareErr = prepareCheckpoint(checkpointCtx)
+			return prepareErr
+		})
+		cancelCheckpoint()
+		if err != nil {
+			errs = append(errs, err)
+		}
+		if !completed {
+			errs = append(errs, errors.New("shutdown incomplete: stores left open because fast-load checkpoint preparation did not stop"))
+			return errors.Join(errs...)
+		}
+		if err == nil {
+			if prepared {
+				r.serverLog.Info("Fast-load checkpoint preparation complete")
+			} else {
+				r.serverLog.Info("Fast-load checkpoint preparation skipped")
+			}
+		}
 	}
 
 	if r.nodeStore != nil {

--- a/shamap/backed_walk_test.go
+++ b/shamap/backed_walk_test.go
@@ -1104,8 +1104,8 @@ func TestPublishAcknowledgedFullBelowPreservesProofDepthAdmission(t *testing.T) 
 	shallow := [32]byte{0x31}
 	deep := [32]byte{0x32}
 	lane := &sm.acquisition.cursor.lanes[0]
-	lane.proofs.add(shallow, fullBelowCacheMaxDepth)
-	lane.proofs.add(deep, fullBelowCacheMaxDepth+1)
+	lane.proofs.add(shallow, FullBelowCacheMaxDepth)
+	lane.proofs.add(deep, FullBelowCacheMaxDepth+1)
 
 	complete, release := sm.publishAcknowledgedFullBelow()
 	if complete {

--- a/shamap/fullbelow.go
+++ b/shamap/fullbelow.go
@@ -10,7 +10,10 @@ const (
 	fullBelowCacheTarget     = 1 << 19
 	fullBelowCacheExpiration = 10 * time.Minute
 	fullBelowCacheShards     = 16
-	fullBelowCacheMaxDepth   = 4
+	// FullBelowCacheMaxDepth is the deepest level at which durable subtree
+	// completeness proofs are retained. Startup verification uses the same
+	// bound when warming the cache for the first network acquisition.
+	FullBelowCacheMaxDepth = 4
 )
 
 // FullBelowStats is a point-in-time cache snapshot.
@@ -273,7 +276,7 @@ func (c *FullBelowCache) Insert(generation uint32, hash [32]byte) {
 }
 
 func cacheFullBelow(c *FullBelowCache, generation uint32, hash [32]byte, depth int) {
-	if c != nil && depth <= fullBelowCacheMaxDepth {
+	if c != nil && depth <= FullBelowCacheMaxDepth {
 		c.Insert(generation, hash)
 	}
 }

--- a/shamap/fullbelow_test.go
+++ b/shamap/fullbelow_test.go
@@ -1063,13 +1063,13 @@ func TestFullBelowCache_DeepProofStreamDoesNotEvictShallowProof(t *testing.T) {
 	c := newFullBelowCacheWithClock(target, time.Hour, time.Now)
 	gen := c.Generation()
 	shallow := [32]byte{0, 0xff}
-	cacheFullBelow(c, gen, shallow, fullBelowCacheMaxDepth)
+	cacheFullBelow(c, gen, shallow, FullBelowCacheMaxDepth)
 
 	var lastDeep [32]byte
 	for i := range 10_000 {
 		var hash [32]byte
 		binary.BigEndian.PutUint64(hash[8:], uint64(i+1))
-		cacheFullBelow(c, gen, hash, fullBelowCacheMaxDepth+1)
+		cacheFullBelow(c, gen, hash, FullBelowCacheMaxDepth+1)
 		lastDeep = hash
 	}
 

--- a/storage/kvstore/kvstore.go
+++ b/storage/kvstore/kvstore.go
@@ -60,3 +60,19 @@ type RotatingStore interface {
 	Rotate(lastRotated, minimumOnline uint32) (committed bool, err error)
 	RotationState() (lastRotated, minimumOnline uint32)
 }
+
+// RotationIdentity is a path-free snapshot of a rotating store's durable
+// manifest identity and generation boundary.
+type RotationIdentity struct {
+	OwnerID       [16]byte
+	WritableID    [32]byte
+	ArchiveID     [32]byte
+	LastRotated   uint32
+	MinimumOnline uint32
+}
+
+// RotationIdentityStore exposes the durable generation manifest without
+// exposing backend paths.
+type RotationIdentityStore interface {
+	RotationIdentity() (RotationIdentity, error)
+}

--- a/storage/kvstore/pebble/rotating.go
+++ b/storage/kvstore/pebble/rotating.go
@@ -3,6 +3,7 @@ package pebble
 import (
 	"bytes"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -634,6 +635,27 @@ func (r *RotatingStore) RotationState() (uint32, uint32) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.lastRotated, r.minimumOnline
+}
+
+// RotationIdentity returns a path-free snapshot of the durable manifest.
+func (r *RotatingStore) RotationIdentity() (kvstore.RotationIdentity, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.closed {
+		return kvstore.RotationIdentity{}, kvstore.ErrClosed
+	}
+	owner, err := hex.DecodeString(r.ownerID)
+	if err != nil || len(owner) != 16 {
+		return kvstore.RotationIdentity{}, errors.New("kvstore/pebble: invalid rotation owner ID")
+	}
+	identity := kvstore.RotationIdentity{
+		WritableID:    sha256.Sum256([]byte(filepath.Base(r.writablePath))),
+		ArchiveID:     sha256.Sum256([]byte(filepath.Base(r.archivePath))),
+		LastRotated:   r.lastRotated,
+		MinimumOnline: r.minimumOnline,
+	}
+	copy(identity.OwnerID[:], owner)
+	return identity, nil
 }
 
 // Rotate durably publishes a fresh writable generation before retiring the

--- a/storage/nodestore/durability.go
+++ b/storage/nodestore/durability.go
@@ -1,0 +1,156 @@
+package nodestore
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/LeJamon/go-xrpl/storage/kvstore"
+)
+
+const durableIdentitySize = 8 + 1 + 16 + 8 + 32
+
+var (
+	durableIdentityMagic = [8]byte{'g', 'o', 'X', 'R', 'P', 'L', 'd', 'i'}
+	durableIdentityKey   = Hash256(sha256.Sum256([]byte("go-xrpl nodestore durable identity v1")))
+)
+
+// DurableDatabase supplies the checkpoint protocol with a stable storage
+// snapshot and a cancellation-safe durable write. The fingerprint tracks
+// managed mutations; it cannot detect out-of-band edits that preserve the
+// identity metadata.
+type DurableDatabase interface {
+	DurableFingerprint(context.Context) ([32]byte, error)
+	StoreDurable(context.Context, *Node) error
+	WithDurableSnapshot(context.Context, func([32]byte) error) error
+}
+
+// WithDurableSnapshot prevents managed destructive mutations while fn checks
+// the fingerprint and publishes work derived from the current store contents.
+func (d *KVDatabase) WithDurableSnapshot(ctx context.Context, fn func([32]byte) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	d.mutationMu.RLock()
+	defer d.mutationMu.RUnlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	fingerprint, err := d.DurableFingerprint(ctx)
+	if err != nil {
+		return err
+	}
+	return fn(fingerprint)
+}
+
+func (d *KVDatabase) DurableFingerprint(ctx context.Context) ([32]byte, error) {
+	if rotating, ok := d.store.(kvstore.RotationIdentityStore); ok {
+		identity, err := rotating.RotationIdentity()
+		if err != nil {
+			return [32]byte{}, err
+		}
+		if identity.OwnerID == ([16]byte{}) || identity.WritableID == ([32]byte{}) ||
+			identity.ArchiveID == ([32]byte{}) ||
+			(identity.LastRotated == 0) != (identity.MinimumOnline == 0) ||
+			identity.MinimumOnline > identity.LastRotated {
+			return [32]byte{}, errors.New("nodestore: invalid rotating durable identity")
+		}
+		payload := make([]byte, 0, 32+16+32+32+8)
+		payload = append(payload, []byte("nodestore-node-codec-v1/rotate-v1")...)
+		payload = append(payload, identity.OwnerID[:]...)
+		payload = append(payload, identity.WritableID[:]...)
+		payload = append(payload, identity.ArchiveID[:]...)
+		payload = binary.BigEndian.AppendUint32(payload, identity.LastRotated)
+		payload = binary.BigEndian.AppendUint32(payload, identity.MinimumOnline)
+		return sha256.Sum256(payload), nil
+	}
+
+	d.identityMu.Lock()
+	defer d.identityMu.Unlock()
+	data, err := d.FetchDataUncached(ctx, durableIdentityKey)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	if data == nil {
+		data, err = newDurableIdentity()
+		if err != nil {
+			return [32]byte{}, err
+		}
+		if err := d.StoreDurable(ctx, &Node{
+			Type: NodeLedger, Hash: durableIdentityKey, Data: data, LedgerSeq: math.MaxUint32,
+		}); err != nil {
+			return [32]byte{}, fmt.Errorf("persist NodeStore identity: %w", err)
+		}
+	}
+	if _, _, err := decodeDurableIdentity(data); err != nil {
+		return [32]byte{}, err
+	}
+	payload := append([]byte("nodestore-node-codec-v1/plain-v1"), data...)
+	return sha256.Sum256(payload), nil
+}
+
+func newDurableIdentity() ([]byte, error) {
+	data := make([]byte, 0, durableIdentitySize)
+	data = append(data, durableIdentityMagic[:]...)
+	data = append(data, 1)
+	var id [16]byte
+	if _, err := rand.Read(id[:]); err != nil {
+		return nil, fmt.Errorf("generate NodeStore identity: %w", err)
+	}
+	data = append(data, id[:]...)
+	data = binary.BigEndian.AppendUint64(data, 0)
+	checksum := sha256.Sum256(data)
+	return append(data, checksum[:]...), nil
+}
+
+func decodeDurableIdentity(data []byte) ([16]byte, uint64, error) {
+	var id [16]byte
+	if len(data) != durableIdentitySize {
+		return id, 0, errors.New("nodestore: malformed durable identity")
+	}
+	if string(data[:8]) != string(durableIdentityMagic[:]) || data[8] != 1 {
+		return id, 0, errors.New("nodestore: unsupported durable identity")
+	}
+	want := sha256.Sum256(data[:durableIdentitySize-32])
+	if string(data[durableIdentitySize-32:]) != string(want[:]) {
+		return id, 0, errors.New("nodestore: durable identity checksum mismatch")
+	}
+	copy(id[:], data[9:25])
+	if id == ([16]byte{}) {
+		return id, 0, errors.New("nodestore: empty durable identity")
+	}
+	return id, binary.BigEndian.Uint64(data[25:33]), nil
+}
+
+func (d *KVDatabase) bumpDurableMutation(ctx context.Context) error {
+	if _, rotating := d.store.(kvstore.RotationIdentityStore); rotating {
+		return nil
+	}
+	d.identityMu.Lock()
+	defer d.identityMu.Unlock()
+	data, err := d.FetchDataUncached(ctx, durableIdentityKey)
+	if err != nil || data == nil {
+		return err
+	}
+	id, generation, err := decodeDurableIdentity(data)
+	if err != nil {
+		return err
+	}
+	if generation == math.MaxUint64 {
+		return errors.New("nodestore: durable mutation generation exhausted")
+	}
+	payload := make([]byte, 0, durableIdentitySize)
+	payload = append(payload, durableIdentityMagic[:]...)
+	payload = append(payload, 1)
+	payload = append(payload, id[:]...)
+	payload = binary.BigEndian.AppendUint64(payload, generation+1)
+	checksum := sha256.Sum256(payload)
+	payload = append(payload, checksum[:]...)
+	return d.StoreDurable(context.WithoutCancel(ctx), &Node{
+		Type: NodeLedger, Hash: durableIdentityKey, Data: payload, LedgerSeq: math.MaxUint32,
+	})
+}

--- a/storage/nodestore/durability.go
+++ b/storage/nodestore/durability.go
@@ -47,6 +47,7 @@ func (d *KVDatabase) WithDurableSnapshot(ctx context.Context, fn func([32]byte) 
 	return fn(fingerprint)
 }
 
+// DurableFingerprint returns a stable identity for the current managed store generation.
 func (d *KVDatabase) DurableFingerprint(ctx context.Context) ([32]byte, error) {
 	if rotating, ok := d.store.(kvstore.RotationIdentityStore); ok {
 		identity, err := rotating.RotationIdentity()

--- a/storage/nodestore/durability_test.go
+++ b/storage/nodestore/durability_test.go
@@ -1,0 +1,246 @@
+package nodestore
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/storage/kvstore"
+	"github.com/LeJamon/go-xrpl/storage/kvstore/memorydb"
+	pebblekv "github.com/LeJamon/go-xrpl/storage/kvstore/pebble"
+)
+
+type identityRotatingStore struct {
+	kvstore.KeyValueStore
+	identity kvstore.RotationIdentity
+}
+
+func (s *identityRotatingStore) RotationIdentity() (kvstore.RotationIdentity, error) {
+	return s.identity, nil
+}
+
+func TestDurableFingerprintPlainIdentityAndManagedMutation(t *testing.T) {
+	database := testDatabase(t, memorydb.New(), noCacheConfig())
+	first, err := database.DurableFingerprint(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := database.DurableFingerprint(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != again {
+		t.Fatal("durable fingerprint changed without a managed mutation")
+	}
+	if _, err := database.DeleteBefore(t.Context(), 1, 1); err != nil {
+		t.Fatal(err)
+	}
+	afterPrune, err := database.DurableFingerprint(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterPrune == first {
+		t.Fatal("managed prune did not advance the durable fingerprint")
+	}
+
+	replacement := testDatabase(t, memorydb.New(), noCacheConfig())
+	replacementFingerprint, err := replacement.DurableFingerprint(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replacementFingerprint == afterPrune {
+		t.Fatal("replacement NodeStore reused the durable identity")
+	}
+}
+
+func TestDurableFingerprintBindsRotatingManifest(t *testing.T) {
+	base := kvstore.RotationIdentity{
+		OwnerID: [16]byte{1}, WritableID: [32]byte{2}, ArchiveID: [32]byte{3},
+		LastRotated: 10, MinimumOnline: 4,
+	}
+	store := &identityRotatingStore{KeyValueStore: memorydb.New(), identity: base}
+	database := testDatabase(t, store, noCacheConfig())
+	want, err := database.DurableFingerprint(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name   string
+		mutate func(*kvstore.RotationIdentity)
+	}{
+		{"owner", func(i *kvstore.RotationIdentity) { i.OwnerID[0]++ }},
+		{"writable generation", func(i *kvstore.RotationIdentity) { i.WritableID[0]++ }},
+		{"archive generation", func(i *kvstore.RotationIdentity) { i.ArchiveID[0]++ }},
+		{"last rotated", func(i *kvstore.RotationIdentity) { i.LastRotated++ }},
+		{"minimum online", func(i *kvstore.RotationIdentity) { i.MinimumOnline++ }},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			store.identity = base
+			test.mutate(&store.identity)
+			got, err := database.DurableFingerprint(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got == want {
+				t.Fatal("rotating manifest mutation did not change fingerprint")
+			}
+		})
+	}
+}
+
+func TestStoreDurableIgnoresCancellationAfterAdmission(t *testing.T) {
+	store := &blockingSyncStore{
+		KeyValueStore: memorydb.New(),
+		started:       make(chan struct{}, 1),
+		release:       make(chan struct{}, 1),
+	}
+	database, err := NewKVDatabase(store, noCacheConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	ctx, cancel := context.WithCancel(context.Background())
+	node := testNode(NodeLedger, []byte("durable"), 1)
+	done := make(chan error, 1)
+	go func() { done <- database.StoreDurable(ctx, node) }()
+	<-store.started
+	cancel()
+	select {
+	case err := <-done:
+		t.Fatalf("StoreDurable returned before backend flush completed: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+	store.release <- struct{}{}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	stored, err := database.Fetch(context.Background(), node.Hash)
+	if err != nil || stored == nil {
+		t.Fatalf("durable node unavailable after completion: node=%v err=%v", stored, err)
+	}
+}
+
+func TestStoreDurableFlushErrorLeavesCompleteRecord(t *testing.T) {
+	wantErr := errors.New("injected flush failure")
+	store := &syncRecordingStore{KeyValueStore: memorydb.New(), syncErr: wantErr}
+	database := testDatabase(t, store, noCacheConfig())
+	node := testNode(NodeLedger, []byte("complete-before-flush"), 1)
+	if err := database.StoreDurable(t.Context(), node); !errors.Is(err, wantErr) {
+		t.Fatalf("StoreDurable error = %v, want %v", err, wantErr)
+	}
+	stored, err := database.Fetch(t.Context(), node.Hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored == nil || string(stored.Data) != string(node.Data) {
+		t.Fatalf("complete admitted record unavailable after flush error: %#v", stored)
+	}
+}
+
+func TestStoreDurableSurvivesReopenForActiveAndTombstone(t *testing.T) {
+	path := t.TempDir()
+	open := func() *KVDatabase {
+		backend, err := pebblekv.New(path, pebblekv.Options{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		database, err := NewKVDatabase(backend, noCacheConfig())
+		if err != nil {
+			t.Fatal(err)
+		}
+		return database
+	}
+	database := open()
+	node := testNode(NodeLedger, []byte("active-record"), 1)
+	if err := database.StoreDurable(t.Context(), node); err != nil {
+		t.Fatal(err)
+	}
+	fingerprint, err := database.DurableFingerprint(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	database = open()
+	reopenedFingerprint, err := database.DurableFingerprint(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reopenedFingerprint != fingerprint {
+		t.Fatal("plain durable identity changed across reopen")
+	}
+	stored, err := database.Fetch(t.Context(), node.Hash)
+	if err != nil || stored == nil || string(stored.Data) != "active-record" {
+		t.Fatalf("active record after reopen = %#v, err=%v", stored, err)
+	}
+	tombstone := node.Clone()
+	tombstone.Data = []byte("tombstone-record")
+	if err := database.StoreDurable(t.Context(), tombstone); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	database = open()
+	defer database.Close()
+	stored, err = database.Fetch(t.Context(), node.Hash)
+	if err != nil || stored == nil || string(stored.Data) != "tombstone-record" {
+		t.Fatalf("tombstone after reopen = %#v, err=%v", stored, err)
+	}
+}
+
+func TestDurableSnapshotExcludesManagedPruneThroughPublication(t *testing.T) {
+	database := testDatabase(t, memorydb.New(), noCacheConfig())
+	if _, err := database.DurableFingerprint(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	old := testNode(NodeLedger, []byte("old"), 1)
+	if err := database.Store(t.Context(), old); err != nil {
+		t.Fatal(err)
+	}
+	acquired := make(chan [32]byte, 1)
+	release := make(chan struct{})
+	snapshotDone := make(chan error, 1)
+	publication := testNode(NodeLedger, []byte("checkpoint"), 99)
+	go func() {
+		snapshotDone <- database.WithDurableSnapshot(context.Background(), func(fingerprint [32]byte) error {
+			acquired <- fingerprint
+			<-release
+			return database.StoreDurable(context.Background(), publication)
+		})
+	}()
+	before := <-acquired
+	pruneDone := make(chan error, 1)
+	go func() {
+		_, err := database.DeleteBefore(context.Background(), 2, 1)
+		pruneDone <- err
+	}()
+	select {
+	case err := <-pruneDone:
+		t.Fatalf("prune crossed the active durable snapshot: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+	close(release)
+	if err := <-snapshotDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-pruneDone; err != nil {
+		t.Fatal(err)
+	}
+	after, err := database.DurableFingerprint(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after == before {
+		t.Fatal("prune did not invalidate the just-published snapshot fingerprint")
+	}
+	stored, err := database.Fetch(t.Context(), publication.Hash)
+	if err != nil || stored == nil {
+		t.Fatalf("publication missing after serialized prune: node=%v err=%v", stored, err)
+	}
+}

--- a/storage/nodestore/kvstore_database.go
+++ b/storage/nodestore/kvstore_database.go
@@ -78,6 +78,8 @@ type KVDatabase struct {
 	lifecycleMu sync.RWMutex
 	closed      bool
 	syncGate    chan struct{}
+	identityMu  sync.Mutex
+	mutationMu  sync.RWMutex
 
 	pruneMu       sync.RWMutex
 	writeMu       sync.Mutex
@@ -144,6 +146,10 @@ func (d *KVDatabase) Store(ctx context.Context, node *Node) error {
 		return err
 	}
 
+	return d.storeNode(node)
+}
+
+func (d *KVDatabase) storeNode(node *Node) error {
 	encoded := encodeNodeData(node)
 	d.writeMu.Lock()
 	defer d.writeMu.Unlock()
@@ -168,6 +174,25 @@ func (d *KVDatabase) Store(ctx context.Context, node *Node) error {
 	}
 	d.pruneMu.RUnlock()
 	return nil
+}
+
+// StoreDurable admits a write only while ctx is live. Once admitted, the write
+// and one backend flush run to completion without observing cancellation.
+func (d *KVDatabase) StoreDurable(ctx context.Context, node *Node) error {
+	if err := d.begin(ctx); err != nil {
+		return err
+	}
+	defer d.lifecycleMu.RUnlock()
+	if err := validateNode(node); err != nil {
+		return err
+	}
+	if err := d.storeNode(node); err != nil {
+		return err
+	}
+	<-d.syncGate
+	err := d.store.Sync()
+	d.syncGate <- struct{}{}
+	return err
 }
 
 // Fetch returns a node by hash, consulting configured caches.

--- a/storage/nodestore/prune.go
+++ b/storage/nodestore/prune.go
@@ -16,13 +16,18 @@ func (d *KVDatabase) DeleteBefore(
 	boundary uint32,
 	batchSize int,
 ) (deleted uint64, err error) {
+	if boundary == 0 {
+		return 0, nil
+	}
+	d.mutationMu.Lock()
+	defer d.mutationMu.Unlock()
+	if err := d.bumpDurableMutation(ctx); err != nil {
+		return 0, fmt.Errorf("delete-before durable generation: %w", err)
+	}
 	if err := d.begin(ctx); err != nil {
 		return 0, err
 	}
 	defer d.lifecycleMu.RUnlock()
-	if boundary == 0 {
-		return 0, nil
-	}
 	if batchSize <= 0 {
 		batchSize = defaultDeleteBatch
 	}

--- a/storage/nodestore/rotating_database.go
+++ b/storage/nodestore/rotating_database.go
@@ -16,6 +16,12 @@ type RotatingKVDatabase struct {
 	rotating kvstore.RotatingStore
 }
 
+// DeleteBefore is unsupported for generation stores. Destructive retention
+// changes must use RotateGeneration so the durable manifest identity advances.
+func (d *RotatingKVDatabase) DeleteBefore(context.Context, uint32, int) (uint64, error) {
+	return 0, errors.New("nodestore: direct DeleteBefore is unsupported for rotating stores")
+}
+
 // NewRotatingKVDatabase constructs one logical NodeStore cache over a rotating
 // key-value backend.
 func NewRotatingKVDatabase(
@@ -85,6 +91,8 @@ func (d *RotatingKVDatabase) RotateGeneration(
 	ctx context.Context,
 	lastRotated, minimumOnline uint32,
 ) (bool, error) {
+	d.mutationMu.Lock()
+	defer d.mutationMu.Unlock()
 	if err := d.begin(ctx); err != nil {
 		return false, err
 	}

--- a/storage/nodestore/rotating_database_test.go
+++ b/storage/nodestore/rotating_database_test.go
@@ -89,3 +89,27 @@ func TestRotatingKVDatabaseCanRotateWithoutRefresh(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, canSkip)
 }
+
+func TestRotatingKVDatabaseRejectsDirectDeleteBefore(t *testing.T) {
+	ctx := context.Background()
+	store, err := kvpebble.NewRotating(
+		filepath.Join(t.TempDir(), "nodes"),
+		kvpebble.Options{BlockCacheBytes: 16 << 20, MaxOpenFiles: 200},
+	)
+	require.NoError(t, err)
+	db, err := NewRotatingKVDatabase(store, positiveCacheConfig(16))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	node := &Node{
+		Type: NodeAccount, Hash: testHash([]byte("retained-node")),
+		Data: []byte("retained-node"), LedgerSeq: 1,
+	}
+	require.NoError(t, db.Store(ctx, node))
+	deleted, err := db.DeleteBefore(ctx, 2, 10)
+	require.Zero(t, deleted)
+	require.ErrorContains(t, err, "unsupported for rotating stores")
+	stored, err := db.Fetch(ctx, node.Hash)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+}

--- a/storage/relationaldb/interface.go
+++ b/storage/relationaldb/interface.go
@@ -265,6 +265,12 @@ type RepositoryManager interface {
 	PersistValidatedLedger(ctx context.Context, ledger ValidatedLedger) error
 }
 
+// SchemaFingerprinter exposes a stable database identity bound to its live
+// schema version. Checkpoint users treat absence as unsupported.
+type SchemaFingerprinter interface {
+	SchemaFingerprint(context.Context) ([32]byte, error)
+}
+
 // Helper methods for Hash type
 func (h Hash) String() string {
 	return fmt.Sprintf("%x", h[:])

--- a/storage/relationaldb/postgres/migrations.go
+++ b/storage/relationaldb/postgres/migrations.go
@@ -202,4 +202,10 @@ var postgresMigrations = []migration{
 				char_length(amendment) = 64 AND amendment ~ '^[0-9A-F]{64}$')`,
 		)
 	}},
+	{version: 5, apply: func(ctx context.Context, tx *sql.Tx) error {
+		return execAll(ctx, tx, `CREATE TABLE IF NOT EXISTS repository_metadata (
+			singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+			instance_id BYTEA NOT NULL CHECK(octet_length(instance_id) = 16)
+		)`)
+	}},
 }

--- a/storage/relationaldb/postgres/postgres_test.go
+++ b/storage/relationaldb/postgres/postgres_test.go
@@ -284,7 +284,7 @@ func assertPersisted(t *testing.T, rm *RepositoryManager, value relationaldb.Val
 func TestLegacySignatureSchemaMigrates(t *testing.T) {
 	rm := setupTestDB(t)
 	ctx := context.Background()
-	if _, err := rm.db.ExecContext(ctx, `DELETE FROM schema_migrations WHERE version = 4`); err != nil {
+	if _, err := rm.db.ExecContext(ctx, `DELETE FROM schema_migrations WHERE version >= 4`); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := rm.db.ExecContext(ctx, `ALTER TABLE validations ADD COLUMN signature BYTEA NOT NULL DEFAULT ''`); err != nil {

--- a/storage/relationaldb/postgres/postgres_test.go
+++ b/storage/relationaldb/postgres/postgres_test.go
@@ -545,6 +545,17 @@ func TestConcurrentMigrationStartup(t *testing.T) {
 	if count != len(postgresMigrations) || minimum != 1 || maximum != len(postgresMigrations) {
 		t.Fatalf("migration history = count %d range %d-%d", count, minimum, maximum)
 	}
+	firstFingerprint, err := managers[0].SchemaFingerprint(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondFingerprint, err := managers[1].SchemaFingerprint(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstFingerprint != secondFingerprint {
+		t.Fatal("concurrent startup produced different repository identities")
+	}
 }
 
 func postgresDSNWithSchema(t *testing.T, dsn, schema string) string {

--- a/storage/relationaldb/postgres/repository_manager.go
+++ b/storage/relationaldb/postgres/repository_manager.go
@@ -82,12 +82,6 @@ func ensureRepositoryIdentity(ctx context.Context, db *sql.DB) error {
 		return err
 	}
 	defer tx.Rollback()
-	if _, err := tx.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS repository_metadata (
-		singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
-		instance_id BYTEA NOT NULL CHECK(octet_length(instance_id) = 16)
-	)`); err != nil {
-		return err
-	}
 	var id [16]byte
 	if _, err := rand.Read(id[:]); err != nil {
 		return err

--- a/storage/relationaldb/postgres/repository_manager.go
+++ b/storage/relationaldb/postgres/repository_manager.go
@@ -2,8 +2,12 @@ package postgres
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/binary"
 	"errors"
+	"fmt"
 
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 	"github.com/LeJamon/go-xrpl/storage/relationaldb/internal/sqlutil"
@@ -58,6 +62,10 @@ func NewRepositoryManager(ctx context.Context, config *relationaldb.Config) (*Re
 		_ = raw.Close()
 		return nil, relationaldb.NewSchemaError("new_repository_manager", "migrate database", err)
 	}
+	if err := ensureRepositoryIdentity(ctx, raw); err != nil {
+		_ = raw.Close()
+		return nil, relationaldb.NewSchemaError("new_repository_manager", "initialize repository identity", err)
+	}
 
 	rm := &RepositoryManager{db: sqlutil.NewDB(raw)}
 	rm.ledgerRepo = newLedgerRepository(rm.db)
@@ -66,6 +74,62 @@ func NewRepositoryManager(ctx context.Context, config *relationaldb.Config) (*Re
 	rm.validationRepo = sqlutil.NewGatedValidationRepository(&rm.gate, newValidationRepository(rm.db))
 	rm.amendmentVoteRepo = newAmendmentVoteRepository(rm.db)
 	return rm, nil
+}
+
+func ensureRepositoryIdentity(ctx context.Context, db *sql.DB) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS repository_metadata (
+		singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+		instance_id BYTEA NOT NULL CHECK(octet_length(instance_id) = 16)
+	)`); err != nil {
+		return err
+	}
+	var id [16]byte
+	if _, err := rand.Read(id[:]); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO repository_metadata(singleton, instance_id) VALUES (1, $1)
+		 ON CONFLICT (singleton) DO NOTHING`, id[:]); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// SchemaFingerprint binds the PostgreSQL instance identity and complete live
+// migration history summary.
+func (rm *RepositoryManager) SchemaFingerprint(ctx context.Context) ([32]byte, error) {
+	end, err := rm.gate.Begin()
+	if err != nil {
+		return [32]byte{}, err
+	}
+	defer end()
+	var count, minimum, maximum uint32
+	if err := rm.db.QueryRowContext(ctx,
+		`SELECT COUNT(*), MIN(version), MAX(version) FROM schema_migrations`).Scan(&count, &minimum, &maximum); err != nil {
+		return [32]byte{}, err
+	}
+	if count == 0 || minimum != 1 || maximum != count {
+		return [32]byte{}, fmt.Errorf("invalid PostgreSQL migration history count=%d min=%d max=%d", count, minimum, maximum)
+	}
+	var id []byte
+	if err := rm.db.QueryRowContext(ctx,
+		`SELECT instance_id FROM repository_metadata WHERE singleton = 1`).Scan(&id); err != nil {
+		return [32]byte{}, err
+	}
+	if len(id) != 16 {
+		return [32]byte{}, errors.New("invalid PostgreSQL repository identity")
+	}
+	payload := []byte("postgres-schema-v1")
+	payload = binary.BigEndian.AppendUint32(payload, count)
+	payload = binary.BigEndian.AppendUint32(payload, minimum)
+	payload = binary.BigEndian.AppendUint32(payload, maximum)
+	payload = append(payload, id...)
+	return sha256.Sum256(payload), nil
 }
 
 // Close waits for active operations and closes the database.

--- a/storage/relationaldb/sqlite/fingerprint_test.go
+++ b/storage/relationaldb/sqlite/fingerprint_test.go
@@ -1,0 +1,59 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSchemaFingerprintBindsInstanceAndVersions(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	rm, err := NewRepositoryManager(ctx, dir, Settings{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := rm.SchemaFingerprint(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rm.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := NewRepositoryManager(ctx, dir, Settings{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reopenedFingerprint, err := reopened.SchemaFingerprint(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reopenedFingerprint != first {
+		t.Fatal("schema fingerprint changed after reopening the same repository")
+	}
+	if _, err := reopened.ledgerDB.ExecContext(ctx, "PRAGMA user_version = 4"); err != nil {
+		t.Fatal(err)
+	}
+	changedVersion, err := reopened.SchemaFingerprint(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changedVersion == first {
+		t.Fatal("schema version change did not alter fingerprint")
+	}
+	if err := reopened.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	replacement, err := NewRepositoryManager(ctx, t.TempDir(), Settings{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer replacement.Close()
+	replacementFingerprint, err := replacement.SchemaFingerprint(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replacementFingerprint == first {
+		t.Fatal("replacement repository reused the persisted instance identity")
+	}
+}

--- a/storage/relationaldb/sqlite/repository_manager.go
+++ b/storage/relationaldb/sqlite/repository_manager.go
@@ -2,7 +2,10 @@ package sqlite
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"os"
@@ -85,6 +88,12 @@ func NewRepositoryManager(ctx context.Context, dbDir string, settings Settings) 
 		cleanup()
 		return nil, relationaldb.NewSchemaError("new_repository_manager", "migrate transaction database", err)
 	}
+	for _, db := range []*sql.DB{ledgerRaw, txRaw} {
+		if err := ensureRepositoryIdentity(ctx, db); err != nil {
+			cleanup()
+			return nil, relationaldb.NewSchemaError("new_repository_manager", "initialize repository identity", err)
+		}
+	}
 
 	rm := &RepositoryManager{
 		ledgerDB: sqlutil.NewDB(ledgerRaw),
@@ -96,6 +105,57 @@ func NewRepositoryManager(ctx context.Context, dbDir string, settings Settings) 
 	rm.validationRepo = sqlutil.NewGatedValidationRepository(&rm.gate, newValidationRepository(rm.ledgerDB))
 	rm.amendmentVoteRepo = newAmendmentVoteRepository(rm.ledgerDB)
 	return rm, nil
+}
+
+func ensureRepositoryIdentity(ctx context.Context, db *sql.DB) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS repository_metadata (
+		singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+		instance_id BLOB NOT NULL CHECK(length(instance_id) = 16)
+	)`); err != nil {
+		return err
+	}
+	var id [16]byte
+	if _, err := rand.Read(id[:]); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx,
+		`INSERT OR IGNORE INTO repository_metadata(singleton, instance_id) VALUES (1, ?)`, id[:]); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// SchemaFingerprint binds both SQLite files, their stable identities, and
+// their live migration versions.
+func (rm *RepositoryManager) SchemaFingerprint(ctx context.Context) ([32]byte, error) {
+	end, err := rm.gate.Begin()
+	if err != nil {
+		return [32]byte{}, err
+	}
+	defer end()
+	payload := []byte("sqlite-schema-v1")
+	for _, db := range []*sqlutil.DB{rm.ledgerDB, rm.txDB} {
+		var version uint32
+		if err := db.QueryRowContext(ctx, "PRAGMA user_version").Scan(&version); err != nil {
+			return [32]byte{}, err
+		}
+		var id []byte
+		if err := db.QueryRowContext(ctx,
+			`SELECT instance_id FROM repository_metadata WHERE singleton = 1`).Scan(&id); err != nil {
+			return [32]byte{}, err
+		}
+		if len(id) != 16 {
+			return [32]byte{}, errors.New("invalid SQLite repository identity")
+		}
+		payload = binary.BigEndian.AppendUint32(payload, version)
+		payload = append(payload, id...)
+	}
+	return sha256.Sum256(payload), nil
 }
 
 func (s Settings) normalized() (Settings, error) {


### PR DESCRIPTION
## Summary

- persist a versioned, single-use fast-load certificate containing the validated ledger identity, state/transaction roots, bounded FullBelow proofs, and prior strict-verification metrics
- bind certificate acceptance to durable plain/rotating NodeStore identity, writable/archive generations and rotation boundaries, NodeStore format, relational database identity, and live schema versions
- invalidate managed destructive mutations before deletion, consume certificates durably before startup workers, and keep fast-loaded ledgers provisional until trusted network confirmation
- bound checkpoint preparation during shutdown and leave stores open if an admitted durable flush is still running

The certificate deliberately trusts the managed NodeStore lifecycle and backend durability. Out-of-band bit rot or a partial filesystem restore that preserves all identity metadata cannot be detected in bounded/O(1) time and still requires strict traversal or backend integrity tooling.

This PR includes the four commits from the issue's referenced `fix/testnet-catchup-handoff` foundation, including `fcbdf088`'s in-memory FullBelow proof reuse.

## Test plan

- `go test ./internal/ledger/service ./internal/node ./storage/nodestore ./storage/kvstore/pebble ./storage/relationaldb/sqlite ./storage/relationaldb/postgres ./shamap`
- `go test -race ./internal/ledger/service ./internal/node ./storage/nodestore`
- `just test-core`
- `just test-libs`
- `just vet`
- `just lint`
- `just build`

Coverage includes one-use restart acceptance, strict fallback, malformed and stale certificates, real managed mutation invalidation, rotating generation identity changes, database/schema replacement, blocking/cancelled durable flushes, shutdown timeout ordering, zero transaction roots, and unchanged provisional network state. A production Testnet database was not available locally; deterministic tests assert the exact reduction from full traversal to bounded shallow reads.

Fixes #1657
