### PR TITLE
fix(consensus): harden frozen pivot recovery runtime

### DIFF
--- a/internal/consensus/adaptor/acquisition_work.go
+++ b/internal/consensus/adaptor/acquisition_work.go
@@ -752,6 +752,7 @@ func (r *Router) handleAcquisitionWorkResult(result acquisitionWorkResult) {
 		}
 		return
 	}
+	r.promoteResolvedFrozenPivot(ledger, ledger.PeerID())
 	if result.complete {
 		r.completeInboundLedgerReady(ledger)
 		return

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -137,6 +137,11 @@ type Router struct {
 	peerDisconnectWake     chan struct{}
 	pendingPeerConnects    sync.Map
 	peerConnectWake        chan struct{}
+	// standardReplayDrainWake resumes a replay apply batch on the router loop
+	// after the preceding batch yielded. Keeping the wake edge-triggered and
+	// buffered prevents a ready replay window from monopolising the same loop
+	// that must drain consensus, control, and acquisition traffic.
+	standardReplayDrainWake chan struct{}
 
 	// replayer coordinates concurrent mtREPLAY_DELTA_REQUEST acquisitions
 	// keyed by target ledger hash, under a configurable concurrency cap, so a
@@ -462,28 +467,29 @@ func newRouter(engine consensus.RouterEngine, adaptor *Adaptor, inbox <-chan *pe
 		network.serve = noop
 	}
 	r := &Router{
-		engine:                 engine,
-		adaptor:                adaptor,
-		gossip:                 network.gossip,
-		txSetNet:               network.txSet,
-		acquisition:            network.acquisition,
-		serve:                  network.serve,
-		inbox:                  inbox,
-		logger:                 logger,
-		peerStates:             make(map[peermanagement.PeerID]*peerLedgerState),
-		peerStatusCandidates:   make(map[peermanagement.PeerID]peerStatusCandidate),
-		peerDisconnectWake:     make(chan struct{}, 1),
-		peerConnectWake:        make(chan struct{}, 1),
-		replayer:               inbound.NewReplayer(logger, inbound.SystemClock, inbound.DefaultMaxInFlightReplays),
-		fetchTracker:           inbound.NewTracker(),
-		fetchPacks:             newFetchPackCache(),
-		messageSeen:            newMessageSuppression(messageDedupTTL, messageDedupMaxEntries),
-		manifestUntrustedLimit: manifest.DefaultMaxUntrustedCount,
-		txSeen:                 newTransactionSuppression(5*time.Minute, 1<<17),
-		txSetAcquire:           make(map[consensus.TxSetID]*txSetAcquireState),
-		txSetRetryKnobs:        defaultTxSetRetryKnobs(),
-		seqHash:                make(map[uint32]ledgerHashEntry),
-		lifecycleCtx:           context.Background(),
+		engine:                  engine,
+		adaptor:                 adaptor,
+		gossip:                  network.gossip,
+		txSetNet:                network.txSet,
+		acquisition:             network.acquisition,
+		serve:                   network.serve,
+		inbox:                   inbox,
+		logger:                  logger,
+		peerStates:              make(map[peermanagement.PeerID]*peerLedgerState),
+		peerStatusCandidates:    make(map[peermanagement.PeerID]peerStatusCandidate),
+		peerDisconnectWake:      make(chan struct{}, 1),
+		peerConnectWake:         make(chan struct{}, 1),
+		standardReplayDrainWake: make(chan struct{}, 1),
+		replayer:                inbound.NewReplayer(logger, inbound.SystemClock, inbound.DefaultMaxInFlightReplays),
+		fetchTracker:            inbound.NewTracker(),
+		fetchPacks:              newFetchPackCache(),
+		messageSeen:             newMessageSuppression(messageDedupTTL, messageDedupMaxEntries),
+		manifestUntrustedLimit:  manifest.DefaultMaxUntrustedCount,
+		txSeen:                  newTransactionSuppression(5*time.Minute, 1<<17),
+		txSetAcquire:            make(map[consensus.TxSetID]*txSetAcquireState),
+		txSetRetryKnobs:         defaultTxSetRetryKnobs(),
+		seqHash:                 make(map[uint32]ledgerHashEntry),
+		lifecycleCtx:            context.Background(),
 	}
 	if adaptor != nil {
 		if _, ok := engine.(consensus.VerifiedValidationProcessor); ok {
@@ -907,6 +913,8 @@ func (r *Router) Run(ctx context.Context) {
 				return
 			}
 			r.handleValidationWorkResult(result)
+		case <-r.standardReplayDrainWake:
+			r.drainStandardReplayPipeline()
 		case <-r.peerConnectWake:
 			r.drainPeerConnects()
 		case <-ticker.C:
@@ -916,10 +924,13 @@ func (r *Router) Run(ctx context.Context) {
 	}
 }
 
-const consensusDrainBatch = 32
+const (
+	consensusDrainBatch         = 32
+	trustedValidationDrainBatch = 32
+)
 
 func (r *Router) drainTrustedValidationResults(ctx context.Context) bool {
-	for {
+	for range trustedValidationDrainBatch {
 		select {
 		case <-ctx.Done():
 			return false
@@ -929,6 +940,7 @@ func (r *Router) drainTrustedValidationResults(ctx context.Context) bool {
 			return true
 		}
 	}
+	return true
 }
 
 func (r *Router) drainConsensusInbox(ctx context.Context) bool {

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -2925,6 +2925,7 @@ func (r *Router) handleInboundLedgerDataOwned(
 			}
 			return true, false
 		}
+		r.promoteResolvedFrozenPivot(il, peerID)
 
 		if il.IsComplete() {
 			r.completeInboundLedger(il)

--- a/internal/consensus/adaptor/router_catchup_incident_test.go
+++ b/internal/consensus/adaptor/router_catchup_incident_test.go
@@ -239,6 +239,12 @@ func TestRouter_Issue1668FrozenPivotCollectsAndReplaysMovingHead(t *testing.T) {
 		require.NoError(t, lookupErr)
 		require.NotNil(t, stored)
 	}
+	select {
+	case <-r.standardReplayDrainWake:
+		r.drainStandardReplayPipeline()
+	default:
+		require.FailNow(t, "replay apply batch did not reschedule through the router loop")
+	}
 
 	completeStandardReplayTestLink(t, r, links[8])
 	completeStandardReplayTestLink(t, r, links[9])

--- a/internal/consensus/adaptor/router_recovery_session.go
+++ b/internal/consensus/adaptor/router_recovery_session.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
 )
 
 func (r *Router) beginFrozenPivotRecovery(seq uint32, hash [32]byte, peerID uint64) bool {
@@ -61,6 +62,42 @@ func (r *Router) beginFrozenPivotRecovery(seq uint32, hash [32]byte, peerID uint
 	r.acquisitionMu.Unlock()
 	r.replayCommitMu.Unlock()
 	return false
+}
+
+// promoteResolvedFrozenPivot turns an already-running hash-only consensus
+// acquisition into the fast-load frozen pivot as soon as its verified header
+// supplies the sequence. Startup can receive a consensus view before peer
+// status/validation bookkeeping has indexed hash -> sequence; without this
+// promotion the full-state fetch remains outside standardReplay and no P+1
+// transaction-only collector is armed.
+func (r *Router) promoteResolvedFrozenPivot(il *inbound.Ledger, peerID uint64) bool {
+	if il == nil || !il.SequenceInitiallyUnknown() || il.Reason() != inbound.ReasonConsensus ||
+		il.TransactionOnly() || il.Seq() == 0 {
+		return false
+	}
+	svc := r.adaptor.LedgerService()
+	if svc == nil || !svc.IsFastLoadProvisional() || il.Seq() <= svc.GetClosedLedgerIndex() ||
+		r.fetchTracker.Find(il.Hash()) != il {
+		return false
+	}
+
+	r.acquisitionMu.Lock()
+	active := r.standardReplay.active
+	eligible := r.consensusRecovery.targetHash == il.Hash() || r.consensusRecovery.stepHash == il.Hash()
+	r.acquisitionMu.Unlock()
+	if active {
+		return r.continueFrozenPivotRecovery(il.Seq(), il.Hash(), peerID)
+	}
+	if !eligible || !r.beginFrozenPivotRecovery(il.Seq(), il.Hash(), peerID) {
+		return false
+	}
+	hash := il.Hash()
+	r.logger.Info("promoted resolved hash-only acquisition to frozen recovery pivot",
+		"seq", il.Seq(),
+		"hash", fmt.Sprintf("%x", hash[:8]),
+		"peer", peerID,
+	)
+	return true
 }
 
 func (r *Router) continueFrozenPivotRecovery(seq uint32, hash [32]byte, peerID uint64) bool {

--- a/internal/consensus/adaptor/router_recovery_session_test.go
+++ b/internal/consensus/adaptor/router_recovery_session_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,6 +46,82 @@ func TestFrozenPivotRecoveryRejectsUnknownSequenceTarget(t *testing.T) {
 	assert.Equal(t, generation, r.standardReplay.generation)
 	assert.Equal(t, pivotSeq, r.standardReplay.targetSeq)
 	assert.Equal(t, pivotHash, r.standardReplay.targetHash)
+}
+
+func TestFrozenPivotRecoverySurvivesUnknownSequenceConsensusRequest(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	pivotSeq := svc.GetClosedLedgerIndex() + maxForwardDeltaGap + 1
+	pivotHash := [32]byte{0xa5}
+	trackCatchupPeer(r, 7, pivotSeq, pivotHash)
+	require.True(t, r.beginFrozenPivotRecovery(pivotSeq, pivotHash, 7))
+	pivotAcquisition := r.fetchTracker.Find(pivotHash)
+	require.NotNil(t, pivotAcquisition)
+	generation := r.standardReplay.generation
+
+	// Reproduce startup ordering from issue #1668: peer status starts the
+	// frozen pivot, then consensus asks for the same hash before lookupSeqForHash
+	// can resolve its sequence. The exact request must join the frozen session,
+	// not cancel it and replace it with an ordinary seq=0 acquisition.
+	require.NoError(t, a.RequestLedger(consensus.LedgerID(pivotHash)))
+
+	assert.True(t, r.standardReplay.active)
+	assert.Equal(t, generation, r.standardReplay.generation)
+	assert.Equal(t, pivotSeq, r.standardReplay.pivotSeq)
+	assert.Equal(t, pivotHash, r.standardReplay.pivotHash)
+	assert.Same(t, pivotAcquisition, r.fetchTracker.Find(pivotHash))
+	assert.Len(t, sender.legacyCalls(), 1)
+}
+
+func TestHashOnlyConsensusAcquisitionPromotesAfterHeaderResolution(t *testing.T) {
+	r, _, svc := makeProvisionalWarmRouter(t)
+	closed := svc.GetClosedLedgerIndex()
+	rootHash, rootData, _ := buildSelfHealSourceState(t)
+	pivotHeader := header.LedgerHeader{
+		LedgerIndex: closed + maxForwardDeltaGap + 1,
+		ParentHash:  [32]byte{0x91},
+		AccountHash: rootHash,
+		CloseTime:   time.Unix(1_700_000_200, 0),
+	}
+	pivotHeader.Hash = header.CalculateHash(pivotHeader)
+
+	// Consensus arrives before any hash -> sequence bookkeeping, reproducing
+	// the live startup order. This creates one ordinary hash-only acquisition.
+	require.NoError(t, r.requestConsensusLedger(consensus.LedgerID(pivotHeader.Hash)))
+	pivotAcquisition := r.fetchTracker.Find(pivotHeader.Hash)
+	require.NotNil(t, pivotAcquisition)
+	require.True(t, pivotAcquisition.SequenceInitiallyUnknown())
+	require.Zero(t, pivotAcquisition.Seq())
+	require.False(t, r.standardReplay.active)
+	require.Len(t, r.fetchTracker.Active(), 1)
+
+	// The verified base header resolves the sequence. The router must promote
+	// the same in-flight object to the frozen session without issuing a second
+	// full-state request.
+	require.True(t, r.handleInboundLedgerData(pivotAcquisition, &message.LedgerData{
+		LedgerHash: pivotHeader.Hash[:],
+		InfoType:   message.LedgerInfoBase,
+		Nodes: []message.LedgerNode{
+			{NodeData: header.AddRaw(pivotHeader, false)},
+			{NodeData: rootData},
+		},
+	}, 7))
+	require.Equal(t, pivotHeader.LedgerIndex, pivotAcquisition.Seq())
+	require.True(t, r.standardReplay.active)
+	require.Equal(t, pivotHeader.LedgerIndex, r.standardReplay.pivotSeq)
+	require.Equal(t, pivotHeader.Hash, r.standardReplay.pivotHash)
+	require.Same(t, pivotAcquisition, r.fetchTracker.Find(pivotHeader.Hash))
+	require.Len(t, r.fetchTracker.Active(), 1)
+
+	// A newly observed successor is now collected as transaction-only replay
+	// data while the pivot's state walk remains in flight.
+	nextSeq := pivotHeader.LedgerIndex + 1
+	nextHash := [32]byte{0xa2}
+	r.recordSeqHash(nextSeq, nextHash, pivotHeader.Hash, true)
+	trackCatchupPeer(r, 7, nextSeq, nextHash)
+	require.True(t, r.continueFrozenPivotRecovery(nextSeq, nextHash, 7))
+	nextAcquisition := r.fetchTracker.Find(nextHash)
+	require.NotNil(t, nextAcquisition)
+	assert.True(t, nextAcquisition.TransactionOnly())
 }
 
 func TestFrozenPivotRecoveryKeepsExactConsensusTarget(t *testing.T) {

--- a/internal/consensus/adaptor/router_replay_pipeline.go
+++ b/internal/consensus/adaptor/router_replay_pipeline.go
@@ -18,6 +18,8 @@ const (
 	standardReplayPreparedLimit  = 2048
 	standardReplayProgressWindow = time.Minute
 	standardReplayStallWindows   = 2
+	standardReplayApplyBatch     = 8
+	standardReplayApplyBudget    = 25 * time.Millisecond
 )
 
 type standardReplayPipeline struct {
@@ -187,6 +189,15 @@ func (r *Router) standardReplayBase(
 }
 
 func (r *Router) reconcileStandardReplayTarget(targetSeq uint32, targetHash [32]byte) {
+	// The consensus engine may request an exact ledger hash before peer status
+	// or validation bookkeeping has associated that hash with a sequence. An
+	// unknown sequence is not evidence that the requested ledger precedes (or
+	// conflicts with) the frozen replay anchor. Treating seq=0 as an older
+	// target cancels the frozen pivot acquisition and drops startup back onto
+	// the moving-head full-state treadmill.
+	if targetSeq == 0 {
+		return
+	}
 	r.acquisitionMu.Lock()
 	identity := r.standardReplayIdentityLocked()
 	r.acquisitionMu.Unlock()
@@ -552,7 +563,16 @@ func (r *Router) updateStandardReplayHeadBlockLocked(now time.Time) {
 	r.standardReplay.headBlockedAt = time.Time{}
 }
 
+func (r *Router) scheduleStandardReplayDrain() {
+	select {
+	case r.standardReplayDrainWake <- struct{}{}:
+	default:
+	}
+}
+
 func (r *Router) drainStandardReplayPipeline() {
+	batchStarted := time.Now()
+	applied := 0
 	for {
 		r.acquisitionMu.Lock()
 		if !r.standardReplay.active {
@@ -657,8 +677,17 @@ func (r *Router) drainStandardReplayPipeline() {
 			r.standardReplay.entries = nil
 			r.standardReplay.headBlockedAt = time.Time{}
 		}
+		active := r.standardReplay.active
 		r.acquisitionMu.Unlock()
 		if !current {
+			return
+		}
+		applied++
+		if active && (applied >= standardReplayApplyBatch || time.Since(batchStarted) >= standardReplayApplyBudget) {
+			// Keep applying set while the edge-triggered wake is pending. A
+			// completion that lands before the wake is consumed joins this same
+			// drain instead of starting a concurrent applier.
+			r.scheduleStandardReplayDrain()
 			return
 		}
 	}

--- a/internal/consensus/adaptor/router_replay_pipeline_test.go
+++ b/internal/consensus/adaptor/router_replay_pipeline_test.go
@@ -120,6 +120,31 @@ func TestStandardReplayPipelineAppliesReadySuccessorsInOrder(t *testing.T) {
 	assert.Zero(t, metrics.ReplayPipelineReadyDepth)
 }
 
+func TestStandardReplayPipelineYieldsAfterBoundedApplyBatch(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	_, err := svc.AcceptLedger(context.Background())
+	require.NoError(t, err)
+	links := buildStandardReplayTestChain(t, r, svc.GetClosedLedger(), standardReplayApplyBatch+1)
+	armStandardReplayTestPipeline(t, r, a, sender, links)
+	require.Len(t, sender.legacyCalls(), standardReplayApplyBatch)
+
+	// Make the whole resident window ready before completing its head. The
+	// head completion then enters one apply call with a full batch available.
+	for i := 1; i < standardReplayApplyBatch; i++ {
+		completeStandardReplayTestLink(t, r, links[i])
+	}
+	completeStandardReplayTestLink(t, r, links[0])
+
+	metrics := r.FastSyncMetrics()
+	require.Equal(t, uint64(standardReplayApplyBatch), metrics.ReplayPipelineApplied)
+	require.True(t, r.standardReplay.active)
+	require.True(t, r.standardReplay.applying)
+	require.Len(t, r.standardReplayDrainWake, 1,
+		"a ready replay batch must reschedule through the router loop before continuing")
+	require.NotNil(t, r.fetchTracker.Find(links[standardReplayApplyBatch].hash),
+		"collector refill must continue while the applier yields")
+}
+
 func TestStandardReplayPipelineBoundsAndRefillsWindow(t *testing.T) {
 	r, a, sender, svc := makeRouter(t)
 	_, err := svc.AcceptLedger(context.Background())

--- a/internal/consensus/adaptor/validation_work_test.go
+++ b/internal/consensus/adaptor/validation_work_test.go
@@ -455,6 +455,27 @@ func TestRouterDrainsTrustedValidationResultsBeforeUntrusted(t *testing.T) {
 	engine.muProcessor.Unlock()
 }
 
+func TestRouterBoundsTrustedValidationDrain(t *testing.T) {
+	adaptor := newTestAdaptor(t)
+	engine := &validationProcessorEngine{mockEngine: &mockEngine{}}
+	router := newTestRouter(engine, adaptor, nil)
+	lane := router.validationWork
+	require.NotNil(t, lane)
+
+	total := trustedValidationDrainBatch + 1
+	for i := range total {
+		lane.trustedResultCh <- validationWorkResult{
+			validation: &consensus.Validation{LedgerID: consensus.LedgerID{byte(i + 1)}},
+			origin:     consensus.ValidationOrigin{PeerID: uint64(i + 1)},
+		}
+	}
+
+	require.True(t, router.drainTrustedValidationResults(t.Context()))
+	require.Equal(t, trustedValidationDrainBatch, engine.processedCount())
+	require.Len(t, lane.trustedResultCh, 1,
+		"a trusted-validation burst must yield before starving the router select loop")
+}
+
 func TestRouterValidationResultChargesOnlyInvalidSignature(t *testing.T) {
 	adaptor := newTestAdaptor(t)
 	sender := &validationCaptureSender{}

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -121,20 +121,25 @@ const (
 //     be read through accessors that take mu (State, PeerID, OnTimer, GotBase,
 //     etc.).
 type Ledger struct {
-	hash      [32]byte
-	seq       uint32
-	header    *header.LedgerHeader
-	stateMap  *shamap.SHAMap
-	txMap     *shamap.SHAMap // nil when the transaction tree is empty (TxHash zero)
-	haveState bool
-	haveTx    bool
-	peers     []uint64 // source peers, broadened on no-progress; peers[0] is the original
-	reason    Reason
-	state     State
-	err       error
-	mu        sync.Mutex
-	logger    *slog.Logger
-	snapshot  atomic.Pointer[Snapshot]
+	hash [32]byte
+	seq  uint32
+	// sequenceInitiallyUnknown records hash-only acquisitions. The verified
+	// header later fills seq, but the router still needs to know how this
+	// acquisition began so it can promote a consensus request into the frozen
+	// fast-load recovery session instead of treating it as an ordinary fetch.
+	sequenceInitiallyUnknown bool
+	header                   *header.LedgerHeader
+	stateMap                 *shamap.SHAMap
+	txMap                    *shamap.SHAMap // nil when the transaction tree is empty (TxHash zero)
+	haveState                bool
+	haveTx                   bool
+	peers                    []uint64 // source peers, broadened on no-progress; peers[0] is the original
+	reason                   Reason
+	state                    State
+	err                      error
+	mu                       sync.Mutex
+	logger                   *slog.Logger
+	snapshot                 atomic.Pointer[Snapshot]
 
 	// family backs the acquisition SHAMaps with the persistent node store when
 	// set, so getMissingNodes only reports nodes not already held locally. nil
@@ -238,13 +243,14 @@ func New(hash [32]byte, seq uint32, peerID uint64, logger *slog.Logger, opts ...
 		"ledger_hash", fmt.Sprintf("%x", hash[:8]),
 	)
 	l := &Ledger{
-		hash:         hash,
-		seq:          seq,
-		state:        StateWantBase,
-		lastTimer:    SystemClock.Now(),
-		logger:       logger,
-		recentNodes:  make(map[[32]byte]uint64),
-		requestPeers: make(map[uint64]struct{}),
+		hash:                     hash,
+		seq:                      seq,
+		sequenceInitiallyUnknown: seq == 0,
+		state:                    StateWantBase,
+		lastTimer:                SystemClock.Now(),
+		logger:                   logger,
+		recentNodes:              make(map[[32]byte]uint64),
+		requestPeers:             make(map[uint64]struct{}),
 	}
 	if peerID != 0 {
 		l.peers = []uint64{peerID}
@@ -575,6 +581,12 @@ func (l *Ledger) Seq() uint32 {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.seq
+}
+
+// SequenceInitiallyUnknown reports whether the acquisition was created by
+// hash before its ledger sequence was available. It is immutable after New.
+func (l *Ledger) SequenceInitiallyUnknown() bool {
+	return l.sequenceInitiallyUnknown
 }
 
 // Hash returns the ledger hash being acquired.

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -1204,13 +1204,14 @@ func (r *nodeRuntime) stopRuntime() {
 	}
 }
 
-const nodeShutdownTimeout = 30 * time.Second
+const nodeShutdownTimeout = 3 * time.Minute
 
 const (
-	transportShutdownGrace = 5 * time.Second
-	producerShutdownGrace  = 5 * time.Second
-	serviceShutdownGrace   = 10 * time.Second
-	storeShutdownGrace     = 5 * time.Second
+	transportShutdownGrace  = 5 * time.Second
+	producerShutdownGrace   = 5 * time.Second
+	serviceShutdownGrace    = 10 * time.Second
+	checkpointShutdownGrace = 2 * time.Minute
+	storeShutdownGrace      = 5 * time.Second
 )
 
 func (r *nodeRuntime) shutdown() error {
@@ -1338,7 +1339,10 @@ func (r *nodeRuntime) shutdownWithin(timeout time.Duration) error {
 		prepareCheckpoint = r.ledger.PrepareFastLoadCheckpoint
 	}
 	if len(errs) == 0 && prepareCheckpoint != nil {
-		checkpointCtx, cancelCheckpoint := context.WithTimeout(ctx, storeShutdownGrace)
+		// Proof collection performs uncached random reads over the shallow
+		// SHAMap frontier. On a cold or busy store it can legitimately take
+		// longer than the small timeout used to close an already-flushed DB.
+		checkpointCtx, cancelCheckpoint := context.WithTimeout(ctx, checkpointShutdownGrace)
 		var prepared bool
 		completed, err := runShutdownPhase(checkpointCtx, "prepare fast-load checkpoint", func() error {
 			var prepareErr error


### PR DESCRIPTION
## Summary

- preserve an active frozen-pivot recovery session when consensus requests the same ledger hash before its sequence is known
- promote an existing hash-only consensus acquisition into the frozen-pivot fast-load path once its verified header resolves the sequence
- bound trusted-validation draining and replay application batches so the router loop continues servicing consensus, control, and acquisition traffic
- allow graceful shutdown enough time to prepare a cold-store fast-load checkpoint

## Background

This follows the frozen-pivot recovery work in #1668. During live Testnet testing, startup ordering could create a hash-only consensus acquisition before peer-status or validation bookkeeping had indexed `hash -> sequence`. Treating `seq=0` as an older target canceled the frozen replay session and returned the node to moving-head full-state acquisition.

Long resident replay windows could also monopolize the router loop, and the previous five-second checkpoint timeout was too short for cold random-read proof collection during graceful shutdown.

The watchdog lock stalls tracked in #1676 and #1677 are separate issues and are not claimed as fixed by this PR.

## Changes

- record whether an inbound acquisition was initially created without a sequence
- reconcile unknown-sequence consensus targets without canceling the frozen pivot
- promote the same in-flight acquisition after verified header resolution instead of issuing a second full-state request
- resume bounded replay batches through an edge-triggered router wake channel
- cap trusted-validation result draining at 32 items per router-loop pass
- raise the overall shutdown timeout to three minutes and the checkpoint preparation allowance to two minutes
- add regression coverage for unknown-sequence handoff, acquisition promotion, replay batching, and trusted-validation fairness

## Validation

```text
go test ./internal/consensus/adaptor ./internal/ledger/inbound ./internal/node

ok  github.com/LeJamon/go-xrpl/internal/consensus/adaptor  11.672s
ok  github.com/LeJamon/go-xrpl/internal/ledger/inbound       (cached)
ok  github.com/LeJamon/go-xrpl/internal/node                 2.709s
```

The current Testnet container was built from these dirty worktree changes before they were committed. This PR publishes that exact source patch for review.

