### PR TITLE
fix: prevent inbound SHAMap stalls from blocking consensus

### DIFF
--- a/internal/consensus/adaptor/acquisition_work_test.go
+++ b/internal/consensus/adaptor/acquisition_work_test.go
@@ -1356,9 +1356,9 @@ func TestAcquisitionWork_TimerCheckPreemptsYieldedTraversal(t *testing.T) {
 	for _, node := range packNodes {
 		entries = append(entries, shamap.FlushEntry{Hash: node.Hash, Data: node.Data})
 	}
-	require.NoError(t, family.StoreBatch(t.Context(), entries))
 	ledger := inbound.New(ledgerHash, h.LedgerIndex, 7, serveTestLogger(), inbound.WithFamily(family))
 	require.NoError(t, ledger.GotBase([]message.LedgerNode{{NodeData: headerData}, {NodeData: rootData}}))
+	require.NoError(t, family.StoreBatch(t.Context(), entries))
 	base := time.Now()
 	ledger.RearmTimer(base)
 	require.Equal(t, inbound.TimerRefresh, ledger.OnTimer(base.Add(4*time.Second)))

--- a/internal/consensus/adaptor/issue_1676_lock_test.go
+++ b/internal/consensus/adaptor/issue_1676_lock_test.go
@@ -1,0 +1,137 @@
+package adaptor
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/crypto/sha512half"
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/consensus/rcl"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/protocol"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/LeJamon/go-xrpl/shamap/backend"
+	"github.com/stretchr/testify/require"
+)
+
+type issue1676BlockingFamily struct {
+	base    shamap.Family
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (f *issue1676BlockingFamily) Fetch(ctx context.Context, hash [32]byte) ([]byte, error) {
+	f.once.Do(func() { close(f.entered) })
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-f.release:
+		return f.base.Fetch(ctx, hash)
+	}
+}
+
+func (f *issue1676BlockingFamily) StoreBatch(ctx context.Context, entries []shamap.FlushEntry) error {
+	return f.base.StoreBatch(ctx, entries)
+}
+
+func TestBlockedInboundTraversalDoesNotStallValidationOrConsensusTick(t *testing.T) {
+	source := newWideWorkSource(t, 16)
+	rootHash, err := source.Hash()
+	require.NoError(t, err)
+	rootData, err := source.SerializeRoot()
+	require.NoError(t, err)
+
+	baseFamily := backend.NewMemory()
+	pack, err := source.WalkFetchPackNodes(1 << 20)
+	require.NoError(t, err)
+	entries := make([]shamap.FlushEntry, 0, len(pack))
+	for _, node := range pack {
+		entries = append(entries, shamap.FlushEntry{Hash: node.Hash, Data: node.Data})
+	}
+	require.NoError(t, baseFamily.StoreBatch(t.Context(), entries))
+
+	family := &issue1676BlockingFamily{
+		base:    baseFamily,
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(family.release) }) })
+
+	const seq = uint32(100)
+	hdr := header.LedgerHeader{LedgerIndex: seq, AccountHash: rootHash}
+	headerData := header.AddRaw(hdr, false)
+	candidateHash := sha512half.Sum(protocol.HashPrefixLedgerMaster().Bytes(), headerData)
+	candidate := inbound.New(
+		candidateHash,
+		seq,
+		7,
+		serveTestLogger(),
+		inbound.WithFamily(family),
+	)
+
+	adaptor := newTestAdaptor(t)
+	engineConfig := rcl.DefaultConfig()
+	engineConfig.ManualTick = true
+	engine := rcl.NewEngine(adaptor, engineConfig)
+	router := newTestRouter(engine, adaptor, nil)
+	router.fetchTracker.Track(candidate)
+	require.NoError(t, engine.Start(t.Context()))
+	t.Cleanup(func() { require.NoError(t, engine.Stop()) })
+
+	baseDone := make(chan error, 1)
+	go func() {
+		baseDone <- candidate.GotBaseContext(t.Context(), []message.LedgerNode{
+			{NodeData: headerData},
+			{NodeData: rootData},
+		})
+	}()
+	select {
+	case <-family.entered:
+	case <-time.After(time.Second):
+		t.Fatal("inbound completeness walk did not reach the blocking store")
+	}
+
+	nodeID, err := adaptor.GetValidatorKey()
+	require.NoError(t, err)
+	now := adaptor.Now()
+	validationDone := make(chan error, 1)
+	go func() {
+		_, processErr := engine.ProcessVerifiedValidation(&consensus.Validation{
+			LedgerSeq: seq,
+			LedgerID:  consensus.LedgerID{0xA7},
+			NodeID:    nodeID,
+			SignTime:  now,
+			SeenTime:  now,
+			Full:      true,
+		}, consensus.ValidationOrigin{PeerID: 8})
+		validationDone <- processErr
+	}()
+
+	select {
+	case processErr := <-validationDone:
+		require.NoError(t, processErr)
+	case <-time.After(time.Second):
+		t.Fatal("trusted validation waited for the inbound completeness walk")
+	}
+	require.Nil(t, router.fetchTracker.Find(candidateHash))
+
+	tickDone := make(chan struct{})
+	go func() {
+		engine.TimerEntry()
+		close(tickDone)
+	}()
+	select {
+	case <-tickDone:
+	case <-time.After(time.Second):
+		t.Fatal("consensus tick waited for the inbound completeness walk")
+	}
+
+	releaseOnce.Do(func() { close(family.release) })
+	require.NoError(t, <-baseDone)
+}

--- a/internal/consensus/adaptor/router_catchup_incident_test.go
+++ b/internal/consensus/adaptor/router_catchup_incident_test.go
@@ -38,10 +38,10 @@ func newIssue1663BackedAcquisition(t *testing.T, seq uint32, peerID uint64) *inb
 	for _, node := range pack {
 		entries = append(entries, shamap.FlushEntry{Hash: node.Hash, Data: node.Data})
 	}
-	require.NoError(t, family.StoreBatch(t.Context(), entries))
 
 	il := inbound.New(ledgerHash, seq, peerID, serveTestLogger(), inbound.WithFamily(family))
 	require.NoError(t, il.GotBase([]message.LedgerNode{{NodeData: headerData}, {NodeData: rootData}}))
+	require.NoError(t, family.StoreBatch(t.Context(), entries))
 	return il
 }
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -229,6 +229,9 @@ type Engine struct {
 	// Mutated only under e.mu; drained by takePendingPostUnlockLocked.
 	pendingPostUnlock []func()
 
+	// pendingValidationBroadcasts run after all queued finality deferrals drain.
+	pendingValidationBroadcasts []*consensus.Validation
+
 	// missedHeartbeats counts dropped heartbeat ticks (gap > 2× interval).
 	// time.Ticker silently coalesces ticks under load; this surfaces that
 	// pressure so stalls don't hide.
@@ -397,9 +400,7 @@ func (e *Engine) enqueueValidationBroadcastLocked(v *consensus.Validation) {
 		e.broadcastValidation(v)
 		return
 	}
-	e.pendingPostUnlock = append(e.pendingPostUnlock, func() {
-		e.broadcastValidation(v)
-	})
+	e.pendingValidationBroadcasts = append(e.pendingValidationBroadcasts, v)
 }
 
 // broadcastValidation emits our own validation, logging on failure. Like
