### PR TITLE
fix: keep catch-up replay on frozen pivot

### DIFF
--- a/internal/consensus/adaptor/acquisition_store_test.go
+++ b/internal/consensus/adaptor/acquisition_store_test.go
@@ -1035,6 +1035,37 @@ func TestCompleteInboundLedgerPromotesResultMapPersistence(t *testing.T) {
 	require.ErrorContains(t, err, "store failed")
 }
 
+func TestStandardReplayReloadsPromotedTransactionMap(t *testing.T) {
+	base := newAcquisitionStoreTestFamily()
+	router := newTestRouter(nil, nil, make(chan *peermanagement.InboundMessage))
+	router.SetAcquisitionFamily(base)
+	router.acquisitionStore.start(t.Context())
+	defer router.acquisitionStore.stopDrain()
+
+	txMap := shamap.New(shamap.TypeTransaction)
+	blob, txID := txWithMetaBlob(t, []byte{0x10, 0x20, 0x30, 0x40}, 1)
+	require.NoError(t, txMap.PutWithNodeType(txID, blob, shamap.NodeTypeTransactionWithMeta))
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+	batch, err := txMap.FlushDirty()
+	require.NoError(t, err)
+
+	scope := router.acquisitionStore.scope().(*acquisitionStoreScope)
+	require.NoError(t, scope.StoreBatch(t.Context(), batch.Entries))
+	require.NoError(t, scope.Promote(t.Context()))
+	base.clearCached()
+
+	entry := &standardReplayEntry{
+		header:  header.LedgerHeader{TxHash: txRoot},
+		durable: true,
+	}
+	reloaded, err := router.loadStandardReplayTransactionMap(t.Context(), entry)
+	require.NoError(t, err)
+	reloadedRoot, err := reloaded.Hash()
+	require.NoError(t, err)
+	require.Equal(t, txRoot, reloadedRoot)
+}
+
 func TestCompleteInboundLedgerReadyReleasesUnconsumedScopes(t *testing.T) {
 	t.Run("result error", func(t *testing.T) {
 		base := newAcquisitionStoreTestFamily()

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -310,6 +310,7 @@ type Router struct {
 	replayPipelinePersistUs              atomic.Uint64
 
 	acquisitionMu     sync.Mutex
+	replayCommitMu    sync.Mutex
 	consensusRecovery consensusRecovery
 	lastHandoffSeq    uint32
 	standardReplay    standardReplayPipeline
@@ -680,6 +681,7 @@ func (r *Router) StopAcquisitions() (legacy, replay int) {
 	if r == nil {
 		return 0, 0
 	}
+	r.replayCommitMu.Lock()
 	r.acquisitionMu.Lock()
 	legacyLedgers := r.fetchTracker.Stop()
 	legacy = len(legacyLedgers)
@@ -690,6 +692,7 @@ func (r *Router) StopAcquisitions() (legacy, replay int) {
 	r.consensusRecovery = consensusRecovery{}
 	r.lastHandoffSeq = 0
 	r.acquisitionMu.Unlock()
+	r.replayCommitMu.Unlock()
 
 	r.catchupMu.Lock()
 	r.catchup = catchupTarget{}
@@ -1204,6 +1207,7 @@ func (r *Router) maintenanceTick() {
 	now := time.Now()
 
 	r.retryInboundLedgerAcquisitions(now)
+	r.rebootstrapFrozenPivotIfStalled(now)
 
 	// Timer-driven catch-up re-arm (rippled LedgerMaster::doAdvance cadence): a
 	// reaped/failed sole acquisition (cap=1) can't park catch-up until the next

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -218,10 +218,9 @@ const maxConcurrentSpeculativeCatchup = maxConcurrentCatchup - 1
 // newer trusted targets remain queued and are armed when it completes.
 const maxConcurrentProvisionalFullStateCatchup = 1
 
-// maxForwardDeltaGap bounds how far behind the tip the router walks forward
-// before it prefers a single full-state jump-adopt. Within the gap a proven
-// same-branch walk replays transactions against each accepted predecessor;
-// beyond it a cold or far-behind start jumps straight to the validated tip.
+// maxForwardDeltaGap bounds the initial recovery strategy and peer ancestry
+// hints. A healthy frozen-pivot replay is governed by measured progress instead
+// of its absolute distance from the moving tip.
 const maxForwardDeltaGap = 128
 
 const catchupLinkageGracePeriod = 2 * time.Second
@@ -924,6 +923,9 @@ func (r *Router) armCatchupTowardTargetWithPeer(peerHint uint64) {
 	if tSeq == 0 {
 		return
 	}
+	if r.continueFrozenPivotRecovery(tSeq, tHash, peerHint) {
+		return
+	}
 	r.reconcileStandardReplayTarget(tSeq, tHash)
 	closed := svc.GetClosedLedgerIndex()
 	if tSeq <= closed {
@@ -983,7 +985,7 @@ func (r *Router) armCatchupTowardTargetWithPeer(peerHint uint64) {
 	if r.isBuildingLedger(tSeq) {
 		return
 	}
-	r.startLedgerAcquisition(tSeq, tHash, peer)
+	r.beginFrozenPivotRecovery(tSeq, tHash, peer)
 }
 
 func (r *Router) withinCatchupLinkageGrace(
@@ -1295,6 +1297,9 @@ func (r *Router) startLedgerReplayAcquisitionLegacyLocked(seq uint32, hash [32]b
 }
 
 func (r *Router) startLedgerAcquisitionLegacyLocked(seq uint32, hash [32]byte, peerID uint64) {
+	if r.catchupRetryBlocked(hash, time.Now()) {
+		return
+	}
 	if seq != 0 && r.belowFloor(seq) {
 		return
 	}
@@ -1434,6 +1439,7 @@ func (r *Router) requestConsensusLedger(id consensus.LedgerID) error {
 
 	r.acquisitionMu.Lock()
 	r.consensusRecovery.targetHash = hash
+	recovery := r.consensusRecovery
 	step := r.consensusRecovery.stepHash
 	pipelineStep := r.standardReplayOwnsLocked(step)
 	if step != ([32]byte{}) && r.isAcquiring(step) && !pipelineStep {
@@ -1451,6 +1457,30 @@ func (r *Router) requestConsensusLedger(id consensus.LedgerID) error {
 	}
 	r.acquisitionMu.Unlock()
 	seq, _ := r.lookupSeqForHash(hash)
+	if r.continueFrozenPivotRecovery(seq, hash, 0) {
+		return nil
+	}
+	if svc := r.adaptor.LedgerService(); svc != nil && seq > svc.GetClosedLedgerIndex() {
+		held, _ := svc.GetLedgerByHash(hash)
+		provenReplay := held != nil && held.Sequence() == seq && held.Hash() == hash
+		_, _, _, forwardReplay, discardAnchor := r.recoveryForwardStep(svc, seq, hash, recovery)
+		provenReplay = provenReplay || forwardReplay
+		if discardAnchor {
+			r.acquisitionMu.Lock()
+			if r.consensusRecovery.anchorSeq == recovery.anchorSeq &&
+				r.consensusRecovery.anchorHash == recovery.anchorHash {
+				r.consensusRecovery.anchorSeq = 0
+				r.consensusRecovery.anchorHash = [32]byte{}
+			}
+			r.acquisitionMu.Unlock()
+		}
+		if !provenReplay {
+			peerID, found := r.resolveAcquisitionPeer(seq, 0)
+			if found && r.beginFrozenPivotRecovery(seq, hash, peerID) {
+				return nil
+			}
+		}
+	}
 	r.reconcileStandardReplayTarget(seq, hash)
 	r.armConsensusCatchup()
 	return nil
@@ -1543,6 +1573,7 @@ func (r *Router) onLedgerFullyValidated(seq uint32, hash [32]byte) {
 	removed := make(map[[32]byte]struct{})
 	var legacy []*inbound.Ledger
 
+	r.replayCommitMu.Lock()
 	r.acquisitionMu.Lock()
 	for _, candidate := range r.fetchTracker.Active() {
 		if candidate.Reason() != inbound.ReasonConsensus ||
@@ -1580,6 +1611,7 @@ func (r *Router) onLedgerFullyValidated(seq uint32, hash [32]byte) {
 		r.consensusRecovery = consensusRecovery{}
 	}
 	r.acquisitionMu.Unlock()
+	r.replayCommitMu.Unlock()
 
 	r.recordValidationCatchupTarget(seq, hash, 0, catchupSourceQuorum)
 
@@ -1821,10 +1853,12 @@ func (r *Router) recordCompletionRecheck(result validationRecheckResult) {
 // ClearFetchInfo resets the acquisition counters and recent-failure history,
 // backing fetch_info's `clear` param.
 func (r *Router) ClearFetchInfo() {
+	r.replayCommitMu.Lock()
 	r.acquisitionMu.Lock()
 	ledgers := r.fetchTracker.Clear()
 	r.cancelStandardReplayPipelineLocked()
 	r.acquisitionMu.Unlock()
+	r.replayCommitMu.Unlock()
 	r.retireLegacyAcquisitions(ledgers)
 }
 
@@ -3187,6 +3221,7 @@ func (r *Router) failInboundAcquisitionWithSnapshot(il *inbound.Ledger, snapshot
 	}
 	if reason == inbound.ReasonConsensus {
 		r.markFailedCatchupAcquisition(hash)
+		r.failFrozenPivotRecovery(hash)
 		r.failConsensusRecoveryStep(hash)
 	}
 	if reason == inbound.ReasonConsensus && r.engine != nil {
@@ -3213,8 +3248,16 @@ func (r *Router) discardFailedInboundAcquisitionWithSnapshot(il *inbound.Ledger,
 
 func (r *Router) finishDiscardedInboundAcquisition(il *inbound.Ledger) {
 	r.retireAcquisitionStore(r.lifecycleContext(), il)
-	if il.Reason() == inbound.ReasonConsensus && il.TransactionOnly() {
+	if il.Reason() != inbound.ReasonConsensus {
+		return
+	}
+	if il.TransactionOnly() {
 		r.failStandardReplayPipelineEntry(il)
+		return
+	}
+	if r.failFrozenPivotRecovery(il.Hash()) {
+		r.failConsensusRecoveryStep(il.Hash())
+		r.armConsensusCatchup()
 	}
 }
 
@@ -3329,6 +3372,7 @@ func (r *Router) completeInboundLedgerReady(il *inbound.Ledger) {
 		handled, startDrain := r.completeStandardReplayPipelineEntryLocked(il, h, txMap, peerID)
 		r.acquisitionMu.Unlock()
 		if handled {
+			r.refillStandardReplayCollector(peerID)
 			if startDrain {
 				r.drainStandardReplayPipeline()
 			}
@@ -3395,6 +3439,9 @@ func (r *Router) completeInboundLedgerReady(il *inbound.Ledger) {
 		"account_hash", fmt.Sprintf("%x", h.AccountHash[:8]),
 		"initial_candidate", initialCandidate,
 	)
+	if r.completeFrozenPivotAcquisition(h, initialCandidate) {
+		return
+	}
 	r.completeStoredConsensusRecovery(h.LedgerIndex, h.Hash, h.ParentHash, initialCandidate)
 }
 

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -3430,6 +3430,11 @@ func (r *Router) completeInboundLedgerReady(il *inbound.Ledger) {
 	initialCandidate, err := svc.BootstrapLedgerWithState(r.lifecycleContext(), h, stateMap, txMap)
 	if err != nil {
 		r.logger.Warn("inbound ledger: failed to store consensus ledger", "error", err, "seq", h.LedgerIndex)
+		frozenPivot := r.failFrozenPivotRecovery(h.Hash)
+		r.retireAcquisitionStore(r.lifecycleContext(), il)
+		if frozenPivot {
+			r.armConsensusCatchup()
+		}
 		return
 	}
 

--- a/internal/consensus/adaptor/router_catchup_bound_test.go
+++ b/internal/consensus/adaptor/router_catchup_bound_test.go
@@ -40,8 +40,8 @@ func TestRouter_CatchupFanoutBoundedByCap(t *testing.T) {
 
 	assert.LessOrEqual(t, acquireCount(rs), maxConcurrentCatchup,
 		"feeding %d ever-higher trusted tips must arm at most maxConcurrentCatchup acquisitions, not one per event", n)
-	assert.Equal(t, maxConcurrentSpeculativeCatchup, r.catchupInFlight(),
-		"gossip catch-up must leave one slot for an exact consensus target")
+	assert.Equal(t, 1, r.catchupInFlight(),
+		"moving trusted tips must keep one frozen full-state pivot")
 
 	tSeq, _, _ := r.bestCatchupTarget()
 	assert.Equal(t, highest, tSeq,

--- a/internal/consensus/adaptor/router_catchup_incident_test.go
+++ b/internal/consensus/adaptor/router_catchup_incident_test.go
@@ -192,3 +192,73 @@ func TestRouter_Issue1663CatchupCascadeRecoversToFull(t *testing.T) {
 	assert.Equal(t, "proposing", consensusServerState(a.GetOperatingMode(), consensus.ModeProposing, true))
 	assert.LessOrEqual(t, r.protectedCatchupInFlight(), maxConcurrentSpeculativeCatchup)
 }
+
+func TestRouter_Issue1668FrozenPivotCollectsAndReplaysMovingHead(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	_, err := svc.AcceptLedger(context.Background())
+	require.NoError(t, err)
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+
+	_, pivot, pivotHash, pivotSeq := buildSuccessorAgainstParent(t, closed)
+	r.recordSeqHash(pivotSeq, pivotHash, [32]byte{}, false)
+	links := buildStandardReplayTestChain(t, r, pivot, maxForwardDeltaGap+16)
+	sender.mu.Lock()
+	sender.peerSupportsReplay = false
+	sender.mu.Unlock()
+
+	trackCatchupPeer(r, 7, pivotSeq, pivotHash)
+	require.NoError(t, a.RequestLedger(consensus.LedgerID(pivotHash)))
+	pivotAcquisition := r.fetchTracker.Find(pivotHash)
+	require.NotNil(t, pivotAcquisition)
+	require.False(t, pivotAcquisition.TransactionOnly())
+	generation := r.standardReplay.generation
+
+	initialHead := links[11]
+	trackCatchupPeer(r, 7, initialHead.seq, initialHead.hash)
+	a.OnLedgerFullyValidated(consensus.LedgerID(initialHead.hash), initialHead.seq)
+	require.Equal(t, initialHead.seq, r.standardReplay.targetSeq)
+	require.Equal(t, standardReplayPipelineWindow, r.standardReplayResidentCountLocked())
+	for i := range standardReplayPipelineWindow {
+		completeStandardReplayTestLink(t, r, links[i])
+	}
+	for i := range standardReplayPipelineWindow {
+		stored, _ := svc.GetLedgerByHash(links[i].hash)
+		assert.Nil(t, stored)
+	}
+
+	storeRecoveryLedger(t, svc, pivot)
+	require.True(t, r.fetchTracker.RemoveExpectedWithSnapshot(
+		pivotAcquisition, pivotAcquisition.Snapshot(), true,
+	))
+	pivotHeader := pivot.Header()
+	require.True(t, r.completeFrozenPivotAcquisition(&pivotHeader, true))
+	require.True(t, r.standardReplay.initialCandidate)
+	for i := range standardReplayPipelineWindow {
+		stored, lookupErr := svc.GetLedgerByHash(links[i].hash)
+		require.NoError(t, lookupErr)
+		require.NotNil(t, stored)
+	}
+
+	completeStandardReplayTestLink(t, r, links[8])
+	completeStandardReplayTestLink(t, r, links[9])
+	require.Equal(t, links[9].seq, r.standardReplay.anchorSeq)
+
+	movedHead := links[maxForwardDeltaGap+8]
+	trackCatchupPeer(r, 7, movedHead.seq, movedHead.hash)
+	a.OnLedgerFullyValidated(consensus.LedgerID(movedHead.hash), movedHead.seq)
+	assert.Equal(t, generation, r.standardReplay.generation)
+	assert.Equal(t, pivotSeq, r.standardReplay.pivotSeq)
+	assert.Equal(t, pivotHash, r.standardReplay.pivotHash)
+	assert.Equal(t, movedHead.seq, r.standardReplay.targetSeq)
+	assert.Equal(t, movedHead.hash, r.standardReplay.targetHash)
+	assert.NotNil(t, r.fetchTracker.Find(links[10].hash))
+
+	pivotRequests := 0
+	for _, call := range sender.legacyCalls() {
+		if call.hash == pivotHash {
+			pivotRequests++
+		}
+	}
+	assert.Equal(t, 1, pivotRequests)
+}

--- a/internal/consensus/adaptor/router_recovery_session.go
+++ b/internal/consensus/adaptor/router_recovery_session.go
@@ -34,7 +34,6 @@ func (r *Router) beginFrozenPivotRecovery(seq uint32, hash [32]byte, peerID uint
 	r.standardReplay.headBlockedAt = time.Time{}
 	r.standardReplay.progressSampleAt = time.Time{}
 	r.standardReplay.sampleAnchorSeq = seq
-	r.standardReplay.sampleTargetSeq = seq
 	r.standardReplay.stalledSamples = 0
 	if r.consensusRecovery.targetHash != ([32]byte{}) {
 		r.consensusRecovery.stepHash = hash
@@ -65,6 +64,10 @@ func (r *Router) beginFrozenPivotRecovery(seq uint32, hash [32]byte, peerID uint
 }
 
 func (r *Router) continueFrozenPivotRecovery(seq uint32, hash [32]byte, peerID uint64) bool {
+	if seq == 0 || hash == ([32]byte{}) {
+		return false
+	}
+
 	r.catchupMu.Lock()
 	trustedReplacement := r.catchup.source != catchupSourcePeer &&
 		r.catchup.seq == seq && r.catchup.hash == hash
@@ -92,9 +95,6 @@ func (r *Router) continueFrozenPivotRecovery(seq uint32, hash [32]byte, peerID u
 	if seq > r.standardReplay.targetSeq {
 		r.standardReplay.targetSeq = seq
 		r.standardReplay.targetHash = hash
-		if r.consensusRecovery.targetHash != ([32]byte{}) {
-			r.consensusRecovery.targetHash = hash
-		}
 	}
 	r.acquisitionMu.Unlock()
 
@@ -117,7 +117,6 @@ func (r *Router) completeFrozenPivotAcquisition(h *header.LedgerHeader, initialC
 	now := time.Now()
 	r.standardReplay.progressSampleAt = now
 	r.standardReplay.sampleAnchorSeq = h.LedgerIndex
-	r.standardReplay.sampleTargetSeq = r.standardReplay.targetSeq
 	r.standardReplay.stalledSamples = 0
 	generation := r.standardReplay.generation
 	reachedTarget := r.standardReplay.targetSeq == h.LedgerIndex && r.standardReplay.targetHash == h.Hash
@@ -191,7 +190,6 @@ func (r *Router) rebootstrapFrozenPivotIfStalled(now time.Time) bool {
 	if r.standardReplay.progressSampleAt.IsZero() {
 		r.standardReplay.progressSampleAt = now
 		r.standardReplay.sampleAnchorSeq = r.standardReplay.anchorSeq
-		r.standardReplay.sampleTargetSeq = r.standardReplay.targetSeq
 		r.acquisitionMu.Unlock()
 		return false
 	}
@@ -200,16 +198,13 @@ func (r *Router) rebootstrapFrozenPivotIfStalled(now time.Time) bool {
 		return false
 	}
 
-	oldGap := r.standardReplay.sampleTargetSeq - r.standardReplay.sampleAnchorSeq
-	newGap := r.standardReplay.targetSeq - r.standardReplay.anchorSeq
-	if newGap < oldGap {
+	if r.standardReplay.anchorSeq > r.standardReplay.sampleAnchorSeq {
 		r.standardReplay.stalledSamples = 0
 	} else if r.standardReplay.stalledSamples < ^uint8(0) {
 		r.standardReplay.stalledSamples++
 	}
 	r.standardReplay.progressSampleAt = now
 	r.standardReplay.sampleAnchorSeq = r.standardReplay.anchorSeq
-	r.standardReplay.sampleTargetSeq = r.standardReplay.targetSeq
 	if r.standardReplay.stalledSamples < standardReplayStallWindows {
 		r.acquisitionMu.Unlock()
 		return false

--- a/internal/consensus/adaptor/router_recovery_session.go
+++ b/internal/consensus/adaptor/router_recovery_session.go
@@ -95,6 +95,9 @@ func (r *Router) continueFrozenPivotRecovery(seq uint32, hash [32]byte, peerID u
 	if seq > r.standardReplay.targetSeq {
 		r.standardReplay.targetSeq = seq
 		r.standardReplay.targetHash = hash
+		if trustedReplacement && r.consensusRecovery.targetHash != ([32]byte{}) {
+			r.consensusRecovery.targetHash = hash
+		}
 	}
 	r.acquisitionMu.Unlock()
 

--- a/internal/consensus/adaptor/router_recovery_session.go
+++ b/internal/consensus/adaptor/router_recovery_session.go
@@ -1,0 +1,267 @@
+package adaptor
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+)
+
+func (r *Router) beginFrozenPivotRecovery(seq uint32, hash [32]byte, peerID uint64) bool {
+	if seq == 0 || hash == ([32]byte{}) {
+		return false
+	}
+
+	r.acquisitionMu.Lock()
+	if r.standardReplay.active {
+		r.acquisitionMu.Unlock()
+		return r.continueFrozenPivotRecovery(seq, hash, peerID)
+	}
+	r.standardReplay.generation++
+	r.standardReplay.active = true
+	r.standardReplay.applying = false
+	r.standardReplay.pivotReady = false
+	r.standardReplay.initialCandidate = false
+	r.standardReplay.pivotSeq = seq
+	r.standardReplay.pivotHash = hash
+	r.standardReplay.anchorSeq = seq
+	r.standardReplay.anchorHash = hash
+	r.standardReplay.collectSeq = seq
+	r.standardReplay.collectHash = hash
+	r.standardReplay.targetSeq = seq
+	r.standardReplay.targetHash = hash
+	r.standardReplay.entries = make(map[uint32]*standardReplayEntry, standardReplayPreparedLimit)
+	r.standardReplay.headBlockedAt = time.Time{}
+	r.standardReplay.progressSampleAt = time.Time{}
+	r.standardReplay.sampleAnchorSeq = seq
+	r.standardReplay.sampleTargetSeq = seq
+	r.standardReplay.stalledSamples = 0
+	if r.consensusRecovery.targetHash != ([32]byte{}) {
+		r.consensusRecovery.stepHash = hash
+	}
+	identity := r.standardReplayIdentityLocked()
+	r.startLedgerAcquisitionLegacyLocked(seq, hash, peerID)
+	il := r.fetchTracker.Find(hash)
+	if il != nil && !il.TransactionOnly() {
+		r.acquisitionMu.Unlock()
+		return true
+	}
+	r.acquisitionMu.Unlock()
+
+	r.replayCommitMu.Lock()
+	r.acquisitionMu.Lock()
+	if r.standardReplay.active && r.standardReplay.generation == identity.generation &&
+		!r.standardReplay.pivotReady && r.standardReplay.pivotSeq == identity.pivotSeq &&
+		r.standardReplay.pivotHash == identity.pivotHash {
+		retired := r.cancelStandardReplayPipelineLocked()
+		r.acquisitionMu.Unlock()
+		r.replayCommitMu.Unlock()
+		r.retireLegacyAcquisitions(retired)
+		return false
+	}
+	r.acquisitionMu.Unlock()
+	r.replayCommitMu.Unlock()
+	return false
+}
+
+func (r *Router) continueFrozenPivotRecovery(seq uint32, hash [32]byte, peerID uint64) bool {
+	r.catchupMu.Lock()
+	trustedReplacement := r.catchup.source != catchupSourcePeer &&
+		r.catchup.seq == seq && r.catchup.hash == hash
+	r.catchupMu.Unlock()
+
+	r.acquisitionMu.Lock()
+	if !r.standardReplay.active {
+		r.acquisitionMu.Unlock()
+		return false
+	}
+
+	conflict := (seq == r.standardReplay.pivotSeq && hash != r.standardReplay.pivotHash) ||
+		(seq == r.standardReplay.anchorSeq && hash != r.standardReplay.anchorHash) ||
+		(seq == r.standardReplay.targetSeq && hash != r.standardReplay.targetHash) ||
+		(trustedReplacement && seq < r.standardReplay.targetSeq)
+	if entry := r.standardReplay.entries[seq]; entry != nil && entry.hash != hash {
+		conflict = true
+	}
+	if conflict {
+		identity := r.standardReplayIdentityLocked()
+		r.acquisitionMu.Unlock()
+		r.cancelStandardReplayPipelineIdentity(identity)
+		return false
+	}
+	if seq > r.standardReplay.targetSeq {
+		r.standardReplay.targetSeq = seq
+		r.standardReplay.targetHash = hash
+		if r.consensusRecovery.targetHash != ([32]byte{}) {
+			r.consensusRecovery.targetHash = hash
+		}
+	}
+	r.acquisitionMu.Unlock()
+
+	return r.refillStandardReplayCollector(peerID)
+}
+
+func (r *Router) completeFrozenPivotAcquisition(h *header.LedgerHeader, initialCandidate bool) bool {
+	if h == nil {
+		return false
+	}
+
+	r.acquisitionMu.Lock()
+	if !r.standardReplay.active || r.standardReplay.pivotReady ||
+		r.standardReplay.pivotSeq != h.LedgerIndex || r.standardReplay.pivotHash != h.Hash {
+		r.acquisitionMu.Unlock()
+		return false
+	}
+	r.standardReplay.pivotReady = true
+	r.standardReplay.initialCandidate = initialCandidate
+	now := time.Now()
+	r.standardReplay.progressSampleAt = now
+	r.standardReplay.sampleAnchorSeq = h.LedgerIndex
+	r.standardReplay.sampleTargetSeq = r.standardReplay.targetSeq
+	r.standardReplay.stalledSamples = 0
+	generation := r.standardReplay.generation
+	reachedTarget := r.standardReplay.targetSeq == h.LedgerIndex && r.standardReplay.targetHash == h.Hash
+	startDrain := false
+	if entry := r.standardReplay.entries[h.LedgerIndex+1]; entry != nil &&
+		(!entry.readyAt.IsZero() || entry.failed) && !r.standardReplay.applying {
+		r.standardReplay.applying = true
+		startDrain = true
+	}
+	r.acquisitionMu.Unlock()
+
+	r.logger.Info("verified frozen recovery pivot",
+		"seq", h.LedgerIndex,
+		"hash", fmt.Sprintf("%x", h.Hash[:8]),
+		"initial_candidate", initialCandidate,
+	)
+	if !reachedTarget {
+		_, result := r.adaptor.recheckFullyValidated(h.LedgerIndex, h.Hash)
+		r.recordCompletionRecheck(result)
+		r.recordAcquiredSeqHash(h.LedgerIndex, h.Hash, h.ParentHash)
+		if result == validationRecheckAccepted {
+			r.promoteCompletedLedger(h.LedgerIndex, h.Hash)
+		}
+	}
+	r.acquisitionMu.Lock()
+	current := r.standardReplay.active && r.standardReplay.generation == generation &&
+		r.standardReplay.pivotReady && r.standardReplay.pivotSeq == h.LedgerIndex &&
+		r.standardReplay.pivotHash == h.Hash
+	if current {
+		if r.consensusRecovery.stepHash == h.Hash {
+			r.consensusRecovery.stepHash = [32]byte{}
+		}
+		if r.consensusRecovery.targetHash != ([32]byte{}) {
+			r.consensusRecovery.anchorSeq = h.LedgerIndex
+			r.consensusRecovery.anchorHash = h.Hash
+		}
+	}
+	r.acquisitionMu.Unlock()
+	if !current {
+		return true
+	}
+	if reachedTarget {
+		r.completeStoredConsensusRecovery(h.LedgerIndex, h.Hash, h.ParentHash, initialCandidate)
+		r.acquisitionMu.Lock()
+		current = r.standardReplay.active && r.standardReplay.generation == generation &&
+			r.standardReplay.pivotReady && r.standardReplay.pivotSeq == h.LedgerIndex &&
+			r.standardReplay.pivotHash == h.Hash
+		if current && r.standardReplay.targetSeq == h.LedgerIndex && r.standardReplay.targetHash == h.Hash {
+			r.standardReplay.active = false
+			r.standardReplay.entries = nil
+		}
+		r.acquisitionMu.Unlock()
+		if !current {
+			return true
+		}
+	}
+	r.refillStandardReplayCollector(0)
+	if startDrain {
+		r.drainStandardReplayPipeline()
+	}
+	return true
+}
+
+func (r *Router) rebootstrapFrozenPivotIfStalled(now time.Time) bool {
+	r.acquisitionMu.Lock()
+	if !r.standardReplay.active || !r.standardReplay.pivotReady || r.standardReplay.applying ||
+		r.standardReplay.targetSeq <= r.standardReplay.anchorSeq {
+		r.acquisitionMu.Unlock()
+		return false
+	}
+	if r.standardReplay.progressSampleAt.IsZero() {
+		r.standardReplay.progressSampleAt = now
+		r.standardReplay.sampleAnchorSeq = r.standardReplay.anchorSeq
+		r.standardReplay.sampleTargetSeq = r.standardReplay.targetSeq
+		r.acquisitionMu.Unlock()
+		return false
+	}
+	if now.Sub(r.standardReplay.progressSampleAt) < standardReplayProgressWindow {
+		r.acquisitionMu.Unlock()
+		return false
+	}
+
+	oldGap := r.standardReplay.sampleTargetSeq - r.standardReplay.sampleAnchorSeq
+	newGap := r.standardReplay.targetSeq - r.standardReplay.anchorSeq
+	if newGap < oldGap {
+		r.standardReplay.stalledSamples = 0
+	} else if r.standardReplay.stalledSamples < ^uint8(0) {
+		r.standardReplay.stalledSamples++
+	}
+	r.standardReplay.progressSampleAt = now
+	r.standardReplay.sampleAnchorSeq = r.standardReplay.anchorSeq
+	r.standardReplay.sampleTargetSeq = r.standardReplay.targetSeq
+	if r.standardReplay.stalledSamples < standardReplayStallWindows {
+		r.acquisitionMu.Unlock()
+		return false
+	}
+	generation := r.standardReplay.generation
+	frontierSeq := r.standardReplay.anchorSeq
+	r.acquisitionMu.Unlock()
+
+	r.replayCommitMu.Lock()
+	r.acquisitionMu.Lock()
+	if !r.standardReplay.active || !r.standardReplay.pivotReady ||
+		r.standardReplay.generation != generation || r.standardReplay.anchorSeq != frontierSeq ||
+		r.standardReplay.stalledSamples < standardReplayStallWindows {
+		r.acquisitionMu.Unlock()
+		r.replayCommitMu.Unlock()
+		return false
+	}
+	targetSeq := r.standardReplay.targetSeq
+	targetHash := r.standardReplay.targetHash
+	retired := r.cancelStandardReplayPipelineLocked()
+	r.consensusRecovery.anchorSeq = 0
+	r.consensusRecovery.anchorHash = [32]byte{}
+	r.consensusRecovery.stepHash = [32]byte{}
+	r.acquisitionMu.Unlock()
+	r.replayCommitMu.Unlock()
+	r.retireLegacyAcquisitions(retired)
+	r.replayPipelineFallbacks.Add(1)
+	r.logger.Warn("replay recovery is not converging; selecting a new full-state pivot",
+		"frontier_seq", frontierSeq,
+		"target_seq", targetSeq,
+		"target_hash", fmt.Sprintf("%x", targetHash[:8]),
+	)
+	if peerID, ok := r.resolveAcquisitionPeer(targetSeq, 0); ok {
+		r.beginFrozenPivotRecovery(targetSeq, targetHash, peerID)
+	}
+	return true
+}
+
+func (r *Router) failFrozenPivotRecovery(hash [32]byte) bool {
+	r.replayCommitMu.Lock()
+	r.acquisitionMu.Lock()
+	if !r.standardReplay.active || r.standardReplay.pivotReady || r.standardReplay.pivotHash != hash {
+		r.acquisitionMu.Unlock()
+		r.replayCommitMu.Unlock()
+		return false
+	}
+	retired := r.cancelStandardReplayPipelineLocked()
+	if r.consensusRecovery.stepHash == hash {
+		r.consensusRecovery.stepHash = [32]byte{}
+	}
+	r.acquisitionMu.Unlock()
+	r.replayCommitMu.Unlock()
+	r.retireLegacyAcquisitions(retired)
+	return true
+}

--- a/internal/consensus/adaptor/router_recovery_session_test.go
+++ b/internal/consensus/adaptor/router_recovery_session_test.go
@@ -1,0 +1,233 @@
+package adaptor
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFrozenPivotRecoveryWaitsForUnknownSuccessorLink(t *testing.T) {
+	r, _, sender, svc := makeRouter(t)
+	pivotSeq := svc.GetClosedLedgerIndex() + maxForwardDeltaGap + 1
+	pivotHash := [32]byte{0xa1}
+	require.True(t, r.beginFrozenPivotRecovery(pivotSeq, pivotHash, 7))
+	generation := r.standardReplay.generation
+	require.True(t, r.continueFrozenPivotRecovery(pivotSeq, pivotHash, 7))
+	require.True(t, r.standardReplay.active)
+	require.Equal(t, generation, r.standardReplay.generation)
+
+	targetSeq := pivotSeq + 2
+	targetHash := [32]byte{0xa3}
+	require.True(t, r.continueFrozenPivotRecovery(targetSeq, targetHash, 7))
+	require.True(t, r.standardReplay.active)
+	require.Equal(t, generation, r.standardReplay.generation)
+	require.Equal(t, pivotSeq, r.standardReplay.pivotSeq)
+	require.Equal(t, targetSeq, r.standardReplay.targetSeq)
+	require.Empty(t, r.standardReplay.entries)
+	require.Len(t, sender.legacyCalls(), 1)
+}
+
+func TestFrozenPivotRecoveryCancelsConflictingPivotEvidence(t *testing.T) {
+	r, _, sender, svc := makeRouter(t)
+	pivotSeq := svc.GetClosedLedgerIndex() + maxForwardDeltaGap + 1
+	pivotHash := [32]byte{0xb1}
+	require.True(t, r.beginFrozenPivotRecovery(pivotSeq, pivotHash, 7))
+	generation := r.standardReplay.generation
+
+	require.False(t, r.continueFrozenPivotRecovery(pivotSeq, [32]byte{0xb2}, 7))
+	assert.False(t, r.standardReplay.active)
+	assert.Greater(t, r.standardReplay.generation, generation)
+	assert.Nil(t, r.fetchTracker.Find(pivotHash))
+	assert.Len(t, sender.legacyCalls(), 1)
+}
+
+func TestFrozenPivotRecoveryFailureReleasesPivotGeneration(t *testing.T) {
+	r, _, _, svc := makeRouter(t)
+	pivotSeq := svc.GetClosedLedgerIndex() + maxForwardDeltaGap + 1
+	pivotHash := [32]byte{0xc1}
+	require.True(t, r.beginFrozenPivotRecovery(pivotSeq, pivotHash, 7))
+	generation := r.standardReplay.generation
+
+	require.True(t, r.failFrozenPivotRecovery(pivotHash))
+	assert.False(t, r.standardReplay.active)
+	assert.Greater(t, r.standardReplay.generation, generation)
+	assert.Nil(t, r.fetchTracker.Find(pivotHash))
+}
+
+func TestFrozenPivotFailedStartCannotBeKeptAliveByTargetAdvance(t *testing.T) {
+	r, _, _, svc := makeRouter(t)
+	pivotSeq := svc.GetClosedLedgerIndex() + maxForwardDeltaGap + 1
+	pivotHash := [32]byte{0xc2}
+	r.markFailedCatchupAcquisition(pivotHash)
+
+	r.replayCommitMu.Lock()
+	done := make(chan bool, 1)
+	go func() {
+		done <- r.beginFrozenPivotRecovery(pivotSeq, pivotHash, 7)
+	}()
+	require.Eventually(t, func() bool {
+		r.acquisitionMu.Lock()
+		defer r.acquisitionMu.Unlock()
+		return r.standardReplay.active && r.standardReplay.pivotHash == pivotHash
+	}, time.Second, time.Millisecond)
+	require.Nil(t, r.fetchTracker.Find(pivotHash))
+
+	advancedHash := [32]byte{0xc3}
+	require.True(t, r.continueFrozenPivotRecovery(pivotSeq+1, advancedHash, 7))
+	r.replayCommitMu.Unlock()
+
+	require.False(t, <-done)
+	assert.False(t, r.standardReplay.active)
+	assert.Nil(t, r.fetchTracker.Find(pivotHash))
+}
+
+func TestFrozenPivotRecoveryRebootstrapsAfterTwoNonConvergingWindows(t *testing.T) {
+	r, _, _, _ := makeRouter(t)
+	started := time.Unix(100, 0)
+	targetHash := [32]byte{0xd1}
+	trackCatchupPeer(r, 7, 200, targetHash)
+	r.standardReplay = standardReplayPipeline{
+		generation:       3,
+		active:           true,
+		pivotReady:       true,
+		pivotSeq:         100,
+		anchorSeq:        100,
+		targetSeq:        200,
+		targetHash:       targetHash,
+		entries:          make(map[uint32]*standardReplayEntry),
+		progressSampleAt: started,
+		sampleAnchorSeq:  100,
+		sampleTargetSeq:  200,
+	}
+
+	assert.False(t, r.rebootstrapFrozenPivotIfStalled(started.Add(standardReplayProgressWindow)))
+	assert.True(t, r.standardReplay.active)
+	assert.Equal(t, uint8(1), r.standardReplay.stalledSamples)
+
+	assert.True(t, r.rebootstrapFrozenPivotIfStalled(started.Add(2*standardReplayProgressWindow)))
+	assert.True(t, r.standardReplay.active)
+	assert.False(t, r.standardReplay.pivotReady)
+	assert.Equal(t, uint64(5), r.standardReplay.generation)
+	assert.Equal(t, uint32(200), r.standardReplay.pivotSeq)
+	assert.Equal(t, targetHash, r.standardReplay.pivotHash)
+	pivot := r.fetchTracker.Find(targetHash)
+	require.NotNil(t, pivot)
+	assert.False(t, pivot.TransactionOnly())
+	assert.Equal(t, uint64(1), r.FastSyncMetrics().ReplayPipelineFallbacks)
+}
+
+func TestFrozenPivotRecoveryKeepsConvergingReplay(t *testing.T) {
+	r, _, _, _ := makeRouter(t)
+	started := time.Unix(200, 0)
+	r.standardReplay = standardReplayPipeline{
+		generation:       5,
+		active:           true,
+		pivotReady:       true,
+		pivotSeq:         100,
+		anchorSeq:        100,
+		targetSeq:        200,
+		targetHash:       [32]byte{0xe1},
+		entries:          make(map[uint32]*standardReplayEntry),
+		progressSampleAt: started,
+		sampleAnchorSeq:  100,
+		sampleTargetSeq:  200,
+		stalledSamples:   1,
+	}
+	r.standardReplay.anchorSeq = 110
+	r.standardReplay.targetSeq = 205
+
+	assert.False(t, r.rebootstrapFrozenPivotIfStalled(started.Add(standardReplayProgressWindow)))
+	assert.True(t, r.standardReplay.active)
+	assert.Zero(t, r.standardReplay.stalledSamples)
+	assert.Equal(t, uint64(5), r.standardReplay.generation)
+}
+
+func TestFrozenPivotRecoveryDoesNotTimeoutPivotDownload(t *testing.T) {
+	r, _, _, _ := makeRouter(t)
+	started := time.Unix(300, 0)
+	r.standardReplay = standardReplayPipeline{
+		generation:       8,
+		active:           true,
+		pivotReady:       false,
+		pivotSeq:         100,
+		anchorSeq:        100,
+		targetSeq:        300,
+		targetHash:       [32]byte{0xf1},
+		entries:          make(map[uint32]*standardReplayEntry),
+		progressSampleAt: started,
+		sampleAnchorSeq:  100,
+		sampleTargetSeq:  100,
+	}
+
+	assert.False(t, r.rebootstrapFrozenPivotIfStalled(started.Add(24*time.Hour)))
+	assert.True(t, r.standardReplay.active)
+	assert.Equal(t, uint64(8), r.standardReplay.generation)
+}
+
+func TestFrozenPivotHandoffKeepsSessionWhenTargetAdvances(t *testing.T) {
+	r, a, _, svc := makeRouter(t)
+	_, err := svc.AcceptLedger(context.Background())
+	require.NoError(t, err)
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	_, pivot, pivotHash, pivotSeq := buildSuccessorAgainstParent(t, closed)
+	links := buildStandardReplayTestChain(t, r, pivot, 1)
+	r.recordSeqHash(pivotSeq, pivotHash, closed.Hash(), true)
+	trackCatchupPeer(r, 7, pivotSeq, pivotHash)
+	r.acquisitionMu.Lock()
+	r.consensusRecovery.targetHash = pivotHash
+	r.acquisitionMu.Unlock()
+	require.True(t, r.beginFrozenPivotRecovery(pivotSeq, pivotHash, 7))
+	pivotAcquisition := r.fetchTracker.Find(pivotHash)
+	require.NotNil(t, pivotAcquisition)
+	generation := r.standardReplay.generation
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	r.engine = &mockEngine{
+		switchResult: consensus.LedgerSwitchAccepted,
+		switchHook: func(consensus.LedgerID) {
+			once.Do(func() {
+				close(entered)
+				<-release
+			})
+		},
+	}
+	storeRecoveryLedger(t, svc, pivot)
+	require.True(t, r.fetchTracker.RemoveExpectedWithSnapshot(
+		pivotAcquisition, pivotAcquisition.Snapshot(), true,
+	))
+	pivotHeader := pivot.Header()
+	done := make(chan bool, 1)
+	go func() {
+		done <- r.completeFrozenPivotAcquisition(&pivotHeader, true)
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("pivot did not reach the handoff barrier")
+	}
+	trackCatchupPeer(r, 7, links[0].seq, links[0].hash)
+	require.NoError(t, a.RequestLedger(consensus.LedgerID(links[0].hash)))
+	assert.True(t, r.standardReplay.active)
+	assert.Equal(t, generation, r.standardReplay.generation)
+	assert.Equal(t, pivotHash, r.standardReplay.pivotHash)
+	next := r.fetchTracker.Find(links[0].hash)
+	require.NotNil(t, next)
+	assert.True(t, next.TransactionOnly())
+
+	close(release)
+	select {
+	case handled := <-done:
+		assert.True(t, handled)
+	case <-time.After(time.Second):
+		t.Fatal("pivot did not leave the handoff barrier")
+	}
+}

--- a/internal/consensus/adaptor/router_recovery_session_test.go
+++ b/internal/consensus/adaptor/router_recovery_session_test.go
@@ -32,6 +32,38 @@ func TestFrozenPivotRecoveryWaitsForUnknownSuccessorLink(t *testing.T) {
 	require.Len(t, sender.legacyCalls(), 1)
 }
 
+func TestFrozenPivotRecoveryRejectsUnknownSequenceTarget(t *testing.T) {
+	r, _, _, svc := makeRouter(t)
+	pivotSeq := svc.GetClosedLedgerIndex() + maxForwardDeltaGap + 1
+	pivotHash := [32]byte{0xa4}
+	require.True(t, r.beginFrozenPivotRecovery(pivotSeq, pivotHash, 7))
+	generation := r.standardReplay.generation
+
+	assert.False(t, r.continueFrozenPivotRecovery(0, [32]byte{0xa5}, 7))
+	assert.True(t, r.standardReplay.active)
+	assert.Equal(t, generation, r.standardReplay.generation)
+	assert.Equal(t, pivotSeq, r.standardReplay.targetSeq)
+	assert.Equal(t, pivotHash, r.standardReplay.targetHash)
+}
+
+func TestFrozenPivotRecoveryKeepsExactConsensusTarget(t *testing.T) {
+	r, _, _, svc := makeRouter(t)
+	pivotSeq := svc.GetClosedLedgerIndex() + maxForwardDeltaGap + 1
+	pivotHash := [32]byte{0xa6}
+	exactHash := [32]byte{0xa7}
+	movingHash := [32]byte{0xa8}
+	require.True(t, r.beginFrozenPivotRecovery(pivotSeq, pivotHash, 7))
+	require.True(t, r.continueFrozenPivotRecovery(pivotSeq+1, exactHash, 7))
+	r.acquisitionMu.Lock()
+	r.consensusRecovery.targetHash = exactHash
+	r.acquisitionMu.Unlock()
+
+	require.True(t, r.continueFrozenPivotRecovery(pivotSeq+2, movingHash, 7))
+	assert.Equal(t, pivotSeq+2, r.standardReplay.targetSeq)
+	assert.Equal(t, movingHash, r.standardReplay.targetHash)
+	assert.Equal(t, exactHash, r.consensusRecovery.targetHash)
+}
+
 func TestFrozenPivotRecoveryCancelsConflictingPivotEvidence(t *testing.T) {
 	r, _, sender, svc := makeRouter(t)
 	pivotSeq := svc.GetClosedLedgerIndex() + maxForwardDeltaGap + 1
@@ -86,7 +118,7 @@ func TestFrozenPivotFailedStartCannotBeKeptAliveByTargetAdvance(t *testing.T) {
 	assert.Nil(t, r.fetchTracker.Find(pivotHash))
 }
 
-func TestFrozenPivotRecoveryRebootstrapsAfterTwoNonConvergingWindows(t *testing.T) {
+func TestFrozenPivotRecoveryRebootstrapsAfterTwoNoProgressWindows(t *testing.T) {
 	r, _, _, _ := makeRouter(t)
 	started := time.Unix(100, 0)
 	targetHash := [32]byte{0xd1}
@@ -102,7 +134,6 @@ func TestFrozenPivotRecoveryRebootstrapsAfterTwoNonConvergingWindows(t *testing.
 		entries:          make(map[uint32]*standardReplayEntry),
 		progressSampleAt: started,
 		sampleAnchorSeq:  100,
-		sampleTargetSeq:  200,
 	}
 
 	assert.False(t, r.rebootstrapFrozenPivotIfStalled(started.Add(standardReplayProgressWindow)))
@@ -121,7 +152,7 @@ func TestFrozenPivotRecoveryRebootstrapsAfterTwoNonConvergingWindows(t *testing.
 	assert.Equal(t, uint64(1), r.FastSyncMetrics().ReplayPipelineFallbacks)
 }
 
-func TestFrozenPivotRecoveryKeepsConvergingReplay(t *testing.T) {
+func TestFrozenPivotRecoveryKeepsAdvancingReplayAtMovingTipRate(t *testing.T) {
 	r, _, _, _ := makeRouter(t)
 	started := time.Unix(200, 0)
 	r.standardReplay = standardReplayPipeline{
@@ -135,11 +166,10 @@ func TestFrozenPivotRecoveryKeepsConvergingReplay(t *testing.T) {
 		entries:          make(map[uint32]*standardReplayEntry),
 		progressSampleAt: started,
 		sampleAnchorSeq:  100,
-		sampleTargetSeq:  200,
 		stalledSamples:   1,
 	}
 	r.standardReplay.anchorSeq = 110
-	r.standardReplay.targetSeq = 205
+	r.standardReplay.targetSeq = 210
 
 	assert.False(t, r.rebootstrapFrozenPivotIfStalled(started.Add(standardReplayProgressWindow)))
 	assert.True(t, r.standardReplay.active)
@@ -161,12 +191,48 @@ func TestFrozenPivotRecoveryDoesNotTimeoutPivotDownload(t *testing.T) {
 		entries:          make(map[uint32]*standardReplayEntry),
 		progressSampleAt: started,
 		sampleAnchorSeq:  100,
-		sampleTargetSeq:  100,
 	}
 
 	assert.False(t, r.rebootstrapFrozenPivotIfStalled(started.Add(24*time.Hour)))
 	assert.True(t, r.standardReplay.active)
 	assert.Equal(t, uint64(8), r.standardReplay.generation)
+}
+
+func TestFrozenPivotBootstrapFailureRearmsTrustedTarget(t *testing.T) {
+	r, _, _, svc := makeRouter(t)
+	pivot := completedCatchUpAcquisition(t, svc.GetClosedLedgerIndex()+10)
+	pivotSeq, pivotHash := pivot.Seq(), pivot.Hash()
+	r.fetchTracker.Track(pivot)
+	trackCatchupPeer(r, 7, pivotSeq, pivotHash)
+	require.True(t, r.beginFrozenPivotRecovery(pivotSeq, pivotHash, 7))
+
+	replacement := completedCatchUpAcquisition(t, pivotSeq+10)
+	trackCatchupPeer(r, 7, replacement.Seq(), replacement.Hash())
+	r.recordValidationCatchupTarget(
+		replacement.Seq(), replacement.Hash(), 7, catchupSourceQuorum,
+	)
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	r.lifecycleMu.Lock()
+	r.lifecycleCtx = canceled
+	r.lifecycleMu.Unlock()
+	t.Cleanup(func() {
+		r.lifecycleMu.Lock()
+		r.lifecycleCtx = context.Background()
+		r.lifecycleMu.Unlock()
+	})
+
+	r.completeInboundLedger(pivot)
+
+	assert.Nil(t, r.fetchTracker.Find(pivotHash))
+	assert.True(t, r.standardReplay.active)
+	assert.False(t, r.standardReplay.pivotReady)
+	assert.Equal(t, replacement.Seq(), r.standardReplay.pivotSeq)
+	assert.Equal(t, replacement.Hash(), r.standardReplay.pivotHash)
+	rearmed := r.fetchTracker.Find(replacement.Hash())
+	require.NotNil(t, rearmed)
+	assert.False(t, rearmed.TransactionOnly())
 }
 
 func TestFrozenPivotHandoffKeepsSessionWhenTargetAdvances(t *testing.T) {

--- a/internal/consensus/adaptor/router_recovery_session_test.go
+++ b/internal/consensus/adaptor/router_recovery_session_test.go
@@ -64,6 +64,26 @@ func TestFrozenPivotRecoveryKeepsExactConsensusTarget(t *testing.T) {
 	assert.Equal(t, exactHash, r.consensusRecovery.targetHash)
 }
 
+func TestFrozenPivotRecoveryAdvancesConsensusTargetOnTrustedEvidence(t *testing.T) {
+	r, _, _, svc := makeRouter(t)
+	pivotSeq := svc.GetClosedLedgerIndex() + maxForwardDeltaGap + 1
+	pivotHash := [32]byte{0xa9}
+	exactHash := [32]byte{0xaa}
+	validatedHash := [32]byte{0xab}
+	require.True(t, r.beginFrozenPivotRecovery(pivotSeq, pivotHash, 7))
+	require.True(t, r.continueFrozenPivotRecovery(pivotSeq+1, exactHash, 7))
+	r.acquisitionMu.Lock()
+	r.consensusRecovery.targetHash = exactHash
+	r.acquisitionMu.Unlock()
+	r.recordValidationCatchupTarget(
+		pivotSeq+2, validatedHash, 7, catchupSourceQuorum,
+	)
+
+	require.True(t, r.continueFrozenPivotRecovery(pivotSeq+2, validatedHash, 7))
+	assert.Equal(t, validatedHash, r.standardReplay.targetHash)
+	assert.Equal(t, validatedHash, r.consensusRecovery.targetHash)
+}
+
 func TestFrozenPivotRecoveryCancelsConflictingPivotEvidence(t *testing.T) {
 	r, _, sender, svc := makeRouter(t)
 	pivotSeq := svc.GetClosedLedgerIndex() + maxForwardDeltaGap + 1

--- a/internal/consensus/adaptor/router_replay_pipeline.go
+++ b/internal/consensus/adaptor/router_replay_pipeline.go
@@ -1,6 +1,7 @@
 package adaptor
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -12,27 +13,48 @@ import (
 	"github.com/LeJamon/go-xrpl/shamap"
 )
 
-const standardReplayPipelineWindow = 8
+const (
+	standardReplayPipelineWindow = 8
+	standardReplayPreparedLimit  = 2048
+	standardReplayProgressWindow = time.Minute
+	standardReplayStallWindows   = 2
+)
 
 type standardReplayPipeline struct {
-	generation    uint64
-	active        bool
-	applying      bool
-	anchorSeq     uint32
-	anchorHash    [32]byte
-	targetSeq     uint32
-	targetHash    [32]byte
-	entries       map[uint32]*standardReplayEntry
-	headBlockedAt time.Time
+	generation       uint64
+	active           bool
+	applying         bool
+	pivotReady       bool
+	initialCandidate bool
+	pivotSeq         uint32
+	pivotHash        [32]byte
+	anchorSeq        uint32
+	anchorHash       [32]byte
+	collectSeq       uint32
+	collectHash      [32]byte
+	targetSeq        uint32
+	targetHash       [32]byte
+	entries          map[uint32]*standardReplayEntry
+	headBlockedAt    time.Time
+	progressSampleAt time.Time
+	sampleAnchorSeq  uint32
+	sampleTargetSeq  uint32
+	stalledSamples   uint8
 }
 
 type standardReplayIdentity struct {
-	generation uint64
-	active     bool
-	anchorSeq  uint32
-	anchorHash [32]byte
-	targetSeq  uint32
-	targetHash [32]byte
+	generation       uint64
+	active           bool
+	pivotReady       bool
+	initialCandidate bool
+	pivotSeq         uint32
+	pivotHash        [32]byte
+	anchorSeq        uint32
+	anchorHash       [32]byte
+	collectSeq       uint32
+	collectHash      [32]byte
+	targetSeq        uint32
+	targetHash       [32]byte
 }
 
 type standardReplayTarget struct {
@@ -51,6 +73,7 @@ type standardReplayEntry struct {
 	header      header.LedgerHeader
 	txMap       *shamap.SHAMap
 	acquisition *inbound.Ledger
+	durable     bool
 	failed      bool
 }
 
@@ -60,35 +83,51 @@ type standardReplayLink struct {
 	parentHash [32]byte
 }
 
+type standardReplayLinkState uint8
+
+const (
+	standardReplayLinkUnknown standardReplayLinkState = iota
+	standardReplayLinkReady
+	standardReplayLinkConflict
+)
+
 func (r *Router) standardReplayLinks(
-	anchor *ledger.Ledger,
+	anchorSeq uint32,
+	anchorHash [32]byte,
 	targetSeq uint32,
 	targetHash [32]byte,
-) ([]standardReplayLink, bool) {
-	if anchor == nil || targetSeq <= anchor.Sequence() || targetHash == ([32]byte{}) {
-		return nil, false
+) ([]standardReplayLink, standardReplayLinkState) {
+	if targetSeq <= anchorSeq || anchorHash == ([32]byte{}) || targetHash == ([32]byte{}) {
+		return nil, standardReplayLinkUnknown
 	}
 
 	links := make([]standardReplayLink, 0, standardReplayPipelineWindow)
-	parentHash := anchor.Hash()
-	for seq := anchor.Sequence() + 1; seq <= targetSeq; seq++ {
+	parentHash := anchorHash
+	for seq := anchorSeq + 1; seq <= targetSeq && len(links) < standardReplayPipelineWindow; seq++ {
 		entry, ok := r.lookupSeqHash(seq)
-		if !ok || entry.hash == ([32]byte{}) || !entry.haveParent || entry.parentHash != parentHash {
-			return nil, false
+		if !ok || entry.hash == ([32]byte{}) || !entry.haveParent {
+			if len(links) == 0 {
+				return nil, standardReplayLinkUnknown
+			}
+			return links, standardReplayLinkReady
+		}
+		if entry.parentHash != parentHash {
+			return nil, standardReplayLinkConflict
 		}
 		if seq == targetSeq && entry.hash != targetHash {
-			return nil, false
+			return nil, standardReplayLinkConflict
 		}
-		if len(links) < standardReplayPipelineWindow {
-			links = append(links, standardReplayLink{
-				seq:        seq,
-				hash:       entry.hash,
-				parentHash: parentHash,
-			})
-		}
+		links = append(links, standardReplayLink{
+			seq:        seq,
+			hash:       entry.hash,
+			parentHash: parentHash,
+		})
 		parentHash = entry.hash
 	}
-	return links, len(links) > 0
+	if len(links) == 0 {
+		return nil, standardReplayLinkUnknown
+	}
+	return links, standardReplayLinkReady
 }
 
 func (r *Router) standardReplayBase(
@@ -107,17 +146,10 @@ func (r *Router) standardReplayBase(
 
 	base := fallback
 	if identity.active {
-		compatible := targetSeq == identity.targetSeq && targetHash == identity.targetHash
-		if !compatible && targetSeq > identity.anchorSeq {
-			compatible = r.recoveryAnchorReachesTarget(identity.anchorSeq, identity.anchorHash, targetHash)
+		if !identity.pivotReady {
+			return nil, identity, true
 		}
-		if !compatible {
-			var current bool
-			identity, current = r.cancelStandardReplayPipelineIdentity(identity)
-			if !current {
-				return fallback, standardReplayIdentity{}, false
-			}
-		} else if anchor, err := svc.GetLedgerByHash(identity.anchorHash); err == nil && anchor != nil && anchor.Sequence() == identity.anchorSeq {
+		if anchor, err := svc.GetLedgerByHash(identity.anchorHash); err == nil && anchor != nil && anchor.Sequence() == identity.anchorSeq {
 			base = anchor
 		} else {
 			var current bool
@@ -162,11 +194,9 @@ func (r *Router) reconcileStandardReplayTarget(targetSeq uint32, targetHash [32]
 	if !identity.active {
 		return
 	}
-	compatible := targetSeq == identity.targetSeq && targetHash == identity.targetHash
-	if !compatible && targetSeq > identity.anchorSeq {
-		compatible = r.recoveryAnchorReachesTarget(identity.anchorSeq, identity.anchorHash, targetHash)
-	}
-	if !compatible {
+	if targetSeq < identity.anchorSeq ||
+		(targetSeq == identity.anchorSeq && targetHash != identity.anchorHash) ||
+		(targetSeq == identity.targetSeq && targetHash != identity.targetHash) {
 		r.cancelStandardReplayPipelineIdentity(identity)
 	}
 }
@@ -189,9 +219,34 @@ func (r *Router) tryArmStandardReplayPipeline(
 		r.completeStoredConsensusRecovery(targetSeq, targetHash, anchor.ParentHash(), false)
 		return true
 	}
-	links, proven := r.standardReplayLinks(anchor, targetSeq, targetHash)
-	if !proven {
+	anchorSeq := identity.collectSeq
+	anchorHash := identity.collectHash
+	if identity.active && anchorHash == ([32]byte{}) {
+		anchorSeq = identity.anchorSeq
+		anchorHash = identity.anchorHash
+	}
+	if !identity.active {
+		if anchor == nil {
+			return false
+		}
+		anchorSeq = anchor.Sequence()
+		anchorHash = anchor.Hash()
+	}
+	links, linkState := r.standardReplayLinks(anchorSeq, anchorHash, targetSeq, targetHash)
+	if linkState == standardReplayLinkConflict {
 		r.cancelStandardReplayPipelineIdentity(identity)
+		return false
+	}
+	if linkState != standardReplayLinkReady {
+		if identity.active {
+			r.acquisitionMu.Lock()
+			if r.standardReplayIdentityMatchesLocked(identity) && targetSeq > r.standardReplay.targetSeq {
+				r.standardReplay.targetSeq = targetSeq
+				r.standardReplay.targetHash = targetHash
+			}
+			r.acquisitionMu.Unlock()
+			return true
+		}
 		return false
 	}
 
@@ -205,31 +260,53 @@ func (r *Router) tryArmStandardReplayPipeline(
 		r.acquisitionMu.Unlock()
 		return false
 	}
-	if !initial && (r.standardReplay.anchorSeq != anchor.Sequence() || r.standardReplay.anchorHash != anchor.Hash()) {
-		retired := r.cancelStandardReplayPipelineLocked()
+	if !initial && len(links) == 0 {
 		r.acquisitionMu.Unlock()
-		r.retireLegacyAcquisitions(retired)
+		return true
+	}
+	if !initial && anchor != nil &&
+		(r.standardReplay.anchorSeq != anchor.Sequence() || r.standardReplay.anchorHash != anchor.Hash()) {
+		r.acquisitionMu.Unlock()
+		r.cancelStandardReplayPipelineIdentity(identity)
 		return false
 	}
 	if initial {
 		r.standardReplay.generation++
 		r.standardReplay.active = true
+		r.standardReplay.pivotReady = true
+		r.standardReplay.pivotSeq = anchor.Sequence()
+		r.standardReplay.pivotHash = anchor.Hash()
 		r.standardReplay.anchorSeq = anchor.Sequence()
 		r.standardReplay.anchorHash = anchor.Hash()
-		r.standardReplay.entries = make(map[uint32]*standardReplayEntry, standardReplayPipelineWindow)
+		r.standardReplay.collectSeq = anchor.Sequence()
+		r.standardReplay.collectHash = anchor.Hash()
+		r.standardReplay.entries = make(map[uint32]*standardReplayEntry, standardReplayPreparedLimit)
+		r.standardReplay.progressSampleAt = time.Now()
+		r.standardReplay.sampleAnchorSeq = anchor.Sequence()
+		r.standardReplay.sampleTargetSeq = targetSeq
+		r.standardReplay.stalledSamples = 0
 	}
-	r.standardReplay.targetSeq = targetSeq
-	r.standardReplay.targetHash = targetHash
-
-	desired := make(map[uint32]standardReplayLink, len(links))
-	for _, link := range links {
-		desired[link.seq] = link
+	if targetSeq > r.standardReplay.targetSeq ||
+		(targetSeq == r.standardReplay.targetSeq && targetHash == r.standardReplay.targetHash) {
+		r.standardReplay.targetSeq = targetSeq
+		r.standardReplay.targetHash = targetHash
 	}
-	retired := r.pruneStandardReplayEntriesLocked(desired, targetSeq)
 
 	now := time.Now()
 	for _, link := range links {
+		if len(r.standardReplay.entries) >= standardReplayPreparedLimit ||
+			r.standardReplayResidentCountLocked() >= standardReplayPipelineWindow {
+			break
+		}
 		if existing := r.standardReplay.entries[link.seq]; existing != nil {
+			if existing.hash != link.hash || existing.parentHash != link.parentHash {
+				cancelIdentity := r.standardReplayIdentityLocked()
+				r.acquisitionMu.Unlock()
+				r.cancelStandardReplayPipelineIdentity(cancelIdentity)
+				return false
+			}
+			r.standardReplay.collectSeq = link.seq
+			r.standardReplay.collectHash = link.hash
 			continue
 		}
 		peerID, ok := r.resolveAcquisitionPeer(link.seq, peerHint)
@@ -249,6 +326,8 @@ func (r *Router) tryArmStandardReplayPipeline(
 			requestedAt: now,
 			acquisition: il,
 		}
+		r.standardReplay.collectSeq = link.seq
+		r.standardReplay.collectHash = link.hash
 		if created {
 			r.replayPipelineRequested.Add(1)
 		}
@@ -259,46 +338,41 @@ func (r *Router) tryArmStandardReplayPipeline(
 			r.consensusRecovery.stepHash = head.hash
 		}
 	}
-	armed := len(r.standardReplay.entries) > 0
+	armed := !initial || len(r.standardReplay.entries) > 0
 	if !armed {
-		retired = append(retired, r.cancelStandardReplayPipelineLocked()...)
+		cancelIdentity := r.standardReplayIdentityLocked()
+		r.acquisitionMu.Unlock()
+		r.cancelStandardReplayPipelineIdentity(cancelIdentity)
+		return false
 	}
 	r.acquisitionMu.Unlock()
-	r.retireLegacyAcquisitions(retired)
 	return armed
 }
 
-func (r *Router) pruneStandardReplayEntriesLocked(
-	desired map[uint32]standardReplayLink,
-	targetSeq uint32,
-) []*inbound.Ledger {
-	var retired []*inbound.Ledger
-	for seq, entry := range r.standardReplay.entries {
-		link, keep := desired[seq]
-		keep = keep && seq <= targetSeq && entry.hash == link.hash && entry.parentHash == link.parentHash
-		if keep {
-			continue
-		}
-		if entry.acquisition != nil && r.fetchTracker.DiscardExpected(entry.acquisition) {
-			retired = append(retired, entry.acquisition)
-		}
-		delete(r.standardReplay.entries, seq)
-		r.replayPipelineDiscarded.Add(1)
-		if r.consensusRecovery.stepHash == entry.hash {
-			r.consensusRecovery.stepHash = [32]byte{}
+func (r *Router) standardReplayResidentCountLocked() int {
+	count := 0
+	for _, entry := range r.standardReplay.entries {
+		if entry.acquisition != nil || (!entry.readyAt.IsZero() && !entry.durable) {
+			count++
 		}
 	}
-	return retired
+	return count
 }
 
 func (r *Router) standardReplayIdentityLocked() standardReplayIdentity {
 	return standardReplayIdentity{
-		generation: r.standardReplay.generation,
-		active:     r.standardReplay.active,
-		anchorSeq:  r.standardReplay.anchorSeq,
-		anchorHash: r.standardReplay.anchorHash,
-		targetSeq:  r.standardReplay.targetSeq,
-		targetHash: r.standardReplay.targetHash,
+		generation:       r.standardReplay.generation,
+		active:           r.standardReplay.active,
+		pivotReady:       r.standardReplay.pivotReady,
+		initialCandidate: r.standardReplay.initialCandidate,
+		pivotSeq:         r.standardReplay.pivotSeq,
+		pivotHash:        r.standardReplay.pivotHash,
+		anchorSeq:        r.standardReplay.anchorSeq,
+		anchorHash:       r.standardReplay.anchorHash,
+		collectSeq:       r.standardReplay.collectSeq,
+		collectHash:      r.standardReplay.collectHash,
+		targetSeq:        r.standardReplay.targetSeq,
+		targetHash:       r.standardReplay.targetHash,
 	}
 }
 
@@ -307,15 +381,18 @@ func (r *Router) standardReplayIdentityMatchesLocked(identity standardReplayIden
 }
 
 func (r *Router) cancelStandardReplayPipelineIdentity(identity standardReplayIdentity) (standardReplayIdentity, bool) {
+	r.replayCommitMu.Lock()
 	r.acquisitionMu.Lock()
 	if !r.standardReplayIdentityMatchesLocked(identity) {
 		current := r.standardReplayIdentityLocked()
 		r.acquisitionMu.Unlock()
+		r.replayCommitMu.Unlock()
 		return current, false
 	}
 	retired := r.cancelStandardReplayPipelineLocked()
 	current := r.standardReplayIdentityLocked()
 	r.acquisitionMu.Unlock()
+	r.replayCommitMu.Unlock()
 	r.retireLegacyAcquisitions(retired)
 	return current, true
 }
@@ -325,6 +402,12 @@ func (r *Router) cancelStandardReplayPipelineLocked() []*inbound.Ledger {
 		return nil
 	}
 	var retired []*inbound.Ledger
+	if !r.standardReplay.pivotReady {
+		if pivot := r.fetchTracker.Find(r.standardReplay.pivotHash); pivot != nil &&
+			!pivot.TransactionOnly() && r.fetchTracker.DiscardExpected(pivot) {
+			retired = append(retired, pivot)
+		}
+	}
 	for _, entry := range r.standardReplay.entries {
 		if entry.acquisition != nil && r.fetchTracker.DiscardExpected(entry.acquisition) {
 			retired = append(retired, entry.acquisition)
@@ -336,16 +419,35 @@ func (r *Router) cancelStandardReplayPipelineLocked() []*inbound.Ledger {
 	}
 	r.standardReplay.generation++
 	r.standardReplay.active = false
+	r.standardReplay.pivotReady = false
+	r.standardReplay.initialCandidate = false
+	r.standardReplay.pivotSeq = 0
+	r.standardReplay.pivotHash = [32]byte{}
 	r.standardReplay.anchorSeq = 0
 	r.standardReplay.anchorHash = [32]byte{}
+	r.standardReplay.collectSeq = 0
+	r.standardReplay.collectHash = [32]byte{}
 	r.standardReplay.targetSeq = 0
 	r.standardReplay.targetHash = [32]byte{}
 	r.standardReplay.entries = nil
 	r.standardReplay.headBlockedAt = time.Time{}
+	r.standardReplay.progressSampleAt = time.Time{}
+	r.standardReplay.sampleAnchorSeq = 0
+	r.standardReplay.sampleTargetSeq = 0
+	r.standardReplay.stalledSamples = 0
 	return retired
 }
 
+func (r *Router) waitStandardReplayCommit() {
+	r.replayCommitMu.Lock()
+	r.replayCommitMu.Unlock()
+}
+
 func (r *Router) standardReplayOwnsLocked(hash [32]byte) bool {
+	if r.standardReplay.active &&
+		(hash == r.standardReplay.pivotHash || hash == r.standardReplay.targetHash) {
+		return true
+	}
 	for _, entry := range r.standardReplay.entries {
 		if entry.hash == hash {
 			return true
@@ -371,18 +473,38 @@ func (r *Router) completeStandardReplayPipelineEntryLocked(
 	}
 	entry.header = *h
 	entry.txMap = txMap
+	if r.acquisitionStore != nil && r.acquisitionFamily != nil {
+		entry.durable = true
+		entry.txMap = nil
+	}
 	entry.peerID = peerID
 	entry.readyAt = now
 	entry.acquisition = nil
 	r.replayPipelineReady.Add(1)
 	r.replayPipelineRetried.Add(uint64(il.Timeouts()))
 	r.replayPipelineAcquireUs.Add(durationMicros(now.Sub(entry.requestedAt)))
-	startDrain := !r.standardReplay.applying
+	startDrain := r.standardReplay.pivotReady && !r.standardReplay.applying
 	if startDrain {
 		r.standardReplay.applying = true
 	}
 	r.updateStandardReplayHeadBlockLocked(now)
 	return true, startDrain
+}
+
+func (r *Router) refillStandardReplayCollector(peerHint uint64) bool {
+	r.acquisitionMu.Lock()
+	active := r.standardReplay.active
+	targetSeq := r.standardReplay.targetSeq
+	targetHash := r.standardReplay.targetHash
+	r.acquisitionMu.Unlock()
+	if !active || targetSeq == 0 || targetHash == ([32]byte{}) || r.adaptor == nil {
+		return false
+	}
+	svc := r.adaptor.LedgerService()
+	if svc == nil {
+		return false
+	}
+	return r.tryArmStandardReplayPipeline(svc, nil, targetSeq, targetHash, peerHint)
 }
 
 func (r *Router) failStandardReplayPipelineEntry(il *inbound.Ledger) bool {
@@ -452,6 +574,7 @@ func (r *Router) drainStandardReplayPipeline() {
 		if entry.failed {
 			retired, target, current := r.discardStandardReplayHeadLocked(entry, generation)
 			r.acquisitionMu.Unlock()
+			r.waitStandardReplayCommit()
 			r.retireLegacyAcquisitions(retired)
 			if current {
 				r.replayPipelineFallbacks.Add(1)
@@ -463,7 +586,7 @@ func (r *Router) drainStandardReplayPipeline() {
 		r.acquisitionMu.Unlock()
 
 		applyStarted := time.Now()
-		hdr, initialCandidate, persistDuration, err := r.applyStandardReplayEntry(&copyEntry, entry, generation)
+		hdr, initialCandidate, persistDuration, releaseCommit, err := r.applyStandardReplayEntry(&copyEntry, entry, generation)
 		applyDuration := time.Since(applyStarted) - persistDuration
 		if applyDuration < 0 {
 			applyDuration = 0
@@ -473,6 +596,7 @@ func (r *Router) drainStandardReplayPipeline() {
 			retired, target, current := r.discardStandardReplayHeadLocked(entry, generation)
 			continueDrain := !current && r.standardReplay.active
 			r.acquisitionMu.Unlock()
+			r.waitStandardReplayCommit()
 			r.retireLegacyAcquisitions(retired)
 			if current {
 				r.replayPipelineFallbacks.Add(1)
@@ -495,10 +619,12 @@ func (r *Router) drainStandardReplayPipeline() {
 		if !current {
 			if r.standardReplay.active {
 				r.acquisitionMu.Unlock()
+				releaseCommit()
 				continue
 			}
 			r.standardReplay.applying = false
 			r.acquisitionMu.Unlock()
+			releaseCommit()
 			return
 		}
 		delete(r.standardReplay.entries, entry.seq)
@@ -508,12 +634,12 @@ func (r *Router) drainStandardReplayPipeline() {
 		r.replayPipelineApplyUs.Add(durationMicros(applyDuration))
 		r.replayPipelinePersistUs.Add(durationMicros(persistDuration))
 		r.replayPipelineReadyWaitUs.Add(durationMicros(applyStarted.Sub(entry.readyAt)))
-		if entry.seq == r.standardReplay.targetSeq && entry.hash == r.standardReplay.targetHash {
-			r.standardReplay.active = false
-			r.standardReplay.entries = nil
-			r.standardReplay.headBlockedAt = time.Time{}
+		reachedTarget := entry.seq == r.standardReplay.targetSeq && entry.hash == r.standardReplay.targetHash
+		if reachedTarget {
+			initialCandidate = initialCandidate || r.standardReplay.initialCandidate
 		}
 		r.acquisitionMu.Unlock()
+		releaseCommit()
 
 		r.logger.Info("applied standard transaction replay pipeline entry",
 			"seq", entry.seq,
@@ -524,6 +650,20 @@ func (r *Router) drainStandardReplayPipeline() {
 			"persist_us", durationMicros(persistDuration),
 		)
 		r.completeStoredConsensusRecovery(hdr.LedgerIndex, hdr.Hash, hdr.ParentHash, initialCandidate)
+
+		r.acquisitionMu.Lock()
+		current = r.standardReplay.active && r.standardReplay.generation == generation &&
+			r.standardReplay.anchorSeq == entry.seq && r.standardReplay.anchorHash == entry.hash
+		if current && reachedTarget && r.standardReplay.targetSeq == entry.seq && r.standardReplay.targetHash == entry.hash {
+			r.standardReplay.active = false
+			r.standardReplay.applying = false
+			r.standardReplay.entries = nil
+			r.standardReplay.headBlockedAt = time.Time{}
+		}
+		r.acquisitionMu.Unlock()
+		if !current {
+			return
+		}
 	}
 }
 
@@ -553,84 +693,106 @@ func (r *Router) discardStandardReplayHeadLocked(
 func (r *Router) applyStandardReplayEntry(
 	entry, activeEntry *standardReplayEntry,
 	generation uint64,
-) (header.LedgerHeader, bool, time.Duration, error) {
+) (header.LedgerHeader, bool, time.Duration, func(), error) {
 	if entry == nil {
-		return header.LedgerHeader{}, false, 0, errors.New("nil standard replay pipeline entry")
+		return header.LedgerHeader{}, false, 0, nil, errors.New("nil standard replay pipeline entry")
 	}
 	h := entry.header
 	if h.Hash != entry.hash {
-		return header.LedgerHeader{}, false, 0, errors.New("prepared ledger hash changed")
+		return header.LedgerHeader{}, false, 0, nil, errors.New("prepared ledger hash changed")
 	}
 	if h.LedgerIndex != entry.seq {
-		return header.LedgerHeader{}, false, 0, fmt.Errorf("prepared ledger sequence %d does not match expected %d", h.LedgerIndex, entry.seq)
+		return header.LedgerHeader{}, false, 0, nil, fmt.Errorf("prepared ledger sequence %d does not match expected %d", h.LedgerIndex, entry.seq)
 	}
 	if h.ParentHash != entry.parentHash {
-		return header.LedgerHeader{}, false, 0, errors.New("prepared ledger no longer attaches to the accepted predecessor")
+		return header.LedgerHeader{}, false, 0, nil, errors.New("prepared ledger no longer attaches to the accepted predecessor")
 	}
 
 	svc := r.adaptor.LedgerService()
 	if svc == nil {
-		return header.LedgerHeader{}, false, 0, errors.New("no ledger service")
+		return header.LedgerHeader{}, false, 0, nil, errors.New("no ledger service")
 	}
 	parent, err := svc.GetLedgerByHash(entry.parentHash)
 	if err != nil || parent == nil {
 		if err == nil {
 			err = errors.New("accepted replay predecessor is unavailable")
 		}
-		return header.LedgerHeader{}, false, 0, err
+		return header.LedgerHeader{}, false, 0, nil, err
 	}
 	if parent.Sequence()+1 != entry.seq {
-		return header.LedgerHeader{}, false, 0, fmt.Errorf("replay predecessor sequence %d is not before %d", parent.Sequence(), entry.seq)
+		return header.LedgerHeader{}, false, 0, nil, fmt.Errorf("replay predecessor sequence %d is not before %d", parent.Sequence(), entry.seq)
 	}
 
 	stateMap, err := parent.StateMapSnapshot()
 	if err != nil {
-		return header.LedgerHeader{}, false, 0, fmt.Errorf("snapshot replay predecessor state: %w", err)
+		return header.LedgerHeader{}, false, 0, nil, fmt.Errorf("snapshot replay predecessor state: %w", err)
 	}
-	txMap := entry.txMap
-	if txMap == nil {
-		if h.TxHash != ([32]byte{}) {
-			return header.LedgerHeader{}, false, 0, errors.New("missing transaction map for non-empty transaction root")
-		}
-		txMap = shamap.New(shamap.TypeTransaction)
-	} else {
-		txHash, hashErr := txMap.Hash()
-		if hashErr != nil {
-			return header.LedgerHeader{}, false, 0, fmt.Errorf("hash prepared transaction map: %w", hashErr)
-		}
-		if txHash != h.TxHash {
-			return header.LedgerHeader{}, false, 0, errors.New("prepared transaction map root changed")
-		}
+	txMap, err := r.loadStandardReplayTransactionMap(r.lifecycleContext(), entry)
+	if err != nil {
+		return header.LedgerHeader{}, false, 0, nil, err
 	}
 
 	target, err := ledger.NewFromHeader(h, stateMap, txMap, parent.Fees())
 	if err != nil {
-		return header.LedgerHeader{}, false, 0, fmt.Errorf("construct transaction-only replay target: %w", err)
+		return header.LedgerHeader{}, false, 0, nil, fmt.Errorf("construct transaction-only replay target: %w", err)
 	}
 	replay, err := inbound.NewStoredLedgerReplay(parent, target, r.logger)
 	if err != nil {
-		return header.LedgerHeader{}, false, 0, fmt.Errorf("prepare transaction-only replay: %w", err)
+		return header.LedgerHeader{}, false, 0, nil, fmt.Errorf("prepare transaction-only replay: %w", err)
 	}
 	derived, err := replay.Apply(r.adaptor.EngineConfigForReplay(parent))
 	if err != nil {
-		return header.LedgerHeader{}, false, 0, err
+		return header.LedgerHeader{}, false, 0, nil, err
 	}
 
+	r.replayCommitMu.Lock()
 	r.acquisitionMu.Lock()
 	current := r.standardReplay.active && r.standardReplay.generation == generation &&
 		r.standardReplay.entries[activeEntry.seq] == activeEntry && r.standardReplay.anchorSeq+1 == activeEntry.seq
 	if !current {
 		r.acquisitionMu.Unlock()
-		return header.LedgerHeader{}, false, 0, errors.New("standard replay pipeline entry was superseded")
+		r.replayCommitMu.Unlock()
+		return header.LedgerHeader{}, false, 0, nil, errors.New("standard replay pipeline entry was superseded")
 	}
+	r.acquisitionMu.Unlock()
 	persistStarted := time.Now()
 	storedHeader, initialCandidate, err := r.storeVerifiedLedger(derived)
 	persistDuration := time.Since(persistStarted)
-	r.acquisitionMu.Unlock()
 	if err != nil {
-		return header.LedgerHeader{}, false, persistDuration, err
+		r.replayCommitMu.Unlock()
+		return header.LedgerHeader{}, false, persistDuration, nil, err
 	}
-	return storedHeader, initialCandidate, persistDuration, nil
+	return storedHeader, initialCandidate, persistDuration, r.replayCommitMu.Unlock, nil
+}
+
+func (r *Router) loadStandardReplayTransactionMap(ctx context.Context, entry *standardReplayEntry) (*shamap.SHAMap, error) {
+	if entry == nil {
+		return nil, errors.New("nil standard replay pipeline entry")
+	}
+	txMap := entry.txMap
+	if txMap == nil {
+		if entry.header.TxHash == ([32]byte{}) {
+			return shamap.New(shamap.TypeTransaction), nil
+		}
+		if !entry.durable || r.acquisitionFamily == nil {
+			return nil, errors.New("missing transaction map for non-empty transaction root")
+		}
+		var err error
+		txMap, err = shamap.NewFromRootHashContext(
+			ctx, shamap.TypeTransaction, entry.header.TxHash, r.acquisitionFamily,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("reload prepared transaction map: %w", err)
+		}
+	}
+	txHash, err := txMap.Hash()
+	if err != nil {
+		return nil, fmt.Errorf("hash prepared transaction map: %w", err)
+	}
+	if txHash != entry.header.TxHash {
+		return nil, errors.New("prepared transaction map root changed")
+	}
+	return txMap, nil
 }
 
 func durationMicros(d time.Duration) uint64 {

--- a/internal/consensus/adaptor/router_replay_pipeline.go
+++ b/internal/consensus/adaptor/router_replay_pipeline.go
@@ -38,7 +38,6 @@ type standardReplayPipeline struct {
 	headBlockedAt    time.Time
 	progressSampleAt time.Time
 	sampleAnchorSeq  uint32
-	sampleTargetSeq  uint32
 	stalledSamples   uint8
 }
 
@@ -283,7 +282,6 @@ func (r *Router) tryArmStandardReplayPipeline(
 		r.standardReplay.entries = make(map[uint32]*standardReplayEntry, standardReplayPreparedLimit)
 		r.standardReplay.progressSampleAt = time.Now()
 		r.standardReplay.sampleAnchorSeq = anchor.Sequence()
-		r.standardReplay.sampleTargetSeq = targetSeq
 		r.standardReplay.stalledSamples = 0
 	}
 	if targetSeq > r.standardReplay.targetSeq ||
@@ -433,7 +431,6 @@ func (r *Router) cancelStandardReplayPipelineLocked() []*inbound.Ledger {
 	r.standardReplay.headBlockedAt = time.Time{}
 	r.standardReplay.progressSampleAt = time.Time{}
 	r.standardReplay.sampleAnchorSeq = 0
-	r.standardReplay.sampleTargetSeq = 0
 	r.standardReplay.stalledSamples = 0
 	return retired
 }

--- a/internal/consensus/adaptor/router_replay_pipeline_test.go
+++ b/internal/consensus/adaptor/router_replay_pipeline_test.go
@@ -3,6 +3,7 @@ package adaptor
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -449,4 +451,101 @@ func TestStandardReplayPipelineStaleCancellationKeepsReplacement(t *testing.T) {
 	assert.False(t, current)
 	assert.True(t, r.standardReplay.active)
 	assert.Same(t, replacement, r.standardReplay.entries[replacement.seq])
+}
+
+func TestStandardReplayCancellationWaitsBeforeInvalidatingGeneration(t *testing.T) {
+	r := newTestRouter(nil, nil, make(chan *peermanagement.InboundMessage))
+	r.standardReplay = standardReplayPipeline{
+		generation: 7,
+		active:     true,
+		entries:    make(map[uint32]*standardReplayEntry),
+	}
+
+	r.replayCommitMu.Lock()
+	done := make(chan struct{})
+	go func() {
+		r.StopAcquisitions()
+		close(done)
+	}()
+	select {
+	case <-done:
+		t.Fatal("cancellation passed an active replay commit")
+	case <-time.After(25 * time.Millisecond):
+	}
+	require.True(t, r.standardReplay.active)
+	require.Equal(t, uint64(7), r.standardReplay.generation)
+
+	r.replayCommitMu.Unlock()
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+	require.False(t, r.standardReplay.active)
+	require.Equal(t, uint64(8), r.standardReplay.generation)
+}
+
+func TestStandardReplayHandoffKeepsSessionWhenTargetAdvances(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	_, err := svc.AcceptLedger(context.Background())
+	require.NoError(t, err)
+	links := buildStandardReplayTestChain(t, r, svc.GetClosedLedger(), 3)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	r.engine = &mockEngine{
+		switchResult: consensus.LedgerSwitchAccepted,
+		switchHook: func(consensus.LedgerID) {
+			once.Do(func() {
+				close(entered)
+				<-release
+			})
+		},
+	}
+	armStandardReplayTestPipeline(t, r, a, sender, links[:2])
+	generation := r.standardReplay.generation
+	pivotHash := r.standardReplay.pivotHash
+	completeStandardReplayTestLink(t, r, links[0])
+
+	final := r.fetchTracker.Find(links[1].hash)
+	require.NotNil(t, final)
+	require.NoError(t, final.GotBase([]message.LedgerNode{
+		{NodeData: links[1].response.LedgerHeader},
+		{NodeData: []byte{1}},
+	}))
+	require.True(t, final.IsComplete())
+	done := make(chan struct{})
+	go func() {
+		r.completeInboundLedger(final)
+		close(done)
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("final replay did not reach the handoff barrier")
+	}
+	trackCatchupPeer(r, 7, links[2].seq, links[2].hash)
+	require.NoError(t, a.RequestLedger(consensus.LedgerID(links[2].hash)))
+	assert.True(t, r.standardReplay.active)
+	assert.Equal(t, generation, r.standardReplay.generation)
+	assert.Equal(t, pivotHash, r.standardReplay.pivotHash)
+	assert.Equal(t, links[2].seq, r.standardReplay.targetSeq)
+	next := r.fetchTracker.Find(links[2].hash)
+	require.NotNil(t, next)
+	assert.True(t, next.TransactionOnly())
+	for _, acquisition := range r.fetchTracker.Active() {
+		assert.True(t, acquisition.TransactionOnly())
+	}
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("final replay did not leave the handoff barrier")
+	}
 }


### PR DESCRIPTION
## Summary

- freeze one trusted full-state pivot and collect transaction-only successors while its SHAMap state is downloading
- keep the same recovery generation as the validated head advances, then replay prepared successors in strict parent order
- rebootstrap to one new full-state pivot only after explicit conflicts, verification/fetch failures, or two one-minute non-converging progress windows

## Design

The active network window remains bounded to eight transaction-only acquisitions. Completed transaction SHAMaps are promoted to the durable acquisition store and lazily reloaded by root, while a bounded 2,048-entry in-process catalog retains ordering metadata.

Pivot and replay handoffs remain generation-owned through the consensus finality check, preventing a moving target from opening a second full-state acquisition in the handoff window. Unknown ancestry waits for linkage; explicit parent/hash conflicts cancel and rebootstrap the generation.

This is an intentional goXRPL liveness policy. Rippled 3.3.0 acquires the exact preferred consensus ledger as a full immutable ledger; this change preserves its verification and final switch boundaries while combining that state acquisition with concurrent forward-data collection.

## Verification

- `go test ./internal/consensus/... ./internal/ledger/inbound/... ./internal/ledger/service/... -count=1`
- `go test -race ./internal/consensus/adaptor/... ./internal/consensus/rcl/... ./internal/ledger/inbound/... -count=1`
- focused frozen-pivot and handoff race tests, 20 repetitions
- `just test-core`
- `just vet`
- `just build-all`
- `just lint`
- `git diff --check`

Fixes #1668
