### PR TITLE
fix(consensus): restore catch-up liveness

### DIFF
--- a/internal/consensus/adaptor/acquisition_work.go
+++ b/internal/consensus/adaptor/acquisition_work.go
@@ -326,7 +326,7 @@ func (l *acquisitionWorkLane) runBatch(batch *acquisitionWorkBatch) bool {
 		}
 	}
 	for i := range events {
-		if !result.yielded && events[i].kind == acquisitionWorkTimer {
+		if !result.yielded && !result.timerEscalate && events[i].kind == acquisitionWorkTimer {
 			result.rearmTimer = true
 			break
 		}
@@ -555,19 +555,6 @@ func processAcquisitionWorkWithBudget(ctx context.Context, ledger *inbound.Ledge
 		}
 	}
 
-	workCtx := shamap.WithTraversalBudget(ctx, visitBudget)
-
-	if runLocal || runTimer {
-		_, complete, err := ledger.CheckLocalContext(workCtx, fetch)
-		if err != nil {
-			result.err = err
-			return result
-		}
-		if complete {
-			result.complete = true
-			return result
-		}
-	}
 	if runTimerCheck {
 		switch ledger.OnTimer(timerAt) {
 		case inbound.TimerFailed:
@@ -582,6 +569,20 @@ func processAcquisitionWorkWithBudget(ctx context.Context, ledger *inbound.Ledge
 			return result
 		case inbound.TimerRefresh:
 			addedPeers = append(addedPeers, acquisitionRequestCandidates(nil, ledger.Peers())...)
+		}
+	}
+
+	workCtx := shamap.WithTraversalBudget(ctx, visitBudget)
+
+	if runLocal || runTimer {
+		_, complete, err := ledger.CheckLocalContext(workCtx, fetch)
+		if err != nil {
+			result.err = err
+			return result
+		}
+		if complete {
+			result.complete = true
+			return result
 		}
 	}
 

--- a/internal/consensus/adaptor/acquisition_work_test.go
+++ b/internal/consensus/adaptor/acquisition_work_test.go
@@ -1423,6 +1423,98 @@ func TestAcquisitionWork_EscalationDoesNotRearmPreemptedTraversal(t *testing.T) 
 	require.True(t, <-done)
 }
 
+func TestAcquisitionWork_YieldedWantStateEscalationRearmsAfterWork(t *testing.T) {
+	source := newWideWorkSource(t, 16)
+	require.NoError(t, source.Delete([32]byte{}))
+	rootHash, err := source.Hash()
+	require.NoError(t, err)
+	rootData, err := source.SerializeRoot()
+	require.NoError(t, err)
+	h := header.LedgerHeader{LedgerIndex: 205, AccountHash: rootHash}
+	headerData := header.AddRaw(h, false)
+	ledgerHash := sha512half.Sum(protocol.HashPrefixLedgerMaster().Bytes(), headerData)
+	family := backend.NewMemory()
+	ledger := inbound.New(ledgerHash, h.LedgerIndex, 7, serveTestLogger(), inbound.WithFamily(family))
+	require.NoError(t, ledger.GotBase([]message.LedgerNode{{NodeData: headerData}, {NodeData: rootData}}))
+	base := time.Now().Add(-time.Hour)
+	ledger.RearmTimer(base)
+	require.Equal(t, inbound.TimerRefresh, ledger.OnTimer(base.Add(4*time.Second)))
+	timerAt := base.Add(8 * time.Second)
+
+	router := newTestRouter(nil, newTestAdaptor(t), nil)
+	router.fetchTracker.Track(ledger)
+	lane := newAcquisitionWorkLane(1)
+	var blockMu sync.Mutex
+	blockEscalation := false
+	escalationStarted := make(chan struct{})
+	releaseEscalation := make(chan struct{})
+	lane.process = func(ctx context.Context, current *inbound.Ledger, events []acquisitionWorkEvent) acquisitionWorkResult {
+		blockMu.Lock()
+		block := blockEscalation
+		if block {
+			blockEscalation = false
+		}
+		blockMu.Unlock()
+		if block {
+			close(escalationStarted)
+			select {
+			case <-ctx.Done():
+				return acquisitionWorkResult{ledger: current, err: ctx.Err()}
+			case <-releaseEscalation:
+			}
+			return processAcquisitionWork(ctx, current, events)
+		}
+		return processAcquisitionWorkWithBudget(ctx, current, events, 1)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	lane.start(ctx)
+	router.acquisitionWork = lane
+	defer func() {
+		cancel()
+		lane.stop()
+	}()
+
+	require.True(t, lane.submit(ledger, acquisitionWorkEvent{
+		kind:  acquisitionWorkTimer,
+		fetch: func([32]byte) ([]byte, bool) { return nil, false },
+	}))
+	first := <-lane.results()
+	require.True(t, first.yielded)
+	require.True(t, lane.submit(ledger, acquisitionWorkEvent{
+		kind: acquisitionWorkTimerCheck,
+		at:   timerAt,
+	}))
+	router.handleAcquisitionWorkResult(first)
+
+	escalate := <-lane.results()
+	require.True(t, escalate.timerEscalate)
+	blockMu.Lock()
+	blockEscalation = true
+	blockMu.Unlock()
+	router.handleAcquisitionWorkResult(escalate)
+	select {
+	case <-escalationStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timer escalation work was not enqueued on the pending batch")
+	}
+	assert.True(t, lane.has(ledger))
+	assert.True(t, ledger.TimerDue(time.Now()), "timer rearmed before escalation work completed")
+	close(releaseEscalation)
+
+	for {
+		result := <-lane.results()
+		if !result.yielded {
+			require.NoError(t, result.err)
+			require.True(t, result.rearmTimer)
+			assert.True(t, ledger.TimerDue(time.Now()))
+			router.handleAcquisitionWorkResult(result)
+			break
+		}
+		router.handleAcquisitionWorkResult(result)
+	}
+	assert.False(t, ledger.TimerDue(time.Now()), "timer was not rearmed after escalation work completed")
+}
+
 func TestRouter_MaintenanceDrainsBufferedReplyBeforeTerminalTimer(t *testing.T) {
 	ledger, replies := newWideWorkLedger(t)
 	timerAt := primeAcquisitionForTerminalTimer(t, ledger)

--- a/internal/consensus/adaptor/acquisition_work_test.go
+++ b/internal/consensus/adaptor/acquisition_work_test.go
@@ -1325,6 +1325,104 @@ func TestAcquisitionWork_UsefulLargeReplyPrecedesTerminalTimerCheck(t *testing.T
 	lane.stop()
 }
 
+func TestAcquisitionWork_TerminalTimerPreemptsRetainedTraversal(t *testing.T) {
+	ledger, _ := newWideWorkLedger(t)
+	timerAt := primeAcquisitionForTerminalTimer(t, ledger)
+
+	result := processAcquisitionWorkBudgeted(t.Context(), ledger, []acquisitionWorkEvent{
+		{kind: acquisitionWorkTimer, fetch: func([32]byte) ([]byte, bool) { return nil, false }},
+		{kind: acquisitionWorkTimerCheck, at: timerAt},
+	})
+
+	require.NoError(t, result.err)
+	require.True(t, result.remove)
+	require.True(t, result.timerFailure)
+	require.Equal(t, 7, ledger.Timeouts())
+}
+
+func TestAcquisitionWork_TimerCheckPreemptsYieldedTraversal(t *testing.T) {
+	source := newWideWorkSource(t, 16)
+	rootHash, err := source.Hash()
+	require.NoError(t, err)
+	rootData, err := source.SerializeRoot()
+	require.NoError(t, err)
+	h := header.LedgerHeader{LedgerIndex: 204, AccountHash: rootHash}
+	headerData := header.AddRaw(h, false)
+	ledgerHash := sha512half.Sum(protocol.HashPrefixLedgerMaster().Bytes(), headerData)
+	family := backend.NewMemory()
+	packNodes, err := source.WalkFetchPackNodes(1 << 20)
+	require.NoError(t, err)
+	entries := make([]shamap.FlushEntry, 0, len(packNodes))
+	for _, node := range packNodes {
+		entries = append(entries, shamap.FlushEntry{Hash: node.Hash, Data: node.Data})
+	}
+	require.NoError(t, family.StoreBatch(t.Context(), entries))
+	ledger := inbound.New(ledgerHash, h.LedgerIndex, 7, serveTestLogger(), inbound.WithFamily(family))
+	require.NoError(t, ledger.GotBase([]message.LedgerNode{{NodeData: headerData}, {NodeData: rootData}}))
+	base := time.Now()
+	ledger.RearmTimer(base)
+	require.Equal(t, inbound.TimerRefresh, ledger.OnTimer(base.Add(4*time.Second)))
+	timerAt := base.Add(8 * time.Second)
+
+	lane := newAcquisitionWorkLane(1)
+	lane.process = func(ctx context.Context, ledger *inbound.Ledger, events []acquisitionWorkEvent) acquisitionWorkResult {
+		return processAcquisitionWorkWithBudget(ctx, ledger, events, 1)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	lane.start(ctx)
+	defer func() {
+		cancel()
+		lane.stop()
+	}()
+	require.True(t, lane.submit(ledger, acquisitionWorkEvent{
+		kind:  acquisitionWorkTimer,
+		fetch: func([32]byte) ([]byte, bool) { return nil, false },
+	}))
+
+	first := <-lane.results()
+	require.True(t, first.yielded, "result: %+v", first)
+	require.Equal(t, inbound.TimerRefresh, ledger.OnTimer(timerAt))
+	require.True(t, lane.submit(ledger, acquisitionWorkEvent{
+		kind: acquisitionWorkTimerCheck,
+		at:   timerAt.Add(4 * time.Second),
+	}))
+	close(first.ack)
+
+	second := <-lane.results()
+	require.False(t, second.yielded)
+	require.True(t, second.timerEscalate)
+	require.Equal(t, 1, ledger.Timeouts())
+	close(second.ack)
+}
+
+func TestAcquisitionWork_EscalationDoesNotRearmPreemptedTraversal(t *testing.T) {
+	ledger := inbound.New([32]byte{0xc1}, 204, 7, serveTestLogger())
+	base := time.Now()
+	ledger.RearmTimer(base)
+
+	lane := newAcquisitionWorkLane(1)
+	lane.ctx = t.Context()
+	batchCtx, cancel := context.WithCancel(t.Context())
+	batch := &acquisitionWorkBatch{
+		ledger: ledger,
+		ctx:    batchCtx,
+		cancel: cancel,
+		events: []acquisitionWorkEvent{
+			{kind: acquisitionWorkTimer, fetch: func([32]byte) ([]byte, bool) { return nil, false }},
+			{kind: acquisitionWorkTimerCheck, at: base.Add(4 * time.Second)},
+		},
+	}
+	lane.pending[ledger] = batch
+	done := make(chan bool, 1)
+	go func() { done <- lane.runBatch(batch) }()
+
+	result := <-lane.results()
+	require.True(t, result.timerEscalate)
+	require.False(t, result.rearmTimer)
+	close(result.ack)
+	require.True(t, <-done)
+}
+
 func TestRouter_MaintenanceDrainsBufferedReplyBeforeTerminalTimer(t *testing.T) {
 	ledger, replies := newWideWorkLedger(t)
 	timerAt := primeAcquisitionForTerminalTimer(t, ledger)

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -33,13 +33,13 @@ const inboundReplayDeltaTickInterval = 100 * time.Millisecond
 type peerLedgerState struct {
 	LedgerSeq  uint32
 	LedgerHash [32]byte
+	parentHash [32]byte
+	haveParent bool
 }
 
 type peerStatusCandidate struct {
 	peerLedgerState
-	peerID     peermanagement.PeerID
-	parentHash [32]byte
-	haveParent bool
+	peerID peermanagement.PeerID
 }
 
 type peerSessionView interface {

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -35,6 +35,13 @@ type peerLedgerState struct {
 	LedgerHash [32]byte
 }
 
+type peerStatusCandidate struct {
+	peerLedgerState
+	peerID     peermanagement.PeerID
+	parentHash [32]byte
+	haveParent bool
+}
+
 type peerSessionView interface {
 	IsPeerConnected(peermanagement.PeerID) bool
 }
@@ -119,9 +126,10 @@ type Router struct {
 	logger        *slog.Logger
 
 	// Peer ledger tracking for catch-up detection
-	peerSessions peerSessionView
-	peersMu      sync.RWMutex
-	peerStates   map[peermanagement.PeerID]*peerLedgerState
+	peerSessions         peerSessionView
+	peersMu              sync.RWMutex
+	peerStates           map[peermanagement.PeerID]*peerLedgerState
+	peerStatusCandidates map[peermanagement.PeerID]peerStatusCandidate
 
 	// The overlay callback only records disconnects; a router-owned worker performs
 	// cleanup so acquisition scans never block the overlay event loop.
@@ -319,10 +327,10 @@ type Router struct {
 	// parent hash) per ledger sequence, from trusted validations and peer
 	// status_change gossip. Supplies the hash of closed+1 (the forward-delta
 	// catch-up target) and the parent linkage proving closed+1 descends from our
-	// closed ledger. Bounded to seqHashRetain; seqHashMax keeps a trailing window.
-	seqHashMu  sync.Mutex
-	seqHash    map[uint32]ledgerHashEntry
-	seqHashMax uint32
+	// closed ledger. Only local or trusted evidence advances seqHashAnchor.
+	seqHashMu     sync.Mutex
+	seqHash       map[uint32]ledgerHashEntry
+	seqHashAnchor uint32
 }
 
 type routerNetworkConfig struct {
@@ -371,7 +379,18 @@ type ledgerHashEntry struct {
 	hash       [32]byte
 	parentHash [32]byte
 	haveParent bool
+	source     seqHashSource
+	parentFrom seqHashSource
 }
+
+type seqHashSource uint8
+
+const (
+	seqHashSourcePeer seqHashSource = iota
+	seqHashSourceAcquired
+	seqHashSourceValidation
+	seqHashSourceQuorum
+)
 
 // txWorkerCount bounds the goroutines draining inbound peer transactions off
 // the consensus Run loop, and txQueueDepth bounds the pending backlog before
@@ -451,6 +470,7 @@ func newRouter(engine consensus.RouterEngine, adaptor *Adaptor, inbox <-chan *pe
 		inbox:                  inbox,
 		logger:                 logger,
 		peerStates:             make(map[peermanagement.PeerID]*peerLedgerState),
+		peerStatusCandidates:   make(map[peermanagement.PeerID]peerStatusCandidate),
 		peerDisconnectWake:     make(chan struct{}, 1),
 		peerConnectWake:        make(chan struct{}, 1),
 		replayer:               inbound.NewReplayer(logger, inbound.SystemClock, inbound.DefaultMaxInFlightReplays),
@@ -691,6 +711,7 @@ func (r *Router) HandlePeerDisconnect(peerID peermanagement.PeerID) {
 	r.pendingPeerConnects.Delete(peerID)
 	r.peersMu.Lock()
 	delete(r.peerStates, peerID)
+	delete(r.peerStatusCandidates, peerID)
 	r.peersMu.Unlock()
 	r.invalidateCatchupPeer(uint64(peerID))
 	r.invalidateHistoryPeer(uint64(peerID))

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -1,6 +1,7 @@
 package adaptor
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -42,7 +43,10 @@ func (r *Router) handleStatusChange(msg *peermanagement.InboundMessage) {
 	if sc.NewEvent == message.NodeEventLostSync {
 		r.peersMu.Lock()
 		delete(r.peerStates, msg.PeerID)
+		delete(r.peerStatusCandidates, msg.PeerID)
 		r.peersMu.Unlock()
+		r.invalidateCatchupPeer(uint64(msg.PeerID))
+		r.invalidateHistoryPeer(uint64(msg.PeerID))
 		r.adaptor.UpdatePeerLCL(uint64(msg.PeerID), consensus.LedgerID{})
 		return
 	}
@@ -55,6 +59,7 @@ func (r *Router) handleStatusChange(msg *peermanagement.InboundMessage) {
 		if peerHash == ([32]byte{}) {
 			r.peersMu.Lock()
 			delete(r.peerStates, msg.PeerID)
+			delete(r.peerStatusCandidates, msg.PeerID)
 			r.peersMu.Unlock()
 			r.adaptor.UpdatePeerLCL(uint64(msg.PeerID), consensus.LedgerID{})
 			return
@@ -65,23 +70,19 @@ func (r *Router) handleStatusChange(msg *peermanagement.InboundMessage) {
 			copy(parentHash[:], sc.LedgerHashPrevious)
 		}
 
-		// status_change is the only gossip source carrying the parent hash
-		// (validations don't), so the forward-delta catch-up learns linkage here.
-		if len(sc.LedgerHash) == 32 {
-			r.recordSeqHash(sc.LedgerSeq, peerHash, parentHash, haveParent)
+		admitted := r.admitPeerStatus(peerStatusCandidate{
+			peerLedgerState: peerLedgerState{LedgerSeq: sc.LedgerSeq, LedgerHash: peerHash},
+			peerID:          msg.PeerID,
+			parentHash:      parentHash,
+			haveParent:      haveParent,
+		})
+		if len(admitted) == 0 {
+			return
 		}
-
-		r.peersMu.Lock()
-		r.peerStates[msg.PeerID] = &peerLedgerState{
-			LedgerSeq:  sc.LedgerSeq,
-			LedgerHash: peerHash,
+		for _, status := range admitted {
+			r.recordPeerSeqHash(status.LedgerSeq, status.LedgerHash, status.parentHash, status.haveParent)
+			r.adaptor.UpdatePeerLCL(uint64(status.peerID), consensus.LedgerID(status.LedgerHash))
 		}
-		r.peersMu.Unlock()
-
-		// Surface the peer's reported LCL to the adaptor so the
-		// engine's getNetworkLedger can consider it as a vote even
-		// when no proposal has (yet) arrived from this peer.
-		r.adaptor.UpdatePeerLCL(uint64(msg.PeerID), consensus.LedgerID(peerHash))
 
 		// During network startup or fast-load confirmation, acquire the
 		// peer-preferred ledger. Don't adopt with synthetic headers — wait for
@@ -142,6 +143,42 @@ func (r *Router) handleStatusChange(msg *peermanagement.InboundMessage) {
 	}
 }
 
+func (r *Router) admitPeerStatus(status peerStatusCandidate) []peerStatusCandidate {
+	if r.isValidationCatchupTarget(status.LedgerSeq, status.LedgerHash) ||
+		r.peerStatusWithinAnchor(status.LedgerSeq) {
+		r.peersMu.Lock()
+		delete(r.peerStatusCandidates, status.peerID)
+		r.peerStates[status.peerID] = &peerLedgerState{
+			LedgerSeq:  status.LedgerSeq,
+			LedgerHash: status.LedgerHash,
+		}
+		r.peersMu.Unlock()
+		return []peerStatusCandidate{status}
+	}
+
+	r.peersMu.Lock()
+	r.peerStatusCandidates[status.peerID] = status
+	matching := make([]peerStatusCandidate, 0, 2)
+	for _, candidate := range r.peerStatusCandidates {
+		if candidate.LedgerSeq == status.LedgerSeq && candidate.LedgerHash == status.LedgerHash {
+			matching = append(matching, candidate)
+		}
+	}
+	if len(matching) < 2 {
+		r.peersMu.Unlock()
+		return nil
+	}
+	for _, candidate := range matching {
+		delete(r.peerStatusCandidates, candidate.peerID)
+		r.peerStates[candidate.peerID] = &peerLedgerState{
+			LedgerSeq:  candidate.LedgerSeq,
+			LedgerHash: candidate.LedgerHash,
+		}
+	}
+	r.peersMu.Unlock()
+	return matching
+}
+
 func (r *Router) peerLedgerIsPreferred(hash [32]byte) bool {
 	closed, err := r.adaptor.GetLastClosedLedger()
 	if err != nil || closed == nil {
@@ -179,29 +216,66 @@ const maxForwardDeltaGap = 128
 
 const catchupLinkageGracePeriod = 2 * time.Second
 
-// seqHashRetain bounds the seqHash table to a trailing window of sequences so a
-// long-running node never grows it unbounded.
+// seqHashRetain bounds the ancestry retained behind the local or trusted
+// frontier. Peer gossip is admitted only through maxForwardDeltaGap ahead.
 const seqHashRetain = 2048
 
-// recordSeqHash records the network's hash — and, from a status_change, the
-// parent hash — for a ledger sequence, backing the forward-delta catch-up. A
-// later fuller entry (with parent) upgrades an earlier hash-only one rather than
-// clobbering it.
 func (r *Router) recordSeqHash(seq uint32, hash, parentHash [32]byte, haveParent bool) {
+	r.recordSeqHashFrom(seq, hash, parentHash, haveParent, seqHashSourceQuorum)
+}
+
+func (r *Router) recordValidationSeqHash(seq uint32, hash [32]byte) {
+	r.recordSeqHashFrom(seq, hash, [32]byte{}, false, seqHashSourceValidation)
+}
+
+func (r *Router) recordAcquiredSeqHash(seq uint32, hash, parentHash [32]byte) {
+	r.recordSeqHashFrom(seq, hash, parentHash, true, seqHashSourceAcquired)
+}
+
+func (r *Router) recordPeerSeqHash(seq uint32, hash, parentHash [32]byte, haveParent bool) {
+	r.recordSeqHashFrom(seq, hash, parentHash, haveParent, seqHashSourcePeer)
+}
+
+func (r *Router) recordSeqHashFrom(
+	seq uint32,
+	hash, parentHash [32]byte,
+	haveParent bool,
+	source seqHashSource,
+) {
 	if seq == 0 || hash == ([32]byte{}) {
 		return
 	}
+	localAnchor := r.localSeqHashAnchor()
+
 	r.seqHashMu.Lock()
 	defer r.seqHashMu.Unlock()
 
+	if localAnchor > r.seqHashAnchor {
+		r.seqHashAnchor = localAnchor
+	}
+	if source >= seqHashSourceValidation && seq > r.seqHashAnchor {
+		r.seqHashAnchor = seq
+	}
+	r.pruneSeqHashLocked()
+	if source < seqHashSourceValidation && !seqHashWithinAnchor(seq, r.seqHashAnchor) {
+		return
+	}
+
 	e := r.seqHash[seq]
 	if e.hash != ([32]byte{}) && e.hash != hash {
+		if source < e.source || (source == e.source && source != seqHashSourceQuorum) {
+			return
+		}
 		e = ledgerHashEntry{}
 	}
 	e.hash = hash
-	if haveParent {
+	if source > e.source {
+		e.source = source
+	}
+	if haveParent && (!e.haveParent || source > e.parentFrom) {
 		e.parentHash = parentHash
 		e.haveParent = true
+		e.parentFrom = source
 	}
 	r.seqHash[seq] = e
 
@@ -209,29 +283,73 @@ func (r *Router) recordSeqHash(seq uint32, hash, parentHash [32]byte, haveParent
 	// same-branch check against our closed seq succeeds without a direct
 	// validation for it.
 	if haveParent && seq > 1 {
-		if pe, ok := r.seqHash[seq-1]; !ok || pe.hash == ([32]byte{}) {
+		pe := r.seqHash[seq-1]
+		if pe.hash == ([32]byte{}) || pe.hash == parentHash || source > pe.source {
+			if pe.hash != ([32]byte{}) && pe.hash != parentHash {
+				pe = ledgerHashEntry{}
+			}
 			pe.hash = parentHash
+			if source > pe.source {
+				pe.source = source
+			}
 			r.seqHash[seq-1] = pe
 		}
 	}
 
-	if seq > r.seqHashMax {
-		r.seqHashMax = seq
-	}
-	if len(r.seqHash) > seqHashRetain {
-		r.pruneSeqHashLocked()
-	}
+	r.pruneSeqHashLocked()
 }
 
-// pruneSeqHashLocked drops entries older than the trailing seqHashRetain window.
-// Caller holds seqHashMu.
-func (r *Router) pruneSeqHashLocked() {
-	if r.seqHashMax <= seqHashRetain {
-		return
+func (r *Router) localSeqHashAnchor() uint32 {
+	if r.adaptor == nil {
+		return 0
 	}
-	floor := r.seqHashMax - seqHashRetain
+	svc := r.adaptor.LedgerService()
+	if svc == nil {
+		return 0
+	}
+	anchor := svc.GetClosedLedgerIndex()
+	if validated := svc.GetValidatedLedgerIndex(); validated > anchor {
+		anchor = validated
+	}
+	return anchor
+}
+
+func (r *Router) peerStatusWithinAnchor(seq uint32) bool {
+	localAnchor := r.localSeqHashAnchor()
+	r.seqHashMu.Lock()
+	defer r.seqHashMu.Unlock()
+	if localAnchor > r.seqHashAnchor {
+		r.seqHashAnchor = localAnchor
+	}
+	r.pruneSeqHashLocked()
+	anchor := r.seqHashAnchor
+	if anchor == 0 {
+		return false
+	}
+	if seq >= anchor {
+		return seq-anchor <= maxForwardDeltaGap
+	}
+	return anchor-seq <= maxForwardDeltaGap
+}
+
+func seqHashWithinAnchor(seq, anchor uint32) bool {
+	if anchor == 0 {
+		return false
+	}
+	floor := uint32(0)
+	if anchor > seqHashRetain {
+		floor = anchor - seqHashRetain
+	}
+	ceiling := anchor + maxForwardDeltaGap
+	if ceiling < anchor {
+		ceiling = ^uint32(0)
+	}
+	return seq >= floor && seq <= ceiling
+}
+
+func (r *Router) pruneSeqHashLocked() {
 	for s := range r.seqHash {
-		if s < floor {
+		if !seqHashWithinAnchor(s, r.seqHashAnchor) {
 			delete(r.seqHash, s)
 		}
 	}
@@ -314,7 +432,6 @@ func (r *Router) recordValidationCatchupTarget(
 	source catchupTargetSource,
 ) {
 	r.catchupMu.Lock()
-	defer r.catchupMu.Unlock()
 	previous := r.catchup
 	// Trusted evidence replaces a peer-derived target at any sequence. Once
 	// validation-driven, only a higher sequence or same-sequence quorum can
@@ -322,13 +439,44 @@ func (r *Router) recordValidationCatchupTarget(
 	if r.catchup.source == catchupSourcePeer ||
 		(source == catchupSourceQuorum && seq == r.catchup.seq) ||
 		seq > r.catchup.seq {
+		if peerID == 0 && previous.seq == seq && previous.hash == hash {
+			peerID = previous.peerID
+		}
 		r.catchup = catchupTarget{seq: seq, hash: hash, peerID: peerID, source: source}
 	} else if seq == r.catchup.seq && hash == r.catchup.hash {
-		r.catchup.peerID = peerID
+		if peerID != 0 {
+			r.catchup.peerID = peerID
+		}
 	}
 	if previous.hash != ([32]byte{}) && previous.hash != r.catchup.hash &&
 		previous.source != catchupSourcePeer && r.catchup.source != catchupSourcePeer {
 		r.targetSuperseded.Add(1)
+	}
+	target := r.catchup
+	r.catchupMu.Unlock()
+
+	if target.source != catchupSourcePeer {
+		r.promotePeerStatusCandidates(target.seq, target.hash)
+	}
+}
+
+func (r *Router) promotePeerStatusCandidates(seq uint32, hash [32]byte) {
+	r.peersMu.Lock()
+	matching := make([]peerStatusCandidate, 0, 1)
+	for peerID, candidate := range r.peerStatusCandidates {
+		if candidate.LedgerSeq != seq || candidate.LedgerHash != hash {
+			continue
+		}
+		matching = append(matching, candidate)
+		delete(r.peerStatusCandidates, peerID)
+		r.peerStates[peerID] = &peerLedgerState{LedgerSeq: seq, LedgerHash: hash}
+	}
+	r.peersMu.Unlock()
+
+	for _, candidate := range matching {
+		r.recordPeerSeqHash(seq, hash, candidate.parentHash, candidate.haveParent)
+		r.adaptor.UpdatePeerLCL(uint64(candidate.peerID), consensus.LedgerID(hash))
+		r.recordCatchupTarget(seq, hash, uint64(candidate.peerID))
 	}
 }
 
@@ -341,11 +489,34 @@ func (r *Router) isValidationCatchupTarget(seq uint32, hash [32]byte) bool {
 }
 
 func (r *Router) invalidateCatchupPeer(peerID uint64) {
+	type peerTip struct {
+		peerID uint64
+		seq    uint32
+		hash   [32]byte
+	}
+	r.peersMu.RLock()
+	peers := make([]peerTip, 0, len(r.peerStates))
+	for id, state := range r.peerStates {
+		peers = append(peers, peerTip{peerID: uint64(id), seq: state.LedgerSeq, hash: state.LedgerHash})
+	}
+	r.peersMu.RUnlock()
+
 	r.catchupMu.Lock()
 	defer r.catchupMu.Unlock()
-	if r.catchup.peerID == peerID {
-		r.catchup.peerID = 0
+	if r.catchup.peerID != peerID {
+		return
 	}
+	if r.catchup.source != catchupSourcePeer {
+		r.catchup.peerID = 0
+		return
+	}
+	for _, peer := range peers {
+		if peer.seq == r.catchup.seq && peer.hash == r.catchup.hash {
+			r.catchup.peerID = peer.peerID
+			return
+		}
+	}
+	r.catchup = catchupTarget{}
 }
 
 const catchupFailureCooldown = 5 * time.Minute
@@ -1252,6 +1423,10 @@ func (r *Router) onLedgerFullyValidated(seq uint32, hash [32]byte) {
 		}
 		legacy = append(legacy, r.cancelStandardReplayPipelineLocked()...)
 	}
+	if victim := r.obsoleteCatchupVictimLocked(seq); victim != nil && r.fetchTracker.DiscardExpected(victim) {
+		legacy = append(legacy, victim)
+		removed[victim.Hash()] = struct{}{}
+	}
 	if _, ok := removed[r.consensusRecovery.stepHash]; ok {
 		r.consensusRecovery.stepHash = [32]byte{}
 	}
@@ -1271,6 +1446,36 @@ func (r *Router) onLedgerFullyValidated(seq uint32, hash [32]byte) {
 		)
 	}
 	r.armValidatedLedgerAcquisition(seq, hash)
+}
+
+func (r *Router) obsoleteCatchupVictimLocked(targetSeq uint32) *inbound.Ledger {
+	if r.protectedCatchupInFlight() < maxConcurrentSpeculativeCatchup {
+		return nil
+	}
+	var victim *inbound.Ledger
+	for _, candidate := range r.fetchTracker.Active() {
+		seq := candidate.Seq()
+		if candidate.Reason() != inbound.ReasonConsensus || candidate.TransactionOnly() ||
+			seq == 0 || seq >= targetSeq || candidate.Hash() == r.consensusRecovery.targetHash ||
+			candidate.Hash() == r.consensusRecovery.stepHash {
+			continue
+		}
+		consecutive := candidate.ConsecutiveTimeouts()
+		if consecutive < 2 && targetSeq-seq <= maxForwardDeltaGap {
+			continue
+		}
+		if victim == nil || seq < victim.Seq() ||
+			(seq == victim.Seq() && consecutive > victim.ConsecutiveTimeouts()) ||
+			(seq == victim.Seq() && consecutive == victim.ConsecutiveTimeouts() &&
+				hashLess(candidate.Hash(), victim.Hash())) {
+			victim = candidate
+		}
+	}
+	return victim
+}
+
+func hashLess(left, right [32]byte) bool {
+	return bytes.Compare(left[:], right[:]) < 0
 }
 
 func (r *Router) completeHistoryBackfill(seq uint32, hash, parentHash [32]byte, peerID uint64) {
@@ -1783,7 +1988,7 @@ func (r *Router) storeVerifiedLedger(l *ledger.Ledger) (header.LedgerHeader, boo
 }
 
 func (r *Router) completeStoredConsensusRecovery(seq uint32, hash, parentHash [32]byte, initialCandidate bool) bool {
-	r.recordSeqHash(seq, hash, parentHash, true)
+	r.recordAcquiredSeqHash(seq, hash, parentHash)
 	_, result := r.adaptor.recheckFullyValidated(seq, hash)
 	r.recordCompletionRecheck(result)
 	if result == validationRecheckAccepted {
@@ -2054,7 +2259,7 @@ func (r *Router) maybeAcquireFromValidation(v *consensus.Validation, originPeer 
 	// Record the hash for this seq regardless of the acquire gate below: the
 	// forward-delta decision needs it for closed+1 and for our own closed seq
 	// (same-branch check). Validations carry no parent hash.
-	r.recordSeqHash(v.LedgerSeq, [32]byte(v.LedgerID), [32]byte{}, false)
+	r.recordValidationSeqHash(v.LedgerSeq, [32]byte(v.LedgerID))
 
 	svc := r.adaptor.LedgerService()
 	if svc == nil {
@@ -2226,17 +2431,18 @@ func (r *Router) checkBehind(peerSeq uint32, peerHash [32]byte, peerID uint64) {
 	}
 
 	ourSeq := svc.GetClosedLedgerIndex()
-	networkSeq := peerSeq
-	r.peersMu.RLock()
-	for _, state := range r.peerStates {
-		if state.LedgerSeq > networkSeq {
-			networkSeq = state.LedgerSeq
-		}
+	networkSeq := ourSeq
+	if validatedSeq := svc.GetValidatedLedgerIndex(); validatedSeq > networkSeq {
+		networkSeq = validatedSeq
 	}
-	r.peersMu.RUnlock()
-	if targetSeq, _, _ := r.bestCatchupTarget(); targetSeq > networkSeq {
-		networkSeq = targetSeq
+	if validatedSeq := r.adaptor.networkValidatedSeq.Load(); validatedSeq > networkSeq {
+		networkSeq = validatedSeq
 	}
+	r.catchupMu.Lock()
+	if r.catchup.source != catchupSourcePeer && r.catchup.seq > networkSeq {
+		networkSeq = r.catchup.seq
+	}
+	r.catchupMu.Unlock()
 
 	// If we're caught up (gap ≤ 1) and not yet Full, transition to Full
 	// only if our LCL hash matches what the majority of peers report.

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -61,6 +61,7 @@ func (r *Router) handleStatusChange(msg *peermanagement.InboundMessage) {
 			delete(r.peerStates, msg.PeerID)
 			delete(r.peerStatusCandidates, msg.PeerID)
 			r.peersMu.Unlock()
+			r.invalidateCatchupPeer(uint64(msg.PeerID))
 			r.adaptor.UpdatePeerLCL(uint64(msg.PeerID), consensus.LedgerID{})
 			return
 		}
@@ -71,17 +72,22 @@ func (r *Router) handleStatusChange(msg *peermanagement.InboundMessage) {
 		}
 
 		admitted := r.admitPeerStatus(peerStatusCandidate{
-			peerLedgerState: peerLedgerState{LedgerSeq: sc.LedgerSeq, LedgerHash: peerHash},
-			peerID:          msg.PeerID,
-			parentHash:      parentHash,
-			haveParent:      haveParent,
+			peerLedgerState: peerLedgerState{
+				LedgerSeq:  sc.LedgerSeq,
+				LedgerHash: peerHash,
+				parentHash: parentHash,
+				haveParent: haveParent,
+			},
+			peerID: msg.PeerID,
 		})
 		if len(admitted) == 0 {
 			return
 		}
 		for _, status := range admitted {
-			r.recordPeerSeqHash(status.LedgerSeq, status.LedgerHash, status.parentHash, status.haveParent)
 			r.adaptor.UpdatePeerLCL(uint64(status.peerID), consensus.LedgerID(status.LedgerHash))
+		}
+		for _, status := range admitted {
+			r.reconcilePeerSeqHash(status.LedgerSeq)
 		}
 
 		// During network startup or fast-load confirmation, acquire the
@@ -151,6 +157,8 @@ func (r *Router) admitPeerStatus(status peerStatusCandidate) []peerStatusCandida
 		r.peerStates[status.peerID] = &peerLedgerState{
 			LedgerSeq:  status.LedgerSeq,
 			LedgerHash: status.LedgerHash,
+			parentHash: status.parentHash,
+			haveParent: status.haveParent,
 		}
 		r.peersMu.Unlock()
 		return []peerStatusCandidate{status}
@@ -173,6 +181,8 @@ func (r *Router) admitPeerStatus(status peerStatusCandidate) []peerStatusCandida
 		r.peerStates[candidate.peerID] = &peerLedgerState{
 			LedgerSeq:  candidate.LedgerSeq,
 			LedgerHash: candidate.LedgerHash,
+			parentHash: candidate.parentHash,
+			haveParent: candidate.haveParent,
 		}
 	}
 	r.peersMu.Unlock()
@@ -236,6 +246,132 @@ func (r *Router) recordPeerSeqHash(seq uint32, hash, parentHash [32]byte, havePa
 	r.recordSeqHashFrom(seq, hash, parentHash, haveParent, seqHashSourcePeer)
 }
 
+func (r *Router) reconcilePeerSeqHash(seq uint32) {
+	type peerEvidence struct {
+		peerID     uint64
+		hash       [32]byte
+		parentHash [32]byte
+		haveParent bool
+	}
+	r.peersMu.RLock()
+	peers := make([]peerEvidence, 0, len(r.peerStates))
+	hashSupport := make(map[[32]byte]int)
+	for peerID, state := range r.peerStates {
+		if state == nil || state.LedgerSeq != seq {
+			continue
+		}
+		peers = append(peers, peerEvidence{
+			peerID:     uint64(peerID),
+			hash:       state.LedgerHash,
+			parentHash: state.parentHash,
+			haveParent: state.haveParent,
+		})
+		hashSupport[state.LedgerHash]++
+	}
+	r.peersMu.RUnlock()
+	if len(peers) == 0 {
+		return
+	}
+
+	entry, known := r.lookupSeqHash(seq)
+	chosenHash := entry.hash
+	chosenPreferred := false
+	if !known || entry.source < seqHashSourceValidation {
+		chosenHash = [32]byte{}
+		for _, peer := range peers {
+			if r.peerLedgerIsPreferred(peer.hash) {
+				chosenHash = peer.hash
+				chosenPreferred = true
+				break
+			}
+		}
+		if chosenHash == ([32]byte{}) {
+			best := 0
+			for hash, count := range hashSupport {
+				if count > best || (count == best && bytes.Compare(hash[:], chosenHash[:]) > 0) {
+					chosenHash, best = hash, count
+				}
+			}
+		}
+	}
+	if chosenHash == ([32]byte{}) {
+		return
+	}
+
+	parents := make(map[[32]byte]int)
+	var peerID uint64
+	for _, peer := range peers {
+		if peer.hash != chosenHash {
+			continue
+		}
+		if peerID == 0 || peer.peerID < peerID {
+			peerID = peer.peerID
+		}
+		if peer.haveParent {
+			parents[peer.parentHash]++
+		}
+	}
+	if peerID == 0 {
+		return
+	}
+	parentHash, haveParent := r.preferredPeerParent(seq, parents)
+	r.recordPeerSeqHash(seq, chosenHash, parentHash, haveParent)
+	if !haveParent {
+		r.seqHashMu.Lock()
+		entry = r.seqHash[seq]
+		if entry.hash == chosenHash && entry.parentFrom == seqHashSourcePeer {
+			entry.parentHash = [32]byte{}
+			entry.haveParent = false
+			entry.parentFrom = seqHashSourcePeer
+			r.seqHash[seq] = entry
+		}
+		if len(parents) > 1 && seq > 1 {
+			parent := r.seqHash[seq-1]
+			if parent.source == seqHashSourcePeer {
+				delete(r.seqHash, seq-1)
+			}
+		}
+		r.seqHashMu.Unlock()
+	}
+
+	r.catchupMu.Lock()
+	if chosenPreferred && r.catchup.source == catchupSourcePeer && r.catchup.seq == seq {
+		r.catchup.hash = chosenHash
+		r.catchup.peerID = peerID
+	}
+	r.catchupMu.Unlock()
+}
+
+func (r *Router) preferredPeerParent(seq uint32, support map[[32]byte]int) ([32]byte, bool) {
+	if seq > 1 && r.adaptor != nil {
+		if svc := r.adaptor.LedgerService(); svc != nil {
+			if parent, err := svc.GetLedgerBySequence(seq - 1); err == nil && parent != nil {
+				if support[parent.Hash()] > 0 {
+					return parent.Hash(), true
+				}
+			}
+		}
+	}
+	if len(support) == 1 {
+		for parent := range support {
+			return parent, true
+		}
+	}
+
+	var chosen [32]byte
+	best, second := 0, 0
+	for parent, count := range support {
+		if count > best || (count == best && bytes.Compare(parent[:], chosen[:]) > 0) {
+			second = best
+			best = count
+			chosen = parent
+		} else if count > second {
+			second = count
+		}
+	}
+	return chosen, best >= 2 && best > second
+}
+
 func (r *Router) recordSeqHashFrom(
 	seq uint32,
 	hash, parentHash [32]byte,
@@ -263,7 +399,8 @@ func (r *Router) recordSeqHashFrom(
 
 	e := r.seqHash[seq]
 	if e.hash != ([32]byte{}) && e.hash != hash {
-		if source < e.source || (source == e.source && source != seqHashSourceQuorum) {
+		if source < e.source ||
+			(source == e.source && source != seqHashSourcePeer && source != seqHashSourceQuorum) {
 			return
 		}
 		e = ledgerHashEntry{}
@@ -272,7 +409,8 @@ func (r *Router) recordSeqHashFrom(
 	if source > e.source {
 		e.source = source
 	}
-	if haveParent && (!e.haveParent || source > e.parentFrom) {
+	if haveParent && (!e.haveParent || source > e.parentFrom ||
+		(source == seqHashSourcePeer && e.parentFrom == seqHashSourcePeer)) {
 		e.parentHash = parentHash
 		e.haveParent = true
 		e.parentFrom = source
@@ -284,7 +422,8 @@ func (r *Router) recordSeqHashFrom(
 	// validation for it.
 	if haveParent && seq > 1 {
 		pe := r.seqHash[seq-1]
-		if pe.hash == ([32]byte{}) || pe.hash == parentHash || source > pe.source {
+		if pe.hash == ([32]byte{}) || pe.hash == parentHash || source > pe.source ||
+			(source == seqHashSourcePeer && pe.source == seqHashSourcePeer) {
 			if pe.hash != ([32]byte{}) && pe.hash != parentHash {
 				pe = ledgerHashEntry{}
 			}
@@ -414,14 +553,16 @@ func (r *Router) protectedCatchupInFlight() int {
 func (r *Router) recordCatchupTarget(seq uint32, hash [32]byte, peerID uint64) {
 	r.catchupMu.Lock()
 	defer r.catchupMu.Unlock()
-	if r.catchup.source != catchupSourcePeer && r.catchup.hash == hash {
-		r.catchup.peerID = peerID
+	if r.catchup.source != catchupSourcePeer {
+		if r.catchup.hash == hash {
+			r.catchup.peerID = peerID
+		}
 		return
 	}
 	if seq > r.catchup.seq {
 		r.catchup = catchupTarget{seq: seq, hash: hash, peerID: peerID}
-	} else if seq == r.catchup.seq && hash == r.catchup.hash {
-		r.catchup.peerID = peerID
+	} else if seq == r.catchup.seq {
+		r.catchup = catchupTarget{seq: seq, hash: hash, peerID: peerID}
 	}
 }
 
@@ -469,14 +610,21 @@ func (r *Router) promotePeerStatusCandidates(seq uint32, hash [32]byte) {
 		}
 		matching = append(matching, candidate)
 		delete(r.peerStatusCandidates, peerID)
-		r.peerStates[peerID] = &peerLedgerState{LedgerSeq: seq, LedgerHash: hash}
+		r.peerStates[peerID] = &peerLedgerState{
+			LedgerSeq:  seq,
+			LedgerHash: hash,
+			parentHash: candidate.parentHash,
+			haveParent: candidate.haveParent,
+		}
 	}
 	r.peersMu.Unlock()
 
 	for _, candidate := range matching {
-		r.recordPeerSeqHash(seq, hash, candidate.parentHash, candidate.haveParent)
 		r.adaptor.UpdatePeerLCL(uint64(candidate.peerID), consensus.LedgerID(hash))
-		r.recordCatchupTarget(seq, hash, uint64(candidate.peerID))
+	}
+	if len(matching) > 0 {
+		r.reconcilePeerSeqHash(seq)
+		r.recordCatchupTarget(seq, hash, uint64(matching[0].peerID))
 	}
 }
 
@@ -768,9 +916,7 @@ func (r *Router) armCatchupTowardTargetWithPeer(peerHint uint64) {
 	if svc == nil {
 		return
 	}
-	r.catchupMu.Lock()
-	target := r.catchup
-	r.catchupMu.Unlock()
+	target := r.credibleCatchupFrontier()
 	if peerHint == 0 && target.source == catchupSourceQuorum {
 		peerHint = target.peerID
 	}
@@ -1988,13 +2134,16 @@ func (r *Router) storeVerifiedLedger(l *ledger.Ledger) (header.LedgerHeader, boo
 }
 
 func (r *Router) completeStoredConsensusRecovery(seq uint32, hash, parentHash [32]byte, initialCandidate bool) bool {
-	r.recordAcquiredSeqHash(seq, hash, parentHash)
 	_, result := r.adaptor.recheckFullyValidated(seq, hash)
 	r.recordCompletionRecheck(result)
+	obsolete := r.isObsoleteRecoveryCompletion(seq, hash)
 	if result == validationRecheckAccepted {
+		r.recordAcquiredSeqHash(seq, hash, parentHash)
 		r.promoteCompletedLedger(seq, hash)
+	} else if !obsolete {
+		r.recordAcquiredSeqHash(seq, hash, parentHash)
 	}
-	if r.isObsoleteRecoveryCompletion(seq, hash) {
+	if obsolete {
 		r.obsoleteAcquisitionCompleted.Add(1)
 		r.armConsensusCatchup()
 		return false
@@ -2030,10 +2179,11 @@ func (r *Router) isObsoleteRecoveryCompletion(seq uint32, hash [32]byte) bool {
 	if target != ([32]byte{}) {
 		return target != hash && step != hash
 	}
-	r.catchupMu.Lock()
-	frontier := r.catchup
-	r.catchupMu.Unlock()
-	return frontier.source != catchupSourcePeer && frontier.hash != ([32]byte{}) &&
+	frontier := r.credibleCatchupFrontier()
+	if frontier.source == catchupSourcePeer {
+		return frontier.seq == seq && frontier.hash != hash
+	}
+	return frontier.hash != ([32]byte{}) &&
 		frontier.hash != hash && frontier.seq >= seq
 }
 
@@ -2059,7 +2209,7 @@ func (r *Router) promoteCompletedLedger(seq uint32, hash [32]byte) {
 }
 
 func (r *Router) shouldSwitchConsensusLedger(seq uint32, hash [32]byte) bool {
-	frontierSeq, _, _ := r.bestCatchupTarget()
+	frontier := r.credibleCatchupFrontier()
 
 	r.acquisitionMu.Lock()
 	defer r.acquisitionMu.Unlock()
@@ -2068,7 +2218,10 @@ func (r *Router) shouldSwitchConsensusLedger(seq uint32, hash [32]byte) bool {
 	if target != ([32]byte{}) {
 		return target == hash
 	}
-	return !aheadByMoreThan(frontierSeq, seq, 1) && seq > r.lastHandoffSeq
+	if frontier.seq == seq && frontier.hash != ([32]byte{}) && frontier.hash != hash {
+		return false
+	}
+	return !aheadByMoreThan(frontier.seq, seq, 1) && seq > r.lastHandoffSeq
 }
 
 func (r *Router) tryConsensusLedgerSwitch(seq uint32, hash [32]byte) (accepted, rearm bool) {
@@ -2103,7 +2256,7 @@ func (r *Router) retainConsensusLedgerSwitch(hash [32]byte) {
 }
 
 func (r *Router) finishConsensusRecoveryStep(seq uint32, hash [32]byte) (notify, rearm bool) {
-	frontierSeq, _, _ := r.bestCatchupTarget()
+	frontierSeq := r.credibleCatchupFrontier().seq
 
 	r.acquisitionMu.Lock()
 	defer r.acquisitionMu.Unlock()
@@ -2171,7 +2324,7 @@ func (r *Router) finishInitialLedgerSwitch(
 	hash [32]byte,
 	result consensus.LedgerSwitchResult,
 ) bool {
-	frontierSeq, _, _ := r.bestCatchupTarget()
+	frontierSeq := r.credibleCatchupFrontier().seq
 
 	r.acquisitionMu.Lock()
 	defer r.acquisitionMu.Unlock()
@@ -2438,11 +2591,14 @@ func (r *Router) checkBehind(peerSeq uint32, peerHash [32]byte, peerID uint64) {
 	if validatedSeq := r.adaptor.networkValidatedSeq.Load(); validatedSeq > networkSeq {
 		networkSeq = validatedSeq
 	}
-	r.catchupMu.Lock()
-	if r.catchup.source != catchupSourcePeer && r.catchup.seq > networkSeq {
-		networkSeq = r.catchup.seq
+	frontier := r.credibleCatchupFrontier()
+	if frontier.seq > networkSeq {
+		networkSeq = frontier.seq
 	}
-	r.catchupMu.Unlock()
+	peerPreferred := r.peerLedgerIsPreferred(peerHash)
+	if peerPreferred && peerSeq > networkSeq {
+		networkSeq = peerSeq
+	}
 
 	// If we're caught up (gap ≤ 1) and not yet Full, transition to Full
 	// only if our LCL hash matches what the majority of peers report.
@@ -2468,7 +2624,7 @@ func (r *Router) checkBehind(peerSeq uint32, peerHash [32]byte, peerID uint64) {
 	if !aheadByMoreThan(peerSeq, ourSeq, 1) {
 		return
 	}
-	if !r.peerLedgerIsPreferred(peerHash) {
+	if !peerPreferred {
 		return
 	}
 
@@ -2487,6 +2643,36 @@ func (r *Router) checkBehind(peerSeq uint32, peerHash [32]byte, peerID uint64) {
 
 func aheadByMoreThan(seq, base, distance uint32) bool {
 	return seq > base && seq-base > distance
+}
+
+func (r *Router) catchupFrontierIsCredible(target catchupTarget) bool {
+	if target.hash == ([32]byte{}) {
+		return false
+	}
+	if target.source != catchupSourcePeer {
+		return true
+	}
+
+	found := false
+	r.peersMu.RLock()
+	for _, state := range r.peerStates {
+		if state != nil && state.LedgerSeq == target.seq && state.LedgerHash == target.hash {
+			found = true
+			break
+		}
+	}
+	r.peersMu.RUnlock()
+	return found && r.peerLedgerIsPreferred(target.hash)
+}
+
+func (r *Router) credibleCatchupFrontier() catchupTarget {
+	r.catchupMu.Lock()
+	target := r.catchup
+	r.catchupMu.Unlock()
+	if !r.catchupFrontierIsCredible(target) {
+		return catchupTarget{}
+	}
+	return target
 }
 
 // ourLCLMatchesPeers checks if our closed ledger hash matches what the

--- a/internal/consensus/adaptor/router_catchup_bound_test.go
+++ b/internal/consensus/adaptor/router_catchup_bound_test.go
@@ -58,8 +58,7 @@ func TestRouter_FarCompletionStoresAndRetargets(t *testing.T) {
 	targetSeq := closedSeq + 40
 	var targetHash [32]byte
 	targetHash[0] = 0xC7
-	trackCatchupPeer(r, 7, targetSeq)
-	r.recordCatchupTarget(targetSeq, targetHash, 7)
+	recordPreferredPeerCatchupTarget(r, 7, targetSeq, targetHash)
 
 	// Completion stores the fetched ledger without moving the service frontier.
 	il := completedCatchUpAcquisition(t, closedSeq+10)

--- a/internal/consensus/adaptor/router_catchup_forward_test.go
+++ b/internal/consensus/adaptor/router_catchup_forward_test.go
@@ -114,7 +114,7 @@ func TestRouter_ForwardDeltaStep_SameBranch(t *testing.T) {
 	// A far tip is the recorded catch-up target (the jump-adopt fallback).
 	var tipHash [32]byte
 	tipHash[0] = 0xF0
-	trackCatchupPeer(r, 7, closed+5)
+	trackCatchupPeer(r, 7, closed+5, tipHash)
 	r.recordCatchupTarget(closed+5, tipHash, 7)
 
 	r.armCatchupTowardTarget()
@@ -130,7 +130,7 @@ func TestRouter_CaughtUpLeavesNextLedgerToConsensus(t *testing.T) {
 	r, _, rs, svc := makeRouter(t)
 	closed := svc.GetClosedLedgerIndex()
 	target := [32]byte{0xC1}
-	trackCatchupPeer(r, 7, closed+1)
+	trackCatchupPeer(r, 7, closed+1, target)
 	r.recordCatchupTarget(closed+1, target, 7)
 
 	r.armCatchupTowardTarget()
@@ -157,7 +157,7 @@ func TestRouter_ForwardDeltaStep_SameBranchViaClosedSeqProxy(t *testing.T) {
 
 	var tipHash [32]byte
 	tipHash[0] = 0xF0
-	trackCatchupPeer(r, 7, closed+3)
+	trackCatchupPeer(r, 7, closed+3, tipHash)
 	r.recordCatchupTarget(closed+3, tipHash, 7)
 
 	r.armCatchupTowardTarget()
@@ -182,7 +182,7 @@ func TestRouter_ForwardDeltaStep_ForkFallsBackToJumpAdopt(t *testing.T) {
 
 	var tipHash [32]byte
 	tipHash[0] = 0xF0
-	trackCatchupPeer(r, 7, closed+5)
+	trackCatchupPeer(r, 7, closed+5, tipHash)
 	r.recordCatchupTarget(closed+5, tipHash, 7)
 
 	r.armCatchupTowardTarget()
@@ -202,7 +202,7 @@ func TestRouter_ForwardDeltaStep_UnknownNextFallsBackToJumpAdopt(t *testing.T) {
 
 	var tipHash [32]byte
 	tipHash[0] = 0xF0
-	trackCatchupPeer(r, 7, closed+5)
+	trackCatchupPeer(r, 7, closed+5, tipHash)
 	r.recordCatchupTarget(closed+5, tipHash, 7)
 	// No seqHash entry for closed+1.
 
@@ -229,7 +229,7 @@ func TestRouter_ForwardDeltaStep_FarGapJumpAdopts(t *testing.T) {
 	var tipHash [32]byte
 	tipHash[0] = 0xF0
 	tipSeq := closed + maxForwardDeltaGap + 10
-	trackCatchupPeer(r, 7, tipSeq)
+	trackCatchupPeer(r, 7, tipSeq, tipHash)
 	r.recordCatchupTarget(tipSeq, tipHash, 7)
 
 	r.armCatchupTowardTarget()
@@ -251,7 +251,7 @@ func TestRouter_ProvisionalWarmStartRecentBranchReplaysForward(t *testing.T) {
 	nextHash[0] = 0xB1
 	r.recordSeqHash(closed.Sequence()+1, nextHash, closed.Hash(), true)
 	tipSeq := closed.Sequence() + 2
-	trackCatchupPeer(r, 7, tipSeq)
+	trackCatchupPeer(r, 7, tipSeq, [32]byte{0xF0})
 	r.recordCatchupTarget(tipSeq, [32]byte{0xF0}, 7)
 
 	r.armCatchupTowardTarget()
@@ -272,7 +272,7 @@ func TestRouter_ProvisionalWarmStartFarGapJumpAdopts(t *testing.T) {
 	r.recordSeqHash(closed.Sequence()+1, [32]byte{0xB1}, closed.Hash(), true)
 	tipSeq := closed.Sequence() + maxForwardDeltaGap + 1
 	tipHash := [32]byte{0xF0}
-	trackCatchupPeer(r, 7, tipSeq)
+	trackCatchupPeer(r, 7, tipSeq, tipHash)
 	r.recordCatchupTarget(tipSeq, tipHash, 7)
 
 	r.armCatchupTowardTarget()
@@ -330,7 +330,7 @@ func TestRouter_ProvisionalWarmStartRecentForkJumpAdopts(t *testing.T) {
 	r.recordSeqHash(closed.Sequence()+1, [32]byte{0xB1}, [32]byte{0xD1}, true)
 	tipSeq := closed.Sequence() + 3
 	tipHash := [32]byte{0xF0}
-	trackCatchupPeer(r, 7, tipSeq)
+	trackCatchupPeer(r, 7, tipSeq, tipHash)
 	r.recordCatchupTarget(tipSeq, tipHash, 7)
 
 	r.armCatchupTowardTarget()
@@ -393,6 +393,72 @@ func TestRouter_ProvisionalWarmStartEventOrderPreservesForwardReplay(t *testing.
 			assert.True(t, svc.IsFastLoadProvisional())
 		})
 	}
+}
+
+func TestRouter_TrustedHashReconcilesConflictingPeerParent(t *testing.T) {
+	r, _, svc := makeProvisionalWarmRouter(t)
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	seq := closed.Sequence() + 1
+	hash := [32]byte{}
+	for i := range hash {
+		hash[i] = 0xff
+	}
+	wrongParent := [32]byte{0x01}
+	setPeer := func(peerID peermanagement.PeerID, parent [32]byte) {
+		r.peersMu.Lock()
+		r.peerStates[peerID] = &peerLedgerState{
+			LedgerSeq: seq, LedgerHash: hash, parentHash: parent, haveParent: true,
+		}
+		r.peersMu.Unlock()
+		r.adaptor.UpdatePeerLCL(uint64(peerID), consensus.LedgerID(hash))
+		r.reconcilePeerSeqHash(seq)
+	}
+
+	setPeer(7, wrongParent)
+	entry, ok := r.lookupSeqHash(seq)
+	require.True(t, ok)
+	require.Equal(t, wrongParent, entry.parentHash)
+	r.recordValidationSeqHash(seq, hash)
+	setPeer(8, closed.Hash())
+
+	entry, ok = r.lookupSeqHash(seq)
+	require.True(t, ok)
+	assert.Equal(t, seqHashSourceValidation, entry.source)
+	assert.True(t, entry.haveParent)
+	assert.Equal(t, closed.Hash(), entry.parentHash)
+	nextSeq, nextHash, replay := r.forwardDeltaStep(svc, closed.Sequence(), seq)
+	assert.True(t, replay)
+	assert.Equal(t, seq, nextSeq)
+	assert.Equal(t, hash, nextHash)
+}
+
+func TestRouter_ConflictingPeerParentsClearSeededPredecessor(t *testing.T) {
+	r, _, svc := makeProvisionalWarmRouter(t)
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	seq := closed.Sequence() + 2
+	hash := [32]byte{0xff}
+	setPeer := func(peerID peermanagement.PeerID, parent [32]byte) {
+		r.peersMu.Lock()
+		r.peerStates[peerID] = &peerLedgerState{
+			LedgerSeq: seq, LedgerHash: hash, parentHash: parent, haveParent: true,
+		}
+		r.peersMu.Unlock()
+		r.adaptor.UpdatePeerLCL(uint64(peerID), consensus.LedgerID(hash))
+		r.reconcilePeerSeqHash(seq)
+	}
+
+	setPeer(7, [32]byte{0x01})
+	_, seeded := r.lookupSeqHash(seq - 1)
+	require.True(t, seeded)
+	setPeer(8, [32]byte{0x02})
+
+	entry, ok := r.lookupSeqHash(seq)
+	require.True(t, ok)
+	assert.False(t, entry.haveParent)
+	_, seeded = r.lookupSeqHash(seq - 1)
+	assert.False(t, seeded)
 }
 
 func TestRouter_ProvisionalWarmStartEventOrderFallsBackWhenLinkageIsIncomplete(t *testing.T) {
@@ -630,7 +696,7 @@ func TestRouter_ForwardWalkStoresNextForConsensus(t *testing.T) {
 	r.recordSeqHash(c+2, next2, childHash, true)
 	var tipHash [32]byte
 	tipHash[0] = 0xF0
-	trackCatchupPeer(r, 7, c+10)
+	trackCatchupPeer(r, 7, c+10, tipHash)
 	r.recordCatchupTarget(c+10, tipHash, 7)
 
 	r.completeInboundLedger(il)
@@ -653,7 +719,7 @@ func TestRouter_ForwardWalk_SerialUnderCap(t *testing.T) {
 	var nextHash [32]byte
 	nextHash[0] = 0xB1
 	r.recordSeqHash(closed+1, nextHash, closedHash, true)
-	trackCatchupPeer(r, 7, closed+5)
+	trackCatchupPeer(r, 7, closed+5, [32]byte{0xF0})
 	r.recordCatchupTarget(closed+5, [32]byte{0xF0}, 7)
 
 	r.armCatchupTowardTarget()
@@ -673,7 +739,7 @@ func TestRouter_ForwardDeltaFailureCooldownUsesChildHash(t *testing.T) {
 	nextHash := [32]byte{0xB1}
 	tipHash := [32]byte{0xF0}
 	r.recordSeqHash(closed+1, nextHash, closedHash, true)
-	trackCatchupPeer(r, 7, closed+5)
+	trackCatchupPeer(r, 7, closed+5, tipHash)
 	r.recordCatchupTarget(closed+5, tipHash, 7)
 
 	il := inbound.New(nextHash, closed+1, 7, serveTestLogger())

--- a/internal/consensus/adaptor/router_catchup_forward_test.go
+++ b/internal/consensus/adaptor/router_catchup_forward_test.go
@@ -2,6 +2,8 @@ package adaptor
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -707,4 +709,90 @@ func TestRouter_SeqHashTableBounded(t *testing.T) {
 	size := len(r.seqHash)
 	r.seqHashMu.Unlock()
 	assert.LessOrEqual(t, size, seqHashRetain+1, "the table stays within the retention window")
+}
+
+func TestRouter_OutlierPeerStatusCannotPoisonSeqHashRetention(t *testing.T) {
+	r, _, _, svc := makeRouter(t)
+	r.logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	r.recordSeqHash(closed.Sequence(), closed.Hash(), [32]byte{}, false)
+
+	normalHash := [32]byte{0xff}
+	r.handleStatusChange(statusChangeMessageWithParent(
+		t,
+		7,
+		closed.Sequence()+1,
+		normalHash,
+		closed.Hash(),
+		true,
+	))
+
+	outlierHash := [32]byte{0x01}
+	const outlierBase = uint32(106_000_000)
+	for offset := uint32(0); offset < seqHashRetain+10; offset++ {
+		r.handleStatusChange(statusChangeMessageWithParent(
+			t,
+			9,
+			outlierBase+offset,
+			outlierHash,
+			[32]byte{0x02},
+			true,
+		))
+	}
+
+	link, ok := r.lookupSeqHash(closed.Sequence() + 1)
+	require.True(t, ok)
+	assert.Equal(t, normalHash, link.hash)
+	assert.Equal(t, closed.Hash(), link.parentHash)
+	assert.True(t, link.haveParent)
+	_, outlierRecorded := r.lookupSeqHash(outlierBase + seqHashRetain + 9)
+	assert.False(t, outlierRecorded)
+
+	r.seqHashMu.Lock()
+	anchor := r.seqHashAnchor
+	size := len(r.seqHash)
+	r.seqHashMu.Unlock()
+	assert.Equal(t, closed.Sequence(), anchor)
+	assert.LessOrEqual(t, size, seqHashRetain+maxForwardDeltaGap+1)
+
+	r.peersMu.RLock()
+	_, outlierAdmitted := r.peerStates[9]
+	candidate, outlierStaged := r.peerStatusCandidates[9]
+	r.peersMu.RUnlock()
+	assert.False(t, outlierAdmitted)
+	require.True(t, outlierStaged)
+	assert.Equal(t, outlierBase+seqHashRetain+9, candidate.LedgerSeq)
+	assert.Equal(t, outlierHash, candidate.LedgerHash)
+}
+
+func TestRouter_PeerSeqHashCannotOverwriteTrustedEvidence(t *testing.T) {
+	r, _, _, svc := makeRouter(t)
+	seq := svc.GetClosedLedgerIndex() + 1
+	trustedHash := [32]byte{0xa1}
+	peerHash := [32]byte{0xb2}
+	parentHash := svc.GetClosedLedger().Hash()
+
+	r.recordValidationSeqHash(seq, trustedHash)
+	r.recordPeerSeqHash(seq, peerHash, [32]byte{0xc3}, true)
+	r.recordPeerSeqHash(seq, trustedHash, parentHash, true)
+
+	entry, ok := r.lookupSeqHash(seq)
+	require.True(t, ok)
+	assert.Equal(t, trustedHash, entry.hash)
+	assert.Equal(t, parentHash, entry.parentHash)
+	assert.True(t, entry.haveParent)
+	assert.Equal(t, seqHashSourceValidation, entry.source)
+	assert.Equal(t, seqHashSourcePeer, entry.parentFrom)
+}
+
+func TestRouter_PeerStatusAdmissionUsesDivergenceWindow(t *testing.T) {
+	r, _, _, _ := makeRouter(t)
+	const anchor = uint32(10_000)
+	r.recordValidationSeqHash(anchor, [32]byte{0xa4})
+
+	assert.True(t, r.peerStatusWithinAnchor(anchor-maxForwardDeltaGap))
+	assert.True(t, r.peerStatusWithinAnchor(anchor+maxForwardDeltaGap))
+	assert.False(t, r.peerStatusWithinAnchor(anchor-maxForwardDeltaGap-1))
+	assert.False(t, r.peerStatusWithinAnchor(anchor+maxForwardDeltaGap+1))
 }

--- a/internal/consensus/adaptor/router_catchup_handoff_test.go
+++ b/internal/consensus/adaptor/router_catchup_handoff_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,9 +20,22 @@ func newCatchupHandoffRouter(t *testing.T) (*Router, *Adaptor, *mockEngine) {
 	return r, a, engine
 }
 
+func recordPreferredPeerCatchupTarget(
+	r *Router,
+	peerID peermanagement.PeerID,
+	seq uint32,
+	hash [32]byte,
+) {
+	r.peersMu.Lock()
+	r.peerStates[peerID] = &peerLedgerState{LedgerSeq: seq, LedgerHash: hash}
+	r.peersMu.Unlock()
+	r.adaptor.UpdatePeerLCL(uint64(peerID), consensus.LedgerID(hash))
+	r.recordCatchupTarget(seq, hash, uint64(peerID))
+}
+
 func TestFarCatchupCompletionRemainsStoreOnly(t *testing.T) {
 	r, a, engine := newCatchupHandoffRouter(t)
-	r.recordCatchupTarget(105, [32]byte{0xA5}, 7)
+	recordPreferredPeerCatchupTarget(r, 7, 105, [32]byte{0xA5})
 
 	r.completeStoredConsensusRecovery(100, [32]byte{0xA0}, [32]byte{0x9F}, false)
 
@@ -73,7 +87,7 @@ func TestOlderCatchupCompletionDoesNotRegressConsensus(t *testing.T) {
 
 func TestMovingCatchupFrontierEventuallyNotifies(t *testing.T) {
 	r, _, engine := newCatchupHandoffRouter(t)
-	r.recordCatchupTarget(105, [32]byte{0xE5}, 7)
+	recordPreferredPeerCatchupTarget(r, 7, 105, [32]byte{0xE5})
 
 	r.completeStoredConsensusRecovery(100, [32]byte{0xE0}, [32]byte{0xDF}, false)
 	assert.Empty(t, engine.getLedgers())

--- a/internal/consensus/adaptor/router_catchup_incident_test.go
+++ b/internal/consensus/adaptor/router_catchup_incident_test.go
@@ -79,6 +79,10 @@ func TestRouter_Issue1663CatchupCascadeRecoversToFull(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, nextHash, entry.hash)
 	require.Equal(t, closed.Hash(), entry.parentHash)
+	r.fetchTracker.Remove(nextHash, false)
+	r.fetchTracker.Remove(next2Hash, false)
+	r.replayer.Abandon(nextHash)
+	r.replayer.Abandon(next2Hash)
 
 	stale1 := newIssue1663BackedAcquisition(t, closed.Sequence()+1, 7)
 	stale2 := newIssue1663BackedAcquisition(t, closed.Sequence()+2, 7)

--- a/internal/consensus/adaptor/router_catchup_incident_test.go
+++ b/internal/consensus/adaptor/router_catchup_incident_test.go
@@ -1,0 +1,190 @@
+package adaptor
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/crypto/sha512half"
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/consensus/rcl"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/protocol"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/LeJamon/go-xrpl/shamap/backend"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newIssue1663BackedAcquisition(t *testing.T, seq uint32, peerID uint64) *inbound.Ledger {
+	t.Helper()
+	source := newWideWorkSource(t, 16)
+	rootHash, err := source.Hash()
+	require.NoError(t, err)
+	rootData, err := source.SerializeRoot()
+	require.NoError(t, err)
+	hdr := header.LedgerHeader{LedgerIndex: seq, AccountHash: rootHash}
+	headerData := header.AddRaw(hdr, false)
+	ledgerHash := sha512half.Sum(protocol.HashPrefixLedgerMaster().Bytes(), headerData)
+
+	family := backend.NewMemory()
+	pack, err := source.WalkFetchPackNodes(1 << 20)
+	require.NoError(t, err)
+	entries := make([]shamap.FlushEntry, 0, len(pack))
+	for _, node := range pack {
+		entries = append(entries, shamap.FlushEntry{Hash: node.Hash, Data: node.Data})
+	}
+	require.NoError(t, family.StoreBatch(t.Context(), entries))
+
+	il := inbound.New(ledgerHash, seq, peerID, serveTestLogger(), inbound.WithFamily(family))
+	require.NoError(t, il.GotBase([]message.LedgerNode{{NodeData: headerData}, {NodeData: rootData}}))
+	return il
+}
+
+func TestRouter_Issue1663CatchupCascadeRecoversToFull(t *testing.T) {
+	svc := newTestLedgerService(t)
+	a, sender := newRecordingAdaptor(t, svc)
+	engine := &mockEngine{switchResult: consensus.LedgerSwitchAccepted}
+	r := newTestRouter(engine, a, nil)
+	r.logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	engine.switchHook = func(id consensus.LedgerID) {
+		selected, err := a.GetLedger(id)
+		require.NoError(t, err)
+		require.NoError(t, a.OnLedgerSwitched(selected))
+	}
+	a.SetOperatingMode(consensus.OpModeTracking)
+
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	nextHash := [32]byte{0x31}
+	next2Hash := [32]byte{0x32}
+	r.handleStatusChange(statusChangeMessageWithParent(
+		t, 7, closed.Sequence()+1, nextHash, closed.Hash(), true,
+	))
+	r.handleStatusChange(statusChangeMessageWithParent(
+		t, 7, closed.Sequence()+2, next2Hash, nextHash, true,
+	))
+
+	const outlierBase = uint32(106_400_000)
+	for offset := uint32(0); offset < seqHashRetain+10; offset++ {
+		r.handleStatusChange(statusChangeMessageWithParent(
+			t, 9, outlierBase+offset, [32]byte{0xee}, [32]byte{0xed}, true,
+		))
+	}
+	entry, ok := r.lookupSeqHash(closed.Sequence() + 1)
+	require.True(t, ok)
+	require.Equal(t, nextHash, entry.hash)
+	require.Equal(t, closed.Hash(), entry.parentHash)
+
+	stale1 := newIssue1663BackedAcquisition(t, closed.Sequence()+1, 7)
+	stale2 := newIssue1663BackedAcquisition(t, closed.Sequence()+2, 7)
+	r.fetchTracker.Track(stale1)
+	r.fetchTracker.Track(stale2)
+	require.Equal(t, maxConcurrentSpeculativeCatchup, r.protectedCatchupInFlight())
+
+	base := time.Unix(1_700_000_000, 0)
+	stale1.RearmTimer(base)
+	require.Equal(t, inbound.TimerRefresh, stale1.OnTimer(base.Add(3900*time.Millisecond)))
+	lane := newAcquisitionWorkLane(1)
+	lane.process = func(ctx context.Context, ledger *inbound.Ledger, events []acquisitionWorkEvent) acquisitionWorkResult {
+		return processAcquisitionWorkWithBudget(ctx, ledger, events, 1)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	lane.start(ctx)
+	defer func() {
+		cancel()
+		lane.stop()
+	}()
+	r.acquisitionWork = lane
+
+	now := base.Add(3900 * time.Millisecond)
+	for range 2 {
+		require.True(t, lane.submit(stale1, acquisitionWorkEvent{
+			kind:  acquisitionWorkTimer,
+			fetch: func([32]byte) ([]byte, bool) { return nil, false },
+		}))
+		yielded := <-lane.results()
+		require.True(t, yielded.yielded)
+
+		now = now.Add(3900 * time.Millisecond)
+		require.Equal(t, inbound.TimerRefresh, stale1.OnTimer(now))
+		now = now.Add(3900 * time.Millisecond)
+		require.True(t, lane.submit(stale1, acquisitionWorkEvent{
+			kind: acquisitionWorkTimerCheck,
+			at:   now,
+		}))
+		close(yielded.ack)
+
+		escalated := <-lane.results()
+		require.True(t, escalated.timerEscalate)
+		require.False(t, escalated.yielded)
+		close(escalated.ack)
+		require.Eventually(t, func() bool { return !lane.has(stale1) }, time.Second, time.Millisecond)
+	}
+	now = now.Add(3900 * time.Millisecond)
+	require.Equal(t, inbound.TimerEscalate, stale1.OnTimer(now))
+	require.Equal(t, 2, stale1.ConsecutiveTimeouts())
+
+	stale2.RearmTimer(base)
+	require.Equal(t, inbound.TimerRefresh, stale2.OnTimer(base.Add(3900*time.Millisecond)))
+	require.Equal(t, inbound.TimerEscalate, stale2.OnTimer(base.Add(7800*time.Millisecond)))
+	require.Equal(t, inbound.TimerEscalate, stale2.OnTimer(base.Add(11700*time.Millisecond)))
+	require.Equal(t, 2, stale2.ConsecutiveTimeouts())
+
+	rootHash, rootData, wire := buildSelfHealSourceState(t)
+	targetSeq := closed.Sequence() + maxForwardDeltaGap + 2
+	hdr := header.LedgerHeader{
+		LedgerIndex: targetSeq,
+		ParentHash:  [32]byte{0x41},
+		AccountHash: rootHash,
+		CloseTime:   time.Unix(1_700_000_100, 0),
+	}
+	headerData := header.AddRaw(hdr, false)
+	targetHash := sha512half.Sum(protocol.HashPrefixLedgerMaster().Bytes(), headerData)
+	r.handleStatusChange(statusChangeMessage(t, 8, targetSeq, targetHash))
+
+	validationTracker := rcl.NewValidationTracker(2)
+	trusted := []consensus.NodeID{{1}, {2}}
+	validationTracker.SetNow(func() time.Time { return hdr.CloseTime })
+	validationTracker.SetTrustedAndQuorum(trusted, 2)
+	a.SetValidationHistorian(validationTracker)
+	for _, nodeID := range trusted {
+		require.True(t, validationTracker.Add(&consensus.Validation{
+			LedgerID:  consensus.LedgerID(targetHash),
+			LedgerSeq: targetSeq,
+			NodeID:    nodeID,
+			SignTime:  hdr.CloseTime,
+			SeenTime:  hdr.CloseTime,
+			Full:      true,
+		}))
+	}
+
+	r.onLedgerFullyValidated(targetSeq, targetHash)
+	require.Nil(t, r.fetchTracker.Find(stale1.Hash()))
+	require.Same(t, stale2, r.fetchTracker.Find(stale2.Hash()))
+	target := r.fetchTracker.Find(targetHash)
+	require.NotNil(t, target)
+	require.LessOrEqual(t, r.protectedCatchupInFlight(), maxConcurrentSpeculativeCatchup)
+	require.GreaterOrEqual(t, acquireCount(sender), 1)
+
+	require.NoError(t, target.GotBase([]message.LedgerNode{
+		{NodeData: headerData},
+		{NodeData: rootData},
+	}))
+	require.NoError(t, target.GotStateNodes(wire))
+	target.CollectMissingRequest(false)
+	require.True(t, target.IsComplete())
+	r.completeInboundLedger(target)
+
+	require.Eventually(t, func() bool {
+		return svc.GetClosedLedgerIndex() == targetSeq && svc.GetValidatedLedgerIndex() == targetSeq
+	}, time.Second, time.Millisecond)
+	r.checkBehind(targetSeq, targetHash, 8)
+	assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode())
+	assert.Equal(t, "proposing", consensusServerState(a.GetOperatingMode(), consensus.ModeProposing, true))
+	assert.LessOrEqual(t, r.protectedCatchupInFlight(), maxConcurrentSpeculativeCatchup)
+}

--- a/internal/consensus/adaptor/router_catchup_peer_test.go
+++ b/internal/consensus/adaptor/router_catchup_peer_test.go
@@ -40,10 +40,17 @@ func (s *disconnectingPeerSession) IsPeerConnected(peermanagement.PeerID) bool {
 	return s.checks.Add(1) == 1
 }
 
-func trackCatchupPeer(r *Router, peerID peermanagement.PeerID, seq uint32) {
+func trackCatchupPeer(r *Router, peerID peermanagement.PeerID, seq uint32, hashes ...[32]byte) {
+	var hash [32]byte
+	if len(hashes) > 0 {
+		hash = hashes[0]
+	}
 	r.peersMu.Lock()
-	r.peerStates[peerID] = &peerLedgerState{LedgerSeq: seq}
+	r.peerStates[peerID] = &peerLedgerState{LedgerSeq: seq, LedgerHash: hash}
 	r.peersMu.Unlock()
+	if hash != ([32]byte{}) {
+		r.adaptor.UpdatePeerLCL(uint64(peerID), consensus.LedgerID(hash))
+	}
 }
 
 func TestRouter_DropsQueuedStatusAfterPeerDisconnect(t *testing.T) {
@@ -142,8 +149,8 @@ func TestRouter_CatchupRevalidatesPeerHint(t *testing.T) {
 	sessions := &testPeerSessions{connected: map[peermanagement.PeerID]bool{1: false, 2: true}}
 	r.setPeerSessionView(sessions)
 
-	trackCatchupPeer(r, 1, targetSeq)
-	trackCatchupPeer(r, 2, targetSeq)
+	trackCatchupPeer(r, 1, targetSeq, targetHash)
+	trackCatchupPeer(r, 2, targetSeq, targetHash)
 	r.ensureCatchupAcquisition(targetSeq, targetHash, 1)
 
 	require.Equal(t, []legacyBaseCall{{peerID: 2, hash: targetHash, seq: targetSeq}}, sender.legacyCalls())
@@ -170,8 +177,8 @@ func TestRouter_CatchupDisconnectErrorRetargetsImmediately(t *testing.T) {
 			targetHash := [32]byte{0xD2}
 			sessions := &testPeerSessions{connected: map[peermanagement.PeerID]bool{1: true, 2: true}}
 			r.setPeerSessionView(sessions)
-			trackCatchupPeer(r, 1, targetSeq)
-			trackCatchupPeer(r, 2, targetSeq)
+			trackCatchupPeer(r, 1, targetSeq, targetHash)
+			trackCatchupPeer(r, 2, targetSeq, targetHash)
 			sender.mu.Lock()
 			sender.legacyBaseErrs = map[uint64]error{1: tc.err}
 			sender.mu.Unlock()
@@ -301,7 +308,7 @@ func TestRouter_CatchupPeerNotFoundWaitsWithoutReplacement(t *testing.T) {
 	targetHash := [32]byte{0xD6}
 	sessions := &testPeerSessions{connected: map[peermanagement.PeerID]bool{1: true}}
 	r.setPeerSessionView(sessions)
-	trackCatchupPeer(r, 1, targetSeq)
+	trackCatchupPeer(r, 1, targetSeq, targetHash)
 	sender.mu.Lock()
 	sender.legacyBaseErrs = map[uint64]error{1: peermanagement.ErrPeerNotFound}
 	sender.mu.Unlock()
@@ -338,7 +345,7 @@ func TestRouter_HistoryPeerNotFoundDoesNotHotLoop(t *testing.T) {
 	targetHash := [32]byte{0xD8}
 	sessions := &testPeerSessions{connected: map[peermanagement.PeerID]bool{1: true}}
 	r.setPeerSessionView(sessions)
-	trackCatchupPeer(r, 1, targetSeq)
+	trackCatchupPeer(r, 1, targetSeq, targetHash)
 	sender.mu.Lock()
 	sender.legacyBaseErrs = map[uint64]error{1: peermanagement.ErrPeerNotFound}
 	sender.mu.Unlock()
@@ -371,7 +378,7 @@ func TestRouter_GenericAcquisitionRetargetsDisconnectedPeer(t *testing.T) {
 			targetSeq := svc.GetClosedLedgerIndex() + 40
 			targetHash := [32]byte{0xD9}
 			r.setPeerSessionView(&testPeerSessions{connected: map[peermanagement.PeerID]bool{1: true, 2: true}})
-			trackCatchupPeer(r, 1, targetSeq)
+			trackCatchupPeer(r, 1, targetSeq, targetHash)
 			trackCatchupPeer(r, 2, targetSeq-1)
 			sender.mu.Lock()
 			sender.legacyBaseErrs = map[uint64]error{1: tc.err}
@@ -400,7 +407,7 @@ func TestRouter_GenericAcquisitionWaitsForReplacementPeer(t *testing.T) {
 	targetHash := [32]byte{0xDA}
 	sessions := &testPeerSessions{connected: map[peermanagement.PeerID]bool{1: true}}
 	r.setPeerSessionView(sessions)
-	trackCatchupPeer(r, 1, targetSeq)
+	trackCatchupPeer(r, 1, targetSeq, targetHash)
 	sender.mu.Lock()
 	sender.legacyBaseErrs = map[uint64]error{1: peermanagement.ErrPeerNotFound}
 	sender.mu.Unlock()
@@ -419,7 +426,7 @@ func TestRouter_GenericAcquisitionWaitsForReplacementPeer(t *testing.T) {
 	assert.Len(t, sender.legacyCalls(), 1)
 
 	sessions.set(2, true)
-	trackCatchupPeer(r, 2, targetSeq)
+	trackCatchupPeer(r, 2, targetSeq, targetHash)
 	r.escalateAcquisition(il, time.Now().Add(4*time.Second))
 
 	calls := sender.legacyCalls()
@@ -457,7 +464,7 @@ func TestRouter_CatchupBaseRequestFailureUsesInboundRetryTimer(t *testing.T) {
 	r, _, sender, svc := makeRouter(t)
 	targetSeq := svc.GetClosedLedgerIndex() + 40
 	targetHash := [32]byte{0xD3}
-	trackCatchupPeer(r, 7, targetSeq)
+	trackCatchupPeer(r, 7, targetSeq, targetHash)
 	sender.mu.Lock()
 	sender.legacyBaseErr = errors.New("temporary send failure")
 	sender.mu.Unlock()

--- a/internal/consensus/adaptor/router_catchup_rearm_test.go
+++ b/internal/consensus/adaptor/router_catchup_rearm_test.go
@@ -18,7 +18,7 @@ func TestRouter_MaintenanceTickReArmsCatchupTarget(t *testing.T) {
 	targetSeq := closedSeq + 40
 	var targetHash [32]byte
 	targetHash[0] = 0xD9
-	trackCatchupPeer(r, 7, targetSeq)
+	trackCatchupPeer(r, 7, targetSeq, targetHash)
 	r.recordCatchupTarget(targetSeq, targetHash, 7)
 	require.Zero(t, r.catchupInFlight(), "setup: nothing in flight")
 

--- a/internal/consensus/adaptor/router_catchup_test.go
+++ b/internal/consensus/adaptor/router_catchup_test.go
@@ -200,6 +200,135 @@ func TestRouter_FullNodeBehindPeerLeavesFullBeforeCatchup(t *testing.T) {
 	require.GreaterOrEqual(t, acquireCount(rs), 1)
 }
 
+func TestRouter_FullNodeAcquiresPreferredPeerTwoLedgersAhead(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	a.SetOperatingMode(consensus.OpModeFull)
+	peerHash := [32]byte{}
+	for i := range peerHash {
+		peerHash[i] = 0xff
+	}
+
+	r.handleMessage(statusChangeMessage(
+		t,
+		peermanagement.PeerID(7),
+		svc.GetClosedLedgerIndex()+2,
+		peerHash,
+	))
+
+	assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode())
+	assert.True(t, r.isAcquiring(peerHash))
+	assert.Equal(t, 1, acquireCount(sender))
+}
+
+func TestRouter_AheadPreferredPeerTargetPreventsFullPromotion(t *testing.T) {
+	r, a, _, svc := makeRouter(t)
+	a.SetOperatingMode(consensus.OpModeTracking)
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	targetSeq := closed.Sequence() + 2
+	targetHash := [32]byte{}
+	for i := range targetHash {
+		targetHash[i] = 0xff
+	}
+
+	r.peersMu.Lock()
+	r.peerStates[7] = &peerLedgerState{LedgerSeq: targetSeq, LedgerHash: targetHash}
+	r.peersMu.Unlock()
+	a.UpdatePeerLCL(7, consensus.LedgerID(targetHash))
+	r.catchupMu.Lock()
+	r.catchup = catchupTarget{seq: targetSeq, hash: targetHash, peerID: 7}
+	r.catchupMu.Unlock()
+	r.fetchTracker.Track(inbound.New(targetHash, targetSeq, 7, r.logger))
+
+	r.checkBehind(closed.Sequence()+1, closed.Hash(), 8)
+
+	assert.Equal(t, consensus.OpModeTracking, a.GetOperatingMode())
+}
+
+func TestRouter_NonPreferredPeerTargetIsNotRearmed(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	seq := svc.GetClosedLedgerIndex() + 3
+	staleHash := [32]byte{0x80}
+	preferredHash := [32]byte{0xff}
+	recordPreferredPeerCatchupTarget(r, 7, seq, staleHash)
+
+	r.peersMu.Lock()
+	r.peerStates[8] = &peerLedgerState{LedgerSeq: seq, LedgerHash: preferredHash}
+	r.peerStates[9] = &peerLedgerState{LedgerSeq: seq, LedgerHash: preferredHash}
+	r.peersMu.Unlock()
+	a.UpdatePeerLCL(8, consensus.LedgerID(preferredHash))
+	a.UpdatePeerLCL(9, consensus.LedgerID(preferredHash))
+
+	r.armCatchupTowardTarget()
+
+	assert.Zero(t, acquireCount(sender))
+	assert.False(t, r.isAcquiring(staleHash))
+}
+
+func TestRouter_CurrentPeerMajorityReplacesSameSequenceFrontier(t *testing.T) {
+	r, _, _, svc := makeRouter(t)
+	seq := svc.GetClosedLedgerIndex() + 3
+	staleHash := [32]byte{0x80}
+	preferredHash := [32]byte{}
+	for i := range preferredHash {
+		preferredHash[i] = 0xff
+	}
+
+	r.handleMessage(statusChangeMessage(t, 7, seq, staleHash))
+	r.handleMessage(statusChangeMessage(t, 8, seq, preferredHash))
+	r.handleMessage(statusChangeMessage(t, 9, seq, preferredHash))
+
+	entry, ok := r.lookupSeqHash(seq)
+	require.True(t, ok)
+	assert.Equal(t, preferredHash, entry.hash)
+	r.catchupMu.Lock()
+	frontier := r.catchup
+	r.catchupMu.Unlock()
+	assert.Equal(t, seq, frontier.seq)
+	assert.Equal(t, preferredHash, frontier.hash)
+	assert.Equal(t, catchupSourcePeer, frontier.source)
+	assert.True(t, r.isObsoleteRecoveryCompletion(seq, staleHash))
+	assert.False(t, r.shouldSwitchConsensusLedger(seq, staleHash))
+	assert.True(t, r.shouldSwitchConsensusLedger(seq, preferredHash))
+
+	r.completeStoredConsensusRecovery(seq, staleHash, [32]byte{0x70}, false)
+	entry, ok = r.lookupSeqHash(seq)
+	require.True(t, ok)
+	assert.Equal(t, preferredHash, entry.hash)
+}
+
+func TestRouter_CorroboratedFarPeerTipReplacesSameSequenceFrontier(t *testing.T) {
+	r, _, _, svc := makeRouter(t)
+	seq := svc.GetClosedLedgerIndex() + maxForwardDeltaGap + 10
+	staleHash := [32]byte{0x80}
+	preferredHash := [32]byte{0xff}
+
+	r.handleMessage(statusChangeMessage(t, 7, seq, staleHash))
+	r.handleMessage(statusChangeMessage(t, 8, seq, staleHash))
+	r.handleMessage(statusChangeMessage(t, 9, seq, preferredHash))
+	r.handleMessage(statusChangeMessage(t, 10, seq, preferredHash))
+
+	r.catchupMu.Lock()
+	frontier := r.catchup
+	r.catchupMu.Unlock()
+	assert.Equal(t, seq, frontier.seq)
+	assert.Equal(t, preferredHash, frontier.hash)
+	assert.Equal(t, catchupSourcePeer, frontier.source)
+}
+
+func TestRouter_PeerTargetCannotReplaceTrustedFrontier(t *testing.T) {
+	r, _, _, svc := makeRouter(t)
+	trustedSeq := svc.GetClosedLedgerIndex() + 3
+	trustedHash := [32]byte{0xc1}
+	r.recordValidationCatchupTarget(trustedSeq, trustedHash, 7, catchupSourceValidation)
+
+	r.recordCatchupTarget(trustedSeq+10, [32]byte{0xff}, 8)
+
+	assert.Equal(t, catchupTarget{
+		seq: trustedSeq, hash: trustedHash, peerID: 7, source: catchupSourceValidation,
+	}, r.catchup)
+}
+
 func TestRouter_FullNodeDoesNotAcquireNonPreferredPeerTip(t *testing.T) {
 	r, a, sender, svc := makeRouter(t)
 	a.SetOperatingMode(consensus.OpModeFull)

--- a/internal/consensus/adaptor/router_catchup_test.go
+++ b/internal/consensus/adaptor/router_catchup_test.go
@@ -20,12 +20,25 @@ import (
 // statusChangeMessage builds a wire-framed TMStatusChange for the given
 // seq/hash and returns the InboundMessage the Router's dispatch expects.
 func statusChangeMessage(t *testing.T, peerID peermanagement.PeerID, seq uint32, hash [32]byte) *peermanagement.InboundMessage {
+	return statusChangeMessageWithParent(t, peerID, seq, hash, [32]byte{}, false)
+}
+
+func statusChangeMessageWithParent(
+	t *testing.T,
+	peerID peermanagement.PeerID,
+	seq uint32,
+	hash, parentHash [32]byte,
+	haveParent bool,
+) *peermanagement.InboundMessage {
 	t.Helper()
 	sc := &message.StatusChange{
 		NewStatus:  message.NodeStatus(0),
 		NewEvent:   message.NodeEventClosingLedger,
 		LedgerSeq:  seq,
 		LedgerHash: hash[:],
+	}
+	if haveParent {
+		sc.LedgerHashPrevious = parentHash[:]
 	}
 	encoded, err := message.Encode(sc)
 	require.NoError(t, err)
@@ -279,6 +292,24 @@ func TestRouter_TrustedCatchupTargetDoesNotRegress(t *testing.T) {
 		"a lower validation must not start a second acquisition after the frontier is set")
 }
 
+func TestRouter_QuorumUpgradePreservesTrustedTargetPeer(t *testing.T) {
+	r, _, _, svc := makeRouter(t)
+	seq := svc.GetClosedLedgerIndex() + 3
+	hash := [32]byte{0xD3}
+	r.recordValidationCatchupTarget(seq, hash, 7, catchupSourceValidation)
+	r.recordValidationCatchupTarget(seq, hash, 0, catchupSourceQuorum)
+
+	r.catchupMu.Lock()
+	target := r.catchup
+	r.catchupMu.Unlock()
+	require.Equal(t, catchupTarget{
+		seq:    seq,
+		hash:   hash,
+		peerID: 7,
+		source: catchupSourceQuorum,
+	}, target)
+}
+
 // acquireCount totals the acquisition requests the router emitted via either
 // the replay-delta or the legacy GET_LEDGER path.
 func acquireCount(rs *recordingSender) int {
@@ -387,6 +418,89 @@ func TestRouter_FullyValidatedHashCancelsOnlyConsensusSiblings(t *testing.T) {
 	recorded, ok := r.lookupSeqHash(seq)
 	require.True(t, ok)
 	assert.Equal(t, canonical, recorded.hash)
+}
+
+func TestRouter_TrustedTargetSupersedesOneObsoleteFullStateAcquisition(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	closed := svc.GetClosedLedgerIndex()
+	firstHash := [32]byte{0x81}
+	secondHash := [32]byte{0x82}
+	targetHash := [32]byte{0x90}
+	first := inbound.New(firstHash, closed+1, 7, r.logger)
+	second := inbound.New(secondHash, closed+2, 8, r.logger)
+	r.fetchTracker.Track(first)
+	r.fetchTracker.Track(second)
+	trackCatchupPeer(r, 9, closed+maxForwardDeltaGap+10)
+
+	a.OnLedgerFullyValidated(consensus.LedgerID(targetHash), closed+maxForwardDeltaGap+10)
+
+	assert.Nil(t, r.fetchTracker.Find(firstHash))
+	assert.Same(t, second, r.fetchTracker.Find(secondHash))
+	assert.NotNil(t, r.fetchTracker.Find(targetHash))
+	assert.Equal(t, maxConcurrentSpeculativeCatchup, r.protectedCatchupInFlight())
+	assert.NotEmpty(t, sender.legacyCalls())
+}
+
+func TestRouter_RecentProgressProtectsNearbyFullStateAcquisition(t *testing.T) {
+	r, a, _, svc := makeRouter(t)
+	closed := svc.GetClosedLedgerIndex()
+	firstHash := [32]byte{0x81}
+	secondHash := [32]byte{0x82}
+	targetHash := [32]byte{0x90}
+	first := inbound.New(firstHash, closed+1, 7, r.logger)
+	second := inbound.New(secondHash, closed+2, 8, r.logger)
+	r.fetchTracker.Track(first)
+	r.fetchTracker.Track(second)
+
+	a.OnLedgerFullyValidated(consensus.LedgerID(targetHash), closed+10)
+
+	assert.Same(t, first, r.fetchTracker.Find(firstHash))
+	assert.Same(t, second, r.fetchTracker.Find(secondHash))
+	assert.Nil(t, r.fetchTracker.Find(targetHash))
+}
+
+func TestRouter_StalledNearbyFullStateAcquisitionIsSuperseded(t *testing.T) {
+	r, a, _, svc := makeRouter(t)
+	closed := svc.GetClosedLedgerIndex()
+	firstHash := [32]byte{0x81}
+	secondHash := [32]byte{0x82}
+	targetHash := [32]byte{0x90}
+	first := inbound.New(firstHash, closed+1, 7, r.logger)
+	second := inbound.New(secondHash, closed+2, 8, r.logger)
+	for _, acquisition := range []*inbound.Ledger{first, second} {
+		now := time.Now()
+		acquisition.RearmTimer(now)
+		for range 2 {
+			now = now.Add(4 * time.Second)
+			require.Equal(t, inbound.TimerEscalate, acquisition.OnTimer(now))
+			acquisition.RearmTimer(now)
+		}
+		r.fetchTracker.Track(acquisition)
+	}
+	trackCatchupPeer(r, 9, closed+10)
+
+	a.OnLedgerFullyValidated(consensus.LedgerID(targetHash), closed+10)
+
+	assert.Nil(t, r.fetchTracker.Find(firstHash))
+	assert.Same(t, second, r.fetchTracker.Find(secondHash))
+	assert.NotNil(t, r.fetchTracker.Find(targetHash))
+}
+
+func TestRouter_ExactRecoveryAcquisitionsAreNeverSuperseded(t *testing.T) {
+	r, _, _, svc := makeRouter(t)
+	closed := svc.GetClosedLedgerIndex()
+	targetHash := [32]byte{0x81}
+	stepHash := [32]byte{0x82}
+	target := inbound.New(targetHash, closed+1, 7, r.logger)
+	step := inbound.New(stepHash, closed+2, 8, r.logger)
+	r.fetchTracker.Track(target)
+	r.fetchTracker.Track(step)
+	r.acquisitionMu.Lock()
+	r.consensusRecovery = consensusRecovery{targetHash: targetHash, stepHash: stepHash}
+	victim := r.obsoleteCatchupVictimLocked(closed + maxForwardDeltaGap + 10)
+	r.acquisitionMu.Unlock()
+
+	assert.Nil(t, victim)
 }
 
 func TestRouter_TrustedValidationAheadLeavesFullBeforeAcquire(t *testing.T) {

--- a/internal/consensus/adaptor/router_initial_sync_test.go
+++ b/internal/consensus/adaptor/router_initial_sync_test.go
@@ -116,3 +116,62 @@ func TestAdaptor_ValidationQuorumConfirmsCurrentInitialLedger(t *testing.T) {
 	require.Equal(t, closed.Hash(), svc.GetClosedLedger().Hash())
 	require.Equal(t, closed.Hash(), svc.GetValidatedLedger().Hash())
 }
+
+func TestRouter_InitialSyncFarPeerStatusRequiresCorroboration(t *testing.T) {
+	svc := adg_newNonStandaloneService(t)
+	a, sender := newRecordingAdaptor(t, svc)
+	r := newTestRouter(nil, a, make(chan *peermanagement.InboundMessage, 2))
+	closed := svc.GetClosedLedgerIndex()
+	targetSeq := closed + maxForwardDeltaGap + 1
+	targetHash := [32]byte{0x91}
+
+	r.handleStatusChange(statusChangeMessage(t, 7, targetSeq, targetHash))
+
+	r.peersMu.RLock()
+	_, admitted := r.peerStates[7]
+	_, staged := r.peerStatusCandidates[7]
+	r.peersMu.RUnlock()
+	require.False(t, admitted)
+	require.True(t, staged)
+	require.Empty(t, a.PeerReportedLedgers())
+	require.Zero(t, acquireCount(sender))
+	require.Equal(t, catchupTarget{}, r.catchup)
+
+	r.handleStatusChange(statusChangeMessage(t, 8, targetSeq, targetHash))
+
+	r.peersMu.RLock()
+	require.Len(t, r.peerStates, 2)
+	require.Empty(t, r.peerStatusCandidates)
+	r.peersMu.RUnlock()
+	require.Len(t, a.PeerReportedLedgers(), 2)
+	require.GreaterOrEqual(t, acquireCount(sender), 1)
+	seq, hash, _ := r.bestCatchupTarget()
+	require.Equal(t, targetSeq, seq)
+	require.Equal(t, targetHash, hash)
+}
+
+func TestRouter_InitialSyncStagedFarPeerPromotedByTrustedTarget(t *testing.T) {
+	svc := adg_newNonStandaloneService(t)
+	a, sender := newRecordingAdaptor(t, svc)
+	r := newTestRouter(nil, a, make(chan *peermanagement.InboundMessage, 1))
+	targetSeq := svc.GetClosedLedgerIndex() + maxForwardDeltaGap + 1
+	targetHash := [32]byte{0x92}
+
+	r.handleStatusChange(statusChangeMessage(t, 7, targetSeq, targetHash))
+	r.peersMu.RLock()
+	_, staged := r.peerStatusCandidates[7]
+	r.peersMu.RUnlock()
+	require.True(t, staged)
+	require.Zero(t, acquireCount(sender))
+
+	r.onLedgerFullyValidated(targetSeq, targetHash)
+
+	r.peersMu.RLock()
+	_, admitted := r.peerStates[7]
+	_, staged = r.peerStatusCandidates[7]
+	r.peersMu.RUnlock()
+	require.True(t, admitted)
+	require.False(t, staged)
+	require.Equal(t, []consensus.LedgerID{consensus.LedgerID(targetHash)}, a.PeerReportedLedgers())
+	require.GreaterOrEqual(t, acquireCount(sender), 1)
+}

--- a/internal/consensus/adaptor/router_replay_pipeline_test.go
+++ b/internal/consensus/adaptor/router_replay_pipeline_test.go
@@ -79,7 +79,7 @@ func armStandardReplayTestPipeline(
 	sender.mu.Lock()
 	sender.peerSupportsReplay = false
 	sender.mu.Unlock()
-	trackCatchupPeer(r, 7, links[len(links)-1].seq)
+	trackCatchupPeer(r, 7, links[len(links)-1].seq, links[len(links)-1].hash)
 	require.NoError(t, a.RequestLedger(consensus.LedgerID(links[len(links)-1].hash)))
 }
 
@@ -380,7 +380,7 @@ func TestStandardReplayPipelineDoesNotFallbackAfterGossipTargetAdvances(t *testi
 	sender.mu.Lock()
 	sender.peerSupportsReplay = false
 	sender.mu.Unlock()
-	trackCatchupPeer(r, 7, links[len(links)-1].seq)
+	trackCatchupPeer(r, 7, links[len(links)-1].seq, links[len(links)-1].hash)
 	r.recordCatchupTarget(links[len(links)-1].seq, links[len(links)-1].hash, 7)
 	r.armCatchupTowardTarget()
 	require.True(t, r.standardReplay.active)

--- a/internal/consensus/adaptor/router_wrong_ledger_acquisition_test.go
+++ b/internal/consensus/adaptor/router_wrong_ledger_acquisition_test.go
@@ -390,7 +390,7 @@ func TestBehindPeerCannotPromoteWhileNetworkTargetIsAhead(t *testing.T) {
 	a.SetOperatingMode(consensus.OpModeTracking)
 	closed := svc.GetClosedLedgerIndex()
 	targetHash := [32]byte{0xC2}
-	r.recordCatchupTarget(closed+10, targetHash, 7)
+	r.recordValidationCatchupTarget(closed+10, targetHash, 7, catchupSourceQuorum)
 
 	lowHash := [32]byte{0xC3}
 	r.checkBehind(1, lowHash, 8)
@@ -402,6 +402,22 @@ func TestBehindPeerCannotPromoteWhileNetworkTargetIsAhead(t *testing.T) {
 	assert.Equal(t, closed+10, seq)
 	assert.Equal(t, targetHash, hash)
 	assert.Equal(t, uint64(7), peerID)
+}
+
+func TestOutlierPeerSequenceCannotBlockPromotion(t *testing.T) {
+	r, a, _, svc := makeRouter(t)
+	a.SetOperatingMode(consensus.OpModeTracking)
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+
+	r.peersMu.Lock()
+	r.peerStates[7] = &peerLedgerState{LedgerSeq: closed.Sequence(), LedgerHash: closed.Hash()}
+	r.peerStates[9] = &peerLedgerState{LedgerSeq: 106_000_000, LedgerHash: [32]byte{0xee}}
+	r.peersMu.Unlock()
+
+	r.checkBehind(closed.Sequence(), closed.Hash(), 7)
+
+	assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode())
 }
 
 func TestAheadByMoreThanDoesNotWrap(t *testing.T) {

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -378,6 +378,14 @@ func (l *Ledger) Timeouts() int {
 	return l.timeouts
 }
 
+// ConsecutiveTimeouts returns the current no-progress streak. Unlike Timeouts,
+// useful peer or local data resets this value.
+func (l *Ledger) ConsecutiveTimeouts() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.consecutiveTimeouts
+}
+
 // TimerDue reports whether the acquisition retry interval has elapsed.
 func (l *Ledger) TimerDue(now time.Time) bool {
 	l.mu.Lock()
@@ -418,6 +426,7 @@ func (l *Ledger) OnTimer(now time.Time) TimerAction {
 		return TimerRefresh
 	}
 
+	l.lastTimer = now
 	l.timeouts++
 	l.consecutiveTimeouts++
 	if l.consecutiveTimeouts > ledgerTimeoutRetriesMax {

--- a/internal/ledger/inbound/onloop_test.go
+++ b/internal/ledger/inbound/onloop_test.go
@@ -279,6 +279,28 @@ func TestLedger_OnTimer_NotDueIsNoop(t *testing.T) {
 	}
 }
 
+func TestLedger_OnTimer_EscalationStartsNextInterval(t *testing.T) {
+	t.Parallel()
+	il := New([32]byte{0x04}, 7, 1, discardLogger())
+	il.state = StateWantState
+	base := time.Unix(1_700_000_000, 0)
+	il.lastTimer = base
+
+	first := base.Add(acquireTimerInterval)
+	if got := il.OnTimer(first); got != TimerEscalate {
+		t.Fatalf("first fire: got %v, want TimerEscalate", got)
+	}
+	if got := il.OnTimer(first.Add(100 * time.Millisecond)); got != TimerNone {
+		t.Fatalf("early retry: got %v, want TimerNone", got)
+	}
+	if got := il.Timeouts(); got != 1 {
+		t.Fatalf("timeouts after early retry = %d, want 1", got)
+	}
+	if got := il.OnTimer(first.Add(acquireTimerInterval)); got != TimerEscalate {
+		t.Fatalf("next interval: got %v, want TimerEscalate", got)
+	}
+}
+
 func TestLedger_RearmTimerStartsIntervalAfterEscalation(t *testing.T) {
 	t.Parallel()
 	il := New([32]byte{0x03}, 7, 1, discardLogger())


### PR DESCRIPTION
## Summary

- quarantine implausible peer ledger tips until corroborated or matched by trusted validation/quorum evidence, and anchor sequence/hash retention to local or trusted state
- let acquisition timers preempt yielded local traversal while preserving useful-data ordering and wall-clock retry cadence
- supersede one stalled or obsolete lower full-state acquisition when a newer trusted quorum target needs capacity
- add a deterministic regression for the complete incident cascade, including the outlier flood, repeated backed traversal yields, occupied catch-up slots, trusted target adoption, and recovery to Full

## Rippled conformance

Reviewed against the clean rippled v3.3.0 oracle at `00a178fb92ca49521b937ae1a99d863765ea8a90`.

- peer divergence uses rippled's 128-ledger boundary and does not let diverged peers influence range availability
- timer state advances before acquisition work and is rearmed after callback processing
- trusted validations remain authoritative for target acquisition
- the stale-acquisition selector is Go-specific resource policy because rippled does not impose goXRPL's bounded speculative acquisition cap

## Test plan

- `go test ./internal/ledger/inbound ./internal/consensus/adaptor -count=1`
- `go test -race ./internal/ledger/inbound ./internal/consensus/adaptor -count=1`
- `just test-core`
- `just build-all`
- `just vet`
- `just lint`
- `git diff --check`

Stacked on #1665.

Closes #1663