### PR TITLE
fix: prevent consensus recovery lock re-entry

### DIFF
--- a/internal/consensus/adaptor/router_catchup_incident_test.go
+++ b/internal/consensus/adaptor/router_catchup_incident_test.go
@@ -20,6 +20,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type issue1677RecheckingHistorian struct {
+	*stubHistorian
+	calls int
+}
+
+func (h *issue1677RecheckingHistorian) RecheckFullyValidated(
+	ledgerID consensus.LedgerID,
+	seq uint32,
+) ([]*consensus.Validation, int, bool) {
+	h.calls++
+	return []*consensus.Validation{{
+		LedgerID:  ledgerID,
+		LedgerSeq: seq,
+		SignTime:  time.Now(),
+		Full:      true,
+	}}, 1, true
+}
+
+type issue1677CanAcceptResult struct {
+	acceptable bool
+	err        error
+}
+
+type issue1677EngineProbe struct {
+	*rcl.Engine
+	entered chan consensus.LedgerID
+	result  chan issue1677CanAcceptResult
+}
+
+func (p *issue1677EngineProbe) CanAcceptLedger(id consensus.LedgerID) (bool, error) {
+	p.entered <- id
+	acceptable, err := p.Engine.CanAcceptLedger(id)
+	p.result <- issue1677CanAcceptResult{acceptable: acceptable, err: err}
+	return acceptable, err
+}
+
 func newIssue1663BackedAcquisition(t *testing.T, seq uint32, peerID uint64) *inbound.Ledger {
 	t.Helper()
 	source := newWideWorkSource(t, 16)
@@ -261,4 +297,120 @@ func TestRouter_Issue1668FrozenPivotCollectsAndReplaysMovingHead(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 1, pivotRequests)
+}
+
+func TestRouter_Issue1677ConsensusRecoveryCallbackDoesNotReenterEngineLock(t *testing.T) {
+	svc := newTestLedgerService(t)
+	a, _ := newRecordingAdaptor(t, svc)
+	a.SetOperatingMode(consensus.OpModeFull)
+
+	parent := svc.GetClosedLedger()
+	require.NotNil(t, parent)
+	historian := &issue1677RecheckingHistorian{stubHistorian: &stubHistorian{}}
+	a.closeOffsetNs.Store(int64(time.Minute))
+
+	now := a.Now()
+	config := rcl.DefaultConfig()
+	config.ManualTick = true
+	config.Clock = func() time.Time { return now }
+	config.Timing.LedgerMinClose = time.Millisecond
+	config.Timing.LedgerMinConsensus = time.Millisecond
+	engine := rcl.NewEngine(a, config)
+	require.NoError(t, engine.Start(t.Context()))
+	t.Cleanup(func() { require.NoError(t, engine.Stop()) })
+	a.SetValidationHistorian(historian)
+	probe := &issue1677EngineProbe{
+		Engine:  engine,
+		entered: make(chan consensus.LedgerID, 1),
+		result:  make(chan issue1677CanAcceptResult, 1),
+	}
+	r := NewRouter(probe, a, nil)
+	require.Equal(t, consensus.OpModeFull, a.GetOperatingMode())
+
+	type builtTarget struct {
+		seq  uint32
+		hash [32]byte
+	}
+	built := make(chan builtTarget, 1)
+	onLedgerBuilt := a.onLedgerBuilt
+	a.setOnLedgerBuilt(func(seq uint32, hash [32]byte) {
+		r.catchupMu.Lock()
+		r.catchup = catchupTarget{seq: seq, hash: hash, source: catchupSourceQuorum}
+		r.catchupMu.Unlock()
+		r.acquisitionMu.Lock()
+		r.standardReplay = standardReplayPipeline{
+			active:     true,
+			pivotReady: true,
+			pivotSeq:   seq,
+			pivotHash:  hash,
+			anchorSeq:  seq,
+			anchorHash: hash,
+			targetSeq:  seq,
+			targetHash: hash,
+			entries:    make(map[uint32]*standardReplayEntry),
+		}
+		r.acquisitionMu.Unlock()
+		built <- builtTarget{seq: seq, hash: hash}
+		onLedgerBuilt(seq, hash)
+	})
+
+	round := consensus.RoundID{
+		Seq:        parent.Sequence() + 1,
+		ParentHash: consensus.LedgerID(parent.Hash()),
+	}
+	require.NoError(t, engine.StartRound(round, false))
+	for range 3 {
+		now = now.Add(time.Minute)
+		engine.TimerEntry()
+		if engine.Phase() == consensus.PhaseEstablish {
+			break
+		}
+	}
+	require.Equal(t, consensus.PhaseEstablish, engine.Phase())
+
+	now = now.Add(time.Minute)
+	done := make(chan struct{})
+	go func() {
+		engine.TimerEntry()
+		close(done)
+	}()
+
+	var target builtTarget
+	select {
+	case target = <-built:
+	case <-time.After(time.Second):
+		t.Fatal("accepted ledger did not reach the router callback")
+	}
+	select {
+	case entered := <-probe.entered:
+		require.Equal(t, consensus.LedgerID(target.hash), entered)
+	case <-time.After(time.Second):
+		t.Fatal("recovery did not check the completed ledger")
+	}
+	select {
+	case result := <-probe.result:
+		require.NoError(t, result.err)
+		require.True(t, result.acceptable)
+	case <-time.After(time.Second):
+		t.Fatal("completed-ledger acceptance check re-entered Engine.mu")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("accepted-ledger recovery callback did not complete")
+	}
+
+	require.Equal(t, consensus.PhaseOpen, engine.Phase())
+	require.Equal(t, consensus.ModeProposing, engine.Mode())
+	r.acquisitionMu.Lock()
+	retryTarget := r.consensusRecovery.targetHash
+	replayActive := r.standardReplay.active
+	r.acquisitionMu.Unlock()
+	assert.Equal(t, target.hash, retryTarget)
+	assert.False(t, replayActive)
+	assert.Equal(t, 3, historian.calls)
+	validated := svc.GetValidatedLedger()
+	require.NotNil(t, validated)
+	assert.Equal(t, target.seq, validated.Sequence())
+	assert.Equal(t, target.hash, validated.Hash())
 }

