### PR TITLE
feat: make ledger cache window configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -149,6 +149,7 @@ func (c *Config) ResolvedLedgerHistory() int {
 	return c.LedgerHistory.Value()
 }
 
+// ResolvedLedgerCacheSize returns the configured size or DefaultLedgerCacheSize when unset.
 func (c *Config) ResolvedLedgerCacheSize() int {
 	if c.LedgerCacheSize == nil {
 		return DefaultLedgerCacheSize

--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	RelayProposals   string        `toml:"relay_proposals" mapstructure:"relay_proposals"`     // optional; "" = default ("trusted")
 	RelayValidations string        `toml:"relay_validations" mapstructure:"relay_validations"` // optional; "" = default ("all")
 	LedgerHistory    LedgerHistory `toml:"ledger_history" mapstructure:"ledger_history"`       // integer, "full", or "none"; absent = 256
+	LedgerCacheSize  *int          `toml:"ledger_cache_size" mapstructure:"ledger_cache_size"` // in-memory ledger and persisted lookup caches; absent = 256
 	FetchDepth       FetchDepth    `toml:"fetch_depth" mapstructure:"fetch_depth"`             // integer, "full", or "none"; absent = "full"; values < 10 are raised to 10
 	ValidationSeed   string        `toml:"validation_seed" mapstructure:"validation_seed"`
 	ValidatorToken   string        `toml:"validator_token" mapstructure:"validator_token"`
@@ -128,6 +129,14 @@ func (c *Config) ResolvedNetworkID() (int, error) {
 // defaultLedgerHistory mirrors rippled's LEDGER_HISTORY default (Config.h).
 const defaultLedgerHistory = 256
 
+// Ledger cache bounds preserve the existing default and use rippled's largest
+// node-size cache target as the safety ceiling.
+const (
+	MinLedgerCacheSize     = 1
+	DefaultLedgerCacheSize = 256
+	MaxLedgerCacheSize     = 384
+)
+
 // ResolvedLedgerHistory returns the configured ledger history as an integer.
 // "full" maps to math.MaxInt32 (matching rippled's uint32 max sentinel)
 // so that downstream comparisons such as the online_delete cross-check
@@ -138,6 +147,14 @@ func (c *Config) ResolvedLedgerHistory() int {
 		return defaultLedgerHistory
 	}
 	return c.LedgerHistory.Value()
+}
+
+// ResolvedLedgerCacheSize returns the configured in-memory ledger cache size.
+func (c *Config) ResolvedLedgerCacheSize() int {
+	if c.LedgerCacheSize == nil {
+		return DefaultLedgerCacheSize
+	}
+	return *c.LedgerCacheSize
 }
 
 // defaultFetchDepth mirrors rippled's FETCH_DEPTH default (Config.h): the

--- a/config/config.go
+++ b/config/config.go
@@ -149,7 +149,6 @@ func (c *Config) ResolvedLedgerHistory() int {
 	return c.LedgerHistory.Value()
 }
 
-// ResolvedLedgerCacheSize returns the configured in-memory ledger cache size.
 func (c *Config) ResolvedLedgerCacheSize() int {
 	if c.LedgerCacheSize == nil {
 		return DefaultLedgerCacheSize

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -966,7 +966,6 @@ func TestConfigHelperMethods_Defaults(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "required but not set")
 
-	// Unset history, cache, and fetch settings fall back to their defaults.
 	assert.Equal(t, 256, config.ResolvedLedgerHistory())
 	assert.Equal(t, DefaultLedgerCacheSize, config.ResolvedLedgerCacheSize())
 	assert.Equal(t, defaultFetchDepth, config.ResolvedFetchDepth())

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,6 +22,7 @@ func completeTestConfig() string {
 database_path = "/tmp/test/db"
 network_id = "main"
 ledger_history = 256
+ledger_cache_size = 300
 fetch_depth = "full"
 node_size = "tiny"
 debug_logfile = "/tmp/test/debug.log"
@@ -124,6 +125,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, int64(2048), config.NodeDB.CacheMB)
 	assert.Equal(t, 1000, config.NodeDB.OpenFiles)
 	assert.Equal(t, 32, config.NodeDB.FastLoadWorkers)
+	assert.Equal(t, 300, config.ResolvedLedgerCacheSize())
 	require.NotNil(t, config.FeeDefault)
 	assert.Equal(t, 13, *config.FeeDefault)
 
@@ -304,6 +306,7 @@ func TestLoadConfig_MinimalConfig(t *testing.T) {
 	require.NotNil(t, config)
 
 	assert.Equal(t, 256, config.ResolvedLedgerHistory())
+	assert.Equal(t, DefaultLedgerCacheSize, config.ResolvedLedgerCacheSize())
 	assert.Equal(t, defaultFetchDepth, config.ResolvedFetchDepth())
 	assert.Zero(t, config.MaxTransactions)
 	assert.Empty(t, config.NodeSize)
@@ -939,10 +942,12 @@ func TestValidatePortString_TrailingGarbage(t *testing.T) {
 }
 
 func TestConfigHelperMethods(t *testing.T) {
+	cacheSize := 300
 	config := &Config{
-		NetworkID:     NetworkID{Set: true, Name: "main"},
-		LedgerHistory: LedgerHistory{Set: true, Count: 1000},
-		FetchDepth:    FetchDepth{Set: true, Full: true},
+		NetworkID:       NetworkID{Set: true, Name: "main"},
+		LedgerHistory:   LedgerHistory{Set: true, Count: 1000},
+		LedgerCacheSize: &cacheSize,
+		FetchDepth:      FetchDepth{Set: true, Full: true},
 	}
 
 	networkID, err := config.ResolvedNetworkID()
@@ -950,6 +955,7 @@ func TestConfigHelperMethods(t *testing.T) {
 	assert.Equal(t, 0, networkID)
 
 	assert.Equal(t, 1000, config.ResolvedLedgerHistory())
+	assert.Equal(t, cacheSize, config.ResolvedLedgerCacheSize())
 	assert.Equal(t, math.MaxInt32, config.ResolvedFetchDepth()) // "full" maps to MaxInt32
 }
 
@@ -960,9 +966,41 @@ func TestConfigHelperMethods_Defaults(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "required but not set")
 
-	// Unset ledger_history / fetch_depth fall back to the rippled defaults.
+	// Unset history, cache, and fetch settings fall back to their defaults.
 	assert.Equal(t, 256, config.ResolvedLedgerHistory())
+	assert.Equal(t, DefaultLedgerCacheSize, config.ResolvedLedgerCacheSize())
 	assert.Equal(t, defaultFetchDepth, config.ResolvedFetchDepth())
+}
+
+func TestLoadConfigLedgerCacheSize(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    int
+		wantErr string
+	}{
+		{name: "minimum", value: "1", want: 1},
+		{name: "default-sized", value: "256", want: 256},
+		{name: "maximum", value: "384", want: 384},
+		{name: "zero", value: "0", wantErr: "ledger_cache_size must be between 1 and 384"},
+		{name: "negative", value: "-1", wantErr: "ledger_cache_size must be between 1 and 384"},
+		{name: "above maximum", value: "385", wantErr: "ledger_cache_size must be between 1 and 384"},
+		{name: "string", value: `"256"`, wantErr: "ledger_cache_size must be an integer count"},
+		{name: "float", value: "256.5", wantErr: "ledger_cache_size must be an integer count"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := writeConfig(t, t.TempDir(), "xrpld.toml", "ledger_cache_size = "+test.value+"\n"+minimalTestConfig())
+			cfg, err := LoadConfig(Paths{Main: path})
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.want, cfg.ResolvedLedgerCacheSize())
+		})
+	}
 }
 
 func TestPortConfigMethods(t *testing.T) {

--- a/config/examples/xrpld.toml
+++ b/config/examples/xrpld.toml
@@ -24,10 +24,11 @@ ips = [
 # Fixed peer connections (optional)
 # ips_fixed = ["192.168.1.100 51235"]
 
-# Ripple Protocol (optional — defaults: trusted / all / 256 / "full")
+# Ripple Protocol (optional — defaults shown below)
 relay_proposals = "trusted"      # all, trusted, drop_untrusted (case-insensitive)
 relay_validations = "all"        # all, trusted, drop_untrusted (case-insensitive)
 ledger_history = 256             # integer, "full", or "none"
+ledger_cache_size = 256          # recent ledger/tx indexes and persisted-ledger lookups (1-384)
 fetch_depth = "full"             # integer, "full", or "none" (values < 10 are clamped to 10)
 
 # Network: "main", "testnet", "devnet", or integer

--- a/config/loader.go
+++ b/config/loader.go
@@ -24,6 +24,9 @@ func LoadConfig(paths Paths) (*Config, error) {
 	if err := validateManifestCounts(v); err != nil {
 		return nil, fmt.Errorf("failed to load main config: %w", err)
 	}
+	if err := validateIntegerSetting(v, "ledger_cache_size", MinLedgerCacheSize, MaxLedgerCacheSize); err != nil {
+		return nil, fmt.Errorf("failed to load main config: %w", err)
+	}
 
 	// Unmarshal into struct.
 	// The custom decode hook is required so viper can decode the typed
@@ -69,27 +72,32 @@ func LoadConfig(paths Paths) (*Config, error) {
 // malformed configuration appear valid after decoding.
 func validateManifestCounts(v *viper.Viper) error {
 	for _, key := range []string{"overlay.max_untrusted_count", "overlay.max_trusted_count"} {
-		if !v.IsSet(key) {
-			continue
+		if err := validateIntegerSetting(v, key, MinManifestCount, MaxManifestCount); err != nil {
+			return err
 		}
+	}
+	return nil
+}
 
-		value := reflect.ValueOf(v.Get(key))
-		switch value.Kind() {
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			count := value.Int()
-			if count < MinManifestCount || count > MaxManifestCount {
-				return fmt.Errorf("%s must be between %d and %d, got %d",
-					key, MinManifestCount, MaxManifestCount, count)
-			}
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			count := value.Uint()
-			if count < MinManifestCount || count > MaxManifestCount {
-				return fmt.Errorf("%s must be between %d and %d, got %d",
-					key, MinManifestCount, MaxManifestCount, count)
-			}
-		default:
-			return fmt.Errorf("%s must be an integer count", key)
+func validateIntegerSetting(v *viper.Viper, key string, minValue, maxValue int) error {
+	if !v.IsSet(key) {
+		return nil
+	}
+
+	value := reflect.ValueOf(v.Get(key))
+	switch value.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		count := value.Int()
+		if count < int64(minValue) || count > int64(maxValue) {
+			return fmt.Errorf("%s must be between %d and %d, got %d", key, minValue, maxValue, count)
 		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		count := value.Uint()
+		if count < uint64(minValue) || count > uint64(maxValue) {
+			return fmt.Errorf("%s must be between %d and %d, got %d", key, minValue, maxValue, count)
+		}
+	default:
+		return fmt.Errorf("%s must be an integer count", key)
 	}
 	return nil
 }

--- a/config/misc.go
+++ b/config/misc.go
@@ -79,6 +79,7 @@ func ValidatePathSearchMax(pathSearchMax *int) error {
 	return validateNonNegative("path_search_max", *pathSearchMax)
 }
 
+// ValidateLedgerCacheSize accepts an unset size or a value within the supported cache bounds.
 func ValidateLedgerCacheSize(size *int) error {
 	if size == nil {
 		return nil

--- a/config/misc.go
+++ b/config/misc.go
@@ -79,6 +79,18 @@ func ValidatePathSearchMax(pathSearchMax *int) error {
 	return validateNonNegative("path_search_max", *pathSearchMax)
 }
 
+// ValidateLedgerCacheSize validates the in-memory ledger cache limit.
+func ValidateLedgerCacheSize(size *int) error {
+	if size == nil {
+		return nil
+	}
+	if *size < MinLedgerCacheSize || *size > MaxLedgerCacheSize {
+		return fmt.Errorf("ledger_cache_size must be between %d and %d, got %d",
+			MinLedgerCacheSize, MaxLedgerCacheSize, *size)
+	}
+	return nil
+}
+
 // ValidateWebsocketPingFrequency validates the websocket ping frequency
 func ValidateWebsocketPingFrequency(frequency int) error {
 	return validateNonNegative("websocket_ping_frequency", frequency)

--- a/config/misc.go
+++ b/config/misc.go
@@ -79,7 +79,6 @@ func ValidatePathSearchMax(pathSearchMax *int) error {
 	return validateNonNegative("path_search_max", *pathSearchMax)
 }
 
-// ValidateLedgerCacheSize validates the in-memory ledger cache limit.
 func ValidateLedgerCacheSize(size *int) error {
 	if size == nil {
 		return nil

--- a/config/validation.go
+++ b/config/validation.go
@@ -228,6 +228,9 @@ func validateMiscSettings(config *Config) []error {
 	if err := ValidatePathSearchMax(config.PathSearchMax); err != nil {
 		errs = append(errs, err)
 	}
+	if err := ValidateLedgerCacheSize(config.LedgerCacheSize); err != nil {
+		errs = append(errs, err)
+	}
 	if err := ValidateWebsocketPingFrequency(config.WebsocketPingFrequency); err != nil {
 		errs = append(errs, err)
 	}

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -226,6 +226,7 @@ keys to precede any `[section]` header.
 | `relay_proposals` | `"trusted"` | `all`, `trusted`, or `drop_untrusted`. |
 | `relay_validations` | `"all"` | `all`, `trusted`, or `drop_untrusted`. |
 | `ledger_history` | `256` | Ledgers to retain: integer, `"full"`, or `"none"`. |
+| `ledger_cache_size` | `256` | Recent in-memory ledger/transaction-index window and persisted-ledger lookup cache; integer from 1 to 384. |
 | `fetch_depth` | `"full"` | Back-fill depth: integer, `"full"`, or `"none"` (values < 10 clamp to 10). |
 | `network_id` | `"main"` | `"main"`, `"testnet"`, `"devnet"`, or an integer. |
 | `ledger_replay` | `0` | `0` = disabled, `1` = advertise peer replay capability. Unrelated to startup `--replay`. |

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -218,10 +218,11 @@ max_transactions = 250
 
 %s
 
-# Ripple Protocol (optional — defaults: trusted / all / 256 / "full")
+# Ripple Protocol (optional — defaults shown below)
 relay_proposals = "trusted"
 relay_validations = "all"
 ledger_history = 256
+ledger_cache_size = 256
 fetch_depth = "full"
 network_id = "%s"
 ledger_replay = 0

--- a/internal/ledger/service/cache.go
+++ b/internal/ledger/service/cache.go
@@ -9,12 +9,6 @@ import (
 	"github.com/LeJamon/go-xrpl/shamap"
 )
 
-// caps in-memory ledgerHistory + tx-index to a window of recent validated
-// ledgers; older seqs fall through to the relational DB
-const historyWindow = 256
-
-const persistedLedgerCacheSize = historyWindow
-
 func (s *historyComponent) ledgerBySequence(seq uint32) *ledger.Ledger {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -223,13 +217,14 @@ func (s *Service) completeLedgerEvictionStatus(seq uint32) (tracked, durable boo
 	return tracked, durable
 }
 
-// evictOldHistoryLocked drops ledgerHistory + tx-index entries older than the
-// historyWindow. Caller holds Service.mu and historyComponent.mu.
+// evictOldHistoryLocked drops ledgerHistory + tx-index entries outside the
+// configured cache window. Caller holds Service.mu and historyComponent.mu.
 func (s *Service) evictOldHistoryLocked(latestValidatedSeq uint32) {
-	if latestValidatedSeq <= historyWindow {
+	window := s.ledgerCacheSize()
+	if latestValidatedSeq <= window {
 		return
 	}
-	cutoff := latestValidatedSeq - historyWindow
+	cutoff := latestValidatedSeq - window
 	for seq, l := range s.ledgerHistory {
 		if seq > cutoff {
 			continue
@@ -266,7 +261,7 @@ func (s *historyComponent) deleteHistoryLocked(seq uint32) {
 	}
 }
 
-func (s *historyComponent) cachePersistedLedgerLocked(l *ledger.Ledger) {
+func (s *Service) cachePersistedLedgerLocked(l *ledger.Ledger) {
 	hash := l.Hash()
 	if existing, ok := s.persistedLedgers[hash]; ok {
 		if existing.IsValidated() && !l.IsValidated() {
@@ -277,7 +272,7 @@ func (s *historyComponent) cachePersistedLedgerLocked(l *ledger.Ledger) {
 	}
 	s.persistedLedgers[hash] = l
 	s.persistedLedgerFIFO = append(s.persistedLedgerFIFO, hash)
-	if len(s.persistedLedgerFIFO) <= persistedLedgerCacheSize {
+	if len(s.persistedLedgerFIFO) <= int(s.ledgerCacheSize()) {
 		return
 	}
 	oldest := s.persistedLedgerFIFO[0]

--- a/internal/ledger/service/cache.go
+++ b/internal/ledger/service/cache.go
@@ -308,6 +308,50 @@ func (s *Service) stashPendingValidationLocked(hash [32]byte, event *LedgerAccep
 	}
 }
 
+func (s *Service) retainValidationCandidateLocked(l *ledger.Ledger) {
+	seq := l.Sequence()
+	if _, exists := s.validationCandidates[seq]; !exists {
+		s.validationCandidateOrder = append(s.validationCandidateOrder, seq)
+	}
+	s.validationCandidates[seq] = l
+	for len(s.validationCandidateOrder) > pendingValidationMaxLen {
+		oldest := s.validationCandidateOrder[0]
+		s.validationCandidateOrder = s.validationCandidateOrder[1:]
+		delete(s.validationCandidates, oldest)
+	}
+}
+
+func (s *Service) drainValidationCandidateLocked(seq uint32, hash [32]byte) {
+	l := s.validationCandidates[seq]
+	if l == nil || l.Hash() != hash {
+		return
+	}
+	s.dropValidationCandidateLocked(seq)
+}
+
+func (s *Service) dropValidationCandidateLocked(seq uint32) {
+	delete(s.validationCandidates, seq)
+	for i, candidateSeq := range s.validationCandidateOrder {
+		if candidateSeq == seq {
+			s.validationCandidateOrder = append(
+				s.validationCandidateOrder[:i],
+				s.validationCandidateOrder[i+1:]...,
+			)
+			break
+		}
+	}
+}
+
+func (s *Service) dropValidationCandidateRangeLocked(first, keepSeq uint32, keepHash [32]byte) {
+	for seq, candidate := range s.validationCandidates {
+		if seq < first || (seq == keepSeq && candidate.Hash() == keepHash) {
+			continue
+		}
+		s.dropValidationCandidateLocked(seq)
+		s.drainPendingValidationLocked(candidate.Hash())
+	}
+}
+
 // drainPendingValidationLocked removes and returns the stashed event for hash,
 // or nil. Caller must hold s.mu.
 func (s *Service) drainPendingValidationLocked(hash [32]byte) *LedgerAcceptedEvent {

--- a/internal/ledger/service/history_eviction_test.go
+++ b/internal/ledger/service/history_eviction_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/LeJamon/go-xrpl/shamap"
+	shamapbackend "github.com/LeJamon/go-xrpl/shamap/backend"
 )
 
 func mustNewOpenWithHeader(t *testing.T, h header.LedgerHeader, stateMap, txMap *shamap.SHAMap) *ledger.Ledger {
@@ -176,6 +178,186 @@ func TestAcceptLedgerLoop_BoundsHistory(t *testing.T) {
 	last := svc.GetClosedLedgerIndex()
 	if got, want := svc.GetServerInfo().CompleteLedgers, formatRange(last-window+1, last); got != want {
 		t.Errorf("complete_ledgers includes evicted in-memory history: got %q, want %q", got, want)
+	}
+}
+
+func TestDelayedValidationSurvivesHistoryEviction(t *testing.T) {
+	for _, evictCandidate := range []bool{false, true} {
+		name := "retained_candidate"
+		if evictCandidate {
+			name = "durable_fallback"
+		}
+		t.Run(name, func(t *testing.T) {
+			db := newTestNodeStore(t, 10_000)
+			t.Cleanup(func() {
+				if err := db.Close(); err != nil {
+					t.Errorf("close nodestore: %v", err)
+				}
+			})
+			cfg := DefaultConfig()
+			cfg.LedgerCacheSize = 1
+			cfg.NodeStore = db
+			cfg.SHAMapFamily = shamapbackend.New(db)
+			svc, err := New(cfg)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			if err := svc.Start(); err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+			t.Cleanup(svc.Stop)
+
+			ctx := context.Background()
+			parent := svc.GetClosedLedger()
+			closeTime := time.Now().UTC()
+			firstSeq, err := svc.AcceptConsensusResult(ctx, parent, nil, nil, closeTime, true)
+			if err != nil {
+				t.Fatalf("AcceptConsensusResult(first): %v", err)
+			}
+			first := svc.GetClosedLedger()
+			firstHash := first.Hash()
+			secondSeq, err := svc.AcceptConsensusResult(ctx, first, nil, nil, closeTime.Add(time.Second), true)
+			if err != nil {
+				t.Fatalf("AcceptConsensusResult(second): %v", err)
+			}
+			second := svc.GetClosedLedger()
+			svc.mu.RLock()
+			_, pendingEvent := svc.pendingValidation[firstHash]
+			svc.mu.RUnlock()
+			if pendingEvent {
+				t.Fatal("validation event retained without an event sink")
+			}
+			if evictCandidate {
+				svc.FlushPersists()
+				svc.mu.Lock()
+				svc.drainValidationCandidateLocked(firstSeq, firstHash)
+				svc.mu.Unlock()
+			}
+
+			svc.SetValidatedLedger(secondSeq, second.Hash())
+			svc.historyComponent.mu.RLock()
+			_, firstStillCached := svc.ledgerHistory[firstSeq]
+			svc.historyComponent.mu.RUnlock()
+			if firstStillCached {
+				t.Fatalf("ledger %d remained in one-ledger history window", firstSeq)
+			}
+			if first.IsValidated() {
+				t.Fatalf("ledger %d validated before delayed quorum", firstSeq)
+			}
+
+			svc.SetValidatedLedger(firstSeq, firstHash)
+			if !first.IsValidated() && !evictCandidate {
+				t.Fatalf("ledger %d was not validated after history eviction", firstSeq)
+			}
+			if evictCandidate {
+				svc.FlushPersists()
+				validated, err := svc.GetLedgerBySequence(firstSeq)
+				if err != nil || !validated.IsValidated() {
+					t.Fatalf("durable ledger %d was not validated after cache eviction: %v", firstSeq, err)
+				}
+			}
+			svc.mu.RLock()
+			candidate := svc.validationCandidates[firstSeq]
+			svc.mu.RUnlock()
+			if candidate != nil {
+				t.Fatalf("ledger %d remained a validation candidate", firstSeq)
+			}
+		})
+	}
+}
+
+func TestSetValidatedLedgerRejectsRetainedCandidateOnConflictingHistory(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(svc.Stop)
+
+	seq, err := svc.AcceptConsensusResult(
+		context.Background(), svc.GetClosedLedger(), nil, nil, time.Now().UTC(), true,
+	)
+	if err != nil {
+		t.Fatalf("AcceptConsensusResult: %v", err)
+	}
+	candidate := svc.GetClosedLedger()
+	candidateHash := candidate.Hash()
+	h, stateMap, txMap := acquiredLedgerFixture(t, seq, 0xF1)
+	conflicting, err := ledger.NewFromHeader(*h, stateMap, txMap, drops.Fees{})
+	if err != nil {
+		t.Fatalf("NewFromHeader: %v", err)
+	}
+	svc.mu.Lock()
+	svc.historyComponent.mu.Lock()
+	svc.putHistoryLocked(conflicting)
+	svc.historyComponent.mu.Unlock()
+	svc.mu.Unlock()
+
+	svc.SetValidatedLedger(seq, candidateHash)
+	if candidate.IsValidated() {
+		t.Fatal("stale validation candidate replaced conflicting history")
+	}
+	svc.historyComponent.mu.RLock()
+	got := svc.ledgerHistory[seq]
+	svc.historyComponent.mu.RUnlock()
+	if got == nil || got.Hash() != conflicting.Hash() {
+		t.Fatal("conflicting history changed after stale validation")
+	}
+}
+
+func TestForkCleanupDropsEvictedValidationCandidate(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(svc.Stop)
+
+	ctx := context.Background()
+	closeTime := time.Now().UTC()
+	parent := svc.GetClosedLedger()
+	_, err = svc.AcceptConsensusResult(ctx, parent, nil, nil, closeTime, true)
+	if err != nil {
+		t.Fatalf("AcceptConsensusResult(parent): %v", err)
+	}
+	staleParent := svc.GetClosedLedger()
+	staleSeq, err := svc.AcceptConsensusResult(
+		ctx, staleParent, nil, nil, closeTime.Add(time.Second), true,
+	)
+	if err != nil {
+		t.Fatalf("AcceptConsensusResult(stale): %v", err)
+	}
+	stale := svc.GetClosedLedger()
+	staleHash := stale.Hash()
+	svc.mu.Lock()
+	svc.historyComponent.mu.Lock()
+	svc.deleteHistoryLocked(staleSeq)
+	svc.historyComponent.mu.Unlock()
+	svc.mu.Unlock()
+
+	replacement, stateMap, txMap := acquiredLedgerFixture(t, staleSeq, 0xF2)
+	if err := svc.AdoptLedgerWithState(ctx, replacement, stateMap, txMap); err != nil {
+		t.Fatalf("AdoptLedgerWithState: %v", err)
+	}
+	svc.mu.RLock()
+	candidate := svc.validationCandidates[staleSeq]
+	svc.mu.RUnlock()
+	if candidate == nil || candidate.Hash() != replacement.Hash {
+		t.Fatal("fork cleanup retained the evicted stale validation candidate")
+	}
+
+	svc.mu.Lock()
+	svc.historyComponent.mu.Lock()
+	svc.deleteHistoryLocked(staleSeq)
+	svc.historyComponent.mu.Unlock()
+	svc.mu.Unlock()
+	svc.SetValidatedLedger(staleSeq, staleHash)
+	if stale.IsValidated() || svc.GetValidatedLedger().Hash() == staleHash {
+		t.Fatal("orphaned validation candidate advanced the validated frontier")
 	}
 }
 

--- a/internal/ledger/service/history_eviction_test.go
+++ b/internal/ledger/service/history_eviction_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/drops"
@@ -20,7 +21,17 @@ func mustNewOpenWithHeader(t *testing.T, h header.LedgerHeader, stateMap, txMap 
 }
 
 func TestEvictOldHistoryLocked(t *testing.T) {
-	svc, err := New(DefaultConfig())
+	for _, window := range []uint32{64, 256, 384} {
+		t.Run(fmt.Sprintf("window_%d", window), func(t *testing.T) {
+			testEvictOldHistoryLocked(t, window)
+		})
+	}
+}
+
+func testEvictOldHistoryLocked(t *testing.T, window uint32) {
+	cfg := DefaultConfig()
+	cfg.LedgerCacheSize = window
+	svc, err := New(cfg)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -59,7 +70,7 @@ func TestEvictOldHistoryLocked(t *testing.T) {
 		return l
 	}
 
-	const totalLedgers = historyWindow * 3
+	totalLedgers := window * 3
 	var latestSeq uint32 = 1
 	for range totalLedgers {
 		svc.ledgerHistory[latestSeq] = makeLedger(latestSeq, 0x42)
@@ -68,14 +79,16 @@ func TestEvictOldHistoryLocked(t *testing.T) {
 	latestValidated := latestSeq - 1
 
 	svc.mu.Lock()
+	svc.historyComponent.mu.Lock()
 	svc.evictOldHistoryLocked(latestValidated)
+	svc.historyComponent.mu.Unlock()
 	svc.mu.Unlock()
 
-	if got := len(svc.ledgerHistory); got != historyWindow {
-		t.Errorf("ledgerHistory size after eviction: got %d, want %d", got, historyWindow)
+	if got := len(svc.ledgerHistory); got != int(window) {
+		t.Errorf("ledgerHistory size after eviction: got %d, want %d", got, window)
 	}
 
-	cutoff := latestValidated - historyWindow
+	cutoff := latestValidated - window
 	for seq, l := range svc.ledgerHistory {
 		if seq <= cutoff {
 			t.Errorf("ledgerHistory[%d] survived eviction; cutoff=%d", seq, cutoff)
@@ -88,16 +101,18 @@ func TestEvictOldHistoryLocked(t *testing.T) {
 			t.Errorf("txIndex[%x]=%d survived eviction; cutoff=%d", txHash[:4], txSeq, cutoff)
 		}
 	}
-	if got, want := len(svc.txIndex), historyWindow; got != want {
+	if got, want := len(svc.txIndex), int(window); got != want {
 		t.Errorf("txIndex size: got %d, want %d", got, want)
 	}
-	if got, want := len(svc.txPositionIndex), historyWindow; got != want {
+	if got, want := len(svc.txPositionIndex), int(window); got != want {
 		t.Errorf("txPositionIndex size: got %d, want %d", got, want)
 	}
 }
 
 func TestEvictOldHistoryLocked_BelowWindow(t *testing.T) {
-	svc, err := New(DefaultConfig())
+	cfg := DefaultConfig()
+	cfg.LedgerCacheSize = 64
+	svc, err := New(cfg)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -105,7 +120,8 @@ func TestEvictOldHistoryLocked_BelowWindow(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 
-	for seq := uint32(1); seq <= historyWindow/2; seq++ {
+	window := svc.ledgerCacheSize()
+	for seq := uint32(1); seq <= window/2; seq++ {
 		stateMap, err := svc.genesisLedger.StateMapSnapshot()
 		if err != nil {
 			t.Fatalf("StateMapSnapshot: %v", err)
@@ -121,7 +137,9 @@ func TestEvictOldHistoryLocked_BelowWindow(t *testing.T) {
 
 	before := len(svc.ledgerHistory)
 	svc.mu.Lock()
-	svc.evictOldHistoryLocked(historyWindow / 2)
+	svc.historyComponent.mu.Lock()
+	svc.evictOldHistoryLocked(window / 2)
+	svc.historyComponent.mu.Unlock()
 	svc.mu.Unlock()
 
 	if got := len(svc.ledgerHistory); got != before {
@@ -130,7 +148,9 @@ func TestEvictOldHistoryLocked_BelowWindow(t *testing.T) {
 }
 
 func TestAcceptLedgerLoop_BoundsHistory(t *testing.T) {
-	svc, err := New(DefaultConfig())
+	cfg := DefaultConfig()
+	cfg.LedgerCacheSize = 64
+	svc, err := New(cfg)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -139,7 +159,8 @@ func TestAcceptLedgerLoop_BoundsHistory(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	for i := range historyWindow * 2 {
+	window := svc.ledgerCacheSize()
+	for i := range window * 2 {
 		if _, err := svc.AcceptLedger(ctx); err != nil {
 			t.Fatalf("AcceptLedger #%d: %v", i, err)
 		}
@@ -149,11 +170,11 @@ func TestAcceptLedgerLoop_BoundsHistory(t *testing.T) {
 	size := len(svc.ledgerHistory)
 	svc.mu.Unlock()
 
-	if size > historyWindow+1 {
-		t.Errorf("ledgerHistory unbounded under AcceptLedger loop: got %d, want <= %d", size, historyWindow+1)
+	if size > int(window+1) {
+		t.Errorf("ledgerHistory unbounded under AcceptLedger loop: got %d, want <= %d", size, window+1)
 	}
 	last := svc.GetClosedLedgerIndex()
-	if got, want := svc.GetServerInfo().CompleteLedgers, formatRange(last-historyWindow+1, last); got != want {
+	if got, want := svc.GetServerInfo().CompleteLedgers, formatRange(last-window+1, last); got != want {
 		t.Errorf("complete_ledgers includes evicted in-memory history: got %q, want %q", got, want)
 	}
 }
@@ -162,7 +183,9 @@ func TestAcceptLedgerLoop_BoundsHistory(t *testing.T) {
 // and is drained + promoted inline — eviction must run on that path
 // because no second SetValidatedLedger arrives for the same seq.
 func TestValidatedPromotionEvictsHistory(t *testing.T) {
-	svc, err := New(DefaultConfig())
+	cfg := DefaultConfig()
+	cfg.LedgerCacheSize = 64
+	svc, err := New(cfg)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -182,7 +205,8 @@ func TestValidatedPromotionEvictsHistory(t *testing.T) {
 		return stateMap, txMap
 	}
 
-	const adoptedSeq uint32 = historyWindow + 50
+	window := svc.ledgerCacheSize()
+	adoptedSeq := window + 50
 	adoptedState, adoptedTx := freshMaps()
 	var adoptedHeader header.LedgerHeader
 	adoptedHeader.LedgerIndex = adoptedSeq
@@ -191,7 +215,7 @@ func TestValidatedPromotionEvictsHistory(t *testing.T) {
 
 	// Seed entries below the post-eviction cutoff so promotion has
 	// observable work to do.
-	cutoff := adoptedSeq - historyWindow
+	cutoff := adoptedSeq - window
 	for seq := uint32(1); seq <= cutoff; seq++ {
 		st, tx := freshMaps()
 		var h header.LedgerHeader
@@ -209,7 +233,7 @@ func TestValidatedPromotionEvictsHistory(t *testing.T) {
 	size := len(svc.ledgerHistory)
 	svc.historyComponent.mu.RUnlock()
 
-	if size > historyWindow+1 {
-		t.Errorf("validated promotion left ledgerHistory unbounded: got %d, want <= %d", size, historyWindow+1)
+	if size > int(window+1) {
+		t.Errorf("validated promotion left ledgerHistory unbounded: got %d, want <= %d", size, window+1)
 	}
 }

--- a/internal/ledger/service/ledger_by_hash_nodestore_test.go
+++ b/internal/ledger/service/ledger_by_hash_nodestore_test.go
@@ -424,13 +424,15 @@ func TestService_GetLedgerByHashTreatsCorruptPersistedHeaderAsNotFound(t *testin
 }
 
 func TestService_PersistedLedgerHashCacheIsBounded(t *testing.T) {
+	const cacheSize uint32 = 32
 	svc := &Service{
+		config: Config{LedgerCacheSize: cacheSize},
 		historyComponent: historyComponent{
 			persistedLedgers: make(map[[32]byte]*ledger.Ledger),
 		},
 	}
 	var firstHash, lastHash [32]byte
-	for i := uint32(1); i <= persistedLedgerCacheSize+1; i++ {
+	for i := uint32(1); i <= cacheSize+1; i++ {
 		l := buildLedgerWithState(t, i)
 		if i == 1 {
 			firstHash = l.Hash()
@@ -439,8 +441,8 @@ func TestService_PersistedLedgerHashCacheIsBounded(t *testing.T) {
 		svc.cachePersistedLedgerLocked(l)
 	}
 
-	require.Len(t, svc.persistedLedgers, persistedLedgerCacheSize)
-	require.Len(t, svc.persistedLedgerFIFO, persistedLedgerCacheSize)
+	require.Len(t, svc.persistedLedgers, int(cacheSize))
+	require.Len(t, svc.persistedLedgerFIFO, int(cacheSize))
 	require.NotContains(t, svc.persistedLedgers, firstHash)
 	require.Contains(t, svc.persistedLedgers, lastHash)
 }

--- a/internal/ledger/service/lifecycle.go
+++ b/internal/ledger/service/lifecycle.go
@@ -285,6 +285,8 @@ func (s *Service) fixMismatchLocked(adopted *ledger.Ledger) {
 			}
 		}
 		s.invalidateCompleteLedger(adoptedSeq - 1)
+		s.dropValidationCandidateLocked(adoptedSeq - 1)
+		s.drainPendingValidationLocked(staleHash)
 		s.deleteHistoryLocked(adoptedSeq - 1)
 		s.logger.Warn("history backfill replaced a stale fork ledger below it",
 			"seq", adoptedSeq-1,
@@ -297,6 +299,7 @@ func (s *Service) fixMismatchLocked(adopted *ledger.Ledger) {
 	// Purge: the mismatched prev-seq, the same-seq alt (caller overwrites it
 	// anyway, but its tx-index must go), and every seq > adoptedSeq (orphans).
 	s.invalidateCompleteLedgerRange(adoptedSeq-1, ^uint32(0))
+	s.dropValidationCandidateRangeLocked(adoptedSeq-1, adoptedSeq, adopted.Hash())
 	var toRemove []uint32
 	toRemove = append(toRemove, adoptedSeq-1)
 	if sameSeq, ok := s.ledgerHistory[adoptedSeq]; ok && sameSeq.Hash() != adopted.Hash() {
@@ -477,12 +480,15 @@ func (s *Service) SwitchToPreferredLedger(parent *ledger.Ledger) error {
 	if parent.IsValidated() {
 		s.evictOldHistoryLocked(parent.Sequence())
 		s.enqueuePersist(parent)
-	} else if s.hasEventSink() {
-		s.stashPendingValidationLocked(parentHash, &LedgerAcceptedEvent{
-			LedgerInfo:         ledgerInfo(parent),
-			Ledger:             parent,
-			TransactionResults: stagedResults.results,
-		})
+	} else {
+		s.retainValidationCandidateLocked(parent)
+		if s.hasEventSink() {
+			s.stashPendingValidationLocked(parentHash, &LedgerAcceptedEvent{
+				LedgerInfo:         ledgerInfo(parent),
+				Ledger:             parent,
+				TransactionResults: stagedResults.results,
+			})
+		}
 	}
 
 	s.logger.Warn("Switched canonical closed ledger",
@@ -495,6 +501,7 @@ func (s *Service) SwitchToPreferredLedger(parent *ledger.Ledger) error {
 func (s *Service) purgeConflictingHistoryLocked(parent *ledger.Ledger) {
 	parentSeq := parent.Sequence()
 	parentHash := parent.Hash()
+	s.dropValidationCandidateRangeLocked(parentSeq, parentSeq, parentHash)
 	if s.closedLedger != nil && s.closedLedger.Sequence() >= parentSeq && s.closedLedger.Hash() != parentHash {
 		s.cachePersistedLedgerLocked(s.closedLedger)
 	}
@@ -713,6 +720,7 @@ func (s *Service) acceptConsensusResult(
 		Ledger:             s.closedLedger,
 		TransactionResults: txResults,
 	}
+	s.retainValidationCandidateLocked(closed)
 	if s.hasEventSink() {
 		s.stashPendingValidationLocked(closedLedgerHash, event)
 	}
@@ -735,6 +743,7 @@ func (s *Service) SetValidatedLedger(seq uint32, expectedHash [32]byte) {
 }
 
 func (s *Service) validatedLedgerEventLocked(l *ledger.Ledger) *LedgerAcceptedEvent {
+	s.drainValidationCandidateLocked(l.Sequence(), l.Hash())
 	event := s.drainPendingValidationLocked(l.Hash())
 	if event == nil {
 		return &LedgerAcceptedEvent{
@@ -774,22 +783,94 @@ func (s *Service) PromoteStoredValidatedLedgerAt(seq uint32, expectedHash [32]by
 }
 
 func (s *Service) setValidatedLedgerAt(seq uint32, expectedHash [32]byte, signTime time.Time, allowStored bool) {
-	s.mu.Lock()
-	s.historyComponent.mu.Lock()
-	previousValidated := s.validatedLedger
-	l, inHistory := s.ledgerHistory[seq]
-	fromStored := !inHistory || l.Hash() != expectedHash
-	if fromStored {
+	var (
+		previousValidated  *ledger.Ledger
+		l                  *ledger.Ledger
+		fromStored         bool
+		loadedStored       *ledger.Ledger
+		verifiedTipHash    [32]byte
+		historicalVerified bool
+	)
+	for {
+		s.mu.Lock()
+		s.historyComponent.mu.Lock()
+		previousValidated = s.validatedLedger
+		l, fromStored = s.ledgerHistory[seq], false
+		if l != nil {
+			if l.Hash() == expectedHash {
+				break
+			}
+			if !allowStored {
+				s.historyComponent.mu.Unlock()
+				s.mu.Unlock()
+				return
+			}
+		}
+		candidate := s.validationCandidates[seq]
 		if !allowStored {
-			s.historyComponent.mu.Unlock()
-			s.mu.Unlock()
+			if previousValidated == nil {
+				s.historyComponent.mu.Unlock()
+				s.mu.Unlock()
+				return
+			}
+			if seq > previousValidated.Sequence() {
+				if candidate != nil && candidate.Hash() == expectedHash {
+					l = candidate
+					break
+				}
+				s.historyComponent.mu.Unlock()
+				s.mu.Unlock()
+				return
+			}
+			tipHash := previousValidated.Hash()
+			if !historicalVerified || verifiedTipHash != tipHash {
+				tip := previousValidated
+				s.historyComponent.mu.Unlock()
+				s.mu.Unlock()
+				canonicalHash, ok, err := tip.HashOfSeq(seq)
+				if err != nil || !ok || canonicalHash != expectedHash {
+					return
+				}
+				verifiedTipHash = tipHash
+				historicalVerified = true
+				continue
+			}
+			if candidate != nil && candidate.Hash() == expectedHash {
+				l = candidate
+				break
+			}
+		} else if candidate != nil && candidate.Hash() == expectedHash {
+			l = candidate
+			fromStored = true
+			break
+		}
+		fromStored = allowStored
+		if cached := s.persistedLedgers[expectedHash]; cached != nil && cached.Sequence() == seq {
+			l = cached
+			break
+		}
+		if loadedStored != nil {
+			l = loadedStored
+			break
+		}
+		s.historyComponent.mu.Unlock()
+		s.mu.Unlock()
+
+		var err error
+		loadedStored, err = s.loadStoredLedgerByHash(context.Background(), expectedHash)
+		if err != nil {
+			s.logger.Warn("failed to load stored ledger for validation",
+				"seq", seq,
+				"hash", fmt.Sprintf("%x", expectedHash[:8]),
+				"error", err,
+			)
 			return
 		}
-		var ok bool
-		l, ok = s.persistedLedgers[expectedHash]
-		if !ok || l.Sequence() != seq {
-			s.historyComponent.mu.Unlock()
-			s.mu.Unlock()
+		if loadedStored == nil || loadedStored.Sequence() != seq {
+			s.logger.Warn("stored ledger unavailable for validation",
+				"seq", seq,
+				"hash", fmt.Sprintf("%x", expectedHash[:8]),
+			)
 			return
 		}
 	}
@@ -1322,6 +1403,7 @@ func (s *Service) adoptLedgerWithStateLocked(
 			Ledger:             adopted,
 			TransactionResults: txResults,
 		}
+		s.retainValidationCandidateLocked(adopted)
 		if s.hasEventSink() {
 			s.stashPendingValidationLocked(h.Hash, event)
 		}

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	appconfig "github.com/LeJamon/go-xrpl/config"
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/feetrack"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
@@ -62,6 +63,9 @@ type Config struct {
 	// FetchDepth limits historical ledger serving relative to the closed ledger.
 	// Zero leaves serving unrestricted.
 	FetchDepth uint32
+	// LedgerCacheSize bounds both recent ledger history and persisted-ledger lookups.
+	// Zero selects config.DefaultLedgerCacheSize.
+	LedgerCacheSize uint32
 
 	// NetworkID is the network identifier for this node.
 	// Legacy networks (ID <= 1024) reject transactions that include NetworkID.
@@ -296,6 +300,13 @@ const (
 func New(cfg Config) (*Service, error) {
 	if err := cfg.Startup.validateMode(); err != nil {
 		return nil, fmt.Errorf("invalid ledger service configuration: %w", err)
+	}
+	if cfg.LedgerCacheSize == 0 {
+		cfg.LedgerCacheSize = appconfig.DefaultLedgerCacheSize
+	}
+	if cfg.LedgerCacheSize > appconfig.MaxLedgerCacheSize {
+		return nil, fmt.Errorf("invalid ledger service configuration: ledger cache size must be between %d and %d, got %d",
+			appconfig.MinLedgerCacheSize, appconfig.MaxLedgerCacheSize, cfg.LedgerCacheSize)
 	}
 
 	logger := cfg.Logger
@@ -600,6 +611,8 @@ func (s *Service) Start() (err error) {
 	s.logger.Info("Ledger service started",
 		"standalone", s.config.Standalone,
 		"openLedger", s.openLedger.Sequence(),
+		"ledgerCacheSize", s.config.LedgerCacheSize,
+		"persistedLedgerCacheSize", s.config.LedgerCacheSize,
 		"needsInitialSync", s.networkLedgerState == networkLedgerNeeded,
 		"fastLoadProvisional", s.networkLedgerState == networkLedgerFastLoadProvisional,
 	)
@@ -609,6 +622,13 @@ func (s *Service) Start() (err error) {
 	s.lifecycleState = serviceRunning
 
 	return nil
+}
+
+func (s *Service) ledgerCacheSize() uint32 {
+	if s.config.LedgerCacheSize == 0 {
+		return appconfig.DefaultLedgerCacheSize
+	}
+	return s.config.LedgerCacheSize
 }
 
 // rebuildOpenLedgerViewLocked rebuilds s.openLedgerView from s.closedLedger

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -181,6 +181,11 @@ type Service struct {
 	// pendingValidationOrder tracks insertion order for LRU eviction.
 	pendingValidationOrder [][32]byte
 
+	// validationCandidates retain accepted ledgers across history eviction until
+	// quorum arrives. They are keyed by sequence so a replacement fork wins.
+	validationCandidates     map[uint32]*ledger.Ledger
+	validationCandidateOrder []uint32
+
 	// Invoked after the validated tip advances and after mu is released.
 	onValidatedLedger func(seq uint32, hash, parentHash [32]byte)
 
@@ -363,14 +368,15 @@ func New(cfg Config) (*Service, error) {
 			completeLedgerTokens: make(map[uint32]uint64),
 			sweepInterval:        nodeStoreSweepIntervalForSize(cfg.NodeSize),
 		},
-		pendingValidation: make(map[[32]byte]*LedgerAcceptedEvent),
-		heldAdoptions:     make(map[uint32]*pendingAdopt),
-		txQueue:           txQueue,
-		localTxs:          localtxs.New(),
-		relayTxCache:      make(map[[32]byte]relayTxRecord),
-		relayTxCacheLimit: relayTxCacheMaxBytes,
-		feeTrack:          feetrack.New(),
-		validatedAgeNow:   time.Now,
+		pendingValidation:    make(map[[32]byte]*LedgerAcceptedEvent),
+		validationCandidates: make(map[uint32]*ledger.Ledger),
+		heldAdoptions:        make(map[uint32]*pendingAdopt),
+		txQueue:              txQueue,
+		localTxs:             localtxs.New(),
+		relayTxCache:         make(map[[32]byte]relayTxRecord),
+		relayTxCacheLimit:    relayTxCacheMaxBytes,
+		feeTrack:             feetrack.New(),
+		validatedAgeNow:      time.Now,
 	}
 	s.persistenceWorker.service = s
 	s.eventPublisher.service = s

--- a/internal/ledger/service/service_test.go
+++ b/internal/ledger/service/service_test.go
@@ -13,6 +13,11 @@ func TestNewValidatesStartupConfiguration(t *testing.T) {
 	if err == nil || svc != nil {
 		t.Fatalf("New = (%v, %v), want nil service and configuration error", svc, err)
 	}
+
+	svc, err = New(Config{LedgerCacheSize: 385})
+	if err == nil || svc != nil {
+		t.Fatalf("New with oversized ledger cache = (%v, %v), want nil service and configuration error", svc, err)
+	}
 }
 
 func TestGetValidatedLedgerAge(t *testing.T) {
@@ -58,6 +63,9 @@ func TestNewService(t *testing.T) {
 
 	if !svc.IsStandalone() {
 		t.Error("Service should be in standalone mode by default")
+	}
+	if svc.config.LedgerCacheSize != historyWindow {
+		t.Errorf("default ledger cache size = %d, want %d", svc.config.LedgerCacheSize, historyWindow)
 	}
 }
 

--- a/internal/ledger/service/store_acquired_test.go
+++ b/internal/ledger/service/store_acquired_test.go
@@ -30,6 +30,30 @@ func acquiredLedgerFixture(t *testing.T, seq uint32, tag byte) (*header.LedgerHe
 	return h, stateMap, txMap
 }
 
+func durableAcquiredLedgerFixture(t *testing.T, svc *Service, seq uint32, tag byte) (*header.LedgerHeader, *shamap.SHAMap, *shamap.SHAMap) {
+	t.Helper()
+	stateMap := shamap.New(shamap.TypeState)
+	stateKey := [32]byte{tag, byte(seq), byte(seq >> 8), 0xAC}
+	require.NoError(t, stateMap.Put(stateKey, []byte("durable-acquired-state")))
+	stateRoot, err := stateMap.Hash()
+	require.NoError(t, err)
+	txMap := shamap.New(shamap.TypeTransaction)
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+	h := &header.LedgerHeader{
+		LedgerIndex:         seq,
+		ParentHash:          [32]byte{tag},
+		Drops:               svc.genesisLedger.TotalDrops(),
+		AccountHash:         stateRoot,
+		TxHash:              txRoot,
+		CloseTime:           time.Unix(1_700_000_000+int64(seq), 0).UTC(),
+		ParentCloseTime:     time.Unix(1_699_999_990+int64(seq), 0).UTC(),
+		CloseTimeResolution: 10,
+	}
+	h.Hash = header.CalculateHash(*h)
+	return h, stateMap, txMap
+}
+
 func TestStoreLedgerWithStateDoesNotMoveCanonicalFrontier(t *testing.T) {
 	svc, err := New(DefaultConfig())
 	require.NoError(t, err)
@@ -162,8 +186,8 @@ func TestStoredLedgerPromotionLoadsAfterCacheEviction(t *testing.T) {
 	require.NoError(t, svc.Start())
 	t.Cleanup(svc.Stop)
 
-	first, firstState, firstTx := acquiredLedgerFixture(t, svc.GetClosedLedgerIndex()+1, 0xC3)
-	second, secondState, secondTx := acquiredLedgerFixture(t, first.LedgerIndex+1, 0xC4)
+	first, firstState, firstTx := durableAcquiredLedgerFixture(t, svc, svc.GetClosedLedgerIndex()+1, 0xC3)
+	second, secondState, secondTx := durableAcquiredLedgerFixture(t, svc, first.LedgerIndex+1, 0xC4)
 	require.NoError(t, svc.StoreLedgerWithState(t.Context(), first, firstState, firstTx))
 	require.NoError(t, svc.StoreLedgerWithState(t.Context(), second, secondState, secondTx))
 	svc.FlushPersists()

--- a/internal/ledger/service/store_acquired_test.go
+++ b/internal/ledger/service/store_acquired_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/LeJamon/go-xrpl/shamap"
+	shamapbackend "github.com/LeJamon/go-xrpl/shamap/backend"
 )
 
 func acquiredLedgerFixture(t *testing.T, seq uint32, tag byte) (*header.LedgerHeader, *shamap.SHAMap, *shamap.SHAMap) {
@@ -147,6 +148,36 @@ func TestStoredLedgerValidationAdvancesIndependentlyOfConsensusSwitch(t *testing
 
 	require.NoError(t, svc.SwitchToPreferredLedger(validated))
 	require.Equal(t, h.Hash, svc.GetClosedLedger().Hash())
+}
+
+func TestStoredLedgerPromotionLoadsAfterCacheEviction(t *testing.T) {
+	db := newTestNodeStore(t, 10_000)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	cfg := DefaultConfig()
+	cfg.LedgerCacheSize = 1
+	cfg.NodeStore = db
+	cfg.SHAMapFamily = shamapbackend.New(db)
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	first, firstState, firstTx := acquiredLedgerFixture(t, svc.GetClosedLedgerIndex()+1, 0xC3)
+	second, secondState, secondTx := acquiredLedgerFixture(t, first.LedgerIndex+1, 0xC4)
+	require.NoError(t, svc.StoreLedgerWithState(t.Context(), first, firstState, firstTx))
+	require.NoError(t, svc.StoreLedgerWithState(t.Context(), second, secondState, secondTx))
+	svc.FlushPersists()
+
+	svc.historyComponent.mu.RLock()
+	_, firstCached := svc.persistedLedgers[first.Hash]
+	svc.historyComponent.mu.RUnlock()
+	require.False(t, firstCached)
+
+	svc.PromoteStoredValidatedLedgerAt(first.LedgerIndex, first.Hash, time.Time{})
+	validated := svc.GetValidatedLedger()
+	require.NotNil(t, validated)
+	require.Equal(t, first.Hash, validated.Hash())
+	require.True(t, validated.IsValidated())
 }
 
 func TestStoredLedgerValidationPublishesTransactionResultsAfterConsensusSwitch(t *testing.T) {

--- a/internal/ledger/service/test_support_test.go
+++ b/internal/ledger/service/test_support_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"strconv"
 
+	appconfig "github.com/LeJamon/go-xrpl/config"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
 )
+
+const historyWindow = uint32(appconfig.DefaultLedgerCacheSize)
 
 func formatRange(min, max uint32) string {
 	return strconv.FormatUint(uint64(min), 10) + "-" + strconv.FormatUint(uint64(max), 10)

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -239,6 +239,7 @@ func (r *nodeRuntime) configureLedger() error {
 		Standalone:      r.standalone,
 		NodeSize:        r.appConfig.NodeSize,
 		FetchDepth:      effectivePeerFetchDepth(r.appConfig.GetFetchDepthUint32(), r.appConfig.NodeDB.OnlineDelete),
+		LedgerCacheSize: uint32(r.appConfig.ResolvedLedgerCacheSize()),
 		NetworkID:       uint32(networkID),
 		NodeStore:       r.nodeStore,
 		SHAMapFamily:    r.nodeFamily,


### PR DESCRIPTION
## Summary
- add a validated `ledger_cache_size` TOML setting with a backward-compatible default of 256 and a rippled-aligned maximum of 384
- apply the resolved value to recent ledger history, transaction indexes, and the persisted-ledger lookup cache, with both coupled limits visible in startup logs
- document the setting and parameterize eviction coverage below, at, and above the default

## Test plan
- [x] `go test ./config ./internal/ledger/service ./internal/cli ./internal/node`
- [x] `go test -race ./config ./internal/ledger/service -count=1`
- [x] `just test-core`
- [x] `just build-all`
- [x] `just vet`
- [x] `just lint`
- [x] `just docs-check`
- [x] `git diff --check`

Fixes #1675
