### PR TITLE
fix: preserve nested signature field presence

### DIFF
--- a/internal/tx/lending/loan_set_ingress_test.go
+++ b/internal/tx/lending/loan_set_ingress_test.go
@@ -1,10 +1,12 @@
 package lending_test
 
 import (
+	"bytes"
 	"encoding/hex"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/crypto/sha512half"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/lending"
 )
@@ -63,4 +65,66 @@ func TestLoanSetCounterpartySignatureIngress(t *testing.T) {
 		t.Fatalf("parse binary: %v", err)
 	}
 	assertCounterparty("binary", parsedBinary)
+}
+
+func TestLoanSetCounterpartyMultisignatureWithoutSigningPubKeyRoundTrip(t *testing.T) {
+	registerLending()
+	fields := map[string]any{
+		"Account":            "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+		"TransactionType":    "LoanSet",
+		"Fee":                "30",
+		"Sequence":           uint32(1),
+		"SigningPubKey":      "ED0000000000000000000000000000000000000000000000000000000000000001",
+		"LoanBrokerID":       "1111111111111111111111111111111111111111111111111111111111111111",
+		"PrincipalRequested": "1",
+		"CounterpartySignature": map[string]any{
+			"Signers": []map[string]any{
+				{
+					"Signer": map[string]any{
+						"Account":       "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+						"SigningPubKey": "ED0000000000000000000000000000000000000000000000000000000000000002",
+						"TxnSignature":  "AA",
+					},
+				},
+				{
+					"Signer": map[string]any{
+						"Account":       "rLs1MzkFWCxTbuAHgjeTZK4fcCDDnf2KRv",
+						"SigningPubKey": "ED0000000000000000000000000000000000000000000000000000000000000003",
+						"TxnSignature":  "BB",
+					},
+				},
+			},
+		},
+	}
+
+	raw, err := binarycodec.EncodeBytes(fields)
+	if err != nil {
+		t.Fatalf("encode transaction: %v", err)
+	}
+	parsed, err := tx.ParseFromBinary(raw)
+	if err != nil {
+		t.Fatalf("parse transaction: %v", err)
+	}
+	if !bytes.Equal(parsed.GetRawBytes(), raw) {
+		t.Fatal("ParseFromBinary did not preserve canonical bytes")
+	}
+	flat, err := parsed.Flatten()
+	if err != nil {
+		t.Fatalf("flatten transaction: %v", err)
+	}
+	counterparty, ok := flat["CounterpartySignature"].(map[string]any)
+	if !ok {
+		t.Fatalf("flattened CounterpartySignature = %#v", flat["CounterpartySignature"])
+	}
+	if _, present := counterparty["SigningPubKey"]; present {
+		t.Fatal("flattened CounterpartySignature injected SigningPubKey")
+	}
+	wantID := sha512half.Sum(append([]byte{0x54, 0x58, 0x4E, 0x00}, raw...))
+	gotID, err := tx.ComputeTransactionHash(parsed)
+	if err != nil {
+		t.Fatalf("compute transaction hash: %v", err)
+	}
+	if gotID != wantID {
+		t.Fatalf("transaction hash = %X, want %X", gotID, wantID)
+	}
 }

