### PR TITLE
fix: trace slow consensus heartbeat stages

### DIFF
--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -132,6 +132,8 @@ type Engine struct {
 
 	// Heartbeat ticker — single global timer at ledgerGRANULARITY cadence.
 	heartbeat *time.Ticker
+	// heartbeatNow stays wall-clock based when simulations replace now.
+	heartbeatNow func() time.Time
 
 	// Lifecycle
 	ctx      context.Context
@@ -446,6 +448,7 @@ func NewEngine(adaptor consensus.Adaptor, config Config) *Engine {
 		comparesTxSets:    make(map[consensus.TxSetID]struct{}),
 		parms:             consensus.DefaultConsensusParms(),
 		now:               config.Clock,
+		heartbeatNow:      time.Now,
 		manualTick:        config.ManualTick,
 		firstRound:        true,
 		trustedSnapshot:   make(map[consensus.NodeID]struct{}),

--- a/internal/consensus/rcl/engine_heartbeat_diagnostics_test.go
+++ b/internal/consensus/rcl/engine_heartbeat_diagnostics_test.go
@@ -68,8 +68,9 @@ func TestEngineHeartbeatSlowStageDiagnostics(t *testing.T) {
 		started := make(chan struct{})
 		var startedOnce sync.Once
 		engine.heartbeatNow = func() time.Time {
+			now := clock.Now()
 			startedOnce.Do(func() { close(started) })
-			return clock.Now()
+			return now
 		}
 
 		out := captureHeartbeatDiagnosticLogs(func() {
@@ -224,6 +225,18 @@ func TestRecordSlowHeartbeatStageThreshold(t *testing.T) {
 	stages = recordSlowHeartbeatStage(nil, "phase-open", slowHeartbeatThreshold+time.Nanosecond, context)
 	if len(stages) != 1 || stages[0].name != "phase-open" || stages[0].context != context {
 		t.Fatalf("slow stage was not retained with its context: %+v", stages)
+	}
+}
+
+func TestHeartbeatContextAcceptedUsesNextRound(t *testing.T) {
+	adaptor := newMockAdaptor()
+	engine := NewEngine(adaptor, DefaultConfig())
+	engine.prevLedger = adaptor.lastLCL
+	engine.state = &roundState{Round: consensus.RoundID{Seq: adaptor.lastLCL.Seq()}}
+
+	context := engine.heartbeatContextLocked()
+	if want := adaptor.lastLCL.Seq() + 1; context.seq != want {
+		t.Fatalf("accepted heartbeat sequence = %d, want next round %d", context.seq, want)
 	}
 }
 

--- a/internal/consensus/rcl/engine_heartbeat_diagnostics_test.go
+++ b/internal/consensus/rcl/engine_heartbeat_diagnostics_test.go
@@ -1,0 +1,322 @@
+package rcl
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+)
+
+type heartbeatDiagnosticClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *heartbeatDiagnosticClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *heartbeatDiagnosticClock) Advance(duration time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(duration)
+	c.mu.Unlock()
+}
+
+type heartbeatDiagnosticAdaptor struct {
+	*mockAdaptor
+
+	pendingStarted   chan struct{}
+	pendingRelease   chan struct{}
+	pendingStartOnce sync.Once
+
+	validatorStarted   chan struct{}
+	validatorRelease   chan struct{}
+	validatorStartOnce sync.Once
+}
+
+func (a *heartbeatDiagnosticAdaptor) GetPendingTxs() [][]byte {
+	if a.pendingStarted != nil {
+		a.pendingStartOnce.Do(func() { close(a.pendingStarted) })
+	}
+	if a.pendingRelease != nil {
+		<-a.pendingRelease
+	}
+	return a.mockAdaptor.GetPendingTxs()
+}
+
+func (a *heartbeatDiagnosticAdaptor) IsValidator() bool {
+	if a.validatorStarted != nil {
+		a.validatorStartOnce.Do(func() { close(a.validatorStarted) })
+	}
+	if a.validatorRelease != nil {
+		<-a.validatorRelease
+	}
+	return a.mockAdaptor.IsValidator()
+}
+
+func TestEngineHeartbeatSlowStageDiagnostics(t *testing.T) {
+	t.Run("lock wait", func(t *testing.T) {
+		base := newMockAdaptor()
+		engine := newHeartbeatDiagnosticEngine(t, base, base)
+		clock := &heartbeatDiagnosticClock{now: time.Now()}
+		started := make(chan struct{})
+		var startedOnce sync.Once
+		engine.heartbeatNow = func() time.Time {
+			startedOnce.Do(func() { close(started) })
+			return clock.Now()
+		}
+
+		out := captureHeartbeatDiagnosticLogs(func() {
+			engine.mu.Lock()
+			done := make(chan struct{})
+			go func() {
+				engine.TimerEntry()
+				close(done)
+			}()
+
+			select {
+			case <-started:
+				clock.Advance(slowHeartbeatThreshold + time.Millisecond)
+				engine.mu.Unlock()
+			case <-time.After(time.Second):
+				engine.mu.Unlock()
+				t.Fatal("heartbeat did not begin waiting for the engine mutex")
+			}
+			waitForHeartbeatDiagnostic(t, done)
+		})
+
+		assertHeartbeatStageLog(t, out, "lock-wait", "open", "observing")
+		assertOnlyHeartbeatStageLog(t, out, "lock-wait")
+	})
+
+	t.Run("check ledger", func(t *testing.T) {
+		adaptor := newMockAdaptor()
+		engine := newHeartbeatDiagnosticEngine(t, adaptor, adaptor)
+		clock := &heartbeatDiagnosticClock{now: time.Now()}
+		engine.heartbeatNow = clock.Now
+
+		started := make(chan struct{})
+		release := make(chan struct{})
+		adaptor.mu.Lock()
+		adaptor.lclStarted = started
+		adaptor.lclRelease = release
+		adaptor.mu.Unlock()
+
+		out := captureHeartbeatDiagnosticLogs(func() {
+			done := make(chan struct{})
+			go func() {
+				engine.TimerEntry()
+				close(done)
+			}()
+			advanceSlowHeartbeatStage(t, clock, started, release, done)
+		})
+
+		assertHeartbeatStageLog(t, out, "check-ledger", "open", "observing")
+		assertOnlyHeartbeatStageLog(t, out, "check-ledger")
+	})
+
+	t.Run("flush stale", func(t *testing.T) {
+		adaptor := newMockAdaptor()
+		engine := newHeartbeatDiagnosticEngine(t, adaptor, adaptor)
+		clock := &heartbeatDiagnosticClock{now: time.Now()}
+		engine.heartbeatNow = clock.Now
+
+		started := make(chan struct{})
+		release := make(chan struct{})
+		var startedOnce sync.Once
+		engine.validationTracker.SetNow(func() time.Time {
+			startedOnce.Do(func() { close(started) })
+			<-release
+			return adaptor.Now()
+		})
+
+		out := captureHeartbeatDiagnosticLogs(func() {
+			done := make(chan struct{})
+			go func() {
+				engine.TimerEntry()
+				close(done)
+			}()
+			advanceSlowHeartbeatStage(t, clock, started, release, done)
+		})
+
+		assertHeartbeatStageLog(t, out, "flush-stale", "open", "observing")
+		assertOnlyHeartbeatStageLog(t, out, "flush-stale")
+	})
+
+	t.Run("open phase", func(t *testing.T) {
+		base := newMockAdaptor()
+		adaptor := &heartbeatDiagnosticAdaptor{mockAdaptor: base}
+		engine := newHeartbeatDiagnosticEngine(t, adaptor, base)
+		clock := &heartbeatDiagnosticClock{now: time.Now()}
+		engine.heartbeatNow = clock.Now
+
+		base.lastLCL.(*mockLedger).closeTime = base.now.Add(-11 * time.Minute)
+		adaptor.pendingStarted = make(chan struct{})
+		adaptor.pendingRelease = make(chan struct{})
+
+		out := captureHeartbeatDiagnosticLogs(func() {
+			done := make(chan struct{})
+			go func() {
+				engine.TimerEntry()
+				close(done)
+			}()
+			advanceSlowHeartbeatStage(t, clock, adaptor.pendingStarted, adaptor.pendingRelease, done)
+		})
+
+		assertHeartbeatStageLog(t, out, "phase-open", "open", "observing")
+		assertOnlyHeartbeatStageLog(t, out, "phase-open")
+	})
+
+	t.Run("establish phase", func(t *testing.T) {
+		base := newMockAdaptor()
+		adaptor := &heartbeatDiagnosticAdaptor{mockAdaptor: base}
+		engine := newHeartbeatDiagnosticEngine(t, adaptor, base)
+		clock := &heartbeatDiagnosticClock{now: time.Now()}
+		engine.heartbeatNow = clock.Now
+
+		engine.mu.Lock()
+		engine.setPhase(consensus.PhaseEstablish)
+		engine.roundStartTime = engine.now().Add(-engine.timing.LedgerMinConsensus)
+		engine.mu.Unlock()
+		adaptor.validatorStarted = make(chan struct{})
+		adaptor.validatorRelease = make(chan struct{})
+
+		out := captureHeartbeatDiagnosticLogs(func() {
+			done := make(chan struct{})
+			go func() {
+				engine.TimerEntry()
+				close(done)
+			}()
+			advanceSlowHeartbeatStage(t, clock, adaptor.validatorStarted, adaptor.validatorRelease, done)
+		})
+
+		assertHeartbeatStageLog(t, out, "phase-establish", "establish", "observing")
+		assertOnlyHeartbeatStageLog(t, out, "phase-establish")
+	})
+}
+
+func TestEngineHeartbeatFastStagesStaySilent(t *testing.T) {
+	adaptor := newMockAdaptor()
+	engine := newHeartbeatDiagnosticEngine(t, adaptor, adaptor)
+	clock := &heartbeatDiagnosticClock{now: time.Now()}
+	engine.heartbeatNow = clock.Now
+	adaptor.opMode = consensus.OpModeDisconnected
+
+	out := captureHeartbeatDiagnosticLogs(engine.TimerEntry)
+	if strings.Contains(out, "event=heartbeat-stage-slow") || strings.Contains(out, "event=tick-slow") {
+		t.Fatalf("fast heartbeat emitted slow diagnostics:\n%s", out)
+	}
+}
+
+func TestRecordSlowHeartbeatStageThreshold(t *testing.T) {
+	context := heartbeatContext{seq: 101, phase: consensus.PhaseOpen, mode: consensus.ModeObserving}
+	stages := recordSlowHeartbeatStage(nil, "phase-open", slowHeartbeatThreshold, context)
+	if len(stages) != 0 {
+		t.Fatalf("threshold duration must stay silent, got %+v", stages)
+	}
+
+	stages = recordSlowHeartbeatStage(nil, "phase-open", slowHeartbeatThreshold+time.Nanosecond, context)
+	if len(stages) != 1 || stages[0].name != "phase-open" || stages[0].context != context {
+		t.Fatalf("slow stage was not retained with its context: %+v", stages)
+	}
+}
+
+func newHeartbeatDiagnosticEngine(t *testing.T, adaptor consensus.Adaptor, base *mockAdaptor) *Engine {
+	t.Helper()
+
+	config := DefaultConfig()
+	config.ManualTick = true
+	engine := NewEngine(adaptor, config)
+	if err := engine.Start(t.Context()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := engine.Stop(); err != nil {
+			t.Errorf("Stop: %v", err)
+		}
+	})
+
+	round := consensus.RoundID{Seq: base.lastLCL.Seq() + 1, ParentHash: base.lastLCL.ID()}
+	if err := engine.StartRound(round, false); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+	return engine
+}
+
+func captureHeartbeatDiagnosticLogs(run func()) string {
+	var buffer bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buffer, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	defer slog.SetDefault(previous)
+	run()
+	return buffer.String()
+}
+
+func waitForHeartbeatDiagnostic(t *testing.T, signal <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for heartbeat diagnostic test hook")
+	}
+}
+
+func advanceSlowHeartbeatStage(
+	t *testing.T,
+	clock *heartbeatDiagnosticClock,
+	started <-chan struct{},
+	release chan struct{},
+	done <-chan struct{},
+) {
+	t.Helper()
+	select {
+	case <-started:
+		clock.Advance(slowHeartbeatThreshold + time.Millisecond)
+		close(release)
+	case <-time.After(time.Second):
+		close(release)
+		waitForHeartbeatDiagnostic(t, done)
+		t.Fatal("heartbeat did not enter the expected stage")
+	}
+	waitForHeartbeatDiagnostic(t, done)
+}
+
+func assertHeartbeatStageLog(t *testing.T, output, stage, phase, mode string) {
+	t.Helper()
+	var stageLine string
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, "event=heartbeat-stage-slow") && strings.Contains(line, "stage="+stage) {
+			stageLine = line
+			break
+		}
+	}
+	if stageLine == "" {
+		t.Fatalf("heartbeat diagnostic missing stage %q:\n%s", stage, output)
+	}
+	for _, field := range []string{
+		"dur_ms=51",
+		"seq=101",
+		"phase=" + phase,
+		"mode=" + mode,
+	} {
+		if !strings.Contains(stageLine, field) {
+			t.Fatalf("heartbeat stage record missing %q:\n%s", field, stageLine)
+		}
+	}
+	if !strings.Contains(output, "event=tick-slow") {
+		t.Fatalf("heartbeat diagnostic missing total tick record:\n%s", output)
+	}
+}
+
+func assertOnlyHeartbeatStageLog(t *testing.T, output, stage string) {
+	t.Helper()
+	if count := strings.Count(output, "event=heartbeat-stage-slow"); count != 1 {
+		t.Fatalf("got %d slow stage logs, want one for %s:\n%s", count, stage, output)
+	}
+}