--- a/internal/consensus/rcl/engine_accept.go
+++ b/internal/consensus/rcl/engine_accept.go
@@ -192,9 +192,9 @@ func (e *Engine) buildAcceptedLedger(work ledgerAcceptWork) (consensus.Ledger, e
 // application. Caller must hold e.mu.
 func (e *Engine) commitAcceptedLedgerLocked(work ledgerAcceptWork, newLedger consensus.Ledger, err error) {
 	e.purgePendingTrustLocked()
-	e.buildInProgress = false
 
 	if err != nil {
+		e.buildInProgress = false
 		// Build/validate/store failed off-lock; unwind to Establish so the next
 		// heartbeat retries (matches the pre-offload early-return).
 		e.setPhase(consensus.PhaseEstablish)
@@ -340,7 +340,8 @@ func (e *Engine) commitAcceptedLedgerLocked(work ledgerAcceptWork, newLedger con
 	validations := e.proposalTracker.ValidationsFor(newLedger.ID())
 
 	e.buildingLedgerSeq.Store(0)
-	e.adaptor.OnConsensusReached(newLedger, validations, roundTime)
+	e.notifyConsensusReachedUnlocked(newLedger, validations, roundTime)
+	e.buildInProgress = false
 
 	e.eventBus.Publish(&consensus.LedgerAcceptedEvent{
 		LedgerID:    newLedger.ID(),
@@ -440,6 +441,19 @@ func (e *Engine) commitAcceptedLedgerLocked(work ledgerAcceptWork, newLedger con
 		}
 		e.startRoundLocked(nextRound, proposing, false)
 	}
+}
+
+// notifyConsensusReachedUnlocked preserves the accepted-ledger callback's
+// ordering while allowing it to call public Engine methods that acquire e.mu.
+// The accepted round remains frozen under buildInProgress until it returns.
+func (e *Engine) notifyConsensusReachedUnlocked(
+	ledger consensus.Ledger,
+	validations []*consensus.Validation,
+	roundTime time.Duration,
+) {
+	e.mu.Unlock()
+	defer e.mu.Lock()
+	e.adaptor.OnConsensusReached(ledger, validations, roundTime)
 }
 
 // updateCloseTimePosition tallies close-time votes, applies avalanche

--- a/internal/consensus/rcl/engine_ledger_check.go
+++ b/internal/consensus/rcl/engine_ledger_check.go
@@ -62,6 +62,11 @@ func (e *Engine) run() {
 func (e *Engine) timerEntry() {
 	tickStart := time.Now()
 	e.mu.Lock()
+	// The accepted round stays immutable while its callback runs without e.mu.
+	if e.buildInProgress {
+		e.mu.Unlock()
+		return
+	}
 	e.purgePendingTrustLocked()
 	e.deferBroadcasts++
 	var pending []func()
@@ -100,13 +105,6 @@ func (e *Engine) timerEntry() {
 	if e.mode == consensus.ModeProposing &&
 		e.adaptor.GetOperatingMode() != consensus.OpModeFull {
 		e.leaveConsensusLocked()
-	}
-
-	// A peer-triggered accept may be applying the LCL off e.mu on another
-	// goroutine; don't drive rounds until its commit tail runs (rippled parks
-	// the timer thread while the jtACCEPT job holds no lock).
-	if e.buildInProgress {
-		return
 	}
 
 	// Sweep validations that aged past the isCurrent window off the steering

--- a/internal/consensus/rcl/engine_reproposal_test.go
+++ b/internal/consensus/rcl/engine_reproposal_test.go
@@ -178,3 +178,40 @@ func TestEngine_TimerEntry_BowsOutWhenOperatingModeLosesFull(t *testing.T) {
 		t.Fatalf("demotion proposal must carry seqLeave, got %d", got)
 	}
 }
+
+func TestEngine_TimerEntry_FreezesAcceptedRoundWhileBuildingLedger(t *testing.T) {
+	adaptor := newMockAdaptor()
+	engine := NewEngine(adaptor, DefaultConfig())
+	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+	if err := engine.StartRound(round, true); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+
+	engine.mu.Lock()
+	engine.phase = consensus.PhaseAccepted
+	engine.buildInProgress = true
+	engine.setMode(consensus.ModeProposing)
+	set := buildMockTxSet(consensus.TxSetID{0x5E})
+	engine.state.OurPosition = &consensus.Proposal{
+		Round: round, Position: 3, TxSet: set.ID(), Timestamp: engine.adaptor.Now(),
+	}
+	engine.mu.Unlock()
+	adaptor.mu.Lock()
+	adaptor.proposalsBroadcast = nil
+	adaptor.opMode = consensus.OpModeConnected
+	adaptor.mu.Unlock()
+
+	engine.timerEntry()
+
+	if got := engine.Mode(); got != consensus.ModeProposing {
+		t.Fatalf("ledger build must preserve proposing mode, got %v", got)
+	}
+	if got := engine.Phase(); got != consensus.PhaseAccepted {
+		t.Fatalf("ledger build must preserve accepted phase, got %v", got)
+	}
+	adaptor.mu.RLock()
+	defer adaptor.mu.RUnlock()
+	if len(adaptor.proposalsBroadcast) != 0 {
+		t.Fatalf("ledger build must not broadcast a bow-out, got %d proposals", len(adaptor.proposalsBroadcast))
+	}
+}


### PR DESCRIPTION
## Summary

- release the consensus engine mutex around the accepted-ledger callback while keeping the accepted round frozen under `buildInProgress`
- preserve callback, validation, event, and deferred broadcast ordering while allowing recovery promotion to call locking engine APIs
- add an end-to-end frozen-pivot recovery regression using the real engine and a freshly built, acceptable ledger

This matches rippled v3.3.0's accepted-ledger handoff boundary: acceptance is dispatched without the consensus mutex while the accepted state remains frozen until the handoff completes.

## Test plan

- [x] `go test -v ./internal/consensus/adaptor -run TestRouter_Issue1677 -count=1 -timeout=10s`
- [x] `go test ./internal/consensus/adaptor -run TestRouter_Issue1677 -count=20 -timeout=30s`
- [x] `go test ./internal/consensus/rcl ./internal/consensus/adaptor -count=1`
- [x] `go test -race ./internal/consensus/rcl ./internal/consensus/adaptor -count=1`
- [x] `just test-core`
- [x] `just vet`
- [x] `just lint`
- [x] `just build-all`
- [x] `git diff --check`

Fixes #1677