--- a/internal/tx/sponsor_protocol_test.go
+++ b/internal/tx/sponsor_protocol_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/crypto/sha512half"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
@@ -143,6 +144,95 @@ func TestSponsorTransactionCodecRoundTrip(t *testing.T) {
 			}
 			if !bytes.Equal(parsed.GetRawBytes(), raw) {
 				t.Fatal("ParseFromBinary did not preserve canonical bytes")
+			}
+		})
+	}
+}
+
+func TestSponsorMultisignatureWithoutSigningPubKeyRoundTrip(t *testing.T) {
+	fields := baseCommon("Payment")
+	fields["Destination"] = testDestination
+	fields["Amount"] = "1"
+	fields["Sponsor"] = testDestination
+	fields["SponsorFlags"] = SpfSponsorFee
+	fields["SponsorSignature"] = map[string]any{
+		"Signers": []map[string]any{
+			{
+				"Signer": map[string]any{
+					"Account":       testAccount,
+					"SigningPubKey": "ED0000000000000000000000000000000000000000000000000000000000000002",
+					"TxnSignature":  "AA",
+				},
+			},
+			{
+				"Signer": map[string]any{
+					"Account":       testDestination,
+					"SigningPubKey": "ED0000000000000000000000000000000000000000000000000000000000000003",
+					"TxnSignature":  "BB",
+				},
+			},
+		},
+	}
+
+	raw, err := binarycodec.EncodeBytes(fields)
+	if err != nil {
+		t.Fatalf("encode transaction: %v", err)
+	}
+	parsed, err := ParseFromBinary(raw)
+	if err != nil {
+		t.Fatalf("parse transaction: %v", err)
+	}
+	if !bytes.Equal(parsed.GetRawBytes(), raw) {
+		t.Fatal("ParseFromBinary did not preserve canonical bytes")
+	}
+	flat, err := parsed.Flatten()
+	if err != nil {
+		t.Fatalf("flatten transaction: %v", err)
+	}
+	sponsor, ok := flat["SponsorSignature"].(map[string]any)
+	if !ok {
+		t.Fatalf("flattened SponsorSignature = %#v", flat["SponsorSignature"])
+	}
+	if _, present := sponsor["SigningPubKey"]; present {
+		t.Fatal("flattened SponsorSignature injected SigningPubKey")
+	}
+	wantID := sha512half.Sum(append([]byte{0x54, 0x58, 0x4E, 0x00}, raw...))
+	gotID, err := ComputeTransactionHash(parsed)
+	if err != nil {
+		t.Fatalf("compute transaction hash: %v", err)
+	}
+	if gotID != wantID {
+		t.Fatalf("transaction hash = %X, want %X", gotID, wantID)
+	}
+}
+
+func TestNestedSignatureSigningPubKeyPresence(t *testing.T) {
+	type presenceAwareSignature interface {
+		ToMap() map[string]any
+		MarkFieldPresent(string)
+	}
+	tests := []struct {
+		name string
+		new  func() presenceAwareSignature
+	}{
+		{
+			name: "counterparty",
+			new:  func() presenceAwareSignature { return &CounterpartySignature{} },
+		},
+		{
+			name: "sponsor",
+			new:  func() presenceAwareSignature { return &SponsorSignature{} },
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			signature := test.new()
+			if _, present := signature.ToMap()["SigningPubKey"]; present {
+				t.Fatal("empty unmarked SigningPubKey was emitted")
+			}
+			signature.MarkFieldPresent("SigningPubKey")
+			if value, present := signature.ToMap()["SigningPubKey"]; !present || value != "" {
+				t.Fatalf("explicit empty SigningPubKey = (%#v, %v)", value, present)
 			}
 		})
 	}

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -286,7 +286,7 @@ type SignerWrapper struct {
 // CounterpartySignature is the nested signature object (sfCounterpartySignature).
 // It lets a second party attach a signature to a transaction without being the
 // signing Account. It carries a single signature (SigningPubKey + TxnSignature)
-// or a multi-signature (Signers without SigningPubKey). The field is excluded
+// or a multi-signature (Signers). The field is excluded
 // from the transaction's signing data (notSigning), so neither the top-level
 // signer nor the counterparty covers it.
 type CounterpartySignature struct {
@@ -360,7 +360,6 @@ func (ss *SponsorSignature) MarkFieldPresent(name string) {
 	ss.presentFields[name] = true
 }
 
-// ToMap serializes the counterparty object for the binary codec.
 func (cs *CounterpartySignature) ToMap() map[string]any {
 	m := make(map[string]any)
 	if cs.SigningPubKey != "" || cs.HasField("SigningPubKey") {

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -286,7 +286,7 @@ type SignerWrapper struct {
 // CounterpartySignature is the nested signature object (sfCounterpartySignature).
 // It lets a second party attach a signature to a transaction without being the
 // signing Account. It carries a single signature (SigningPubKey + TxnSignature)
-// or a multi-signature (empty SigningPubKey + Signers). The field is excluded
+// or a multi-signature (Signers without SigningPubKey). The field is excluded
 // from the transaction's signing data (notSigning), so neither the top-level
 // signer nor the counterparty covers it.
 type CounterpartySignature struct {
@@ -360,12 +360,12 @@ func (ss *SponsorSignature) MarkFieldPresent(name string) {
 	ss.presentFields[name] = true
 }
 
-// ToMap serializes the counterparty object for the binary codec. SigningPubKey
-// is always emitted — a single-signed object carries the signer's key and a
-// multi-signed object carries an empty key — so a decode/encode round-trip
-// reproduces the original wire bytes.
+// ToMap serializes the counterparty object for the binary codec.
 func (cs *CounterpartySignature) ToMap() map[string]any {
-	m := map[string]any{"SigningPubKey": cs.SigningPubKey}
+	m := make(map[string]any)
+	if cs.SigningPubKey != "" || cs.HasField("SigningPubKey") {
+		m["SigningPubKey"] = cs.SigningPubKey
+	}
 	if cs.TxnSignature != "" || cs.HasField("TxnSignature") {
 		m["TxnSignature"] = cs.TxnSignature
 	}
@@ -386,7 +386,10 @@ func (cs *CounterpartySignature) ToMap() map[string]any {
 }
 
 func (ss *SponsorSignature) ToMap() map[string]any {
-	m := map[string]any{"SigningPubKey": ss.SigningPubKey}
+	m := make(map[string]any)
+	if ss.SigningPubKey != "" || ss.HasField("SigningPubKey") {
+		m["SigningPubKey"] = ss.SigningPubKey
+	}
 	if ss.TxnSignature != "" || ss.HasField("TxnSignature") {
 		m["TxnSignature"] = ss.TxnSignature
 	}


### PR DESCRIPTION
## Summary
- preserve nested `SigningPubKey` presence when flattening counterparty and sponsor signatures
- allow multisigned nested signature objects without `SigningPubKey` to retain their canonical bytes and transaction IDs
- add binary parse and round-trip regressions for both signature types

## Test plan
- [x] `just test-pkg ./internal/tx/...`
- [x] `just vet`
- [x] `just build`
- [x] `just lint`

Fixes #1672