@@ -413,11 +414,19 @@ func (e *Engine) broadcastValidation(v *consensus.Validation) {
 // takePendingPostUnlockLocked drains the queued post-lock closures.
 // Caller must hold e.mu; pass the result to runPostUnlock after Unlock.
 func (e *Engine) takePendingPostUnlockLocked() []func() {
-	if len(e.pendingPostUnlock) == 0 {
+	total := len(e.pendingPostUnlock) + len(e.pendingValidationBroadcasts)
+	if total == 0 {
 		return nil
 	}
-	out := e.pendingPostUnlock
+	out := make([]func(), 0, total)
+	out = append(out, e.pendingPostUnlock...)
+	for _, validation := range e.pendingValidationBroadcasts {
+		out = append(out, func() {
+			e.broadcastValidation(validation)
+		})
+	}
 	e.pendingPostUnlock = nil
+	e.pendingValidationBroadcasts = nil
 	return out
 }
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -225,11 +225,9 @@ type Engine struct {
 	// Start. Nil keeps flat-count semantics.
 	ledgerAncestry LedgerAncestryProvider
 
-	// pendingBroadcasts queues broadcasts produced under e.mu so they flush
-	// after Unlock: holding e.mu across BroadcastProposal/Validation blocks
-	// ingress on e.mu.RLock and can stall consensus on a slow peer send
-	// queue. Mutated only under e.mu; drained by takePendingBroadcastsLocked.
-	pendingBroadcasts []func()
+	// pendingPostUnlock queues work produced under e.mu so it runs after Unlock.
+	// Mutated only under e.mu; drained by takePendingPostUnlockLocked.
+	pendingPostUnlock []func()
 
 	// missedHeartbeats counts dropped heartbeat ticks (gap > 2× interval).
 	// time.Ticker silently coalesces ticks under load; this surfaces that
@@ -241,10 +239,10 @@ type Engine struct {
 	// disables it.
 	stallPing atomic.Pointer[func()]
 
-	// deferBroadcasts > 0 inside timerEntry / StartRound enables deferred
-	// broadcast batching; at zero the enqueue helpers send synchronously so
-	// direct callers (tests) observe broadcasts immediately. Mutated under e.mu.
-	deferBroadcasts int
+	// deferPostUnlock > 0 inside timerEntry / StartRound enables deferred work;
+	// at zero the broadcast helpers send synchronously so direct callers (tests)
+	// observe broadcasts immediately. Mutated under e.mu.
+	deferPostUnlock int
 
 	// previousTrustedSet is the trusted set from the previous
 	// startRoundLocked; diffed against the current set each round to derive
@@ -312,6 +310,24 @@ func (e *Engine) refreshValidationConfig() int {
 	return quorum
 }
 
+func (e *Engine) refreshValidationConfigDeferredLocked() int {
+	e.validationConfigMu.Lock()
+	tracker := e.validationTracker
+	if tracker == nil {
+		e.validationConfigMu.Unlock()
+		return 0
+	}
+	trusted, quorum, negativeUNL := validationConfig(e.adaptor)
+	tracker.beginFinalityDeferral()
+	tracker.updateTrustedQuorumAndNegativeUNL(trusted, quorum, negativeUNL)
+	e.validationConfigMu.Unlock()
+	e.pendingPostUnlock = append(e.pendingPostUnlock, func() {
+		tracker.endFinalityDeferral()
+		tracker.checkAcquired()
+	})
+	return quorum
+}
+
 var _ consensus.EngineTerminal = (*Engine)(nil)
 
 // ValidationArchive is the archive API subset the engine consumes,
@@ -334,17 +350,17 @@ func (e *Engine) loadArchive() ValidationArchive {
 }
 
 // enqueueProposalBroadcastLocked stages a proposal to broadcast after e.mu
-// is released (see pendingBroadcasts). Caller must hold e.mu. With no
+// is released (see pendingPostUnlock). Caller must hold e.mu. With no
 // deferred scope active the send is synchronous.
 func (e *Engine) enqueueProposalBroadcastLocked(p *consensus.Proposal) {
 	if p == nil {
 		return
 	}
-	if e.deferBroadcasts == 0 {
+	if e.deferPostUnlock == 0 {
 		e.broadcastProposal(p)
 		return
 	}
-	e.pendingBroadcasts = append(e.pendingBroadcasts, func() {
+	e.pendingPostUnlock = append(e.pendingPostUnlock, func() {
 		e.broadcastProposal(p)
 	})
 }
@@ -365,11 +381,11 @@ func (e *Engine) enqueueValidationBroadcastLocked(v *consensus.Validation) {
 	if v == nil {
 		return
 	}
-	if e.deferBroadcasts == 0 {
+	if e.deferPostUnlock == 0 {
 		e.broadcastValidation(v)
 		return
 	}
-	e.pendingBroadcasts = append(e.pendingBroadcasts, func() {
+	e.pendingPostUnlock = append(e.pendingPostUnlock, func() {
 		e.broadcastValidation(v)
 	})
 }
@@ -382,20 +398,20 @@ func (e *Engine) broadcastValidation(v *consensus.Validation) {
 	}
 }
 
-// takePendingBroadcastsLocked drains the queued broadcast closures.
-// Caller must hold e.mu; pass the result to flushBroadcasts after Unlock.
-func (e *Engine) takePendingBroadcastsLocked() []func() {
-	if len(e.pendingBroadcasts) == 0 {
+// takePendingPostUnlockLocked drains the queued post-lock closures.
+// Caller must hold e.mu; pass the result to runPostUnlock after Unlock.
+func (e *Engine) takePendingPostUnlockLocked() []func() {
+	if len(e.pendingPostUnlock) == 0 {
 		return nil
 	}
-	out := e.pendingBroadcasts
-	e.pendingBroadcasts = nil
+	out := e.pendingPostUnlock
+	e.pendingPostUnlock = nil
 	return out
 }
 
-// flushBroadcasts runs each queued broadcast. MUST be called with e.mu
+// runPostUnlock runs each queued closure. MUST be called with e.mu
 // released.
-func flushBroadcasts(pending []func()) {
+func runPostUnlock(pending []func()) {
 	for _, fn := range pending {
 		fn()
 	}
@@ -693,9 +709,6 @@ func (e *Engine) Start(ctx context.Context) error {
 	}
 	tracker := e.validationTracker
 	e.validationTracker.SetFullyValidatedCallback(func(ledgerID consensus.LedgerID, seq uint32) {
-		// Callback contract: production callers (OnValidation,
-		// sendValidation) hold e.mu; tests call Add without it. So it MUST
-		// NOT take e.mu (non-recursive RWMutex → self-deadlock).
 		// e.archive / e.inMemoryLedgers are read via atomics to stay
 		// race-free against SetArchive.
 		e.adaptor.OnLedgerFullyValidated(ledgerID, seq)
@@ -710,8 +723,7 @@ func (e *Engine) Start(ctx context.Context) error {
 			arc.NoteFullyValidated(seq)
 		}
 		// Drive in-memory retention: ExpireOld fires onStale per evicted
-		// validation (archive captures it first) and takes vt.mu, not e.mu,
-		// so it's safe under the held e.mu. Runs with or without an archive;
+		// validation (archive captures it first). Runs with or without an archive;
 		// the archive's InMemoryLedgers overrides, else defaultInMemoryLedgers.
 		retention := inMem
 		if retention == 0 {
@@ -803,13 +815,13 @@ func (e *Engine) StartRound(round consensus.RoundID, proposing bool) error {
 		e.mu.Unlock()
 		return errLedgerAcceptInProgress
 	}
-	e.deferBroadcasts++
+	e.deferPostUnlock++
 	e.acceptedLCL = consensus.LedgerID{}
 	err := e.startRoundLocked(round, proposing, false)
-	e.deferBroadcasts--
-	pending := e.takePendingBroadcastsLocked()
+	e.deferPostUnlock--
+	pending := e.takePendingPostUnlockLocked()
 	e.mu.Unlock()
-	flushBroadcasts(pending)
+	runPostUnlock(pending)
 	return err
 }
 
@@ -822,7 +834,7 @@ func (e *Engine) RestartRound(proposing bool) error {
 		e.mu.Unlock()
 		return errLedgerAcceptInProgress
 	}
-	e.deferBroadcasts++
+	e.deferPostUnlock++
 
 	working, err := e.adaptor.GetLastClosedLedger()
 	if err == nil && working == nil {
@@ -844,10 +856,10 @@ func (e *Engine) RestartRound(proposing bool) error {
 		err = e.startRoundLocked(round, proposing, false)
 	}
 
-	e.deferBroadcasts--
-	pending := e.takePendingBroadcastsLocked()
+	e.deferPostUnlock--
+	pending := e.takePendingPostUnlockLocked()
 	e.mu.Unlock()
-	flushBroadcasts(pending)
+	runPostUnlock(pending)
 	return err
 }
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -328,6 +328,18 @@ func (e *Engine) refreshValidationConfigDeferredLocked() int {
 	return quorum
 }
 
+// refreshUNLStateDeferredLocked requires e.mu and an active post-unlock scope.
+func (e *Engine) refreshUNLStateDeferredLocked() {
+	tracker := e.validationTracker
+	if tracker == nil {
+		e.adaptor.RefreshUNLState()
+		return
+	}
+	tracker.beginFinalityDeferral()
+	e.adaptor.RefreshUNLState()
+	e.pendingPostUnlock = append(e.pendingPostUnlock, tracker.endFinalityDeferral)
+}
+
 var _ consensus.EngineTerminal = (*Engine)(nil)
 
 // ValidationArchive is the archive API subset the engine consumes,
@@ -905,7 +917,7 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 	// Kick off a trust-view refresh so the bow-out reacts to an expiring list
 	// within a round or two rather than only on the aggregator's 30s tick
 	// (rippled recomputes via updateTrusted at every ledger close).
-	e.adaptor.RefreshUNLState()
+	e.refreshUNLStateDeferredLocked()
 	// RefreshUNLState may synchronously publish a trust-change callback in
 	// tests and lightweight adaptors. Apply its queued removals before the
 	// round resets or replays any buffered proposal state.

--- a/internal/consensus/rcl/engine_accept.go
+++ b/internal/consensus/rcl/engine_accept.go
@@ -26,6 +26,18 @@ type ledgerAcceptWork struct {
 // acceptLedger finalizes consensus and accepts the new ledger. Runs in
 // every mode; only validation emission is mode-gated via isCompatible.
 func (e *Engine) acceptLedger(result consensus.Result) {
+	ownPostUnlockScope := e.deferPostUnlock == 0
+	if ownPostUnlockScope {
+		e.deferPostUnlock++
+		defer func() {
+			e.deferPostUnlock--
+			pending := e.takePendingPostUnlockLocked()
+			e.mu.Unlock()
+			runPostUnlock(pending)
+			e.mu.Lock()
+		}()
+	}
+
 	if e.phase != consensus.PhaseEstablish {
 		return
 	}
@@ -160,12 +172,12 @@ func (e *Engine) completeDeferredLedgerAccept(work ledgerAcceptWork) {
 	newLedger, err := e.buildAcceptedLedger(work)
 
 	e.mu.Lock()
-	e.deferBroadcasts++
+	e.deferPostUnlock++
 	e.commitAcceptedLedgerLocked(work, newLedger, err)
-	e.deferBroadcasts--
-	pending := e.takePendingBroadcastsLocked()
+	e.deferPostUnlock--
+	pending := e.takePendingPostUnlockLocked()
 	e.mu.Unlock()
-	flushBroadcasts(pending)
+	runPostUnlock(pending)
 }
 
 func (e *Engine) buildAcceptedLedger(work ledgerAcceptWork) (consensus.Ledger, error) {
@@ -360,7 +372,7 @@ func (e *Engine) commitAcceptedLedgerLocked(work ledgerAcceptWork, newLedger con
 	// Refresh the tracker's trusted set, quorum, and negative UNL each accept,
 	// and advance the minSeq floor so far-stale validations are rejected at Add().
 	if e.validationTracker != nil {
-		quorum := e.refreshValidationConfig()
+		quorum := e.refreshValidationConfigDeferredLocked()
 		if newLedger.Seq() > 128 {
 			// Keep a small history window so late validations for the
 			// just-accepted ledger still count.
@@ -611,9 +623,10 @@ func (e *Engine) tryAdvanceValidatedSeqLocked(seq uint32) bool {
 	return true
 }
 
-// sendValidation builds and broadcasts a validation. The Full flag (set
-// from mode==ModeProposing) is what makes peers count it toward quorum;
-// partials from non-proposing modes are accepted but don't count.
+// sendValidation builds and broadcasts a validation. Tracker callbacks execute
+// after e.mu is released, either through the caller's deferred scope or by a
+// direct unlock around tracking. The Full flag (set from mode==ModeProposing)
+// is what makes peers count it toward quorum; partials don't count.
 func (e *Engine) sendValidation(ledger consensus.Ledger) {
 	// SeqEnforcer guard + bump; defensive so direct test callers can't bypass.
 	if !e.tryAdvanceValidatedSeqLocked(ledger.Seq()) {
@@ -735,14 +748,25 @@ func (e *Engine) sendValidation(ledger consensus.Ledger) {
 		"sign_time_xrpl", signTime.Unix()-protocol.RippleEpochUnix,
 	)
 
-	e.enqueueValidationBroadcastLocked(validation)
-
 	// Feed our own validation into the tracker. Partials steer our trie but
 	// don't count toward quorum (Full filter); a 1-validator standalone is
 	// always proposing, so Full crosses immediately.
 	if e.validationTracker != nil {
-		e.validationTracker.Add(validation)
+		tracker := e.validationTracker
+		tracker.beginFinalityDeferral()
+		tracker.addStatus(validation, false)
+		if e.deferPostUnlock == 0 {
+			e.mu.Unlock()
+			tracker.endFinalityDeferral()
+			e.mu.Lock()
+		} else {
+			e.pendingPostUnlock = append(e.pendingPostUnlock, func() {
+				tracker.endFinalityDeferral()
+			})
+		}
 	}
+
+	e.enqueueValidationBroadcastLocked(validation)
 }
 
 // roundCloseTime rounds to the nearest multiple of resolution (up at the

--- a/internal/consensus/rcl/engine_accept_offlock_test.go
+++ b/internal/consensus/rcl/engine_accept_offlock_test.go
@@ -149,6 +149,94 @@ func TestEngine_AcceptLedger_OffLockDoesNotBlockPeerHandlers(t *testing.T) {
 	}
 }
 
+func TestEngine_AcceptLedger_BroadcastsValidationAfterFinality(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.standalone = true
+	adaptor.validator = true
+	adaptor.opMode = consensus.OpModeFull
+	adaptor.quorum = 1
+	adaptor.setTrusted([]consensus.NodeID{adaptor.nodeID})
+
+	config := DefaultConfig()
+	config.ManualTick = true
+	engine := NewEngine(adaptor, config)
+	if err := engine.Start(t.Context()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := engine.Stop(); err != nil {
+			t.Errorf("Stop: %v", err)
+		}
+	})
+
+	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+	if err := engine.StartRound(round, true); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+	driveToEstablish(t, engine, adaptor)
+
+	adaptor.mu.Lock()
+	adaptor.validationsBroadcast = nil
+	adaptor.mu.Unlock()
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	adaptor.mu.Lock()
+	adaptor.onFullyValidated = func(consensus.LedgerID, uint32) {
+		close(entered)
+		<-release
+	}
+	adaptor.mu.Unlock()
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+
+	acceptDone := make(chan struct{})
+	go func() {
+		engine.mu.Lock()
+		engine.acceptLedger(consensus.ResultSuccess)
+		engine.mu.Unlock()
+		close(acceptDone)
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("local validation did not reach finality")
+	}
+
+	adaptor.mu.RLock()
+	broadcasts := len(adaptor.validationsBroadcast)
+	adaptor.mu.RUnlock()
+	if broadcasts != 0 {
+		t.Fatalf("validation broadcast overtook finality: got %d broadcasts", broadcasts)
+	}
+
+	tickDone := make(chan struct{})
+	go func() {
+		engine.timerEntry()
+		close(tickDone)
+	}()
+	select {
+	case <-tickDone:
+	case <-time.After(time.Second):
+		t.Fatal("finality callback held the engine lock")
+	}
+
+	releaseOnce.Do(func() { close(release) })
+	select {
+	case <-acceptDone:
+	case <-time.After(time.Second):
+		t.Fatal("accepted-ledger completion did not resume")
+	}
+
+	adaptor.mu.RLock()
+	broadcasts = len(adaptor.validationsBroadcast)
+	adaptor.mu.RUnlock()
+	if broadcasts != 1 {
+		t.Fatalf("validation broadcasts after finality = %d, want 1", broadcasts)
+	}
+}
+
 func TestEngine_AcceptLedger_BuildFailureRetainsBuildingSequence(t *testing.T) {
 	adaptor := newMockAdaptor()
 	adaptor.buildLedgerErr = errors.New("build failed")

--- a/internal/consensus/rcl/engine_handlers.go
+++ b/internal/consensus/rcl/engine_handlers.go
@@ -227,16 +227,17 @@ func (e *Engine) ProcessVerifiedValidation(
 		e.proposalTracker.SetValidation(validation)
 	}
 
-	e.eventBus.Publish(&consensus.ValidationReceivedEvent{
+	event := &consensus.ValidationReceivedEvent{
 		Validation: validation,
 		Trusted:    trusted,
 		Timestamp:  e.adaptor.Now(),
-	})
+	}
 
 	e.mu.Unlock()
 	if deferFinality {
 		tracker.endFinalityDeferral()
 	}
+	e.eventBus.Publish(event)
 	return disposition, nil
 }
 
@@ -384,7 +385,13 @@ func (e *Engine) seedDisputeVotes(txID consensus.TxID) {
 // OnLedger handles receiving a ledger we were missing.
 func (e *Engine) OnLedger(id consensus.LedgerID, ledger []byte) error {
 	e.mu.Lock()
-	defer e.mu.Unlock()
+	e.deferPostUnlock++
+	defer func() {
+		e.deferPostUnlock--
+		pending := e.takePendingPostUnlockLocked()
+		e.mu.Unlock()
+		runPostUnlock(pending)
+	}()
 
 	recovering := e.mode == consensus.ModeWrongLedger
 	exactRecoveryTarget := recovering && id == e.wrongLedgerID
@@ -425,7 +432,13 @@ func (e *Engine) OnLedger(id consensus.LedgerID, ledger []byte) error {
 // selected by consensus recovery, validation, or the current network view.
 func (e *Engine) TrySwitchToLedger(id consensus.LedgerID) (consensus.LedgerSwitchResult, error) {
 	e.mu.Lock()
-	defer e.mu.Unlock()
+	e.deferPostUnlock++
+	defer func() {
+		e.deferPostUnlock--
+		pending := e.takePendingPostUnlockLocked()
+		e.mu.Unlock()
+		runPostUnlock(pending)
+	}()
 
 	exactRecoveryTarget := e.mode == consensus.ModeWrongLedger && id == e.wrongLedgerID
 	networkPreferred := e.prevLedger != nil && e.getNetworkLedger() == id

--- a/internal/consensus/rcl/engine_handlers.go
+++ b/internal/consensus/rcl/engine_handlers.go
@@ -193,7 +193,6 @@ func (e *Engine) ProcessVerifiedValidation(
 	origin consensus.ValidationOrigin,
 ) (consensus.ValidationDisposition, error) {
 	e.mu.Lock()
-	defer e.mu.Unlock()
 
 	trusted := e.adaptor.IsTrusted(validation.NodeID)
 
@@ -217,8 +216,11 @@ func (e *Engine) ProcessVerifiedValidation(
 			(e.relayPolicy != nil && e.relayPolicy.RelayUntrustedValidations()),
 	}
 
-	if tracked && e.validationTracker != nil {
-		disposition.Status = validationDispositionStatus(e.validationTracker.AddStatus(validation))
+	tracker := e.validationTracker
+	deferFinality := tracked && tracker != nil
+	if deferFinality {
+		tracker.beginFinalityDeferral()
+		disposition.Status = validationDispositionStatus(tracker.addStatus(validation, false))
 	}
 
 	if disposition.AcquireEligible() {
@@ -231,6 +233,10 @@ func (e *Engine) ProcessVerifiedValidation(
 		Timestamp:  e.adaptor.Now(),
 	})
 
+	e.mu.Unlock()
+	if deferFinality {
+		tracker.endFinalityDeferral()
+	}
 	return disposition, nil
 }
 

--- a/internal/consensus/rcl/engine_ledger_check.go
+++ b/internal/consensus/rcl/engine_ledger_check.go
@@ -70,16 +70,16 @@ func (e *Engine) timerEntry() {
 		e.heartbeatNow().Sub(tickStart),
 		e.heartbeatContextLocked(),
 	)
-	e.deferBroadcasts++
+	e.deferPostUnlock++
 	var pending []func()
 	defer func() {
-		e.deferBroadcasts--
-		pending = e.takePendingBroadcastsLocked()
+		e.deferPostUnlock--
+		pending = e.takePendingPostUnlockLocked()
 		tickContext := e.heartbeatContextLocked()
 		e.mu.Unlock()
 
 		broadcastStart := e.heartbeatNow()
-		flushBroadcasts(pending)
+		runPostUnlock(pending)
 		slowStages = recordSlowHeartbeatStage(
 			slowStages,
 			"broadcast-flush",

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -3436,14 +3436,11 @@ func TestCheckConsensusState(t *testing.T) {
 	})
 }
 
-// TestEngine_OnValidation_NoSelfDeadlockOnQuorum pins the issue
-// #381 root cause: ValidationTracker.Add fires the
-// fully-validated callback synchronously on the goroutine that
-// called OnValidation — and OnValidation already holds e.mu.Lock.
-// A defensive e.mu.RLock inside the callback self-deadlocks
-// because Go's RWMutex is non-recursive. Once a single
-// fully-validated ledger fires, the engine writer never returns,
-// the heartbeat parks, and every RPC reader piles up.
+// TestEngine_OnValidation_NoSelfDeadlockOnQuorum pins the issue #381 failure:
+// the fully-validated callback used to run while OnValidation held e.mu. A
+// defensive e.mu.RLock inside that callback then self-deadlocked because Go's
+// RWMutex is non-recursive. Finality now drains after the engine lock is
+// released, but the callback must still complete without re-entry deadlock.
 func TestEngine_OnValidation_NoSelfDeadlockOnQuorum(t *testing.T) {
 	adaptor := newMockAdaptor()
 	adaptor.quorum = 1
@@ -3473,11 +3470,9 @@ func TestEngine_OnValidation_NoSelfDeadlockOnQuorum(t *testing.T) {
 		Full:      true,
 	}
 
-	// OnValidation must return cleanly even though Add fires the
-	// fully-validated callback (quorum=1, one trusted validator,
-	// one Full validation = quorum reached). Run on a separate
-	// goroutine with a tight timeout so a regression of the
-	// e.mu.RLock self-deadlock cannot pass by hanging.
+	// OnValidation must return cleanly when one trusted Full validation reaches
+	// quorum and fires the fully-validated callback. Run on a separate goroutine
+	// so a lock-lifetime regression cannot pass by hanging.
 	done := make(chan error, 1)
 	go func() {
 		done <- engine.OnValidation(validation, 1)

--- a/internal/consensus/rcl/engine_validation_disposition_test.go
+++ b/internal/consensus/rcl/engine_validation_disposition_test.go
@@ -1,12 +1,137 @@
 package rcl
 
 import (
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/stretchr/testify/require"
 )
+
+func TestProcessVerifiedValidationDrainsFinalityOutsideEngineLock(t *testing.T) {
+	adaptor := newMockAdaptor()
+	trusted := consensus.NodeID{0x45}
+	adaptor.quorum = 1
+	adaptor.setTrusted([]consensus.NodeID{trusted})
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	adaptor.onFullyValidated = func(consensus.LedgerID, uint32) {
+		close(entered)
+		<-release
+	}
+	engine := startedEngine(t, adaptor)
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	now := adaptor.Now()
+
+	validationDone := make(chan error, 1)
+	go func() {
+		_, err := engine.ProcessVerifiedValidation(&consensus.Validation{
+			LedgerSeq: 101,
+			LedgerID:  consensus.LedgerID{0xA1},
+			NodeID:    trusted,
+			SignTime:  now,
+			SeenTime:  now,
+			Full:      true,
+		}, consensus.ValidationOrigin{PeerID: 7})
+		validationDone <- err
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("fully validated callback did not start")
+	}
+
+	tickDone := make(chan struct{})
+	go func() {
+		engine.timerEntry()
+		close(tickDone)
+	}()
+	select {
+	case <-tickDone:
+	case <-time.After(time.Second):
+		t.Fatal("consensus tick waited for the fully validated callback")
+	}
+
+	processingDone := make(chan struct{})
+	go func() {
+		_, _ = engine.ProcessVerifiedValidation(&consensus.Validation{
+			LedgerSeq: 101,
+			LedgerID:  consensus.LedgerID{0xA1},
+			NodeID:    consensus.NodeID{0x99},
+			SignTime:  now,
+			SeenTime:  now,
+			Full:      true,
+		}, consensus.ValidationOrigin{PeerID: 8})
+		close(processingDone)
+	}()
+	select {
+	case <-processingDone:
+	case <-time.After(time.Second):
+		t.Fatal("validation processing waited for the fully validated callback")
+	}
+
+	releaseOnce.Do(func() { close(release) })
+	require.NoError(t, <-validationDone)
+}
+
+func TestSendValidationDrainsFinalityOutsideEngineLock(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.quorum = 1
+	adaptor.setTrusted([]consensus.NodeID{adaptor.nodeID})
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	adaptor.onFullyValidated = func(consensus.LedgerID, uint32) {
+		close(entered)
+		<-release
+	}
+	engine := startedEngine(t, adaptor)
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+
+	engine.mu.Lock()
+	engine.setMode(consensus.ModeProposing)
+	engine.deferPostUnlock++
+	engine.sendValidation(&mockLedger{
+		id:        consensus.LedgerID{0xA2},
+		seq:       101,
+		closeTime: adaptor.Now(),
+	})
+	engine.deferPostUnlock--
+	pending := engine.takePendingPostUnlockLocked()
+	engine.mu.Unlock()
+
+	flushDone := make(chan struct{})
+	go func() {
+		runPostUnlock(pending)
+		close(flushDone)
+	}()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("self-validation finality callback did not start")
+	}
+
+	tickDone := make(chan struct{})
+	go func() {
+		engine.timerEntry()
+		close(tickDone)
+	}()
+	select {
+	case <-tickDone:
+	case <-time.After(time.Second):
+		t.Fatal("consensus tick waited for the self-validation finality callback")
+	}
+
+	releaseOnce.Do(func() { close(release) })
+	select {
+	case <-flushDone:
+	case <-time.After(time.Second):
+		t.Fatal("deferred finality work did not finish")
+	}
+}
 
 func TestProcessVerifiedValidationDisposition(t *testing.T) {
 	adaptor := newMockAdaptor()

--- a/internal/consensus/rcl/engine_validation_disposition_test.go
+++ b/internal/consensus/rcl/engine_validation_disposition_test.go
@@ -9,6 +9,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type blockingTestSubscriber struct {
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (s *blockingTestSubscriber) OnEvent(event consensus.Event) {
+	s.once.Do(func() {
+		close(s.entered)
+		<-s.release
+	})
+}
+
 func TestProcessVerifiedValidationDrainsFinalityOutsideEngineLock(t *testing.T) {
 	adaptor := newMockAdaptor()
 	trusted := consensus.NodeID{0x45}
@@ -75,6 +88,128 @@ func TestProcessVerifiedValidationDrainsFinalityOutsideEngineLock(t *testing.T) 
 
 	releaseOnce.Do(func() { close(release) })
 	require.NoError(t, <-validationDone)
+}
+
+func TestProcessVerifiedValidationPublishesAfterFinality(t *testing.T) {
+	adaptor := newMockAdaptor()
+	trusted := consensus.NodeID{0x46}
+	adaptor.quorum = 1
+	adaptor.setTrusted([]consensus.NodeID{trusted})
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	adaptor.onFullyValidated = func(consensus.LedgerID, uint32) {
+		close(entered)
+		<-release
+	}
+	engine := NewEngine(adaptor, DefaultConfig())
+	engine.eventBus = consensus.NewEventBus(1)
+	subscriberRelease := make(chan struct{})
+	var subscriberReleaseOnce sync.Once
+	subscriber := &blockingTestSubscriber{
+		entered: make(chan struct{}),
+		release: subscriberRelease,
+	}
+	engine.Subscribe(subscriber)
+	require.NoError(t, engine.Start(t.Context()))
+	t.Cleanup(func() { require.NoError(t, engine.Stop()) })
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	t.Cleanup(func() { subscriberReleaseOnce.Do(func() { close(subscriberRelease) }) })
+	require.True(t, engine.eventBus.Publish(&consensus.PhaseChangedEvent{}))
+	select {
+	case <-subscriber.entered:
+	case <-time.After(time.Second):
+		t.Fatal("event subscriber did not start")
+	}
+	require.True(t, engine.eventBus.Publish(&consensus.PhaseChangedEvent{}))
+	require.Zero(t, engine.eventBus.DroppedEvents())
+	now := adaptor.Now()
+
+	validationDone := make(chan error, 1)
+	go func() {
+		_, err := engine.ProcessVerifiedValidation(&consensus.Validation{
+			LedgerSeq: 102,
+			LedgerID:  consensus.LedgerID{0xA2},
+			NodeID:    trusted,
+			SignTime:  now,
+			SeenTime:  now,
+			Full:      true,
+		}, consensus.ValidationOrigin{PeerID: 7})
+		validationDone <- err
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("fully validated callback did not start")
+	}
+	require.Zero(t, engine.eventBus.DroppedEvents(),
+		"validation event was published before finality completed")
+
+	releaseOnce.Do(func() { close(release) })
+	require.NoError(t, <-validationDone)
+	require.Equal(t, uint64(1), engine.eventBus.DroppedEvents(),
+		"validation event was not published after finality completed")
+}
+
+func TestStartRoundTrustRefreshDrainsFinalityOutsideEngineLock(t *testing.T) {
+	adaptor := newMockAdaptor()
+	listed := consensus.NodeID{0x47}
+	adaptor.setListed([]consensus.NodeID{listed})
+	engine := startedEngine(t, adaptor)
+	now := adaptor.Now()
+	_, err := engine.ProcessVerifiedValidation(&consensus.Validation{
+		LedgerSeq: 103,
+		LedgerID:  consensus.LedgerID{0xA3},
+		NodeID:    listed,
+		SignTime:  now,
+		SeenTime:  now,
+		Full:      true,
+	}, consensus.ValidationOrigin{PeerID: 8})
+	require.NoError(t, err)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	adaptor.onFullyValidated = func(consensus.LedgerID, uint32) {
+		close(entered)
+		<-release
+	}
+	adaptor.onRefreshUNL = func() {
+		adaptor.mu.Lock()
+		adaptor.trusted = map[consensus.NodeID]bool{listed: true}
+		adaptor.quorum = 1
+		adaptor.mu.Unlock()
+		adaptor.notifyTrustChanged()
+	}
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+
+	roundDone := make(chan error, 1)
+	go func() {
+		roundDone <- engine.StartRound(consensus.RoundID{
+			Seq:        101,
+			ParentHash: consensus.LedgerID{1},
+		}, true)
+	}()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("trust refresh did not promote stored validation")
+	}
+
+	tickDone := make(chan struct{})
+	go func() {
+		engine.timerEntry()
+		close(tickDone)
+	}()
+	select {
+	case <-tickDone:
+	case <-time.After(time.Second):
+		t.Fatal("consensus tick waited for trust-refresh finality callback")
+	}
+
+	releaseOnce.Do(func() { close(release) })
+	require.NoError(t, <-roundDone)
 }
 
 func TestSendValidationDrainsFinalityOutsideEngineLock(t *testing.T) {

--- a/internal/consensus/rcl/issue_1676_finality_deferral_test.go
+++ b/internal/consensus/rcl/issue_1676_finality_deferral_test.go
@@ -1,0 +1,55 @@
+package rcl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFinalityDeferralBlocksConcurrentDrain(t *testing.T) {
+	now := time.Date(2026, 8, 23, 0, 0, 0, 0, time.UTC)
+	nodeID := consensus.NodeID{0x51}
+	tracker := NewValidationTracker(1)
+	tracker.SetNow(func() time.Time { return now })
+	tracker.SetTrustedAndQuorum([]consensus.NodeID{nodeID}, 1)
+	fired := make(chan struct{}, 1)
+	tracker.SetFullyValidatedCallback(func(consensus.LedgerID, uint32) {
+		fired <- struct{}{}
+	})
+
+	tracker.beginFinalityDeferral()
+	status := tracker.addStatus(&consensus.Validation{
+		LedgerID:  consensus.LedgerID{0xA5},
+		LedgerSeq: 100,
+		NodeID:    nodeID,
+		SignTime:  now,
+		SeenTime:  now,
+		Full:      true,
+	}, false)
+	require.Equal(t, ValStatusCurrent, status)
+
+	drainDone := make(chan struct{})
+	go func() {
+		tracker.drainFinality()
+		close(drainDone)
+	}()
+	select {
+	case <-drainDone:
+	case <-time.After(time.Second):
+		t.Fatal("concurrent finality drain did not return")
+	}
+	select {
+	case <-fired:
+		t.Fatal("finality callback ran while dispatch was deferred")
+	default:
+	}
+
+	tracker.endFinalityDeferral()
+	select {
+	case <-fired:
+	case <-time.After(time.Second):
+		t.Fatal("finality callback did not run after deferral ended")
+	}
+}

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -192,6 +192,7 @@ type ValidationTracker struct {
 	pendingGeneration   map[finalityKey]uint64
 	finalityGeneration  uint64
 	dispatchingFinality bool
+	finalityDeferrals   int
 
 	// minSeq is the sequence floor for accepting new validations.
 	// Validations with LedgerSeq < minSeq are rejected in Add(). The
@@ -529,21 +530,14 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 //     Sequence monotonicity and equivocation remain enforced independently by
 //     bySequence/seqEnforcers.
 //
-// onFullyValidated is fired OUTSIDE vt.mu so the callback may call
-// back into the tracker (e.g. ExpireOld) or take other locks that
-// vt.mu doesn't shadow without deadlocking. Mirrors the lock-free
-// callback dispatch ExpireOld already uses for onStale.
-//
-// IMPORTANT: the engine's callers (OnValidation, sendValidation) hold
-// engine.e.mu.Lock when they call Add, so the callback runs under that
-// write lock too. The callback MUST NOT take engine.e.mu (RLock or
-// otherwise) — Go's RWMutex is non-recursive and would self-deadlock.
-// Adding new locks the callback may need is fine as long as they are
-// not already held by the caller chain.
-//
-// Defer order is LIFO: vt.mu.Unlock runs first (released before the
-// callback), then the captured fire-tuple is dispatched.
+// onFullyValidated is fired outside vt.mu. Engine callers use addStatus with a
+// finality deferral so tracker and round state remain linearized while callback
+// dispatch waits for the engine mutex to be released.
 func (vt *ValidationTracker) AddStatus(validation *consensus.Validation) ValStatus {
+	return vt.addStatus(validation, true)
+}
+
+func (vt *ValidationTracker) addStatus(validation *consensus.Validation, drainFinality bool) ValStatus {
 	if validation == nil {
 		return ValStatusStale
 	}
@@ -575,7 +569,9 @@ func (vt *ValidationTracker) AddStatus(validation *consensus.Validation) ValStat
 	vt.mu.Lock()
 	defer func() {
 		vt.mu.Unlock()
-		vt.drainFinality()
+		if drainFinality {
+			vt.drainFinality()
+		}
 	}()
 
 	// validation.NodeID is already master-shaped on entry — the
@@ -817,7 +813,7 @@ func (vt *ValidationTracker) cancelFinalityLocked(key finalityKey) {
 // active drainer observes and processes it after the callback returns.
 func (vt *ValidationTracker) drainFinality() {
 	vt.mu.Lock()
-	if vt.dispatchingFinality {
+	if vt.dispatchingFinality || vt.finalityDeferrals > 0 {
 		vt.mu.Unlock()
 		return
 	}
@@ -826,6 +822,11 @@ func (vt *ValidationTracker) drainFinality() {
 
 	for {
 		vt.mu.Lock()
+		if vt.finalityDeferrals > 0 {
+			vt.dispatchingFinality = false
+			vt.mu.Unlock()
+			return
+		}
 		if len(vt.pendingFinality) == 0 {
 			vt.dispatchingFinality = false
 			vt.mu.Unlock()
@@ -851,6 +852,26 @@ func (vt *ValidationTracker) drainFinality() {
 		callback := vt.onFullyValidated
 		vt.mu.Unlock()
 		callback(key.ledgerID, key.ledgerSeq)
+	}
+}
+
+func (vt *ValidationTracker) beginFinalityDeferral() {
+	vt.mu.Lock()
+	vt.finalityDeferrals++
+	vt.mu.Unlock()
+}
+
+func (vt *ValidationTracker) endFinalityDeferral() {
+	vt.mu.Lock()
+	if vt.finalityDeferrals == 0 {
+		vt.mu.Unlock()
+		panic("validation finality deferral underflow")
+	}
+	vt.finalityDeferrals--
+	ready := vt.finalityDeferrals == 0
+	vt.mu.Unlock()
+	if ready {
+		vt.drainFinality()
 	}
 }
 

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -133,8 +133,11 @@ type Ledger struct {
 	state     State
 	err       error
 	mu        sync.Mutex
-	logger    *slog.Logger
-	snapshot  atomic.Pointer[Snapshot]
+	// workMu serializes SHAMap mutation, completion, and persistence. Code that
+	// needs both locks acquires workMu before mu and releases mu before slow work.
+	workMu   sync.Mutex
+	logger   *slog.Logger
+	snapshot atomic.Pointer[Snapshot]
 
 	// family backs the acquisition SHAMaps with the persistent node store when
 	// set, so getMissingNodes only reports nodes not already held locally. nil
@@ -600,19 +603,43 @@ func (l *Ledger) GotBaseContext(ctx context.Context, nodes []message.LedgerNode)
 // while the acquisition remains in StateWantBase.
 func (l *Ledger) GotBaseUsefulContext(ctx context.Context, nodes []message.LedgerNode) (useful int, err error) {
 	var stored []shamap.FlushEntry
+	var stateMap, txMap *shamap.SHAMap
+
+	l.workMu.Lock()
+	defer l.workMu.Unlock()
+
 	l.mu.Lock()
+	if l.state != StateWantBase {
+		l.mu.Unlock()
+		return 0, nil
+	}
 	defer func() {
 		if useful > 0 {
 			l.markProgressLocked()
 		}
+		l.publishSnapshotLocked()
+		l.mu.Unlock()
+
 		l.persistReceived(ctx, stored, "roots")
+		stateComplete := stateMap != nil && stateMap.FinishSyncContext(ctx) == nil
+		txComplete := txMap != nil && txMap.FinishSyncContext(ctx) == nil
+
+		l.mu.Lock()
+		if l.state == StateWantBase || l.state == StateWantState {
+			if stateComplete && l.stateMap == stateMap {
+				l.haveState = true
+			}
+			if txComplete && l.txMap == txMap {
+				l.haveTx = true
+			}
+			if l.state == StateWantState {
+				l.recomputeComplete()
+			} else {
+				l.publishSnapshotLocked()
+			}
+		}
 		l.mu.Unlock()
 	}()
-
-	// Ignore duplicate responses after we've moved past WantBase
-	if l.state != StateWantBase {
-		return 0, nil
-	}
 
 	if len(nodes) > hardMaxReplyNodes {
 		return 0, fmt.Errorf("ledger data exceeds hardMaxReplyNodes: %d > %d", len(nodes), hardMaxReplyNodes)
@@ -678,8 +705,8 @@ func (l *Ledger) GotBaseUsefulContext(ctx context.Context, nodes []message.Ledge
 			return useful, fmt.Errorf("add state root node: %w", rootErr)
 		}
 		l.stateMap = sm
+		stateMap = sm
 		l.publishSnapshotLocked()
-		l.haveState = sm.FinishSyncContext(ctx) == nil
 		stored = append(stored, stateRoot)
 		useful++
 	}
@@ -697,8 +724,8 @@ func (l *Ledger) GotBaseUsefulContext(ctx context.Context, nodes []message.Ledge
 			return useful, fmt.Errorf("add tx root node: %w", rootErr)
 		}
 		l.txMap = tm
+		txMap = tm
 		l.publishSnapshotLocked()
-		l.haveTx = tm.FinishSyncContext(ctx) == nil
 		stored = append(stored, txRoot)
 		useful++
 	}
@@ -737,10 +764,12 @@ func (l *Ledger) GotStateNodesUsefulContext(ctx context.Context, nodes []message
 	}
 
 	var stored []shamap.FlushEntry
+	l.workMu.Lock()
+	defer l.workMu.Unlock()
 	l.mu.Lock()
 	defer func() {
-		l.persistReceived(ctx, stored, "state nodes")
 		l.mu.Unlock()
+		l.persistReceived(ctx, stored, "state nodes")
 	}()
 
 	if l.state == StateComplete || l.haveState {
@@ -797,10 +826,12 @@ func (l *Ledger) GotTransactionNodesUsefulContext(ctx context.Context, nodes []m
 	}
 
 	var stored []shamap.FlushEntry
+	l.workMu.Lock()
+	defer l.workMu.Unlock()
 	l.mu.Lock()
 	defer func() {
-		l.persistReceived(ctx, stored, "transaction nodes")
 		l.mu.Unlock()
+		l.persistReceived(ctx, stored, "transaction nodes")
 	}()
 
 	if l.state == StateComplete || l.haveTx {
@@ -955,18 +986,21 @@ func (l *Ledger) PromotePersistence(ctx context.Context) error {
 		return nil
 	}
 
+	l.workMu.Lock()
+	defer l.workMu.Unlock()
 	l.mu.Lock()
-	defer l.mu.Unlock()
+	stateMap, txMap := l.stateMap, l.txMap
+	l.mu.Unlock()
 	if err := promoter.Promote(ctx); err != nil {
 		return err
 	}
-	if l.stateMap != nil {
-		if err := l.stateMap.AcknowledgePersistedContext(ctx); err != nil {
+	if stateMap != nil {
+		if err := stateMap.AcknowledgePersistedContext(ctx); err != nil {
 			return err
 		}
 	}
-	if l.txMap != nil {
-		if err := l.txMap.AcknowledgePersistedContext(ctx); err != nil {
+	if txMap != nil {
+		if err := txMap.AcknowledgePersistedContext(ctx); err != nil {
 			return err
 		}
 	}
@@ -1025,13 +1059,22 @@ func (f missingNodeExclusionFilter) ShouldFetch(hash [32]byte) bool {
 // path-based NodeIDs of missing SHAMap inner nodes, ordered by depth.
 // Returns nil if the state map is complete or not yet ready (issue #395).
 func (l *Ledger) NeedsMissingNodeIDs() [][]byte {
+	l.workMu.Lock()
+	defer l.workMu.Unlock()
 	l.mu.Lock()
-	defer l.mu.Unlock()
-
 	if l.stateMap == nil || l.haveState || l.state != StateWantState {
+		l.mu.Unlock()
 		return nil
 	}
-	missing := l.stateMap.GetMissingNodes(missingNodeBatch, nil)
+	stateMap := l.stateMap
+	l.mu.Unlock()
+
+	missing := stateMap.GetMissingNodes(missingNodeBatch, nil)
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.stateMap != stateMap || l.haveState || l.state != StateWantState {
+		return nil
+	}
 	l.cacheMissingLocked(false, missing)
 	return missingNodeIDs(missing)
 }
@@ -1040,13 +1083,22 @@ func (l *Ledger) NeedsMissingNodeIDs() [][]byte {
 // missing transaction-tree inner nodes, mirroring NeedsMissingNodeIDs for the
 // tx map. Returns nil once the tx tree is complete (or empty).
 func (l *Ledger) NeedsMissingTxNodeIDs() [][]byte {
+	l.workMu.Lock()
+	defer l.workMu.Unlock()
 	l.mu.Lock()
-	defer l.mu.Unlock()
-
 	if l.txMap == nil || l.haveTx || l.state != StateWantState {
+		l.mu.Unlock()
 		return nil
 	}
-	missing := l.txMap.GetMissingNodes(missingNodeBatch, nil)
+	txMap := l.txMap
+	l.mu.Unlock()
+
+	missing := txMap.GetMissingNodes(missingNodeBatch, nil)
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.txMap != txMap || l.haveTx || l.state != StateWantState {
+		return nil
+	}
 	l.cacheMissingLocked(true, missing)
 	return missingNodeIDs(missing)
 }
@@ -1079,10 +1131,11 @@ func (l *Ledger) CollectMissingRequest(isReply bool) (state, txn [][]byte) {
 }
 
 // CollectMissingRequestContext performs the backing-store traversal without
-// holding the acquisition mutex. Peer replies may therefore continue attaching
-// nodes while a cold scan is in flight. The active tree is checked again before
+// holding the acquisition mutex. The active tree is checked again before
 // recent-node filtering or completion is committed.
 func (l *Ledger) CollectMissingRequestContext(ctx context.Context, isReply bool) (state, txn [][]byte, complete bool, err error) {
+	l.workMu.Lock()
+	defer l.workMu.Unlock()
 	l.mu.Lock()
 	if l.state != StateWantState {
 		complete = l.state == StateComplete
@@ -1111,6 +1164,11 @@ func (l *Ledger) CollectMissingRequestContext(ctx context.Context, isReply bool)
 		l.logger.Info("inbound ledger: missing-node walk delayed", "elapsed", elapsed, "missing", len(missing), "reply", isReply)
 	}
 
+	var finishErr error
+	if len(missing) == 0 {
+		finishErr = m.FinishSyncContext(ctx)
+	}
+
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if l.state != StateWantState {
@@ -1125,7 +1183,7 @@ func (l *Ledger) CollectMissingRequestContext(ctx context.Context, isReply bool)
 	}
 
 	if len(missing) == 0 {
-		if finishErr := m.FinishSyncContext(ctx); finishErr == nil {
+		if finishErr == nil {
 			if stateTree {
 				l.haveState = true
 			} else {
@@ -1200,6 +1258,8 @@ func (l *Ledger) CollectMissingAddedRequestsContext(ctx context.Context, peerIDs
 }
 
 func (l *Ledger) collectMissingPeerRequestsContext(ctx context.Context, peerIDs []uint64, batchLimit int, blind bool) ([]MissingRequest, bool, error) {
+	l.workMu.Lock()
+	defer l.workMu.Unlock()
 	if len(peerIDs) == 0 {
 		return nil, l.IsComplete(), nil
 	}
@@ -1261,6 +1321,7 @@ func (l *Ledger) collectMissingPeerRequestsContext(ctx context.Context, peerIDs 
 				if filter != nil {
 					break
 				}
+				finishErr := m.FinishSyncContext(ctx)
 				l.mu.Lock()
 				if l.state != StateWantState || (!transaction && (l.stateMap != m || l.haveState)) ||
 					(transaction && (l.txMap != m || l.haveTx)) {
@@ -1268,7 +1329,7 @@ func (l *Ledger) collectMissingPeerRequestsContext(ctx context.Context, peerIDs 
 					l.mu.Unlock()
 					return requests, complete, nil
 				}
-				if finishErr := m.FinishSyncContext(ctx); finishErr != nil {
+				if finishErr != nil {
 					l.mu.Unlock()
 					return requests, false, nil
 				}
@@ -1590,6 +1651,8 @@ func (l *Ledger) CheckLocalContext(ctx context.Context, fetch func(hash [32]byte
 	if fetch == nil {
 		return false, false, nil
 	}
+	l.workMu.Lock()
+	defer l.workMu.Unlock()
 
 	l.mu.Lock()
 	if l.state != StateWantState {

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -133,11 +133,9 @@ type Ledger struct {
 	state     State
 	err       error
 	mu        sync.Mutex
-	// workMu serializes SHAMap mutation, completion, and persistence. Code that
-	// needs both locks acquires workMu before mu and releases mu before slow work.
-	workMu   sync.Mutex
-	logger   *slog.Logger
-	snapshot atomic.Pointer[Snapshot]
+	workMu    sync.Mutex
+	logger    *slog.Logger
+	snapshot  atomic.Pointer[Snapshot]
 
 	// family backs the acquisition SHAMaps with the persistent node store when
 	// set, so getMissingNodes only reports nodes not already held locally. nil

--- a/internal/ledger/inbound/inbound_backed_test.go
+++ b/internal/ledger/inbound/inbound_backed_test.go
@@ -151,6 +151,75 @@ func TestGotBase_BackedCompletesEntirelyFromStore(t *testing.T) {
 	}
 }
 
+func TestGotBase_BlockedCompletenessWalkDoesNotHoldLedgerLock(t *testing.T) {
+	source, rootHash, rootData := buildBackedTestState(t, 0)
+	family := &trackerBlockingFamily{
+		base:    seedFamilyFrom(t, source),
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+		block:   true,
+	}
+	headerData, ledgerHash := encodeHeader(header.LedgerHeader{LedgerIndex: 100, AccountHash: rootHash})
+	base := []message.LedgerNode{{NodeData: headerData}, {NodeData: rootData}}
+	acquisition := New(ledgerHash, 100, 7, discardLogger(), WithFamily(family))
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- acquisition.GotBaseContext(ctx, base) }()
+
+	select {
+	case <-family.entered:
+	case <-time.After(time.Second):
+		t.Fatal("completeness walk did not reach the blocking store")
+	}
+
+	seqDone := make(chan uint32, 1)
+	go func() { seqDone <- acquisition.Seq() }()
+	select {
+	case seq := <-seqDone:
+		require.Equal(t, uint32(100), seq)
+	case <-time.After(time.Second):
+		t.Fatal("ledger sequence waited for the completeness walk")
+	}
+
+	peerDone := make(chan bool, 1)
+	go func() { peerDone <- acquisition.RemovePeer(7) }()
+	select {
+	case removed := <-peerDone:
+		require.True(t, removed)
+	case <-time.After(time.Second):
+		t.Fatal("peer removal waited for the completeness walk")
+	}
+
+	type baseResult struct {
+		useful int
+		err    error
+	}
+	stateMap := acquisition.stateMap
+	duplicateDone := make(chan baseResult, 1)
+	go func() {
+		useful, err := acquisition.GotBaseUsefulContext(t.Context(), base)
+		duplicateDone <- baseResult{useful: useful, err: err}
+	}()
+
+	cancel()
+	require.NoError(t, <-done)
+	require.Equal(t, StateWantState, acquisition.State())
+	require.False(t, acquisition.Snapshot().HaveState,
+		"a canceled completeness walk must not publish a stale result")
+
+	duplicate := <-duplicateDone
+	require.NoError(t, duplicate.err)
+	require.Zero(t, duplicate.useful)
+	require.Same(t, stateMap, acquisition.stateMap,
+		"duplicate base data must not replace the active map")
+
+	close(family.release)
+	_, _, complete, err := acquisition.CollectMissingRequestContext(t.Context(), false)
+	require.NoError(t, err)
+	require.True(t, complete)
+	require.True(t, acquisition.IsComplete())
+}
+
 // TestGotBase_ColdStoreMatchesUnbacked proves no regression for forward
 // catch-up of a brand-new ledger: a backed acquisition over an empty store
 // reports the same missing set as an unbacked one, so it still fetches the tree
@@ -483,7 +552,7 @@ func TestGotBase_PersistsStateRootWhileWaitingForTransactionRoot(t *testing.T) {
 	require.NotNil(t, stored, "verified state root must remain reusable while the transaction root is missing")
 }
 
-func TestGotBase_PersistsBeforeReleasingAcquisitionLock(t *testing.T) {
+func TestGotBase_PersistenceDoesNotHoldAcquisitionLock(t *testing.T) {
 	_, rootHash, rootData := buildBackedTestState(t, 0)
 	family := backend.NewMemory()
 	headerData, ledgerHash := encodeHeader(header.LedgerHeader{LedgerIndex: 100, AccountHash: rootHash})
@@ -508,15 +577,12 @@ func TestGotBase_PersistsBeforeReleasingAcquisitionLock(t *testing.T) {
 	stateDone := make(chan State, 1)
 	go func() { stateDone <- acquisition.State() }()
 	select {
-	case <-stateDone:
-		t.Fatal("acquisition lock released before persistence admission")
-	case <-time.After(25 * time.Millisecond):
+	case state := <-stateDone:
+		require.Equal(t, StateWantState, state)
+	case <-time.After(time.Second):
+		t.Fatal("acquisition state waited for persistence admission")
 	}
 	close(release)
 	require.NoError(t, <-done)
-	select {
-	case <-stateDone:
-	case <-time.After(time.Second):
-		t.Fatal("acquisition lock remained held after persistence admission")
-	}
+	require.Equal(t, StateWantState, acquisition.State())
 }


### PR DESCRIPTION
## Summary

- serialize inbound SHAMap mutation, completion, and persistence without holding the acquisition metadata mutex across slow store-backed work
- preserve validation and trust-state ordering under the consensus engine mutex while dispatching finality callbacks only after unlock
- add focused and end-to-end regressions for a blocked traversal through the real inbound, router, validation, and consensus-tick chain

The lock lifetime matches rippled v3.3.0's acquisition pattern: slow missing-node traversal runs outside the per-acquisition mutex, then completion is committed only after state is revalidated.

## Testing

- [x] `go test -race ./internal/ledger/inbound/...`
- [x] `go test -race ./internal/consensus/rcl/...`
- [x] `go test -race ./internal/consensus/adaptor/...`
- [x] `just test-core`
- [x] `just vet`
- [x] `just lint`

Fixes #1676