--- a/internal/consensus/rcl/engine_ledger_check.go
+++ b/internal/consensus/rcl/engine_ledger_check.go
@@ -60,34 +60,68 @@ func (e *Engine) run() {
 // timerEntry is the single heartbeat dispatch; runs each
 // ledgerGRANULARITY and dispatches on current phase.
 func (e *Engine) timerEntry() {
-	tickStart := time.Now()
+	tickStart := e.heartbeatNow()
 	e.mu.Lock()
-	e.purgePendingTrustLocked()
+
+	var slowStages []slowHeartbeatStage
+	slowStages = recordSlowHeartbeatStage(
+		slowStages,
+		"lock-wait",
+		e.heartbeatNow().Sub(tickStart),
+		e.heartbeatContextLocked(),
+	)
 	e.deferBroadcasts++
 	var pending []func()
 	defer func() {
 		e.deferBroadcasts--
 		pending = e.takePendingBroadcastsLocked()
+		tickContext := e.heartbeatContextLocked()
 		e.mu.Unlock()
+
+		broadcastStart := e.heartbeatNow()
 		flushBroadcasts(pending)
-		// 50ms threshold — the 250ms heartbeat needs headroom.
-		dur := time.Since(tickStart)
-		if dur > 50*time.Millisecond {
+		slowStages = recordSlowHeartbeatStage(
+			slowStages,
+			"broadcast-flush",
+			e.heartbeatNow().Sub(broadcastStart),
+			tickContext,
+		)
+
+		dur := e.heartbeatNow().Sub(tickStart)
+		for _, stage := range slowStages {
+			slog.Info("timer stage slow",
+				"t", "consensus",
+				"event", "heartbeat-stage-slow",
+				"stage", stage.name,
+				"dur_ms", stage.duration.Milliseconds(),
+				"seq", stage.context.seq,
+				"phase", stage.context.phase.String(),
+				"mode", stage.context.mode.String(),
+			)
+		}
+		if dur > slowHeartbeatThreshold {
 			slog.Info("timer tick slow",
 				"t", "consensus",
 				"event", "tick-slow",
 				"dur_ms", dur.Milliseconds(),
-				"phase", e.phase.String(),
-				"mode", e.mode.String(),
+				"seq", tickContext.seq,
+				"phase", tickContext.phase.String(),
+				"mode", tickContext.mode.String(),
 			)
 		}
 	}()
 
+	stage := e.startHeartbeatStageLocked("trust-purge")
+	e.purgePendingTrustLocked()
+	slowStages = e.finishHeartbeatStage(slowStages, stage)
+
+	stage = e.startHeartbeatStageLocked("preflight")
 	// Phase work runs in every non-disconnected mode; the proposing gate is
 	// per-round (closeLedger/sendValidation gate on ModeProposing). Without
 	// observer-mode advancement a genesis bootstrap deadlocks at
 	// OpModeConnected — no round closes, so auto-promote never fires.
 	if e.adaptor.GetOperatingMode() == consensus.OpModeDisconnected {
+		slowStages = e.finishHeartbeatStage(slowStages, stage)
 		return
 	}
 
@@ -106,35 +140,111 @@ func (e *Engine) timerEntry() {
 	// goroutine; don't drive rounds until its commit tail runs (rippled parks
 	// the timer thread while the jtACCEPT job holds no lock).
 	if e.buildInProgress {
+		slowStages = e.finishHeartbeatStage(slowStages, stage)
 		return
 	}
+	slowStages = e.finishHeartbeatStage(slowStages, stage)
 
 	// Sweep validations that aged past the isCurrent window off the steering
 	// indexes each tick (rippled doSweep → current()); a silent validator
 	// must not keep steering preferred-ledger selection through a stall.
 	if e.validationTracker != nil {
+		stage = e.startHeartbeatStageLocked("flush-stale")
 		e.validationTracker.FlushStale()
+		slowStages = e.finishHeartbeatStage(slowStages, stage)
 	}
 
 	// checkLedger runs in every non-disconnected mode — the Syncing/Tracking
 	// → Full recovery path; gating on Full would wedge us after a wrongLedger
 	// demotion.
 	if e.phase != consensus.PhaseAccepted {
+		stage = e.startHeartbeatStageLocked("check-ledger")
 		e.checkLedger()
+		slowStages = e.finishHeartbeatStage(slowStages, stage)
 	}
 
 	switch e.phase {
 	case consensus.PhaseOpen:
+		stage = e.startHeartbeatStageLocked("phase-open")
 		e.phaseOpen()
+		slowStages = e.finishHeartbeatStage(slowStages, stage)
 	case consensus.PhaseEstablish:
+		stage = e.startHeartbeatStageLocked("phase-establish")
 		e.phaseEstablish()
+		slowStages = e.finishHeartbeatStage(slowStages, stage)
 	case consensus.PhaseAccepted:
+		stage = e.startHeartbeatStageLocked("round-start")
 		e.checkAndStartRoundInner()
+		slowStages = e.finishHeartbeatStage(slowStages, stage)
 		// Evaluate the new phase in the same tick after starting a round.
 		if e.phase == consensus.PhaseOpen {
+			stage = e.startHeartbeatStageLocked("phase-open")
 			e.phaseOpen()
+			slowStages = e.finishHeartbeatStage(slowStages, stage)
 		}
 	}
+}
+
+const slowHeartbeatThreshold = 50 * time.Millisecond
+
+type heartbeatContext struct {
+	seq   uint32
+	phase consensus.Phase
+	mode  consensus.Mode
+}
+
+type slowHeartbeatStage struct {
+	name     string
+	duration time.Duration
+	context  heartbeatContext
+}
+
+type heartbeatStageTimer struct {
+	name    string
+	started time.Time
+	context heartbeatContext
+}
+
+func (e *Engine) heartbeatContextLocked() heartbeatContext {
+	seq := uint32(0)
+	if e.state != nil {
+		seq = e.state.Round.Seq
+	} else if e.prevLedger != nil {
+		seq = e.prevLedger.Seq() + 1
+	}
+	return heartbeatContext{seq: seq, phase: e.phase, mode: e.mode}
+}
+
+func (e *Engine) startHeartbeatStageLocked(name string) heartbeatStageTimer {
+	return heartbeatStageTimer{
+		name:    name,
+		started: e.heartbeatNow(),
+		context: e.heartbeatContextLocked(),
+	}
+}
+
+func (e *Engine) finishHeartbeatStage(
+	stages []slowHeartbeatStage,
+	stage heartbeatStageTimer,
+) []slowHeartbeatStage {
+	return recordSlowHeartbeatStage(
+		stages,
+		stage.name,
+		e.heartbeatNow().Sub(stage.started),
+		stage.context,
+	)
+}
+
+func recordSlowHeartbeatStage(
+	stages []slowHeartbeatStage,
+	name string,
+	duration time.Duration,
+	context heartbeatContext,
+) []slowHeartbeatStage {
+	if duration <= slowHeartbeatThreshold {
+		return stages
+	}
+	return append(stages, slowHeartbeatStage{name: name, duration: duration, context: context})
 }
 
 // checkAndStartRoundInner is the fallback round-start when acceptLedger's

--- a/internal/consensus/rcl/engine_ledger_check.go
+++ b/internal/consensus/rcl/engine_ledger_check.go
@@ -207,7 +207,10 @@ type heartbeatStageTimer struct {
 
 func (e *Engine) heartbeatContextLocked() heartbeatContext {
 	seq := uint32(0)
-	if e.state != nil {
+	if e.phase == consensus.PhaseAccepted && e.prevLedger != nil {
+		// Accepted retains the completed round state until the next round starts.
+		seq = e.prevLedger.Seq() + 1
+	} else if e.state != nil {
 		seq = e.state.Round.Seq
 	} else if e.prevLedger != nil {
 		seq = e.prevLedger.Seq() + 1


### PR DESCRIPTION
## Summary
- attribute slow consensus heartbeats to mutex wait, cleanup, ledger selection, round/phase work, or post-unlock broadcast flushing
- include mutex-protected ledger sequence, phase, and mode context while keeping stages at or below 50 ms silent
- add deterministic, race-tested diagnostics coverage without changing consensus control flow

## Test plan
- [x] `go test ./internal/consensus/rcl/... -count=1`
- [x] `go test -race ./internal/consensus/rcl/... -count=1`
- [x] `go test -race ./internal/consensus/rcl/... -run 'TestEngineHeartbeat|TestRecordSlowHeartbeatStage' -count=10`
- [x] `just test-core`
- [x] `just build-all`
- [x] `just vet`
- [x] `just lint`
- [x] `git diff --check`

Fixes #1673
