### PR TITLE
fix: enforce gRPC transport and ledger contracts

### DIFF
--- a/config/grpc_test.go
+++ b/config/grpc_test.go
@@ -64,6 +64,41 @@ func TestValidateProtocols_GRPC(t *testing.T) {
 	})
 }
 
+func TestValidateGRPCTLS(t *testing.T) {
+	tests := []struct {
+		name     string
+		cert     string
+		key      string
+		chain    string
+		ciphers  string
+		clientCA string
+		wantErr  string
+	}{
+		{name: "plaintext"},
+		{name: "certificate and key", cert: "server.crt", key: "server.key"},
+		{name: "certificate only", cert: "server.crt", wantErr: "grpc ssl_cert and ssl_key must be configured together"},
+		{name: "key only", key: "server.key", wantErr: "grpc ssl_cert and ssl_key must be configured together"},
+		{name: "chain without credentials", chain: "chain.crt", wantErr: "grpc ssl_chain requires ssl_cert and ssl_key"},
+		{name: "unsupported cipher list", ciphers: "ECDHE-RSA-AES256-GCM-SHA384", wantErr: "grpc ssl_ciphers is not supported"},
+		{name: "unsupported client CA", clientCA: "clients.crt", wantErr: "grpc ssl_client_ca is not supported"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := &PortConfig{
+				Port: 50051, IP: "127.0.0.1", Protocol: "grpc",
+				SSLCert: test.cert, SSLKey: test.key, SSLChain: test.chain, SSLCiphers: test.ciphers,
+				SSLClientCA: test.clientCA,
+			}
+			err := p.Validate()
+			if test.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, test.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidateProtocols_RejectsUnsupportedTLS(t *testing.T) {
 	for _, protocol := range []string{"https", "wss"} {
 		t.Run(protocol, func(t *testing.T) {

--- a/config/server.go
+++ b/config/server.go
@@ -23,8 +23,9 @@ type ServerConfig struct {
 	AllowedOrigins []string `toml:"allowed_origins" mapstructure:"allowed_origins"` // Exact browser origins allowed on HTTP/WS ports
 	SecureGateway  []string `toml:"secure_gateway" mapstructure:"secure_gateway"`   // Default trusted proxy networks
 	SSLCiphers     string   `toml:"ssl_ciphers" mapstructure:"ssl_ciphers"`
-	// MaxConnections is the process-wide ceiling on concurrent HTTP + WebSocket
-	// connections. 0 keeps the bounded built-in default; a negative value
+	// MaxConnections is the process-wide ceiling on concurrent HTTP, WebSocket,
+	// and gRPC connections.
+	// 0 keeps the bounded built-in default; a negative value
 	// disables the global cap (per-port limits still apply).
 	MaxConnections int `toml:"max_connections" mapstructure:"max_connections"`
 }
@@ -52,10 +53,11 @@ type PortConfig struct {
 	SecureGateway []string `toml:"secure_gateway" mapstructure:"secure_gateway"`
 
 	// SSL/TLS configuration
-	SSLKey     string `toml:"ssl_key" mapstructure:"ssl_key"`
-	SSLCert    string `toml:"ssl_cert" mapstructure:"ssl_cert"`
-	SSLChain   string `toml:"ssl_chain" mapstructure:"ssl_chain"`
-	SSLCiphers string `toml:"ssl_ciphers" mapstructure:"ssl_ciphers"`
+	SSLKey      string `toml:"ssl_key" mapstructure:"ssl_key"`
+	SSLCert     string `toml:"ssl_cert" mapstructure:"ssl_cert"`
+	SSLChain    string `toml:"ssl_chain" mapstructure:"ssl_chain"`
+	SSLClientCA string `toml:"ssl_client_ca" mapstructure:"ssl_client_ca"`
+	SSLCiphers  string `toml:"ssl_ciphers" mapstructure:"ssl_ciphers"`
 
 	// WebSocket specific settings
 	SendQueueLimit int `toml:"send_queue_limit" mapstructure:"send_queue_limit"`
@@ -121,6 +123,20 @@ func (p *PortConfig) Validate() error {
 	// Validate protocol combinations
 	if err := p.validateProtocols(); err != nil {
 		return err
+	}
+	if p.HasGRPC() {
+		if (p.SSLCert == "") != (p.SSLKey == "") {
+			return errors.New("grpc ssl_cert and ssl_key must be configured together")
+		}
+		if p.SSLChain != "" && p.SSLCert == "" {
+			return errors.New("grpc ssl_chain requires ssl_cert and ssl_key")
+		}
+		if p.SSLCiphers != "" {
+			return errors.New("grpc ssl_ciphers is not supported")
+		}
+		if p.SSLClientCA != "" {
+			return errors.New("grpc ssl_client_ca is not supported")
+		}
 	}
 
 	// Validate compression settings

--- a/internal/grpc/request.go
+++ b/internal/grpc/request.go
@@ -1,0 +1,136 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+
+	rpcv1 "github.com/LeJamon/go-xrpl/internal/grpc/pb/org/xrpl/rpc/v1"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
+)
+
+type ServerConfig struct {
+	Logger           xrpllog.Logger
+	ResourceManager  *resource.Manager
+	SecureGatewayIPs []net.IP
+}
+
+type Server struct {
+	rpcv1.UnimplementedXRPLedgerAPIServiceServer
+	lookup           LedgerLookup
+	log              xrpllog.Logger
+	resourceManager  *resource.Manager
+	secureGatewayIPs []net.IP
+}
+
+func NewServer(lookup LedgerLookup, configs ...ServerConfig) *Server {
+	config := ServerConfig{Logger: xrpllog.Discard()}
+	if len(configs) > 0 {
+		config = configs[0]
+		if config.Logger == nil {
+			config.Logger = xrpllog.Discard()
+		}
+	}
+	return &Server{
+		lookup:           lookup,
+		log:              config.Logger,
+		resourceManager:  config.ResourceManager,
+		secureGatewayIPs: cloneIPs(config.SecureGatewayIPs),
+	}
+}
+
+func cloneIPs(ips []net.IP) []net.IP {
+	out := make([]net.IP, len(ips))
+	for i, ip := range ips {
+		out[i] = append(net.IP(nil), ip...)
+	}
+	return out
+}
+
+func (s *Server) grpcStorageError(operation string, err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return status.FromContextError(err).Err()
+	}
+	s.log.Error("gRPC request failed", "operation", operation, "err", err)
+	return status.Error(codes.Internal, "Internal error.")
+}
+
+type requestUser interface {
+	GetUser() string
+}
+
+func (s *Server) beginRequest(ctx context.Context, req any, method string) (bool, func(), error) {
+	clientIP, err := grpcPeerIP(ctx)
+	if err != nil {
+		if s.resourceManager == nil {
+			return false, func() {}, nil
+		}
+		return false, func() {}, s.grpcStorageError("identifying client", err)
+	}
+
+	unlimited := false
+	if withUser, ok := req.(requestUser); ok && withUser.GetUser() != "" {
+		for _, gatewayIP := range s.secureGatewayIPs {
+			if gatewayIP.Equal(clientIP) {
+				unlimited = true
+				break
+			}
+		}
+	}
+	if s.resourceManager == nil {
+		return unlimited, func() {}, nil
+	}
+
+	var admission *resource.Admission
+	var disposition resource.Disposition
+	if unlimited {
+		admission, disposition = s.resourceManager.AdmitUnlimited(clientIP.String())
+	} else {
+		admission, disposition = s.resourceManager.AdmitInbound(clientIP.String(), resource.FeeReferenceRPC())
+	}
+	if admission == nil || disposition == resource.Drop {
+		s.log.Warn("gRPC request dropped: client over load threshold", "client", clientIP.String(), "method", method)
+		return unlimited, func() {}, status.Error(codes.ResourceExhausted, "usage balance exceeds threshold")
+	}
+
+	return unlimited, func() {
+		completion := admission.Finish(resource.FeeMediumBurdenRPC(), method)
+		if unlimited {
+			consumer := s.resourceManager.NewInboundEndpoint(clientIP.String())
+			if consumer == nil {
+				s.log.Warn("gRPC unlimited request charge could not acquire client", "client", clientIP.String(), "method", method)
+				return
+			}
+			completion.Disposition = consumer.Charge(resource.FeeMediumBurdenRPC(), method)
+			completion.Balance = consumer.Balance()
+			consumer.Release()
+		}
+		switch completion.Disposition {
+		case resource.Drop:
+			s.log.Warn("gRPC client crossed drop threshold", "client", clientIP.String(), "method", method, "balance", completion.Balance)
+		case resource.Warn:
+			s.log.Info("gRPC client over warn threshold", "client", clientIP.String(), "method", method, "balance", completion.Balance)
+		}
+	}, nil
+}
+
+func grpcPeerIP(ctx context.Context) (net.IP, error) {
+	peerInfo, ok := peer.FromContext(ctx)
+	if !ok || peerInfo.Addr == nil {
+		return nil, errors.New("gRPC peer address unavailable")
+	}
+	host, _, err := net.SplitHostPort(peerInfo.Addr.String())
+	if err != nil {
+		host = peerInfo.Addr.String()
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return nil, errors.New("gRPC peer address is not an IP endpoint")
+	}
+	return ip, nil
+}

--- a/internal/grpc/request_test.go
+++ b/internal/grpc/request_test.go
@@ -1,0 +1,144 @@
+package grpc
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+
+	rpcv1 "github.com/LeJamon/go-xrpl/internal/grpc/pb/org/xrpl/rpc/v1"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
+)
+
+func grpcTestPeerContext(ip string) context.Context {
+	return peer.NewContext(context.Background(), &peer.Peer{
+		Addr: &net.TCPAddr{IP: net.ParseIP(ip), Port: 12345},
+	})
+}
+
+func TestBeginRequestEnforcesPerClientInflightLimit(t *testing.T) {
+	limits := resource.DefaultLimits()
+	limits.MaxInflightPerConsumer = 1
+	manager := resource.NewManagerWithLimits(nil, nil, limits)
+	srv := NewServer(&fakeLookup{}, ServerConfig{ResourceManager: manager})
+	ctx := grpcTestPeerContext("192.0.2.10")
+
+	_, finish, err := srv.beginRequest(ctx, &rpcv1.GetLedgerRequest{}, "GetLedger")
+	if err != nil {
+		t.Fatalf("first request: %v", err)
+	}
+	if _, _, err := srv.beginRequest(ctx, &rpcv1.GetLedgerDataRequest{}, "GetLedgerData"); status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("second request = %v, want ResourceExhausted", err)
+	}
+	finish()
+
+	_, finish, err = srv.beginRequest(ctx, &rpcv1.GetLedgerEntryRequest{}, "GetLedgerEntry")
+	if err != nil {
+		t.Fatalf("request after completion: %v", err)
+	}
+	finish()
+	if stats := manager.Stats(); stats.Inflight != 0 || stats.InflightRejections != 1 {
+		t.Fatalf("resource stats = %+v", stats)
+	}
+}
+
+func TestBeginRequestChargesMediumBurden(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	manager := resource.NewManagerWithLimits(func() time.Time { return now }, nil, resource.DefaultLimits())
+	srv := NewServer(&fakeLookup{}, ServerConfig{ResourceManager: manager})
+	ctx := grpcTestPeerContext("192.0.2.40")
+
+	_, finish, err := srv.beginRequest(ctx, &rpcv1.GetLedgerDiffRequest{}, "GetLedgerDiff")
+	if err != nil {
+		t.Fatalf("begin request: %v", err)
+	}
+	finish()
+	consumer := manager.NewInboundEndpoint("192.0.2.40")
+	if consumer == nil {
+		t.Fatal("acquire charged consumer")
+	}
+	defer consumer.Release()
+	want := int64(resource.FeeMediumBurdenRPC().Cost() / resource.DecayWindowSeconds)
+	if got := consumer.Balance(); got != want {
+		t.Fatalf("request charge balance = %d, want medium burden %d", got, want)
+	}
+}
+
+func TestBeginRequestUsesActualPeerForSecureGateway(t *testing.T) {
+	limits := resource.DefaultLimits()
+	limits.MaxInflightPerConsumer = 1
+	manager := resource.NewManagerWithLimits(nil, nil, limits)
+	srv := NewServer(&fakeLookup{}, ServerConfig{
+		ResourceManager:  manager,
+		SecureGatewayIPs: []net.IP{net.ParseIP("192.0.2.20")},
+	})
+
+	trusted := grpcTestPeerContext("192.0.2.20")
+	unlimited, first, err := srv.beginRequest(trusted, &rpcv1.GetLedgerRequest{User: "clio"}, "GetLedger")
+	if err != nil || !unlimited {
+		t.Fatalf("trusted request = (unlimited=%v, err=%v)", unlimited, err)
+	}
+	unlimited, second, err := srv.beginRequest(trusted, &rpcv1.GetLedgerDataRequest{User: "clio"}, "GetLedgerData")
+	if err != nil || !unlimited {
+		t.Fatalf("second trusted request = (unlimited=%v, err=%v)", unlimited, err)
+	}
+	first()
+	second()
+	charged := manager.NewInboundEndpoint("192.0.2.20")
+	if charged == nil {
+		t.Fatal("acquire unlimited request charge")
+	}
+	if charged.Balance() == 0 {
+		t.Fatal("unlimited requests were not charged medium burden")
+	}
+	charged.Release()
+
+	untrusted := grpcTestPeerContext("192.0.2.21")
+	unlimited, finish, err := srv.beginRequest(untrusted, &rpcv1.GetLedgerRequest{
+		User:     "clio",
+		ClientIp: "192.0.2.20",
+	}, "GetLedger")
+	if err != nil {
+		t.Fatalf("untrusted request: %v", err)
+	}
+	finish()
+	if unlimited {
+		t.Fatal("request client_ip granted unlimited status")
+	}
+
+	unlimited, finish, err = srv.beginRequest(trusted, &rpcv1.GetLedgerRequest{}, "GetLedger")
+	if err != nil {
+		t.Fatalf("trusted peer without user: %v", err)
+	}
+	finish()
+	if unlimited {
+		t.Fatal("trusted peer without user granted unlimited status")
+	}
+}
+
+func TestSecureGatewayResponsesReportUnlimited(t *testing.T) {
+	l := newTestLedger(t, 7, nil, nil)
+	srv := NewServer(&fakeLookup{openLedger: l}, ServerConfig{
+		SecureGatewayIPs: []net.IP{net.ParseIP("192.0.2.30")},
+	})
+	ctx := grpcTestPeerContext("192.0.2.30")
+
+	ledgerResp, err := srv.GetLedger(ctx, &rpcv1.GetLedgerRequest{User: "clio"})
+	if err != nil {
+		t.Fatalf("GetLedger: %v", err)
+	}
+	if !ledgerResp.GetIsUnlimited() {
+		t.Fatal("GetLedger did not report unlimited status")
+	}
+	dataResp, err := srv.GetLedgerData(ctx, &rpcv1.GetLedgerDataRequest{User: "clio"})
+	if err != nil {
+		t.Fatalf("GetLedgerData: %v", err)
+	}
+	if !dataResp.GetIsUnlimited() {
+		t.Fatal("GetLedgerData did not report unlimited status")
+	}
+}

--- a/internal/grpc/serve_test.go
+++ b/internal/grpc/serve_test.go
@@ -2,8 +2,10 @@ package grpc
 
 import (
 	"context"
+	"errors"
 	"net"
 	"testing"
+	"time"
 
 	googlegrpc "google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -24,8 +26,20 @@ func TestGRPC_ServeAndDial(t *testing.T) {
 	}
 	srv := googlegrpc.NewServer()
 	rpcv1.RegisterXRPLedgerAPIServiceServer(srv, NewServer(&fakeLookup{validated: l}))
-	go func() { _ = srv.Serve(lis) }()
-	defer srv.Stop()
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(lis) }()
+	t.Cleanup(func() {
+		srv.Stop()
+		_ = lis.Close()
+		select {
+		case err := <-serveErr:
+			if err != nil && !errors.Is(err, googlegrpc.ErrServerStopped) {
+				t.Errorf("Serve: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Error("Serve did not stop within one second")
+		}
+	})
 
 	conn, err := googlegrpc.NewClient(lis.Addr().String(), googlegrpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
@@ -34,7 +48,9 @@ func TestGRPC_ServeAndDial(t *testing.T) {
 	defer conn.Close()
 
 	client := rpcv1.NewXRPLedgerAPIServiceClient(conn)
-	resp, err := client.GetLedger(context.Background(), &rpcv1.GetLedgerRequest{
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := client.GetLedger(ctx, &rpcv1.GetLedgerRequest{
 		Ledger: &rpcv1.LedgerSpecifier{
 			Ledger: &rpcv1.LedgerSpecifier_Shortcut_{Shortcut: rpcv1.LedgerSpecifier_SHORTCUT_VALIDATED},
 		},

--- a/internal/grpc/service.go
+++ b/internal/grpc/service.go
@@ -8,10 +8,9 @@ package grpc
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"errors"
 	"math"
-	"strconv"
+	"sort"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -22,7 +21,6 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	ledgerselector "github.com/LeJamon/go-xrpl/internal/ledger/selector"
-	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -37,43 +35,17 @@ var errLedgerNotSynced = errors.New("notSynced")
 // LedgerLookup is the slice of the ledger Service that this gRPC
 // implementation needs. Kept narrow so tests can substitute a fake.
 type LedgerLookup interface {
-	GetLedgerByHash(hash [32]byte) (*ledger.Ledger, error)
-	GetLedgerBySequence(seq uint32) (*ledger.Ledger, error)
+	GetLedgerByHashContext(ctx context.Context, hash [32]byte) (*ledger.Ledger, error)
+	GetLedgerBySequenceContext(ctx context.Context, seq uint32) (*ledger.Ledger, error)
 	GetClosedLedger() *ledger.Ledger
 	GetValidatedLedger() *ledger.Ledger
 	GetValidatedLedgerAge() time.Duration
 	GetOpenLedger() *ledger.Ledger
 	IsStandalone() bool
-	GetLedgerEntry(ctx context.Context, entryKey [32]byte, ledgerIndex string) (*service.LedgerEntryResult, error)
-}
-
-type Server struct {
-	rpcv1.UnimplementedXRPLedgerAPIServiceServer
-	lookup LedgerLookup
-}
-
-func NewServer(lookup LedgerLookup) *Server {
-	return &Server{lookup: lookup}
-}
-
-func grpcStorageError(operation string, err error) error {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return status.FromContextError(err).Err()
-	}
-	return status.Errorf(codes.Internal, "%s: %v", operation, err)
 }
 
 func (s *Server) lookupLedgerByHash(ctx context.Context, hash [32]byte) (*ledger.Ledger, error) {
-	if contextual, ok := s.lookup.(interface {
-		GetLedgerByHashContext(context.Context, [32]byte) (*ledger.Ledger, error)
-	}); ok {
-		return contextual.GetLedgerByHashContext(ctx, hash)
-	}
-	return s.lookup.GetLedgerByHash(hash)
-}
-
-func (s *Server) resolveLedger(spec *rpcv1.LedgerSpecifier) (*ledger.Ledger, error) {
-	return s.resolveLedgerContext(context.Background(), spec)
+	return s.lookup.GetLedgerByHashContext(ctx, hash)
 }
 
 func (s *Server) resolveLedgerContext(ctx context.Context, spec *rpcv1.LedgerSpecifier) (*ledger.Ledger, error) {
@@ -148,7 +120,7 @@ func (s *Server) resolveLedgerSelection(ctx context.Context, selection ledgersel
 			return l, l != nil, nil
 		},
 		BySequence: func(sequence uint32) (*ledger.Ledger, bool, error) {
-			l, err := s.lookup.GetLedgerBySequence(sequence)
+			l, err := s.lookup.GetLedgerBySequenceContext(ctx, sequence)
 			if l != nil {
 				if stale, validSequence := s.validatedLedgerState(); stale && l.Sequence() > validSequence {
 					return nil, false, errLedgerNotSynced
@@ -162,8 +134,13 @@ func (s *Server) resolveLedgerSelection(ctx context.Context, selection ledgersel
 		},
 	})
 	if err != nil {
-		return ledgerselector.Result[*ledger.Ledger]{}, ledgerSelectorError(selection, err)
+		return ledgerselector.Result[*ledger.Ledger]{}, s.ledgerSelectorError(selection, err)
 	}
+	snapshot, err := result.Value.SnapshotContext(ctx)
+	if err != nil {
+		return ledgerselector.Result[*ledger.Ledger]{}, s.grpcStorageError("snapshotting ledger", err)
+	}
+	result.Value = snapshot
 	return result, nil
 }
 
@@ -186,7 +163,7 @@ func (s *Server) shortcutLedgerLagged(l *ledger.Ledger) bool {
 	return validated != nil && uint64(l.Sequence())+10 < uint64(validated.Sequence())
 }
 
-func ledgerSelectorError(selection ledgerselector.Selector, err error) error {
+func (s *Server) ledgerSelectorError(selection ledgerselector.Selector, err error) error {
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return status.FromContextError(err).Err()
 	}
@@ -196,10 +173,10 @@ func ledgerSelectorError(selection ledgerselector.Selector, err error) error {
 	if errors.Is(err, errLedgerNotSynced) {
 		return status.Error(codes.NotFound, errLedgerNotSynced.Error())
 	}
-	if selection.Kind() == ledgerselector.KindHash &&
-		!errors.Is(err, ledgerselector.ErrLedgerNotFound) &&
-		!errors.Is(err, svcerr.ErrLedgerNotFound) {
-		return status.Errorf(codes.Internal, "ledger hash lookup: %v", err)
+	if selection.Kind() == ledgerselector.KindHash || selection.Kind() == ledgerselector.KindSequence {
+		if !errors.Is(err, ledgerselector.ErrLedgerNotFound) && !errors.Is(err, svcerr.ErrLedgerNotFound) {
+			return s.grpcStorageError("looking up ledger", err)
+		}
 	}
 
 	switch selection.Kind() {
@@ -224,6 +201,11 @@ func (s *Server) GetLedger(ctx context.Context, req *rpcv1.GetLedgerRequest) (*r
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
 	}
+	unlimited, finish, err := s.beginRequest(ctx, req, "GetLedger")
+	if err != nil {
+		return nil, err
+	}
+	defer finish()
 	l, err := s.resolveLedgerContext(ctx, req.GetLedger())
 	if err != nil {
 		return nil, err
@@ -232,22 +214,33 @@ func (s *Server) GetLedger(ctx context.Context, req *rpcv1.GetLedgerRequest) (*r
 	resp := &rpcv1.GetLedgerResponse{
 		LedgerHeader: header.AddRaw(l.Header(), true),
 		Validated:    l.IsValidated(),
+		IsUnlimited:  unlimited,
 	}
 
 	if req.GetTransactions() {
 		if req.GetExpand() {
-			list, err := expandTransactions(ctx, l)
+			list, err := s.expandTransactions(ctx, l)
 			if err != nil {
 				return nil, err
 			}
 			resp.Transactions = &rpcv1.GetLedgerResponse_TransactionsList{TransactionsList: list}
 		} else {
 			hashes := &rpcv1.TransactionHashList{}
-			if err := l.ForEachTransactionContext(ctx, func(h [32]byte, _ []byte) bool {
-				hashes.Hashes = append(hashes.Hashes, cloneHash(h))
+			if err := l.ForEachTransactionContext(ctx, func(_ [32]byte, data []byte) bool {
+				parsed, _, _, err := decodeLedgerTransaction(l, data)
+				if err != nil {
+					s.log.Error("malformed transaction in ledger", "ledger", l.Sequence(), "err", err)
+					return false
+				}
+				hash, err := tx.ComputeTransactionHash(parsed)
+				if err != nil {
+					s.log.Error("malformed transaction in ledger", "ledger", l.Sequence(), "err", err)
+					return false
+				}
+				hashes.Hashes = append(hashes.Hashes, cloneHash(hash))
 				return true
 			}); err != nil {
-				return nil, grpcStorageError("iterating transactions", err)
+				return nil, s.grpcStorageError("iterating transactions", err)
 			}
 			resp.Transactions = &rpcv1.GetLedgerResponse_HashesList{HashesList: hashes}
 		}
@@ -264,11 +257,12 @@ func (s *Server) GetLedger(ctx context.Context, req *rpcv1.GetLedgerRequest) (*r
 
 // expandTransactions splits each stored tx+metadata blob into its separate
 // transaction and metadata serializations, the shape Clio expects.
-func expandTransactions(ctx context.Context, l *ledger.Ledger) (*rpcv1.TransactionAndMetadataList, error) {
+func (s *Server) expandTransactions(ctx context.Context, l *ledger.Ledger) (*rpcv1.TransactionAndMetadataList, error) {
 	list := &rpcv1.TransactionAndMetadataList{}
 	if err := l.ForEachTransactionContext(ctx, func(_ [32]byte, data []byte) bool {
-		txBlob, metaBlob, e := tx.SplitTxWithMetaBlob(data)
-		if e != nil {
+		_, txBlob, metaBlob, err := decodeLedgerTransaction(l, data)
+		if err != nil {
+			s.log.Error("malformed transaction in ledger", "ledger", l.Sequence(), "err", err)
 			return false
 		}
 		list.Transactions = append(list.Transactions, &rpcv1.TransactionAndMetadata{
@@ -277,9 +271,29 @@ func expandTransactions(ctx context.Context, l *ledger.Ledger) (*rpcv1.Transacti
 		})
 		return true
 	}); err != nil {
-		return nil, grpcStorageError("iterating transactions", err)
+		return nil, s.grpcStorageError("iterating transactions", err)
 	}
 	return list, nil
+}
+
+func decodeLedgerTransaction(l *ledger.Ledger, data []byte) (tx.Transaction, []byte, []byte, error) {
+	txBlob := data
+	var metaBlob []byte
+	var err error
+	if !l.IsOpen() {
+		txBlob, metaBlob, err = tx.SplitTxWithMetaBlobStrict(data)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if _, err := binarycodec.DecodeBytes(metaBlob); err != nil {
+			return nil, nil, nil, err
+		}
+	}
+	parsed, err := tx.ParseFromBinary(txBlob)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return parsed, txBlob, metaBlob, nil
 }
 
 // appendChangedObjects fills the response with the state objects that differ
@@ -287,28 +301,45 @@ func expandTransactions(ctx context.Context, l *ledger.Ledger) (*rpcv1.Transacti
 // DELETED. When wantNeighbors is set it also fills each created/deleted
 // object's predecessor and successor and any order-book successors.
 func (s *Server) appendChangedObjects(ctx context.Context, resp *rpcv1.GetLedgerResponse, l *ledger.Ledger, wantNeighbors bool) error {
-	parent, err := s.lookupLedgerByHash(ctx, l.ParentHash())
+	if l.Sequence() == 0 {
+		return status.Error(codes.NotFound, "parent ledger not validated")
+	}
+	parent, err := s.lookup.GetLedgerBySequenceContext(ctx, l.Sequence()-1)
 	if errors.Is(err, svcerr.ErrLedgerNotFound) || (err == nil && parent == nil) {
 		return status.Error(codes.NotFound, "parent ledger not validated")
 	}
 	if err != nil {
-		return grpcStorageError("looking up parent ledger", err)
+		return s.grpcStorageError("looking up parent ledger", err)
 	}
-	if parent == nil || !parent.IsImmutable() {
+	parent, err = parent.SnapshotContext(ctx)
+	if err != nil {
+		return s.grpcStorageError("snapshotting parent ledger", err)
+	}
+	if !parent.IsClosed() {
 		return status.Error(codes.NotFound, "parent ledger not validated")
 	}
-	if !l.IsImmutable() {
+	if !l.IsClosed() {
 		return status.Error(codes.NotFound, "ledger not validated")
 	}
 	diff, baseMap, desiredMap, err := stateDiff(ctx, parent, l)
 	if err != nil {
-		return grpcStorageError("comparing state maps", err)
+		return s.grpcStorageError("comparing state maps", err)
 	}
 	if !diff.Complete {
 		return status.Error(codes.ResourceExhausted, "too many differences between specified ledgers")
 	}
+	if err := ctx.Err(); err != nil {
+		return status.FromContextError(err).Err()
+	}
+	sortDifferences(diff.Differences)
+	if err := ctx.Err(); err != nil {
+		return status.FromContextError(err).Err()
+	}
 	objects := &rpcv1.RawLedgerObjects{}
 	for _, d := range diff.Differences {
+		if err := ctx.Err(); err != nil {
+			return status.FromContextError(err).Err()
+		}
 		obj := &rpcv1.RawLedgerObject{Key: cloneHash(d.Key)}
 		switch d.Type {
 		case shamap.DiffAdded:
@@ -324,7 +355,7 @@ func (s *Server) appendChangedObjects(ctx context.Context, resp *rpcv1.GetLedger
 		// modified ones.
 		if wantNeighbors && d.Type != shamap.DiffModified {
 			if err := appendNeighbors(ctx, obj, resp, d, baseMap, desiredMap); err != nil {
-				return grpcStorageError("finding object neighbors", err)
+				return s.grpcStorageError("finding object neighbors", err)
 			}
 		}
 		objects.Objects = append(objects.Objects, obj)
@@ -437,6 +468,11 @@ func (s *Server) GetLedgerEntry(ctx context.Context, req *rpcv1.GetLedgerEntryRe
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
 	}
+	_, finish, err := s.beginRequest(ctx, req, "GetLedgerEntry")
+	if err != nil {
+		return nil, err
+	}
+	defer finish()
 	resolved, err := s.resolveLedgerContext(ctx, req.GetLedger())
 	if err != nil {
 		return nil, err
@@ -447,25 +483,17 @@ func (s *Server) GetLedgerEntry(ctx context.Context, req *rpcv1.GetLedgerEntryRe
 	var key [32]byte
 	copy(key[:], req.GetKey())
 
-	ledgerIndex := strconv.FormatUint(uint64(resolved.Sequence()), 10)
-	if spec := req.GetLedger(); spec != nil && len(spec.GetHash()) == 32 {
-		ledgerIndex = hex.EncodeToString(spec.GetHash())
-	}
-	entry, err := s.lookup.GetLedgerEntry(ctx, key, ledgerIndex)
+	data, err := resolved.ReadContext(ctx, keylet.Keylet{Type: entry.TypeAny, Key: key})
 	if err != nil {
-		switch {
-		case errors.Is(err, svcerr.ErrLedgerEntryNotFound):
-			return nil, status.Error(codes.NotFound, "object not found")
-		case errors.Is(err, svcerr.ErrLedgerNotFound), errors.Is(err, svcerr.ErrNoOpenLedger):
-			return nil, status.Error(codes.NotFound, err.Error())
-		default:
-			return nil, grpcStorageError("lookup", err)
-		}
+		return nil, s.grpcStorageError("reading ledger entry", err)
+	}
+	if data == nil {
+		return nil, status.Error(codes.NotFound, "object not found")
 	}
 
 	return &rpcv1.GetLedgerEntryResponse{
 		LedgerObject: &rpcv1.RawLedgerObject{
-			Data: entry.Node,
+			Data: data,
 			Key:  cloneHash(key),
 		},
 		Ledger: req.GetLedger(),
@@ -479,6 +507,11 @@ func (s *Server) GetLedgerData(ctx context.Context, req *rpcv1.GetLedgerDataRequ
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
 	}
+	unlimited, finish, err := s.beginRequest(ctx, req, "GetLedgerData")
+	if err != nil {
+		return nil, err
+	}
+	defer finish()
 	l, err := s.resolveLedgerContext(ctx, req.GetLedger())
 	if err != nil {
 		return nil, err
@@ -487,7 +520,7 @@ func (s *Server) GetLedgerData(ctx context.Context, req *rpcv1.GetLedgerDataRequ
 	var startKey [32]byte
 	hasMarker := false
 	if m := req.GetMarker(); len(m) > 0 {
-		if startKey, err = hash32(m, "marker"); err != nil {
+		if startKey, err = hash32(m); err != nil {
 			return nil, status.Error(codes.InvalidArgument, "marker malformed")
 		}
 		hasMarker = true
@@ -496,20 +529,19 @@ func (s *Server) GetLedgerData(ctx context.Context, req *rpcv1.GetLedgerDataRequ
 	var endKey [32]byte
 	hasEnd := false
 	if m := req.GetEndMarker(); len(m) > 0 {
-		if endKey, err = hash32(m, "end_marker"); err != nil {
+		if endKey, err = hash32(m); err != nil {
 			return nil, status.Error(codes.InvalidArgument, "end marker malformed")
 		}
 		hasEnd = true
 	}
-	if hasMarker && hasEnd && compareKey(endKey, startKey) < 0 {
+	if hasMarker && hasEnd && bytes.Compare(endKey[:], startKey[:]) < 0 {
 		return nil, status.Error(codes.InvalidArgument, "end marker out of range")
 	}
 
 	const pageLimit = 2048
 	resp := &rpcv1.GetLedgerDataResponse{
-		LedgerIndex:   l.Sequence(),
-		LedgerHash:    cloneHash(l.Hash()),
 		LedgerObjects: &rpcv1.RawLedgerObjects{},
+		IsUnlimited:   unlimited,
 	}
 
 	// Resume strictly after the marker via the shared state iterator; the zero
@@ -519,7 +551,7 @@ func (s *Server) GetLedgerData(ctx context.Context, req *rpcv1.GetLedgerDataRequ
 	if err := l.IterateStateFrom(ctx, startKey, func(key [32]byte, data []byte) bool {
 		// end_marker is inclusive: stop only past it, so an entry whose key
 		// equals end_marker is still returned.
-		if hasEnd && compareKey(key, endKey) > 0 {
+		if hasEnd && bytes.Compare(key[:], endKey[:]) > 0 {
 			return false
 		}
 		if count >= pageLimit {
@@ -536,10 +568,7 @@ func (s *Server) GetLedgerData(ctx context.Context, req *rpcv1.GetLedgerDataRequ
 		count++
 		return true
 	}); err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return nil, status.FromContextError(err).Err()
-		}
-		return nil, status.Errorf(codes.Internal, "iterating state: %v", err)
+		return nil, s.grpcStorageError("iterating state", err)
 	}
 	return resp, nil
 }
@@ -552,32 +581,47 @@ func (s *Server) GetLedgerDiff(ctx context.Context, req *rpcv1.GetLedgerDiffRequ
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
 	}
-	base, err := s.resolveLedgerContext(ctx, req.GetBaseLedger())
+	_, finish, err := s.beginRequest(ctx, req, "GetLedgerDiff")
 	if err != nil {
 		return nil, err
+	}
+	defer finish()
+	base, err := s.resolveLedgerContext(ctx, req.GetBaseLedger())
+	if err != nil {
+		return nil, diffLedgerLookupError(err, "base")
 	}
 	desired, err := s.resolveLedgerContext(ctx, req.GetDesiredLedger())
 	if err != nil {
-		return nil, err
+		return nil, diffLedgerLookupError(err, "desired")
 	}
-	if !base.IsImmutable() {
+	if !base.IsClosed() {
 		return nil, status.Error(codes.NotFound, "base ledger not validated")
 	}
-	if !desired.IsImmutable() {
+	if !desired.IsClosed() {
 		return nil, status.Error(codes.NotFound, "desired ledger not validated")
 	}
 
 	diff, _, _, err := stateDiff(ctx, base, desired)
 	if err != nil {
-		return nil, grpcStorageError("comparing state maps", err)
+		return nil, s.grpcStorageError("comparing state maps", err)
 	}
 	if !diff.Complete {
 		return nil, status.Error(codes.ResourceExhausted, "too many differences between specified ledgers")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, status.FromContextError(err).Err()
+	}
+	sortDifferences(diff.Differences)
+	if err := ctx.Err(); err != nil {
+		return nil, status.FromContextError(err).Err()
 	}
 
 	includeBlobs := req.GetIncludeBlobs()
 	out := &rpcv1.GetLedgerDiffResponse{LedgerObjects: &rpcv1.RawLedgerObjects{}}
 	for _, d := range diff.Differences {
+		if err := ctx.Err(); err != nil {
+			return nil, status.FromContextError(err).Err()
+		}
 		var desiredData []byte
 		if d.SecondItem != nil {
 			desiredData = d.SecondItem.Data()
@@ -598,8 +642,23 @@ func diffEntry(key [32]byte, desiredData []byte, includeBlobs bool) *rpcv1.RawLe
 	return obj
 }
 
-// maxStateDifferences bounds a state-map diff. The cap is effectively
-// unreachable, so the incomplete-result path stays dead in practice.
+func diffLedgerLookupError(err error, label string) error {
+	switch status.Code(err) {
+	case codes.Canceled, codes.DeadlineExceeded:
+		return err
+	default:
+		return status.Errorf(codes.NotFound, "%s ledger not found", label)
+	}
+}
+
+func sortDifferences(differences []shamap.DifferenceItem) {
+	sort.Slice(differences, func(i, j int) bool {
+		return bytes.Compare(differences[i].Key[:], differences[j].Key[:]) < 0
+	})
+}
+
+// State diffs retain the protocol service's effectively unlimited item cap;
+// per-client request admission bounds concurrent expensive work instead.
 const maxStateDifferences = math.MaxInt32
 
 // stateDiff diffs base and desired ledgers' state maps, returning the
@@ -623,30 +682,10 @@ func stateDiff(ctx context.Context, base, desired *ledger.Ledger) (*shamap.Diffe
 	return diff, baseMap, desiredMap, nil
 }
 
-func (s *Server) specToIndex(spec *rpcv1.LedgerSpecifier) (string, error) {
-	selection, err := selectorFromSpecifier(spec)
-	if err != nil {
-		return "", err
-	}
-	if selection.Kind() == ledgerselector.KindAbsent {
-		return ledgerselector.Current().String(), nil
-	}
-	if selection.Kind() != ledgerselector.KindHash {
-		return selection.String(), nil
-	}
-	result, err := s.resolveLedgerSelection(context.Background(), selection)
-	if err != nil {
-		return "", err
-	}
-	return ledgerselector.FromSequence(result.Sequence).String(), nil
-}
-
-// hash32 validates that input is exactly 32 bytes and copies it into a
-// fixed-size array, reporting InvalidArgument with the field name otherwise.
-func hash32(input []byte, field string) ([32]byte, error) {
+func hash32(input []byte) ([32]byte, error) {
 	var h [32]byte
 	if len(input) != 32 {
-		return h, status.Errorf(codes.InvalidArgument, "%s must be 32 bytes, got %d", field, len(input))
+		return h, errors.New("hash must be 32 bytes")
 	}
 	copy(h[:], input)
 	return h, nil
@@ -656,16 +695,4 @@ func cloneHash(h [32]byte) []byte {
 	out := make([]byte, 32)
 	copy(out, h[:])
 	return out
-}
-
-func compareKey(a, b [32]byte) int {
-	for i := range a {
-		if a[i] < b[i] {
-			return -1
-		}
-		if a[i] > b[i] {
-			return 1
-		}
-	}
-	return 0
 }

--- a/internal/grpc/service_test.go
+++ b/internal/grpc/service_test.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"encoding/hex"
 	"errors"
-	"math"
 	"testing"
 	"time"
 
@@ -18,9 +16,10 @@ import (
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
-	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
+	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/keylet"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
 	"github.com/LeJamon/go-xrpl/shamap"
 
 	rpcv1 "github.com/LeJamon/go-xrpl/internal/grpc/pb/org/xrpl/rpc/v1"
@@ -29,13 +28,13 @@ import (
 // fakeLookup is a tiny LedgerLookup that returns canned ledgers by hash
 // and sequence. Each ledger may include state objects and transactions.
 type fakeLookup struct {
-	bySeq      map[uint32]*ledger.Ledger
-	byHash     map[[32]byte]*ledger.Ledger
-	validated  *ledger.Ledger
-	closed     *ledger.Ledger
-	openLedger *ledger.Ledger
-	entryErr   error
-	entryIndex string
+	bySeq       map[uint32]*ledger.Ledger
+	byHash      map[[32]byte]*ledger.Ledger
+	validated   *ledger.Ledger
+	closed      *ledger.Ledger
+	openLedger  *ledger.Ledger
+	sequenceErr error
+	hashErr     error
 }
 
 type networkLookup struct {
@@ -44,13 +43,27 @@ type networkLookup struct {
 	validatedAge time.Duration
 }
 
+type blockingSequenceLookup struct {
+	*fakeLookup
+	started chan struct{}
+}
+
+func (l *blockingSequenceLookup) GetLedgerBySequenceContext(ctx context.Context, _ uint32) (*ledger.Ledger, error) {
+	close(l.started)
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
 func (l *networkLookup) IsStandalone() bool                   { return l.standalone }
 func (l *networkLookup) GetValidatedLedgerAge() time.Duration { return l.validatedAge }
 
 func (f *fakeLookup) IsStandalone() bool                   { return true }
 func (f *fakeLookup) GetValidatedLedgerAge() time.Duration { return 0 }
 
-func (f *fakeLookup) GetLedgerByHash(h [32]byte) (*ledger.Ledger, error) {
+func (f *fakeLookup) GetLedgerByHashContext(_ context.Context, h [32]byte) (*ledger.Ledger, error) {
+	if f.hashErr != nil {
+		return nil, f.hashErr
+	}
 	if l, ok := f.byHash[h]; ok {
 		return l, nil
 	}
@@ -61,39 +74,18 @@ func (f *fakeLookup) GetLedgerByHash(h [32]byte) (*ledger.Ledger, error) {
 	}
 	return nil, svcerr.ErrLedgerNotFound
 }
-func (f *fakeLookup) GetLedgerBySequence(seq uint32) (*ledger.Ledger, error) {
+func (f *fakeLookup) GetLedgerBySequenceContext(_ context.Context, seq uint32) (*ledger.Ledger, error) {
+	if f.sequenceErr != nil {
+		return nil, f.sequenceErr
+	}
 	if l, ok := f.bySeq[seq]; ok {
 		return l, nil
 	}
-	return nil, errors.New("not found")
+	return nil, svcerr.ErrLedgerNotFound
 }
 func (f *fakeLookup) GetClosedLedger() *ledger.Ledger    { return f.closed }
 func (f *fakeLookup) GetValidatedLedger() *ledger.Ledger { return f.validated }
 func (f *fakeLookup) GetOpenLedger() *ledger.Ledger      { return f.openLedger }
-func (f *fakeLookup) GetLedgerEntry(_ context.Context, key [32]byte, ledgerIndex string) (*service.LedgerEntryResult, error) {
-	f.entryIndex = ledgerIndex
-	if f.entryErr != nil {
-		return nil, f.entryErr
-	}
-	if f.validated == nil {
-		return nil, svcerr.ErrLedgerEntryNotFound
-	}
-	k := keylet.Keylet{Key: key}
-	exists, _ := f.validated.Exists(k)
-	if !exists {
-		return nil, svcerr.ErrLedgerEntryNotFound
-	}
-	data, err := f.validated.Read(k)
-	if err != nil {
-		return nil, svcerr.ErrLedgerEntryNotFound
-	}
-	return &service.LedgerEntryResult{
-		LedgerIndex: f.validated.Sequence(),
-		LedgerHash:  f.validated.Hash(),
-		Node:        data,
-		Validated:   true,
-	}, nil
-}
 
 // pad right-pads a string with zero bytes to at least n bytes; the
 // SHAMap layer rejects items smaller than 12 bytes.
@@ -114,6 +106,39 @@ func txWithMeta(txBytes, metaBytes []byte) []byte {
 	out = append(out, byte(len(metaBytes)))
 	out = append(out, metaBytes...)
 	return out
+}
+
+func validPaymentBlob(t *testing.T, sequence uint32) []byte {
+	t.Helper()
+	blob, err := binarycodec.EncodeBytes(map[string]any{
+		"TransactionType": "Payment",
+		"Account":         "rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
+		"Destination":     "rweYz56rfmQ98cAdRaeTxQS9wVMGnrdsFp",
+		"Amount":          "1",
+		"Fee":             "10",
+		"Sequence":        sequence,
+		"SigningPubKey":   "",
+	})
+	if err != nil {
+		t.Fatalf("encode payment: %v", err)
+	}
+	if _, err := tx.ParseFromBinary(blob); err != nil {
+		t.Fatalf("parse payment fixture: %v", err)
+	}
+	return blob
+}
+
+func validMetadataBlob(t *testing.T, index uint32) []byte {
+	t.Helper()
+	blob, err := binarycodec.EncodeBytes(map[string]any{
+		"TransactionIndex":  index,
+		"TransactionResult": "tesSUCCESS",
+		"AffectedNodes":     []any{},
+	})
+	if err != nil {
+		t.Fatalf("encode metadata: %v", err)
+	}
+	return blob
 }
 
 // newTestLedger builds an immediately-validated test ledger at the given
@@ -180,6 +205,20 @@ func newClosedTestLedger(t *testing.T, parent *ledger.Ledger) *ledger.Ledger {
 	return l
 }
 
+func newOpenTestLedger(t *testing.T, parent *ledger.Ledger, txs map[[32]byte][]byte) *ledger.Ledger {
+	t.Helper()
+	l, err := ledger.NewOpen(parent, time.Now())
+	if err != nil {
+		t.Fatalf("ledger.NewOpen: %v", err)
+	}
+	for hash, data := range txs {
+		if err := l.AddTransaction(hash, data); err != nil {
+			t.Fatalf("AddTransaction: %v", err)
+		}
+	}
+	return l
+}
+
 func ledgerShortcutSpec(shortcut rpcv1.LedgerSpecifier_Shortcut) *rpcv1.LedgerSpecifier {
 	return &rpcv1.LedgerSpecifier{
 		Ledger: &rpcv1.LedgerSpecifier_Shortcut_{Shortcut: shortcut},
@@ -229,14 +268,36 @@ func TestResolveLedgerSelector(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := srv.resolveLedger(test.spec)
+			got, err := srv.resolveLedgerContext(context.Background(), test.spec)
 			if err != nil {
 				t.Fatalf("resolveLedger() returned error: %v", err)
 			}
-			if got != test.want {
+			if got.Sequence() != test.want.Sequence() || got.Hash() != test.want.Hash() {
 				t.Fatalf("resolveLedger() = ledger %v, want ledger %d", got, test.want.Sequence())
 			}
 		})
+	}
+}
+
+func TestResolveLedgerSelectorSnapshotsOpenLedger(t *testing.T) {
+	parent := newTestLedger(t, 9, nil, nil)
+	open := newOpenTestLedger(t, parent, nil)
+	srv := NewServer(&fakeLookup{openLedger: open})
+
+	resolved, err := srv.resolveLedgerContext(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("resolve current ledger: %v", err)
+	}
+	if !resolved.IsOpen() || !resolved.IsImmutable() {
+		t.Fatalf("resolved ledger state: open=%v immutable=%v", resolved.IsOpen(), resolved.IsImmutable())
+	}
+
+	hash := [32]byte{0xA1}
+	if err := open.AddTransaction(hash, []byte("later-transaction")); err != nil {
+		t.Fatalf("mutate source open ledger: %v", err)
+	}
+	if _, found, err := resolved.GetTransactionContext(context.Background(), hash); err != nil || found {
+		t.Fatalf("snapshot observed later source mutation: found=%v err=%v", found, err)
 	}
 }
 
@@ -289,7 +350,7 @@ func TestResolveLedgerSelectorErrors(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := srv.resolveLedger(test.spec)
+			got, err := srv.resolveLedgerContext(context.Background(), test.spec)
 			if got != nil {
 				t.Fatalf("resolveLedger() returned ledger %d with error %v", got.Sequence(), err)
 			}
@@ -301,6 +362,35 @@ func TestResolveLedgerSelectorErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveLedgerSelectorPreservesCancellationAndHidesStorageDetails(t *testing.T) {
+	t.Run("mid lookup cancellation", func(t *testing.T) {
+		lookup := &blockingSequenceLookup{fakeLookup: &fakeLookup{}, started: make(chan struct{})}
+		srv := NewServer(lookup)
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() {
+			_, err := srv.resolveLedgerContext(ctx, ledgerSequenceSpec(99))
+			done <- err
+		}()
+		<-lookup.started
+		cancel()
+		if err := <-done; status.Code(err) != codes.Canceled {
+			t.Fatalf("resolve after cancellation = %v, want Canceled", err)
+		}
+	})
+
+	t.Run("internal detail is hidden", func(t *testing.T) {
+		srv := NewServer(&fakeLookup{sequenceErr: errors.New("secret nodestore path")})
+		_, err := srv.resolveLedgerContext(context.Background(), ledgerSequenceSpec(99))
+		if status.Code(err) != codes.Internal || status.Convert(err).Message() != "Internal error." {
+			t.Fatalf("resolve internal error = %v, want stable Internal", err)
+		}
+		if bytes.Contains([]byte(err.Error()), []byte("secret")) {
+			t.Fatalf("backend detail leaked to client: %v", err)
+		}
+	})
 }
 
 func TestResolveLedgerSelectorRejectsStaleNetworkState(t *testing.T) {
@@ -324,29 +414,29 @@ func TestResolveLedgerSelectorRejectsStaleNetworkState(t *testing.T) {
 		ledgerShortcutSpec(rpcv1.LedgerSpecifier_SHORTCUT_VALIDATED),
 		ledgerSequenceSpec(newer.Sequence()),
 	} {
-		if got, err := srv.resolveLedger(spec); got != nil || status.Code(err) != codes.NotFound || status.Convert(err).Message() != "notSynced" {
+		if got, err := srv.resolveLedgerContext(context.Background(), spec); got != nil || status.Code(err) != codes.NotFound || status.Convert(err).Message() != "notSynced" {
 			t.Errorf("resolveLedger(%v) = (%v, %v), want NotFound notSynced", spec, got, err)
 		}
 	}
-	if got, err := srv.resolveLedger(ledgerSequenceSpec(validated.Sequence())); err != nil || got != validated {
+	if got, err := srv.resolveLedgerContext(context.Background(), ledgerSequenceSpec(validated.Sequence())); err != nil || got.Sequence() != validated.Sequence() {
 		t.Fatalf("stale exact validated ledger = (%v, %v), want ledger %d", got, err, validated.Sequence())
 	}
 	validatedHash := validated.Hash()
-	if got, err := srv.resolveLedger(ledgerHashSpec(validatedHash[:])); err != nil || got != validated {
+	if got, err := srv.resolveLedgerContext(context.Background(), ledgerHashSpec(validatedHash[:])); err != nil || got.Sequence() != validated.Sequence() {
 		t.Fatalf("stale hash ledger = (%v, %v), want ledger %d", got, err, validated.Sequence())
 	}
 
 	lookup.validatedAge = maxValidatedLedgerAge
-	if got, err := srv.resolveLedger(nil); err != nil || got != newer {
+	if got, err := srv.resolveLedgerContext(context.Background(), nil); err != nil || got.Sequence() != newer.Sequence() {
 		t.Fatalf("current at freshness boundary = (%v, %v), want ledger %d", got, err, newer.Sequence())
 	}
 	lookup.validatedAge += time.Nanosecond
-	if got, err := srv.resolveLedger(nil); got != nil || status.Code(err) != codes.NotFound || status.Convert(err).Message() != "notSynced" {
+	if got, err := srv.resolveLedgerContext(context.Background(), nil); got != nil || status.Code(err) != codes.NotFound || status.Convert(err).Message() != "notSynced" {
 		t.Fatalf("current beyond freshness boundary = (%v, %v), want NotFound notSynced", got, err)
 	}
 
 	lookup.standalone = true
-	if got, err := srv.resolveLedger(nil); err != nil || got != newer {
+	if got, err := srv.resolveLedgerContext(context.Background(), nil); err != nil || got.Sequence() != newer.Sequence() {
 		t.Fatalf("standalone current = (%v, %v), want ledger %d", got, err, newer.Sequence())
 	}
 }
@@ -365,87 +455,12 @@ func TestResolveLedgerSelectorRejectsLaggingShortcut(t *testing.T) {
 		nil,
 		ledgerShortcutSpec(rpcv1.LedgerSpecifier_SHORTCUT_CLOSED),
 	} {
-		if got, err := srv.resolveLedger(spec); got != nil || status.Code(err) != codes.NotFound || status.Convert(err).Message() != "notSynced" {
+		if got, err := srv.resolveLedgerContext(context.Background(), spec); got != nil || status.Code(err) != codes.NotFound || status.Convert(err).Message() != "notSynced" {
 			t.Errorf("resolveLedger(%v) = (%v, %v), want NotFound notSynced", spec, got, err)
 		}
 	}
-	if got, err := srv.resolveLedger(ledgerShortcutSpec(rpcv1.LedgerSpecifier_SHORTCUT_VALIDATED)); err != nil || got != validated {
+	if got, err := srv.resolveLedgerContext(context.Background(), ledgerShortcutSpec(rpcv1.LedgerSpecifier_SHORTCUT_VALIDATED)); err != nil || got.Sequence() != validated.Sequence() {
 		t.Fatalf("validated shortcut = (%v, %v), want ledger %d", got, err, validated.Sequence())
-	}
-}
-
-func TestSpecToIndexSelectorParity(t *testing.T) {
-	exact := newTestLedger(t, 40, nil, nil)
-	exactHash := exact.Hash()
-	srv := NewServer(&fakeLookup{byHash: map[[32]byte]*ledger.Ledger{exactHash: exact}})
-
-	tests := []struct {
-		name string
-		spec *rpcv1.LedgerSpecifier
-		want string
-	}{
-		{name: "nil defaults current", want: "current"},
-		{name: "empty defaults current", spec: &rpcv1.LedgerSpecifier{}, want: "current"},
-		{name: "unspecified defaults current", spec: ledgerShortcutSpec(rpcv1.LedgerSpecifier_SHORTCUT_UNSPECIFIED), want: "current"},
-		{name: "current", spec: ledgerShortcutSpec(rpcv1.LedgerSpecifier_SHORTCUT_CURRENT), want: "current"},
-		{name: "closed", spec: ledgerShortcutSpec(rpcv1.LedgerSpecifier_SHORTCUT_CLOSED), want: "closed"},
-		{name: "validated", spec: ledgerShortcutSpec(rpcv1.LedgerSpecifier_SHORTCUT_VALIDATED), want: "validated"},
-		{name: "sequence", spec: ledgerSequenceSpec(math.MaxUint32), want: "4294967295"},
-		{name: "hash resolves exact sequence", spec: ledgerHashSpec(exactHash[:]), want: "40"},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got, err := srv.specToIndex(test.spec)
-			if err != nil {
-				t.Fatalf("specToIndex() returned error: %v", err)
-			}
-			if got != test.want {
-				t.Fatalf("specToIndex() = %q, want %q", got, test.want)
-			}
-		})
-	}
-}
-
-func TestSpecToIndexSelectorErrors(t *testing.T) {
-	missingHash := [32]byte{0xff}
-	srv := NewServer(&fakeLookup{})
-	tests := []struct {
-		name    string
-		spec    *rpcv1.LedgerSpecifier
-		code    codes.Code
-		message string
-	}{
-		{
-			name: "malformed hash",
-			spec: ledgerHashSpec([]byte("short")),
-			code: codes.InvalidArgument, message: "ledgerHashMalformed",
-		},
-		{
-			name: "missing hash",
-			spec: ledgerHashSpec(missingHash[:]),
-			code: codes.NotFound, message: "ledgerNotFound",
-		},
-		{
-			name: "unknown shortcut",
-			spec: ledgerShortcutSpec(rpcv1.LedgerSpecifier_Shortcut(99)),
-			code: codes.InvalidArgument, message: "unknown ledger shortcut 99",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got, err := srv.specToIndex(test.spec)
-			if got != "" {
-				t.Fatalf("specToIndex() = %q with error %v, want empty result", got, err)
-			}
-			if status.Code(err) != test.code {
-				t.Fatalf("specToIndex() code = %s, want %s: %v", status.Code(err), test.code, err)
-			}
-			if message := status.Convert(err).Message(); message != test.message {
-				t.Fatalf("specToIndex() message = %q, want %q", message, test.message)
-			}
-		})
 	}
 }
 
@@ -472,8 +487,8 @@ func TestGRPC_GetLedger_HeaderAndValidated(t *testing.T) {
 func TestGRPC_GetLedger_TransactionsHashesAndExpand(t *testing.T) {
 	tx1Key := [32]byte{0xAA}
 	tx2Key := [32]byte{0xBB}
-	tx1, meta1 := []byte("tx-one-bytes"), []byte("meta-one-bytes")
-	tx2, meta2 := []byte("tx-two-bytes"), []byte("meta-two-bytes")
+	tx1, meta1 := validPaymentBlob(t, 1), validMetadataBlob(t, 1)
+	tx2, meta2 := validPaymentBlob(t, 2), validMetadataBlob(t, 2)
 	l := newTestLedger(t, 200, nil, map[[32]byte][]byte{
 		tx1Key: txWithMeta(tx1, meta1),
 		tx2Key: txWithMeta(tx2, meta2),
@@ -489,7 +504,18 @@ func TestGRPC_GetLedger_TransactionsHashesAndExpand(t *testing.T) {
 		t.Fatalf("expected HashesList, got %T", resp.Transactions)
 	}
 	if len(hashes.HashesList.Hashes) != 2 {
-		t.Errorf("expected 2 hashes, got %d", len(hashes.HashesList.Hashes))
+		t.Fatalf("expected 2 hashes, got %d", len(hashes.HashesList.Hashes))
+	}
+	parsed1, err := tx.ParseFromBinary(tx1)
+	if err != nil {
+		t.Fatalf("parse first transaction: %v", err)
+	}
+	wantHash1, err := tx.ComputeTransactionHash(parsed1)
+	if err != nil {
+		t.Fatalf("hash first transaction: %v", err)
+	}
+	if !bytes.Equal(hashes.HashesList.Hashes[0], wantHash1[:]) {
+		t.Errorf("first hash = %x, want parsed transaction ID %x", hashes.HashesList.Hashes[0], wantHash1)
 	}
 
 	resp, err = srv.GetLedger(context.Background(), &rpcv1.GetLedgerRequest{Transactions: true, Expand: true})
@@ -518,10 +544,33 @@ func TestGRPC_GetLedger_TransactionsHashesAndExpand(t *testing.T) {
 	}
 }
 
+func TestGRPC_GetLedger_ExpandsOpenTransactionWithoutMetadata(t *testing.T) {
+	raw := validPaymentBlob(t, 1)
+	parent := newTestLedger(t, 199, nil, nil)
+	open := newOpenTestLedger(t, parent, map[[32]byte][]byte{{0xAA}: raw})
+	srv := NewServer(&fakeLookup{openLedger: open})
+
+	resp, err := srv.GetLedger(context.Background(), &rpcv1.GetLedgerRequest{Transactions: true, Expand: true})
+	if err != nil {
+		t.Fatalf("GetLedger: %v", err)
+	}
+	list := resp.GetTransactionsList().GetTransactions()
+	if len(list) != 1 {
+		t.Fatalf("expanded transactions = %d, want 1", len(list))
+	}
+	if !bytes.Equal(list[0].GetTransactionBlob(), raw) || len(list[0].GetMetadataBlob()) != 0 {
+		t.Fatalf("open transaction = (%x, %x), want raw transaction without metadata", list[0].GetTransactionBlob(), list[0].GetMetadataBlob())
+	}
+}
+
 func TestGRPC_GetLedger_MalformedExpandedTransactionReturnsPartialSuccess(t *testing.T) {
 	badKey := [32]byte{0xAA}
 	l := newTestLedger(t, 200, nil, map[[32]byte][]byte{badKey: pad("bad", 12)})
-	srv := NewServer(&fakeLookup{openLedger: l})
+	var logs bytes.Buffer
+	logConfig := &xrpllog.Config{Level: xrpllog.LevelError, Format: "text", Output: &logs}
+	srv := NewServer(&fakeLookup{openLedger: l}, ServerConfig{
+		Logger: xrpllog.New(xrpllog.NewHandler(logConfig), logConfig),
+	})
 
 	resp, err := srv.GetLedger(context.Background(), &rpcv1.GetLedgerRequest{Transactions: true, Expand: true})
 	if err != nil {
@@ -533,6 +582,49 @@ func TestGRPC_GetLedger_MalformedExpandedTransactionReturnsPartialSuccess(t *tes
 	}
 	if len(full.TransactionsList.Transactions) != 0 {
 		t.Fatalf("expanded transactions = %d, want partial empty response", len(full.TransactionsList.Transactions))
+	}
+	if !bytes.Contains(logs.Bytes(), []byte("malformed transaction in ledger")) {
+		t.Fatalf("malformed transaction was not logged: %s", logs.String())
+	}
+}
+
+func TestGRPC_GetLedger_MalformedTransactionStopsHashList(t *testing.T) {
+	meta := validMetadataBlob(t, 1)
+	l := newTestLedger(t, 200, nil, map[[32]byte][]byte{
+		{0x01}: txWithMeta(validPaymentBlob(t, 1), meta),
+		{0x02}: pad("bad", 12),
+		{0x03}: txWithMeta(validPaymentBlob(t, 3), meta),
+	})
+	srv := NewServer(&fakeLookup{openLedger: l})
+
+	resp, err := srv.GetLedger(context.Background(), &rpcv1.GetLedgerRequest{Transactions: true})
+	if err != nil {
+		t.Fatalf("GetLedger hashes: %v", err)
+	}
+	if got := len(resp.GetHashesList().GetHashes()); got != 1 {
+		t.Fatalf("transaction hashes = %d, want partial list stopped at malformed record", got)
+	}
+}
+
+func TestGRPC_GetLedger_MalformedOpenTransactionReturnsPartialSuccess(t *testing.T) {
+	open := newOpenTestLedger(t, newTestLedger(t, 199, nil, nil), map[[32]byte][]byte{
+		{0xAA}: pad("bad", 12),
+	})
+	var logs bytes.Buffer
+	logConfig := &xrpllog.Config{Level: xrpllog.LevelError, Format: "text", Output: &logs}
+	srv := NewServer(&fakeLookup{openLedger: open}, ServerConfig{
+		Logger: xrpllog.New(xrpllog.NewHandler(logConfig), logConfig),
+	})
+
+	resp, err := srv.GetLedger(context.Background(), &rpcv1.GetLedgerRequest{Transactions: true, Expand: true})
+	if err != nil {
+		t.Fatalf("GetLedger expand: %v", err)
+	}
+	if got := len(resp.GetTransactionsList().GetTransactions()); got != 0 {
+		t.Fatalf("expanded transactions = %d, want partial empty response", got)
+	}
+	if !bytes.Contains(logs.Bytes(), []byte("malformed transaction in ledger")) {
+		t.Fatalf("malformed transaction was not logged: %s", logs.String())
 	}
 }
 
@@ -614,7 +706,7 @@ func TestGRPC_GetLedgerEntry_ResolvesLedgerBeforeKeyValidation(t *testing.T) {
 // failure (unknown sequence) maps to NotFound — not Internal.
 func TestGRPC_GetLedgerEntry_LedgerNotFound(t *testing.T) {
 	l := newTestLedger(t, 7, nil, nil)
-	srv := NewServer(&fakeLookup{validated: l, entryErr: svcerr.ErrLedgerNotFound})
+	srv := NewServer(&fakeLookup{validated: l})
 
 	key := make([]byte, 32)
 	key[0] = 0xCC
@@ -643,11 +735,11 @@ func TestGRPC_GetLedgerData_PaginatesAndStopsAtEndMarker(t *testing.T) {
 	if len(resp.LedgerObjects.Objects) != 10 {
 		t.Errorf("expected 10 objects, got %d", len(resp.LedgerObjects.Objects))
 	}
-	if resp.LedgerIndex != 1 {
-		t.Errorf("ledger_index=%d, want 1", resp.LedgerIndex)
+	if resp.LedgerIndex != 0 {
+		t.Errorf("ledger_index=%d, want unset", resp.LedgerIndex)
 	}
-	if len(resp.LedgerHash) != 32 {
-		t.Errorf("ledger_hash len=%d, want 32", len(resp.LedgerHash))
+	if len(resp.LedgerHash) != 0 {
+		t.Errorf("ledger_hash len=%d, want unset", len(resp.LedgerHash))
 	}
 }
 
@@ -824,6 +916,53 @@ func TestGRPC_GetLedgerDiff_DetectsCreateModifyDelete(t *testing.T) {
 	if _, ok := got[keyKeep]; ok {
 		t.Errorf("unchanged key %x should not appear in diff", keyKeep)
 	}
+	assertLedgerObjectsSorted(t, resp.LedgerObjects.Objects)
+}
+
+func TestGRPC_GetLedgerDiffMapsSelectorFailuresByEndpoint(t *testing.T) {
+	base := newTestLedger(t, 10, nil, nil)
+	tests := []struct {
+		name    string
+		lookup  *fakeLookup
+		request *rpcv1.GetLedgerDiffRequest
+		message string
+	}{
+		{
+			name:   "base failure wins",
+			lookup: &fakeLookup{},
+			request: &rpcv1.GetLedgerDiffRequest{
+				BaseLedger:    ledgerSequenceSpec(9),
+				DesiredLedger: ledgerHashSpec([]byte("short")),
+			},
+			message: "base ledger not found",
+		},
+		{
+			name:   "desired failure",
+			lookup: &fakeLookup{bySeq: map[uint32]*ledger.Ledger{10: base}},
+			request: &rpcv1.GetLedgerDiffRequest{
+				BaseLedger:    ledgerSequenceSpec(10),
+				DesiredLedger: ledgerSequenceSpec(11),
+			},
+			message: "desired ledger not found",
+		},
+		{
+			name:   "base storage failure",
+			lookup: &fakeLookup{sequenceErr: errors.New("backend detail")},
+			request: &rpcv1.GetLedgerDiffRequest{
+				BaseLedger:    ledgerSequenceSpec(10),
+				DesiredLedger: ledgerSequenceSpec(11),
+			},
+			message: "base ledger not found",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := NewServer(test.lookup).GetLedgerDiff(context.Background(), test.request)
+			if status.Code(err) != codes.NotFound || status.Convert(err).Message() != test.message {
+				t.Fatalf("GetLedgerDiff() = %v, want NotFound %q", err, test.message)
+			}
+		})
+	}
 }
 
 func TestGRPC_GetLedgerDiff_RequiresImmutableLedgers(t *testing.T) {
@@ -970,25 +1109,26 @@ func TestGRPC_GetLedgerData_MalformedMarkerRejected(t *testing.T) {
 }
 
 func TestGRPC_GetLedgerEntry_ByHash(t *testing.T) {
-	l := newTestLedger(t, 9, nil, nil)
+	key := [32]byte{0xCC}
+	selectedData := pad("selected", 12)
+	selected := newTestLedger(t, 9, map[[32]byte][]byte{key: selectedData}, nil)
+	validated := newTestLedger(t, 10, map[[32]byte][]byte{key: pad("other", 12)}, nil)
 	lookup := &fakeLookup{
-		validated: l,
-		byHash:    map[[32]byte]*ledger.Ledger{l.Hash(): l},
+		validated: validated,
+		byHash:    map[[32]byte]*ledger.Ledger{selected.Hash(): selected},
 	}
 	srv := NewServer(lookup)
 
-	key := make([]byte, 32)
-	key[0] = 0xCC
-	h := l.Hash()
-	_, err := srv.GetLedgerEntry(context.Background(), &rpcv1.GetLedgerEntryRequest{
-		Key:    key,
+	h := selected.Hash()
+	resp, err := srv.GetLedgerEntry(context.Background(), &rpcv1.GetLedgerEntryRequest{
+		Key:    key[:],
 		Ledger: &rpcv1.LedgerSpecifier{Ledger: &rpcv1.LedgerSpecifier_Hash{Hash: h[:]}},
 	})
-	if status.Code(err) != codes.NotFound {
-		t.Errorf("by-hash GetLedgerEntry: expected NotFound, got %v", err)
+	if err != nil {
+		t.Fatalf("by-hash GetLedgerEntry: %v", err)
 	}
-	if want := hex.EncodeToString(h[:]); lookup.entryIndex != want {
-		t.Errorf("ledger selector = %q, want exact hash %q", lookup.entryIndex, want)
+	if !bytes.Equal(resp.GetLedgerObject().GetData(), selectedData) {
+		t.Errorf("ledger entry data = %x, want selected snapshot data %x", resp.GetLedgerObject().GetData(), selectedData)
 	}
 }
 
@@ -1068,6 +1208,28 @@ func TestGRPC_GetLedger_GetObjectsDiffsParent(t *testing.T) {
 	}
 	if _, ok := got[keyKeep]; ok {
 		t.Errorf("unchanged key %x should not appear", keyKeep)
+	}
+	assertLedgerObjectsSorted(t, resp.LedgerObjects.Objects)
+}
+
+func TestGRPC_GetLedger_GetObjectsUsesSequencePredecessor(t *testing.T) {
+	key := [32]byte{0x01}
+	parent := newTestLedger(t, 9, map[[32]byte][]byte{key: pad("canonical", 12)}, nil)
+	desired := newTestLedger(t, 10, map[[32]byte][]byte{key: pad("desired", 12)}, nil)
+	wrongParent := newTestLedger(t, 8, map[[32]byte][]byte{key: pad("desired", 12)}, nil)
+	srv := NewServer(&fakeLookup{
+		bySeq:  map[uint32]*ledger.Ledger{9: parent, 10: desired},
+		byHash: map[[32]byte]*ledger.Ledger{desired.ParentHash(): wrongParent},
+	})
+
+	resp, err := srv.GetLedger(context.Background(), &rpcv1.GetLedgerRequest{
+		Ledger: ledgerSequenceSpec(10), GetObjects: true,
+	})
+	if err != nil {
+		t.Fatalf("GetLedger: %v", err)
+	}
+	if len(resp.GetLedgerObjects().GetObjects()) != 1 || resp.GetLedgerObjects().GetObjects()[0].GetModType() != rpcv1.RawLedgerObject_MODIFIED {
+		t.Fatalf("objects = %+v, want modification against sequence predecessor", resp.GetLedgerObjects().GetObjects())
 	}
 }
 
@@ -1343,6 +1505,15 @@ func TestIsBookDirectory(t *testing.T) {
 	}
 	if isBookDirectory([]byte{0x11, 0x00}) {
 		t.Error("too-short blob must not be a book directory")
+	}
+}
+
+func assertLedgerObjectsSorted(t *testing.T, objects []*rpcv1.RawLedgerObject) {
+	t.Helper()
+	for i := 1; i < len(objects); i++ {
+		if bytes.Compare(objects[i-1].GetKey(), objects[i].GetKey()) >= 0 {
+			t.Fatalf("ledger objects are not strictly key ordered at %d: %x >= %x", i, objects[i-1].GetKey(), objects[i].GetKey())
+		}
 	}
 }
 

--- a/internal/ledger/service/fast_load_test.go
+++ b/internal/ledger/service/fast_load_test.go
@@ -1524,7 +1524,7 @@ func TestService_FastLoadFallsBackWhenTreeIsCorrupt(t *testing.T) {
 	require.Zero(t, second.GetValidatedLedgerIndex())
 }
 
-func TestService_GetLedgerByHashTreatsCorruptDescendantAsNotFound(t *testing.T) {
+func TestService_GetLedgerByHashReportsCorruptDescendant(t *testing.T) {
 	ctx := context.Background()
 	db := newTestNodeStore(t, 10_000)
 	t.Cleanup(func() { require.NoError(t, db.Close()) })
@@ -1565,6 +1565,6 @@ func TestService_GetLedgerByHashTreatsCorruptDescendantAsNotFound(t *testing.T) 
 	require.NoError(t, err)
 
 	_, err = reader.GetLedgerByHash(wantHash)
-	require.ErrorIs(t, err, ErrLedgerNotFound)
-	require.False(t, errors.Is(err, shamap.ErrInvalidNodeData))
+	require.ErrorIs(t, err, errStoredLedgerUnavailable)
+	require.False(t, errors.Is(err, ErrLedgerNotFound))
 }

--- a/internal/ledger/service/ledger_by_hash_nodestore_test.go
+++ b/internal/ledger/service/ledger_by_hash_nodestore_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -28,6 +29,18 @@ type fetchErrorDatabase struct {
 
 func (d *fetchErrorDatabase) Fetch(context.Context, nodestore.Hash256) (*nodestore.Node, error) {
 	return nil, d.err
+}
+
+type blockingFetchDatabase struct {
+	nodestore.Database
+	entered chan struct{}
+	once    sync.Once
+}
+
+func (d *blockingFetchDatabase) Fetch(ctx context.Context, _ nodestore.Hash256) (*nodestore.Node, error) {
+	d.once.Do(func() { close(d.entered) })
+	<-ctx.Done()
+	return nil, ctx.Err()
 }
 
 func TestService_GetLedgerByHashLoadsEvictedLedgerFromNodeStore(t *testing.T) {
@@ -397,7 +410,53 @@ func TestService_GetLedgerByHashReturnsNotFoundWithoutPersistedLedger(t *testing
 	})
 }
 
-func TestService_GetLedgerByHashTreatsCorruptPersistedHeaderAsNotFound(t *testing.T) {
+func TestService_GetLedgerBySequenceContextCancelsDurableLoad(t *testing.T) {
+	ctx := context.Background()
+	backend := newTestNodeStore(t, 100)
+	t.Cleanup(func() { require.NoError(t, backend.Close()) })
+	db := &blockingFetchDatabase{Database: backend, entered: make(chan struct{})}
+	rm := newTestRepositories(t, ctx)
+	wantHash := [32]byte{0x07}
+	const wantSequence = 10
+	require.NoError(t, rm.Ledger().SaveValidatedLedger(ctx, relationaldb.LedgerInfo{
+		Hash:     relationaldb.Hash(wantHash),
+		Sequence: wantSequence,
+	}))
+	svc, err := New(Config{
+		NodeStore:    db,
+		SHAMapFamily: shamapbackend.New(db),
+		RelationalDB: rm,
+	})
+	require.NoError(t, err)
+	svc.completeMu.Lock()
+	svc.ensureCompleteLedgerStateLocked()
+	svc.completedLedgers.addRange(wantSequence, wantSequence)
+	svc.completeLedgerHashes[wantSequence] = wantHash
+	svc.completeMu.Unlock()
+
+	lookupCtx, cancel := context.WithCancel(ctx)
+	result := make(chan error, 1)
+	go func() {
+		_, lookupErr := svc.GetLedgerBySequenceContext(lookupCtx, wantSequence)
+		result <- lookupErr
+	}()
+
+	select {
+	case <-db.entered:
+	case <-time.After(time.Second):
+		t.Fatal("durable lookup did not reach nodestore")
+	}
+	cancel()
+	select {
+	case lookupErr := <-result:
+		require.ErrorIs(t, lookupErr, context.Canceled)
+		require.False(t, errors.Is(lookupErr, ErrLedgerNotFound))
+	case <-time.After(time.Second):
+		t.Fatal("durable lookup did not stop after cancellation")
+	}
+}
+
+func TestService_GetLedgerByHashReportsCorruptPersistedHeader(t *testing.T) {
 	ctx := context.Background()
 	db := newTestNodeStore(t, 100)
 	t.Cleanup(func() { require.NoError(t, db.Close()) })
@@ -420,7 +479,8 @@ func TestService_GetLedgerByHashTreatsCorruptPersistedHeaderAsNotFound(t *testin
 	require.NoError(t, err)
 
 	_, err = svc.GetLedgerByHash(wantHash)
-	require.ErrorIs(t, err, ErrLedgerNotFound)
+	require.ErrorIs(t, err, errStoredLedgerUnavailable)
+	require.False(t, errors.Is(err, ErrLedgerNotFound))
 }
 
 func TestService_PersistedLedgerHashCacheIsBounded(t *testing.T) {

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -1268,6 +1268,10 @@ func (s *Service) GetLedgerBySequence(seq uint32) (*ledger.Ledger, error) {
 	return s.getLedgerBySequence(context.Background(), seq)
 }
 
+func (s *Service) GetLedgerBySequenceContext(ctx context.Context, seq uint32) (*ledger.Ledger, error) {
+	return s.getLedgerBySequence(ctx, seq)
+}
+
 func (s *Service) getLedgerBySequence(ctx context.Context, seq uint32) (*ledger.Ledger, error) {
 	s.mu.RLock()
 	s.historyComponent.mu.RLock()
@@ -1312,13 +1316,13 @@ func (s *Service) getLedgerBySequence(ctx context.Context, seq uint32) (*ledger.
 
 	loaded, err := s.loadStoredLedgerByHash(ctx, hash)
 	if err != nil {
-		if errors.Is(err, errStoredLedgerUnavailable) {
-			return nil, fmt.Errorf("%w: load ledger %d from nodestore: %v", ErrLedgerNotFound, seq, err)
-		}
 		return nil, fmt.Errorf("load ledger %d from nodestore: %w", seq, err)
 	}
-	if loaded == nil || loaded.Sequence() != seq {
+	if loaded == nil {
 		return nil, ErrLedgerNotFound
+	}
+	if loaded.Sequence() != seq {
+		return nil, fmt.Errorf("load ledger %d from nodestore: stored sequence is %d", seq, loaded.Sequence())
 	}
 	if err := loaded.SetValidated(); err != nil {
 		return nil, err
@@ -1412,16 +1416,13 @@ func (s *Service) loadPersistedLedgerByHash(ctx context.Context, hash [32]byte) 
 	}
 	loaded, err := s.loadStoredLedgerByHash(ctx, hash)
 	if err != nil {
-		if errors.Is(err, errStoredLedgerUnavailable) {
-			return nil, fmt.Errorf("%w: load ledger %x from nodestore: %v", ErrLedgerNotFound, hash[:8], err)
-		}
 		return nil, fmt.Errorf("load ledger %x from nodestore: %w", hash[:8], err)
 	}
 	if loaded == nil {
 		return nil, ErrLedgerNotFound
 	}
 	if !storedHeaderMatchesInfo(loaded.Header(), info) {
-		return nil, fmt.Errorf("%w: ledger %x header does not match persisted metadata", ErrLedgerNotFound, hash[:8])
+		return nil, fmt.Errorf("ledger %x header does not match persisted metadata", hash[:8])
 	}
 	return loaded, nil
 }

--- a/internal/ledger/view.go
+++ b/internal/ledger/view.go
@@ -7,15 +7,19 @@ import (
 )
 
 func (l *Ledger) Snapshot() (*Ledger, error) {
+	return l.SnapshotContext(context.Background())
+}
+
+func (l *Ledger) SnapshotContext(ctx context.Context) (*Ledger, error) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 
-	stateMapCopy, err := l.stateMap.SnapshotImmutable()
+	stateMapCopy, err := l.stateMap.SnapshotImmutableContext(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	txMapCopy, err := l.txMap.SnapshotImmutable()
+	txMapCopy, err := l.txMap.SnapshotImmutableContext(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/node/grpc.go
+++ b/internal/node/grpc.go
@@ -2,20 +2,24 @@ package node
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	rtdebug "runtime/debug"
 	"strings"
 	"sync"
 
 	googlegrpc "google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/status"
 
 	"github.com/LeJamon/go-xrpl/config"
 	xrplgrpc "github.com/LeJamon/go-xrpl/internal/grpc"
 	rpcv1 "github.com/LeJamon/go-xrpl/internal/grpc/pb/org/xrpl/rpc/v1"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 )
 
@@ -67,7 +71,7 @@ func prepareGRPCServer(
 	if err := validateGRPCPort(name, p); err != nil {
 		return nil, err
 	}
-	return bindGRPCServer(ctx, name, p, lookup, log, listen)
+	return bindGRPCServer(ctx, name, p, lookup, log, listen, newConnectionLimiter(-1), nil)
 }
 
 func bindGRPCServer(
@@ -77,13 +81,27 @@ func bindGRPCServer(
 	lookup xrplgrpc.LedgerLookup,
 	log xrpllog.Logger,
 	listen listenFunc,
+	limiter *connectionLimiter,
+	resourceManager *resource.Manager,
 ) (*boundGRPCServer, error) {
+	secureGatewayIPs, err := grpcSecureGatewayIPs(name, p)
+	if err != nil {
+		return nil, err
+	}
+	transportCredentials, err := grpcTransportCredentials(p)
+	if err != nil {
+		return nil, fmt.Errorf("configure grpc transport: %w", err)
+	}
+
 	addr := p.BindAddress()
 	lis, err := listen(ctx, "tcp", addr)
 	if err != nil {
 		return nil, fmt.Errorf("grpc listen on %s: %w", addr, err)
 	}
 	boundAddr := lis.Addr().String()
+	if limiter != nil {
+		lis = &limitedListener{Listener: lis, limiter: limiter, portName: name, portLimit: p.Limit}
+	}
 	readyListener := newServeReadyListener(lis)
 
 	bound := &boundGRPCServer{
@@ -93,11 +111,19 @@ func bindGRPCServer(
 		ready:     readyListener.ready,
 		markReady: readyListener.markReady,
 	}
-	srv := googlegrpc.NewServer(
+	serverOptions := []googlegrpc.ServerOption{
 		googlegrpc.ChainUnaryInterceptor(bound.trackUnary, grpcRecoveryInterceptor(log)),
 		googlegrpc.ChainStreamInterceptor(bound.trackStream),
-	)
-	rpcv1.RegisterXRPLedgerAPIServiceServer(srv, xrplgrpc.NewServer(lookup))
+	}
+	if transportCredentials != nil {
+		serverOptions = append(serverOptions, googlegrpc.Creds(transportCredentials))
+	}
+	srv := googlegrpc.NewServer(serverOptions...)
+	rpcv1.RegisterXRPLedgerAPIServiceServer(srv, xrplgrpc.NewServer(lookup, xrplgrpc.ServerConfig{
+		Logger:           log,
+		ResourceManager:  resourceManager,
+		SecureGatewayIPs: secureGatewayIPs,
+	}))
 	bound.server = srv
 	return bound, nil
 }
@@ -154,18 +180,70 @@ func (s *boundGRPCServer) waitRequests() {
 }
 
 func validateGRPCPort(name string, p config.PortConfig) error {
-	if _, err := p.ParseSecureGatewayNets(); err != nil {
-		return fmt.Errorf("parse secure_gateway nets for grpc port %q: %w", name, err)
+	if _, err := grpcSecureGatewayIPs(name, p); err != nil {
+		return err
 	}
-	// rippled forbids an unspecified address in grpc secure_gateway
-	// (GRPCServer.cpp:361-368) — match-all would defeat the rate-limit
-	// bypass it scopes to known Clio hosts.
-	for _, entry := range p.SecureGateway {
-		if ip := net.ParseIP(strings.TrimSpace(entry)); ip != nil && ip.IsUnspecified() {
-			return fmt.Errorf("grpc port %q: unspecified IP %q in secure_gateway", name, entry)
-		}
+	if (p.SSLCert == "") != (p.SSLKey == "") {
+		return fmt.Errorf("grpc port %q: ssl_cert and ssl_key must be configured together", name)
+	}
+	if p.SSLChain != "" && p.SSLCert == "" {
+		return fmt.Errorf("grpc port %q: ssl_chain requires ssl_cert and ssl_key", name)
+	}
+	if p.SSLCiphers != "" {
+		return fmt.Errorf("grpc port %q: ssl_ciphers is not supported", name)
+	}
+	if p.SSLClientCA != "" {
+		return fmt.Errorf("grpc port %q: ssl_client_ca is not supported", name)
 	}
 	return nil
+}
+
+func grpcSecureGatewayIPs(name string, p config.PortConfig) ([]net.IP, error) {
+	secureGatewayIPs := make([]net.IP, 0, len(p.SecureGateway))
+	for _, entry := range p.SecureGateway {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			return nil, fmt.Errorf("grpc port %q: secure_gateway entry must not be empty", name)
+		}
+		ip := net.ParseIP(entry)
+		if ip == nil {
+			return nil, fmt.Errorf("grpc port %q: secure_gateway entry %q must be an IP address", name, entry)
+		}
+		if ip.IsUnspecified() {
+			return nil, fmt.Errorf("grpc port %q: unspecified IP %q in secure_gateway", name, entry)
+		}
+		secureGatewayIPs = append(secureGatewayIPs, ip)
+	}
+	return secureGatewayIPs, nil
+}
+
+func grpcTransportCredentials(p config.PortConfig) (credentials.TransportCredentials, error) {
+	if p.SSLCert == "" && p.SSLKey == "" {
+		return nil, nil
+	}
+	certPEM, err := os.ReadFile(p.SSLCert)
+	if err != nil {
+		return nil, fmt.Errorf("read ssl_cert: %w", err)
+	}
+	if p.SSLChain != "" {
+		chainPEM, chainErr := os.ReadFile(p.SSLChain)
+		if chainErr != nil {
+			return nil, fmt.Errorf("read ssl_chain: %w", chainErr)
+		}
+		certPEM = append(append(certPEM, '\n'), chainPEM...)
+	}
+	keyPEM, err := os.ReadFile(p.SSLKey)
+	if err != nil {
+		return nil, fmt.Errorf("read ssl_key: %w", err)
+	}
+	certificate, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("load ssl certificate: %w", err)
+	}
+	return credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{certificate},
+		MinVersion:   tls.VersionTLS12,
+	}), nil
 }
 
 func (s *boundGRPCServer) serve(log xrpllog.Logger, errCh chan<- error, done func()) {

--- a/internal/node/grpc_test.go
+++ b/internal/node/grpc_test.go
@@ -2,11 +2,23 @@ package node
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	googlegrpc "google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
@@ -16,8 +28,6 @@ import (
 	rpcv1 "github.com/LeJamon/go-xrpl/internal/grpc/pb/org/xrpl/rpc/v1"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
-	"github.com/LeJamon/go-xrpl/internal/ledger/service"
-	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 	"github.com/LeJamon/go-xrpl/shamap"
 )
@@ -28,16 +38,17 @@ type stubLookup struct {
 	validated *ledger.Ledger
 }
 
-func (s *stubLookup) GetLedgerByHash([32]byte) (*ledger.Ledger, error)   { return s.validated, nil }
-func (s *stubLookup) GetLedgerBySequence(uint32) (*ledger.Ledger, error) { return s.validated, nil }
-func (s *stubLookup) GetClosedLedger() *ledger.Ledger                    { return s.validated }
-func (s *stubLookup) GetValidatedLedger() *ledger.Ledger                 { return s.validated }
-func (s *stubLookup) GetOpenLedger() *ledger.Ledger                      { return s.validated }
-func (s *stubLookup) GetValidatedLedgerAge() time.Duration               { return 0 }
-func (s *stubLookup) IsStandalone() bool                                 { return true }
-func (s *stubLookup) GetLedgerEntry(context.Context, [32]byte, string) (*service.LedgerEntryResult, error) {
-	return nil, svcerr.ErrLedgerEntryNotFound
+func (s *stubLookup) GetLedgerByHashContext(context.Context, [32]byte) (*ledger.Ledger, error) {
+	return s.validated, nil
 }
+func (s *stubLookup) GetLedgerBySequenceContext(context.Context, uint32) (*ledger.Ledger, error) {
+	return s.validated, nil
+}
+func (s *stubLookup) GetClosedLedger() *ledger.Ledger      { return s.validated }
+func (s *stubLookup) GetValidatedLedger() *ledger.Ledger   { return s.validated }
+func (s *stubLookup) GetOpenLedger() *ledger.Ledger        { return s.validated }
+func (s *stubLookup) GetValidatedLedgerAge() time.Duration { return 0 }
+func (s *stubLookup) IsStandalone() bool                   { return true }
 
 var _ xrplgrpc.LedgerLookup = (*stubLookup)(nil)
 
@@ -117,8 +128,8 @@ func TestGRPCServer_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetLedgerData RPC: %v", err)
 	}
-	if dataResp.LedgerIndex != 123 {
-		t.Errorf("ledger_index=%d, want 123", dataResp.LedgerIndex)
+	if dataResp.LedgerIndex != 0 || len(dataResp.LedgerHash) != 0 {
+		t.Errorf("ledger identity fields must be unset: index=%d hash=%x", dataResp.LedgerIndex, dataResp.LedgerHash)
 	}
 	if got := len(dataResp.LedgerObjects.Objects); got != 1 {
 		t.Errorf("expected 1 ledger object, got %d", got)
@@ -129,6 +140,89 @@ func TestGRPCServer_RoundTrip(t *testing.T) {
 		t.Fatalf("unexpected listener error: %v", e)
 	default:
 	}
+}
+
+func TestGRPCServer_TLSRoundTripRejectsPlaintext(t *testing.T) {
+	certPath, keyPath, roots := writeGRPCTestCertificate(t)
+	lookup := &stubLookup{validated: newStubLedger(t)}
+	p := config.PortConfig{
+		Port: 0, IP: "127.0.0.1", Protocol: "grpc",
+		SSLCert: certPath, SSLKey: keyPath,
+	}
+	errCh := make(chan error, 1)
+	bound, err := prepareGRPCServer(context.Background(), "port_grpc", p, lookup, xrpllog.Discard(), systemListen)
+	if err != nil {
+		t.Fatalf("prepareGRPCServer: %v", err)
+	}
+	bound.serve(xrpllog.Discard(), errCh, nil)
+	t.Cleanup(bound.server.Stop)
+
+	tlsConn, err := googlegrpc.NewClient(bound.address, googlegrpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+		RootCAs: roots, ServerName: "localhost", MinVersion: tls.VersionTLS12,
+	})))
+	if err != nil {
+		t.Fatalf("TLS client: %v", err)
+	}
+	t.Cleanup(func() { _ = tlsConn.Close() })
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := rpcv1.NewXRPLedgerAPIServiceClient(tlsConn).GetLedger(ctx, &rpcv1.GetLedgerRequest{}); err != nil {
+		t.Fatalf("TLS GetLedger: %v", err)
+	}
+
+	plainConn, err := googlegrpc.NewClient(bound.address, googlegrpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("plaintext client: %v", err)
+	}
+	t.Cleanup(func() { _ = plainConn.Close() })
+	plainCtx, plainCancel := context.WithTimeout(context.Background(), time.Second)
+	defer plainCancel()
+	if _, err := rpcv1.NewXRPLedgerAPIServiceClient(plainConn).GetLedger(plainCtx, &rpcv1.GetLedgerRequest{}); err == nil {
+		t.Fatal("plaintext request succeeded against TLS gRPC listener")
+	}
+}
+
+func writeGRPCTestCertificate(t *testing.T) (string, string, *x509.CertPool) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    now.Add(-time.Minute),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "server.crt")
+	keyPath := filepath.Join(dir, "server.key")
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatalf("write certificate: %v", err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(certPEM) {
+		t.Fatal("append test certificate")
+	}
+	return certPath, keyPath, roots
 }
 
 // TestGRPCServer_RejectsUnspecifiedSecureGateway mirrors rippled
@@ -147,6 +241,30 @@ func TestGRPCServer_RejectsUnspecifiedSecureGateway(t *testing.T) {
 	)
 	if err == nil {
 		t.Fatal("expected prepareGRPCServer to reject unspecified secure_gateway IP")
+	}
+}
+
+func TestGRPCServer_RejectsSecureGatewayCIDR(t *testing.T) {
+	lookup := &stubLookup{validated: newStubLedger(t)}
+	p := config.PortConfig{
+		Port: 0, IP: "127.0.0.1", Protocol: "grpc",
+		SecureGateway: []string{"127.0.0.0/8"},
+	}
+	_, err := prepareGRPCServer(context.Background(), "port_grpc", p, lookup, xrpllog.Discard(), systemListen)
+	if err == nil {
+		t.Fatal("expected secure_gateway CIDR validation error")
+	}
+}
+
+func TestGRPCServer_RejectsEmptySecureGateway(t *testing.T) {
+	lookup := &stubLookup{validated: newStubLedger(t)}
+	p := config.PortConfig{
+		Port: 0, IP: "127.0.0.1", Protocol: "grpc",
+		SecureGateway: []string{""},
+	}
+	_, err := prepareGRPCServer(context.Background(), "port_grpc", p, lookup, xrpllog.Discard(), systemListen)
+	if err == nil {
+		t.Fatal("expected empty secure_gateway validation error")
 	}
 }
 

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -1114,6 +1114,7 @@ func (r *nodeRuntime) bindTransports() error {
 		r.wsServer,
 		r.ledger,
 		systemListen,
+		r.resourceManager,
 	)
 	r.transports = transports
 	if err != nil {

--- a/internal/node/transports.go
+++ b/internal/node/transports.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/config"
 	xrplgrpc "github.com/LeJamon/go-xrpl/internal/grpc"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 	"github.com/LeJamon/go-xrpl/internal/rpc"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 )
@@ -73,8 +74,13 @@ func bindRPCTransports(
 	wsServer *rpc.WebSocketServer,
 	grpcLookup xrplgrpc.LedgerLookup,
 	listen listenFunc,
+	resourceManagers ...*resource.Manager,
 ) (_ *boundRPCTransports, err error) {
 	connLimiter := newConnectionLimiter(cfg.Server.MaxConnections)
+	var resourceManager *resource.Manager
+	if len(resourceManagers) > 0 {
+		resourceManager = resourceManagers[0]
+	}
 
 	httpMux := http.NewServeMux()
 	httpMux.Handle("/", httpHandler)
@@ -181,7 +187,9 @@ func bindRPCTransports(
 	}
 
 	if hasGRPC {
-		grpcServer, grpcErr := bindGRPCServer(ctx, grpcName, grpcPort, grpcLookup, log, listen)
+		grpcServer, grpcErr := bindGRPCServer(
+			ctx, grpcName, grpcPort, grpcLookup, log, listen, connLimiter, resourceManager,
+		)
 		if grpcErr != nil {
 			return nil, grpcErr
 		}

--- a/internal/node/transports_test.go
+++ b/internal/node/transports_test.go
@@ -26,7 +26,7 @@ func newConnectionLimitTestTransports(t *testing.T, protocol string, limit int) 
 	ports := map[string]config.PortConfig{
 		protocol: {IP: "127.0.0.1", Port: 0, Protocol: protocol, Limit: limit},
 	}
-	if protocol == "ws" {
+	if protocol == "ws" || protocol == "grpc" {
 		ports["http"] = config.PortConfig{IP: "127.0.0.1", Port: 0, Protocol: "http"}
 	}
 	bound, err := bindRPCTransports(
@@ -47,10 +47,101 @@ func newConnectionLimitTestTransports(t *testing.T, protocol string, limit int) 
 		for _, server := range append(append([]*boundHTTPServer(nil), bound.ws...), bound.http...) {
 			_ = server.server.Close()
 		}
+		if bound.grpc != nil {
+			bound.grpc.server.Stop()
+		}
 		_ = bound.closeListeners()
 		bound.wait()
 	})
 	return bound
+}
+
+func TestRPCConnectionLimitCountsGRPCConnections(t *testing.T) {
+	bound := newConnectionLimitTestTransports(t, "grpc", 1)
+	address := bound.grpc.address
+
+	first, err := net.Dial("tcp", address)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		bound.limiter.mu.Lock()
+		defer bound.limiter.mu.Unlock()
+		return bound.limiter.counts["grpc"] == 1
+	}, time.Second, time.Millisecond)
+
+	second, err := net.Dial("tcp", address)
+	require.NoError(t, err)
+	require.NoError(t, second.SetDeadline(time.Now().Add(time.Second)))
+	_, _ = io.WriteString(second, "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+	buffer := make([]byte, 1)
+	_, err = second.Read(buffer)
+	require.Error(t, err)
+	_ = second.Close()
+
+	require.NoError(t, first.Close())
+	require.Eventually(t, func() bool {
+		bound.limiter.mu.Lock()
+		defer bound.limiter.mu.Unlock()
+		return bound.limiter.counts["grpc"] == 0
+	}, time.Second, time.Millisecond)
+}
+
+func TestRPCConnectionLimitIsGlobalAcrossHTTPAndGRPCPorts(t *testing.T) {
+	bound, err := bindRPCTransports(
+		t.Context(),
+		xrpllog.Discard(),
+		&config.Config{
+			Server: config.ServerConfig{MaxConnections: 1},
+			Ports: map[string]config.PortConfig{
+				"http": {IP: "127.0.0.1", Port: 0, Protocol: "http"},
+				"grpc": {IP: "127.0.0.1", Port: 0, Protocol: "grpc"},
+			},
+		},
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+		rpc.NewWebSocketServer(rpc.WebSocketServerOptions{Timeout: time.Second}),
+		&stubLookup{validated: newStubLedger(t)},
+		systemListen,
+	)
+	require.NoError(t, err)
+	require.NoError(t, bound.serve(xrpllog.Discard()))
+	t.Cleanup(func() {
+		for _, server := range bound.http {
+			_ = server.server.Close()
+		}
+		if bound.grpc != nil {
+			bound.grpc.server.Stop()
+		}
+		_ = bound.closeListeners()
+		bound.wait()
+	})
+
+	idleHTTP, err := net.Dial("tcp", bound.http[0].address)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		bound.limiter.mu.Lock()
+		defer bound.limiter.mu.Unlock()
+		return bound.limiter.total == 1
+	}, time.Second, time.Millisecond)
+
+	blocked, err := net.Dial("tcp", bound.grpc.address)
+	require.NoError(t, err)
+	require.NoError(t, blocked.SetDeadline(time.Now().Add(time.Second)))
+	_, _ = io.WriteString(blocked, "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+	buffer := make([]byte, 1)
+	_, err = blocked.Read(buffer)
+	require.Error(t, err)
+	_ = blocked.Close()
+	require.NoError(t, idleHTTP.Close())
+
+	require.Eventually(t, func() bool {
+		conn, dialErr := net.Dial("tcp", bound.grpc.address)
+		if dialErr != nil {
+			return false
+		}
+		defer conn.Close()
+		bound.limiter.mu.Lock()
+		defer bound.limiter.mu.Unlock()
+		return bound.limiter.counts["grpc"] == 1
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestRPCConnectionLimitCountsIdleTCPConnections(t *testing.T) {


### PR DESCRIPTION
## Summary

- install and validate configured gRPC TLS credentials, apply shared global/per-port connection limits, and integrate request resource charging
- derive secure-gateway unlimited status from the actual transport peer and authenticated user field
- serve each ledger RPC from one context-aware immutable snapshot with direct entry reads and stable sanitized errors
- match rippled v3.3.0 transaction decoding, parent selection, diff ordering/error mapping, and ledger-data response behavior
- harden gRPC startup/shutdown tests and add focused TLS, load-shedding, cancellation, snapshot, decoding, and ordering regressions

## Testing

- `just test`
- `go test -race ./internal/grpc ./internal/node ./internal/ledger/service ./config`
- `just build-all`
- `just vet`
- `just lint`
- `git diff --check`

Fixes #1465
