### PR TITLE
fix: bound online-delete state refresh

### DIFF
--- a/docs/operating.md
+++ b/docs/operating.md
@@ -272,6 +272,15 @@ browser origin must also configure Basic Auth.
 | `earliest_seq` | `32570` | Lowest ledger sequence to retain. |
 | `delete_batch` / `back_off_milliseconds` / `age_threshold_seconds` / `recovery_wait_seconds` | `100`/`100`/`60`/`5` | Online-delete pacing (batch size, inter-batch pause, minimum age, catch-up wait). |
 
+Before swapping Pebble generations, online delete refreshes the complete live
+state with up to four workers, bounded by the available Go CPUs. Health checks
+pause all refresh reads during the configured backoff. The ledger log reports
+start, periodic node/rate progress, completion, failure, and cancellation.
+Generation metadata advances only after the refreshed writable generation is
+synced and the swap is durable. An interrupted refresh restarts its state-tree
+walk from the root; any records that remain in the writable generation are
+reused, but every live node is read again.
+
 ### `[sqlite]` — relational index databases
 
 | Key | Example | Meaning |

--- a/internal/ledger/service/fast_load.go
+++ b/internal/ledger/service/fast_load.go
@@ -377,7 +377,7 @@ const (
 type storedSHAMapWalkControl struct {
 	progress        *storedSHAMapVerificationProgress
 	progressTicks   <-chan time.Time
-	checkpoint      func(time.Duration) error
+	checkpoint      func(context.Context, time.Duration) error
 	checkpointTicks <-chan time.Time
 	now             func() time.Time
 }
@@ -413,7 +413,6 @@ func (s *Service) walkStoredSHAMapConcurrentWithFetch(
 	}
 
 	walkCtx, cancel := context.WithCancelCause(ctx)
-	defer cancel(nil)
 	var cancelOnce sync.Once
 	var checkpointGate sync.RWMutex
 	workStartedAt := control.now()
@@ -430,17 +429,89 @@ func (s *Service) walkStoredSHAMapConcurrentWithFetch(
 		}
 	}
 
-	checkpointSignal := make(chan struct{}, 1)
+	runCheckpoint := func() {
+		if walkCtx.Err() != nil {
+			return
+		}
+		checkpointGate.Lock()
+		defer checkpointGate.Unlock()
+		if walkCtx.Err() != nil {
+			return
+		}
+		checkpointAt := control.now()
+		work := checkpointAt.Sub(workStartedAt)
+		if work < 0 {
+			work = 0
+		}
+		visited := control.progress.nodesChecked.Load()
+		if work < refreshHealthCheckPeriod &&
+			visited-lastCheckpointNodes < refreshHealthCheckInterval {
+			return
+		}
+		if checkpointErr := control.checkpoint(walkCtx, work); checkpointErr != nil {
+			cancelOnce.Do(func() { cancel(checkpointErr) })
+			return
+		}
+		lastCheckpointNodes = visited
+		workStartedAt = control.now()
+	}
+
+	type checkpointRequest struct {
+		done chan struct{}
+	}
+	var checkpointRequests chan checkpointRequest
+	var checkpointDone chan struct{}
+	if control.checkpoint != nil {
+		checkpointRequests = make(chan checkpointRequest)
+		checkpointDone = make(chan struct{})
+		go func() {
+			defer close(checkpointDone)
+			ticks := control.checkpointTicks
+			for {
+				select {
+				case request := <-checkpointRequests:
+					runCheckpoint()
+					close(request.done)
+				case _, open := <-ticks:
+					if !open {
+						ticks = nil
+						continue
+					}
+					runCheckpoint()
+				case <-walkCtx.Done():
+					return
+				}
+			}
+		}()
+	}
+	defer func() {
+		cancel(nil)
+		if checkpointDone != nil {
+			<-checkpointDone
+		}
+	}()
+	requestCheckpoint := func() {
+		if checkpointRequests == nil || walkCtx.Err() != nil {
+			return
+		}
+		request := checkpointRequest{done: make(chan struct{})}
+		select {
+		case checkpointRequests <- request:
+		case <-walkCtx.Done():
+			return
+		}
+		select {
+		case <-request.done:
+		case <-walkCtx.Done():
+		}
+	}
 	onNode := func(node storedSHAMapNode) {
 		visited := control.progress.nodesChecked.Add(1)
 		if visit != nil {
 			visit(node)
 		}
-		if control.checkpoint != nil && visited%refreshHealthCheckInterval == 0 {
-			select {
-			case checkpointSignal <- struct{}{}:
-			default:
-			}
+		if checkpointRequests != nil && visited%refreshHealthCheckInterval == 0 {
+			requestCheckpoint()
 		}
 	}
 
@@ -451,6 +522,9 @@ func (s *Service) walkStoredSHAMapConcurrentWithFetch(
 		controlledFetch,
 	)
 	if err != nil {
+		if cause := context.Cause(walkCtx); cause != nil {
+			return cause
+		}
 		return err
 	}
 	onNode(storedSHAMapNode{hash: root})
@@ -486,6 +560,9 @@ func (s *Service) walkStoredSHAMapConcurrentWithFetch(
 		}
 	}
 	if err != nil {
+		if cause := context.Cause(walkCtx); cause != nil {
+			return cause
+		}
 		return err
 	}
 
@@ -493,6 +570,7 @@ func (s *Service) walkStoredSHAMapConcurrentWithFetch(
 	control.progress.configureWorkers(workers, startedWorkers, len(frontier))
 	control.progress.start()
 	if len(frontier) == 0 {
+		requestCheckpoint()
 		return context.Cause(walkCtx)
 	}
 
@@ -567,39 +645,7 @@ func (s *Service) walkStoredSHAMapConcurrentWithFetch(
 		close(workersDone)
 	}()
 
-	runCheckpoint := func() {
-		if control.checkpoint == nil || walkCtx.Err() != nil {
-			return
-		}
-		checkpointGate.Lock()
-		defer checkpointGate.Unlock()
-		if walkCtx.Err() != nil {
-			return
-		}
-		checkpointAt := control.now()
-		work := checkpointAt.Sub(workStartedAt)
-		if work < 0 {
-			work = 0
-		}
-		visited := control.progress.nodesChecked.Load()
-		if work < refreshHealthCheckPeriod &&
-			visited-lastCheckpointNodes < refreshHealthCheckInterval {
-			return
-		}
-		if checkpointErr := control.checkpoint(work); checkpointErr != nil {
-			cancelOnce.Do(func() { cancel(checkpointErr) })
-			return
-		}
-		lastCheckpointNodes = visited
-		workStartedAt = control.now()
-	}
-
 	progressTicks := control.progressTicks
-	checkpointTicks := control.checkpointTicks
-	if control.checkpoint == nil {
-		checkpointSignal = nil
-		checkpointTicks = nil
-	}
 	ctxDone := ctx.Done()
 	for {
 		select {
@@ -610,28 +656,11 @@ func (s *Service) walkStoredSHAMapConcurrentWithFetch(
 			}
 			select {
 			case <-workersDone:
+				requestCheckpoint()
 				return context.Cause(walkCtx)
 			default:
 			}
 			control.progress.report(tick)
-		case _, open := <-checkpointTicks:
-			if !open {
-				checkpointTicks = nil
-				continue
-			}
-			select {
-			case <-workersDone:
-				return context.Cause(walkCtx)
-			default:
-			}
-			runCheckpoint()
-		case <-checkpointSignal:
-			select {
-			case <-workersDone:
-				return context.Cause(walkCtx)
-			default:
-			}
-			runCheckpoint()
 		case <-ctxDone:
 			ctxDone = nil
 			cause := context.Cause(ctx)
@@ -640,6 +669,7 @@ func (s *Service) walkStoredSHAMapConcurrentWithFetch(
 			}
 			cancelOnce.Do(func() { cancel(cause) })
 		case <-workersDone:
+			requestCheckpoint()
 			return context.Cause(walkCtx)
 		}
 	}

--- a/internal/ledger/service/fast_load.go
+++ b/internal/ledger/service/fast_load.go
@@ -293,175 +293,25 @@ func (s *Service) verifyStoredSHAMapWithTicksReport(
 		}
 	}()
 
-	if root == ([32]byte{}) {
-		return fmt.Errorf("zero root")
-	}
-
 	// The strict startup walk proves these durable subtrees complete. Retain
 	// shallow proofs and publish them only after the whole traversal succeeds,
 	// so the first inbound-ledger missing-node walk can skip the shared stored
 	// state instead of reading it all again. A concurrent generation reset makes
 	// Insert reject these old-generation proofs.
 	proofs := newStoredSHAMapProofs(s.shamapFamily)
-	proofs.record(storedSHAMapNode{hash: root})
-
-	fetch := s.storedSHAMapVerificationFetch()
-	rootNode, _, err := s.loadStoredSHAMapNodeWithFetch(
+	err = s.walkStoredSHAMapConcurrentWithFetch(
 		ctx,
-		storedSHAMapNode{hash: root},
+		root,
 		mapType,
-		fetch,
+		s.storedSHAMapVerificationFetch(),
+		resolveStoredSHAMapWorkers(s.config.FastLoadWorkers),
+		storedSHAMapWalkControl{progress: progress, progressTicks: ticks, now: now},
+		proofs.record,
 	)
-	if err != nil {
-		return err
-	}
-	progress.nodesChecked.Add(1)
-	inner, ok := rootNode.(shamap.InnerNodeReader)
-	if !ok {
-		return fmt.Errorf("root node %x is not an inner node", root[:8])
-	}
-
-	branches := make([][32]byte, 0, shamap.BranchFactor)
-	for branch := range shamap.BranchFactor {
-		if inner.IsEmptyBranch(branch) {
-			continue
-		}
-		child, childErr := inner.ChildHash(branch)
-		if childErr != nil {
-			return childErr
-		}
-		branches = append(branches, child)
-	}
-	progress.branchesTotal = uint32(len(branches))
-	workers := resolveStoredSHAMapWorkers(s.config.FastLoadWorkers)
-	progress.configureWorkers(workers, 0, len(branches))
-	progress.start()
-	frontier, outstanding, err := s.buildStoredSHAMapFrontier(
-		ctx,
-		branches,
-		workers*storedSHAMapFrontierTasksPerWorker,
-		mapType,
-		fetch,
-		func(node storedSHAMapNode) {
-			progress.nodesChecked.Add(1)
-			proofs.record(node)
-		},
-	)
-	for _, count := range outstanding {
-		if count == 0 {
-			progress.branchesComplete.Add(1)
-		}
-	}
-	if err != nil {
-		return err
-	}
-
-	startedWorkers := min(workers, len(frontier))
-	progress.configureWorkers(workers, startedWorkers, len(frontier))
-	if len(frontier) == 0 {
+	if err == nil {
 		proofs.publish()
-		return nil
 	}
-
-	walkCtx, cancel := context.WithCancelCause(ctx)
-	defer cancel(nil)
-	var cancelOnce sync.Once
-	branchOutstanding := make([]atomic.Int64, len(outstanding))
-	for branch, count := range outstanding {
-		branchOutstanding[branch].Store(int64(count))
-	}
-
-	tasks := make(chan storedSHAMapTask, len(frontier))
-	for _, task := range frontier {
-		tasks <- task
-	}
-	close(tasks)
-
-	var wg sync.WaitGroup
-	for range startedWorkers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for {
-				if walkCtx.Err() != nil {
-					return
-				}
-				var task storedSHAMapTask
-				var ok bool
-				select {
-				case task, ok = <-tasks:
-					if !ok {
-						return
-					}
-				case <-walkCtx.Done():
-					return
-				}
-
-				progress.frontierSize.Add(-1)
-				progress.activeWorkers.Add(1)
-				var unreportedNodes uint64
-				walkErr := s.walkStoredSHAMapNodesWithFetch(
-					walkCtx,
-					[]storedSHAMapNode{task.node},
-					mapType,
-					fetch,
-					func(node storedSHAMapNode, _ *nodestore.Node) error {
-						unreportedNodes++
-						proofs.record(node)
-						if unreportedNodes == storedSHAMapNodeCountBatch {
-							progress.nodesChecked.Add(unreportedNodes)
-							unreportedNodes = 0
-						}
-						return nil
-					},
-				)
-				if unreportedNodes > 0 {
-					progress.nodesChecked.Add(unreportedNodes)
-				}
-				progress.activeWorkers.Add(-1)
-				if walkErr != nil {
-					cancelOnce.Do(func() {
-						cancel(walkErr)
-					})
-					return
-				}
-				if branchOutstanding[task.branch].Add(-1) == 0 {
-					progress.branchesComplete.Add(1)
-				}
-			}
-		}()
-	}
-	workersDone := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(workersDone)
-	}()
-
-	for {
-		select {
-		case tick, ok := <-ticks:
-			if !ok {
-				ticks = nil
-				continue
-			}
-			select {
-			case <-workersDone:
-				err = context.Cause(walkCtx)
-				if err == nil {
-					proofs.publish()
-				}
-				return err
-			default:
-			}
-			progress.report(tick)
-		case <-workersDone:
-			err = context.Cause(walkCtx)
-			if err == nil {
-				proofs.publish()
-			}
-			return err
-		}
-	}
+	return err
 }
 
 type storedSHAMapProofs struct {
@@ -520,14 +370,279 @@ type storedSHAMapFetch func(context.Context, nodestore.Hash256) (*nodestore.Node
 
 const (
 	maxStoredSHAMapWorkers             = 64
+	maxOnlineDeleteRefreshWorkers      = 4
 	storedSHAMapFrontierTasksPerWorker = 4
 )
+
+type storedSHAMapWalkControl struct {
+	progress        *storedSHAMapVerificationProgress
+	progressTicks   <-chan time.Time
+	checkpoint      func(time.Duration) error
+	checkpointTicks <-chan time.Time
+	now             func() time.Time
+}
 
 func resolveStoredSHAMapWorkers(configured int) int {
 	if configured <= 0 {
 		configured = runtime.GOMAXPROCS(0)
 	}
 	return min(configured, maxStoredSHAMapWorkers)
+}
+
+func resolveOnlineDeleteRefreshWorkers() int {
+	return min(runtime.GOMAXPROCS(0), maxOnlineDeleteRefreshWorkers)
+}
+
+func (s *Service) walkStoredSHAMapConcurrentWithFetch(
+	ctx context.Context,
+	root [32]byte,
+	mapType shamap.Type,
+	fetch storedSHAMapFetch,
+	workers int,
+	control storedSHAMapWalkControl,
+	visit func(storedSHAMapNode),
+) error {
+	if root == ([32]byte{}) {
+		return fmt.Errorf("zero root")
+	}
+	if workers <= 0 {
+		workers = 1
+	}
+	if control.now == nil {
+		control.now = time.Now
+	}
+
+	walkCtx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+	var cancelOnce sync.Once
+	var checkpointGate sync.RWMutex
+	workStartedAt := control.now()
+	var lastCheckpointNodes uint64
+	controlledFetch := fetch
+	if control.checkpoint != nil {
+		controlledFetch = func(ctx context.Context, hash nodestore.Hash256) (*nodestore.Node, error) {
+			checkpointGate.RLock()
+			defer checkpointGate.RUnlock()
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			return fetch(ctx, hash)
+		}
+	}
+
+	checkpointSignal := make(chan struct{}, 1)
+	onNode := func(node storedSHAMapNode) {
+		visited := control.progress.nodesChecked.Add(1)
+		if visit != nil {
+			visit(node)
+		}
+		if control.checkpoint != nil && visited%refreshHealthCheckInterval == 0 {
+			select {
+			case checkpointSignal <- struct{}{}:
+			default:
+			}
+		}
+	}
+
+	rootNode, _, err := s.loadStoredSHAMapNodeWithFetch(
+		walkCtx,
+		storedSHAMapNode{hash: root},
+		mapType,
+		controlledFetch,
+	)
+	if err != nil {
+		return err
+	}
+	onNode(storedSHAMapNode{hash: root})
+	inner, ok := rootNode.(shamap.InnerNodeReader)
+	if !ok {
+		return fmt.Errorf("root node %x is not an inner node", root[:8])
+	}
+
+	branches := make([][32]byte, 0, shamap.BranchFactor)
+	for branch := range shamap.BranchFactor {
+		if inner.IsEmptyBranch(branch) {
+			continue
+		}
+		child, childErr := inner.ChildHash(branch)
+		if childErr != nil {
+			return childErr
+		}
+		branches = append(branches, child)
+	}
+	control.progress.branchesTotal = uint32(len(branches))
+	control.progress.configureWorkers(workers, 0, len(branches))
+	frontier, outstanding, err := s.buildStoredSHAMapFrontier(
+		walkCtx,
+		branches,
+		workers*storedSHAMapFrontierTasksPerWorker,
+		mapType,
+		controlledFetch,
+		onNode,
+	)
+	for _, count := range outstanding {
+		if count == 0 {
+			control.progress.branchesComplete.Add(1)
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	startedWorkers := min(workers, len(frontier))
+	control.progress.configureWorkers(workers, startedWorkers, len(frontier))
+	control.progress.start()
+	if len(frontier) == 0 {
+		return context.Cause(walkCtx)
+	}
+
+	branchOutstanding := make([]atomic.Int64, len(outstanding))
+	for branch, count := range outstanding {
+		branchOutstanding[branch].Store(int64(count))
+	}
+	tasks := make(chan storedSHAMapTask, len(frontier))
+	for _, task := range frontier {
+		tasks <- task
+	}
+	close(tasks)
+
+	var workersGroup sync.WaitGroup
+	for range startedWorkers {
+		workersGroup.Add(1)
+		go func() {
+			defer workersGroup.Done()
+			for {
+				var task storedSHAMapTask
+				var open bool
+				select {
+				case task, open = <-tasks:
+					if !open {
+						return
+					}
+				case <-walkCtx.Done():
+					return
+				}
+
+				control.progress.frontierSize.Add(-1)
+				control.progress.activeWorkers.Add(1)
+				var unreportedNodes uint64
+				walkErr := s.walkStoredSHAMapNodesWithFetch(
+					walkCtx,
+					[]storedSHAMapNode{task.node},
+					mapType,
+					controlledFetch,
+					func(node storedSHAMapNode, _ *nodestore.Node) error {
+						if control.checkpoint != nil {
+							onNode(node)
+							return nil
+						}
+						unreportedNodes++
+						if visit != nil {
+							visit(node)
+						}
+						if unreportedNodes == storedSHAMapNodeCountBatch {
+							control.progress.nodesChecked.Add(unreportedNodes)
+							unreportedNodes = 0
+						}
+						return nil
+					},
+				)
+				if unreportedNodes > 0 {
+					control.progress.nodesChecked.Add(unreportedNodes)
+				}
+				control.progress.activeWorkers.Add(-1)
+				if walkErr != nil {
+					cancelOnce.Do(func() { cancel(walkErr) })
+					return
+				}
+				if branchOutstanding[task.branch].Add(-1) == 0 {
+					control.progress.branchesComplete.Add(1)
+				}
+			}
+		}()
+	}
+	workersDone := make(chan struct{})
+	go func() {
+		workersGroup.Wait()
+		close(workersDone)
+	}()
+
+	runCheckpoint := func() {
+		if control.checkpoint == nil || walkCtx.Err() != nil {
+			return
+		}
+		checkpointGate.Lock()
+		defer checkpointGate.Unlock()
+		if walkCtx.Err() != nil {
+			return
+		}
+		checkpointAt := control.now()
+		work := checkpointAt.Sub(workStartedAt)
+		if work < 0 {
+			work = 0
+		}
+		visited := control.progress.nodesChecked.Load()
+		if work < refreshHealthCheckPeriod &&
+			visited-lastCheckpointNodes < refreshHealthCheckInterval {
+			return
+		}
+		if checkpointErr := control.checkpoint(work); checkpointErr != nil {
+			cancelOnce.Do(func() { cancel(checkpointErr) })
+			return
+		}
+		lastCheckpointNodes = visited
+		workStartedAt = control.now()
+	}
+
+	progressTicks := control.progressTicks
+	checkpointTicks := control.checkpointTicks
+	if control.checkpoint == nil {
+		checkpointSignal = nil
+		checkpointTicks = nil
+	}
+	ctxDone := ctx.Done()
+	for {
+		select {
+		case tick, open := <-progressTicks:
+			if !open {
+				progressTicks = nil
+				continue
+			}
+			select {
+			case <-workersDone:
+				return context.Cause(walkCtx)
+			default:
+			}
+			control.progress.report(tick)
+		case _, open := <-checkpointTicks:
+			if !open {
+				checkpointTicks = nil
+				continue
+			}
+			select {
+			case <-workersDone:
+				return context.Cause(walkCtx)
+			default:
+			}
+			runCheckpoint()
+		case <-checkpointSignal:
+			select {
+			case <-workersDone:
+				return context.Cause(walkCtx)
+			default:
+			}
+			runCheckpoint()
+		case <-ctxDone:
+			ctxDone = nil
+			cause := context.Cause(ctx)
+			if cause == nil {
+				cause = ctx.Err()
+			}
+			cancelOnce.Do(func() { cancel(cause) })
+		case <-workersDone:
+			return context.Cause(walkCtx)
+		}
+	}
 }
 
 func (s *Service) storedSHAMapVerificationFetch() storedSHAMapFetch {

--- a/internal/ledger/service/fast_load_progress.go
+++ b/internal/ledger/service/fast_load_progress.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -12,13 +14,16 @@ import (
 
 const (
 	storedSHAMapVerificationLogInterval = 15 * time.Second
-	// Workers flush local counts in batches to keep the shared atomic off the
-	// per-node hot path while retaining exact terminal totals.
+	// Worker-local counts avoid a shared atomic operation on every read-only
+	// verification fetch. Refresh walks need exact counts for checkpoint gating.
 	storedSHAMapNodeCountBatch = 256
 )
 
 type storedSHAMapVerificationProgress struct {
-	logger xrpllog.Logger
+	logger             xrpllog.Logger
+	operation          string
+	reportCancellation bool
+	extraFields        []any
 
 	mapType string
 	root    string
@@ -50,6 +55,7 @@ func newStoredSHAMapVerificationProgress(
 ) *storedSHAMapVerificationProgress {
 	progress := &storedSHAMapVerificationProgress{
 		logger:     logger,
+		operation:  "stored SHAMap verification",
 		nodeStore:  nodeStore,
 		mapType:    mapType.String(),
 		root:       fmt.Sprintf("%x", root[:8]),
@@ -60,6 +66,21 @@ func newStoredSHAMapVerificationProgress(
 	if nodeStore != nil {
 		progress.initialStats = nodeStore.Stats()
 	}
+	return progress
+}
+
+func newOnlineDeleteRefreshProgress(
+	logger xrpllog.Logger,
+	nodeStore nodestore.Database,
+	root [32]byte,
+	mapType shamap.Type,
+	sequence uint32,
+	startedAt time.Time,
+) *storedSHAMapVerificationProgress {
+	progress := newStoredSHAMapVerificationProgress(logger, nodeStore, root, mapType, startedAt)
+	progress.operation = "online delete: live-state refresh"
+	progress.reportCancellation = true
+	progress.extraFields = []any{"sequence", sequence}
 	return progress
 }
 
@@ -78,7 +99,8 @@ func (p *storedSHAMapVerificationProgress) start() {
 		return
 	}
 	p.started = true
-	p.logger.Info("stored SHAMap verification started",
+	fields := append([]any(nil), p.extraFields...)
+	fields = append(fields,
 		"map_type", p.mapType,
 		"root", p.root,
 		"active_branches", p.branchesTotal,
@@ -89,6 +111,7 @@ func (p *storedSHAMapVerificationProgress) start() {
 		"node_cache_hits_before", p.initialStats.CacheHits,
 		"node_cache_misses_before", p.initialStats.CacheMisses,
 	)
+	p.logger.Info(p.operation+" started", fields...)
 }
 
 func (p *storedSHAMapVerificationProgress) report(at time.Time) {
@@ -97,17 +120,21 @@ func (p *storedSHAMapVerificationProgress) report(at time.Time) {
 	}
 	fields := p.fields(at)
 	p.lastReport = at
-	p.logger.Info("stored SHAMap verification progress", fields...)
+	p.logger.Info(p.operation+" progress", fields...)
 }
 
 func (p *storedSHAMapVerificationProgress) finish(at time.Time, err error) {
 	p.start()
 	fields := p.fields(at)
 	if err != nil {
-		p.logger.Warn("stored SHAMap verification failed", append(fields, "err", err)...)
+		message := p.operation + " failed"
+		if p.reportCancellation && errors.Is(err, context.Canceled) {
+			message = p.operation + " canceled"
+		}
+		p.logger.Warn(message, append(fields, "err", err)...)
 		return
 	}
-	p.logger.Info("stored SHAMap verification complete", fields...)
+	p.logger.Info(p.operation+" complete", fields...)
 }
 
 func (p *storedSHAMapVerificationProgress) fields(at time.Time) []any {
@@ -138,7 +165,8 @@ func (p *storedSHAMapVerificationProgress) fields(at time.Time) []any {
 	if p.nodeStore != nil {
 		stats = p.nodeStore.Stats()
 	}
-	return []any{
+	fields := append([]any(nil), p.extraFields...)
+	return append(fields,
 		"map_type", p.mapType,
 		"root", p.root,
 		"elapsed", elapsed.String(),
@@ -160,5 +188,5 @@ func (p *storedSHAMapVerificationProgress) fields(at time.Time) []any {
 		"node_cache_hits_after", stats.CacheHits,
 		"node_cache_misses_before", p.initialStats.CacheMisses,
 		"node_cache_misses_after", stats.CacheMisses,
-	}
+	)
 }

--- a/internal/ledger/service/online_delete_refresh_test.go
+++ b/internal/ledger/service/online_delete_refresh_test.go
@@ -21,14 +21,18 @@ import (
 
 type countingGenerationDatabase struct {
 	nodestore.Database
-	generation       nodestore.GenerationDatabase
-	storeBatchNodes  int
-	promotionFetches int
-	promotionDelay   time.Duration
-	refreshChecks    atomic.Int64
-	storeBatchOnce   sync.Once
-	storeBatchStart  chan struct{}
-	storeBatchResume chan struct{}
+	generation            nodestore.GenerationDatabase
+	storeBatchNodes       int
+	promotionFetches      atomic.Int64
+	promotionsInFlight    atomic.Int64
+	maxPromotionsInFlight atomic.Int64
+	promotionDelay        time.Duration
+	promotionStart        chan struct{}
+	promotionOnce         sync.Once
+	refreshChecks         atomic.Int64
+	storeBatchOnce        sync.Once
+	storeBatchStart       chan struct{}
+	storeBatchResume      chan struct{}
 }
 
 func (d *countingGenerationDatabase) StoreBatch(ctx context.Context, nodes []*nodestore.Node) error {
@@ -49,7 +53,18 @@ func (d *countingGenerationDatabase) FetchForPromotion(
 	ctx context.Context,
 	hash nodestore.Hash256,
 ) (*nodestore.Node, error) {
-	d.promotionFetches++
+	d.promotionFetches.Add(1)
+	inFlight := d.promotionsInFlight.Add(1)
+	defer d.promotionsInFlight.Add(-1)
+	for {
+		peak := d.maxPromotionsInFlight.Load()
+		if inFlight <= peak || d.maxPromotionsInFlight.CompareAndSwap(peak, inFlight) {
+			break
+		}
+	}
+	if d.promotionStart != nil {
+		d.promotionOnce.Do(func() { close(d.promotionStart) })
+	}
 	if d.promotionDelay > 0 {
 		timer := time.NewTimer(d.promotionDelay)
 		defer timer.Stop()
@@ -150,16 +165,16 @@ func TestService_RefreshValidatedStatePromotesWithoutRestamping(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, seq, refreshedSeq)
 	require.Zero(t, db.storeBatchNodes)
-	require.Zero(t, db.promotionFetches)
+	require.Zero(t, db.promotionFetches.Load())
 
 	committed, err := db.RotateGeneration(ctx, seq, 1)
 	require.True(t, committed)
 	require.NoError(t, err)
-	db.promotionFetches = 0
+	db.promotionFetches.Store(0)
 	refreshedSeq, err = svc.RefreshValidatedState(ctx, seq, nil)
 	require.NoError(t, err)
 	require.Equal(t, seq, refreshedSeq)
-	require.Positive(t, db.promotionFetches)
+	require.Positive(t, db.promotionFetches.Load())
 	committed, err = db.RotateGeneration(ctx, seq+1, 1)
 	require.True(t, committed)
 	require.NoError(t, err)
@@ -256,7 +271,7 @@ func TestService_RefreshSnapshotsValidatedLedgerBeforePersistenceBarrier(t *test
 		t.Fatal("refresh did not resume after selected-ledger persistence")
 	}
 	require.Equal(t, int64(1), db.refreshChecks.Load())
-	require.Zero(t, db.promotionFetches)
+	require.Zero(t, db.promotionFetches.Load())
 	committed, err := db.RotateGeneration(ctx, selectedSeq, 1)
 	require.True(t, committed)
 	require.NoError(t, err)
@@ -387,7 +402,7 @@ func TestService_RefreshValidatedStateChecksHealthByElapsedWork(t *testing.T) {
 	require.True(t, committed)
 	require.NoError(t, err)
 
-	db.promotionFetches = 0
+	db.promotionFetches.Store(0)
 	db.promotionDelay = 2 * time.Millisecond
 	wantErr := errors.New("health checkpoint reached")
 	refreshedSeq, err := svc.RefreshValidatedState(ctx, seq, func(time.Duration) error {
@@ -395,6 +410,155 @@ func TestService_RefreshValidatedStateChecksHealthByElapsedWork(t *testing.T) {
 	})
 	require.ErrorIs(t, err, wantErr)
 	require.Zero(t, refreshedSeq)
-	require.Positive(t, db.promotionFetches)
-	require.Less(t, db.promotionFetches, refreshHealthCheckInterval)
+	require.Positive(t, db.promotionFetches.Load())
+	require.Less(t, db.promotionFetches.Load(), int64(refreshHealthCheckInterval))
+}
+
+func TestService_RefreshValidatedStateUsesBoundedConcurrencyAndReportsProgress(t *testing.T) {
+	svc, db, seq := newRotatingRefreshFixture(t, 256)
+	db.promotionDelay = 2 * time.Millisecond
+	capture, logger := newVerificationLogCapture()
+	svc.logger = logger
+
+	refreshedSeq, err := svc.RefreshValidatedState(t.Context(), seq, nil)
+	require.NoError(t, err)
+	require.Equal(t, seq, refreshedSeq)
+	require.Greater(t, db.maxPromotionsInFlight.Load(), int64(1))
+	require.LessOrEqual(
+		t,
+		db.maxPromotionsInFlight.Load(),
+		int64(resolveOnlineDeleteRefreshWorkers()),
+	)
+
+	records := decodeVerificationLogs(t, capture)
+	require.Len(t, records, 2)
+	require.Equal(t, "online delete: live-state refresh started", records[0].Message)
+	require.EqualValues(t, resolveOnlineDeleteRefreshWorkers(), records[0].Workers)
+	require.Equal(t, "online delete: live-state refresh complete", records[1].Message)
+	require.EqualValues(t, db.promotionFetches.Load(), records[1].NodesChecked)
+	require.Greater(t, records[1].NodeStoreReadsAfter, records[1].NodeStoreReadsBefore)
+}
+
+func TestService_RefreshValidatedStateReportsCancellation(t *testing.T) {
+	svc, db, seq := newRotatingRefreshFixture(t, 16)
+	db.promotionDelay = time.Second
+	db.promotionStart = make(chan struct{})
+	capture, logger := newVerificationLogCapture()
+	svc.logger = logger
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		_, err := svc.RefreshValidatedState(ctx, seq, nil)
+		done <- err
+	}()
+	<-db.promotionStart
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not stop promptly after cancellation")
+	}
+	records := decodeVerificationLogs(t, capture)
+	require.Len(t, records, 2)
+	require.Equal(t, "online delete: live-state refresh started", records[0].Message)
+	require.Equal(t, "online delete: live-state refresh canceled", records[1].Message)
+	require.Contains(t, records[1].VerificationError, context.Canceled.Error())
+}
+
+func newRotatingRefreshFixture(
+	t *testing.T,
+	entries int,
+) (*Service, *countingGenerationDatabase, uint32) {
+	t.Helper()
+	backend, err := kvpebble.NewRotating(
+		filepath.Join(t.TempDir(), "nodes"),
+		kvpebble.Options{BlockCacheBytes: 16 << 20, MaxOpenFiles: 200},
+	)
+	require.NoError(t, err)
+	base := newTestRotatingNodeStore(t, backend, entries*4)
+	db := &countingGenerationDatabase{Database: base, generation: base}
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	svc, err := New(Config{
+		Standalone:    true,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  shamapbackend.New(db),
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	for i := range entries {
+		var key [32]byte
+		binary.BigEndian.PutUint32(key[28:], uint32(i+1))
+		data := make([]byte, 12)
+		binary.BigEndian.PutUint32(data[8:], uint32(i+1))
+		require.NoError(t, svc.openLedger.Insert(keylet.Keylet{Key: key}, data))
+	}
+	seq, err := svc.AcceptLedger(t.Context())
+	require.NoError(t, err)
+	svc.FlushPersists()
+	committed, err := db.RotateGeneration(t.Context(), seq, 1)
+	require.True(t, committed)
+	require.NoError(t, err)
+	return svc, db, seq
+}
+
+func BenchmarkService_RefreshValidatedState(b *testing.B) {
+	const entries = 16_384
+	backend, err := kvpebble.NewRotating(
+		filepath.Join(b.TempDir(), "nodes"),
+		kvpebble.Options{BlockCacheBytes: 64 << 20, MaxOpenFiles: 200},
+	)
+	require.NoError(b, err)
+	base, err := nodestore.NewRotatingKVDatabase(backend, nodestore.DatabaseConfig{})
+	require.NoError(b, err)
+	db := &countingGenerationDatabase{Database: base, generation: base}
+	b.Cleanup(func() { require.NoError(b, db.Close()) })
+	svc, err := New(Config{
+		Standalone:    true,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  shamapbackend.New(db),
+	})
+	require.NoError(b, err)
+	require.NoError(b, svc.Start())
+	b.Cleanup(svc.Stop)
+
+	for i := range entries {
+		var key [32]byte
+		binary.BigEndian.PutUint32(key[28:], uint32(i+1))
+		data := make([]byte, 12)
+		binary.BigEndian.PutUint32(data[8:], uint32(i+1))
+		require.NoError(b, svc.openLedger.Insert(keylet.Keylet{Key: key}, data))
+	}
+	seq, err := svc.AcceptLedger(b.Context())
+	require.NoError(b, err)
+	svc.FlushPersists()
+	committed, err := db.RotateGeneration(b.Context(), seq, 1)
+	require.True(b, committed)
+	require.NoError(b, err)
+	db.promotionFetches.Store(0)
+
+	b.ResetTimer()
+	for iteration := range b.N {
+		refreshedSeq, refreshErr := svc.RefreshValidatedState(b.Context(), seq, nil)
+		require.NoError(b, refreshErr)
+		require.Equal(b, seq, refreshedSeq)
+
+		b.StopTimer()
+		committed, rotateErr := db.RotateGeneration(b.Context(), seq+uint32(iteration)+1, 1)
+		require.True(b, committed)
+		require.NoError(b, rotateErr)
+		b.StartTimer()
+	}
+	b.StopTimer()
+	b.ReportMetric(
+		float64(db.promotionFetches.Load())/b.Elapsed().Seconds(),
+		"nodes/s",
+	)
+	b.ReportMetric(float64(resolveOnlineDeleteRefreshWorkers()), "workers")
 }

--- a/internal/ledger/service/online_delete_refresh_test.go
+++ b/internal/ledger/service/online_delete_refresh_test.go
@@ -482,7 +482,7 @@ func TestService_ConcurrentRefreshChecksHealthDuringFrontierBuild(t *testing.T) 
 	require.Equal(t, int64(1), fetches.Load())
 }
 
-func TestService_ConcurrentRefreshCancelsBlockedCheckpointAfterFetchError(t *testing.T) {
+func TestService_ConcurrentRefreshDoesNotBlockAfterFetchError(t *testing.T) {
 	svc, _, _ := newRotatingRefreshFixture(t, 16)
 	root, err := svc.GetValidatedLedger().StateMapHash()
 	require.NoError(t, err)
@@ -504,7 +504,6 @@ func TestService_ConcurrentRefreshCancelsBlockedCheckpointAfterFetchError(t *tes
 		return nil, wantErr
 	}
 	checkpointTicks := make(chan time.Time)
-	checkpointStarted := make(chan struct{})
 	done := make(chan error, 1)
 	go func() {
 		done <- svc.walkStoredSHAMapConcurrentWithFetch(
@@ -523,7 +522,6 @@ func TestService_ConcurrentRefreshCancelsBlockedCheckpointAfterFetchError(t *tes
 					startedAt,
 				),
 				checkpoint: func(ctx context.Context, _ time.Duration) error {
-					close(checkpointStarted)
 					<-ctx.Done()
 					return context.Cause(ctx)
 				},
@@ -540,15 +538,10 @@ func TestService_ConcurrentRefreshCancelsBlockedCheckpointAfterFetchError(t *tes
 	close(fetchRelease)
 
 	select {
-	case <-checkpointStarted:
-	case <-time.After(time.Second):
-		t.Fatal("checkpoint did not start after the failed fetch released its read lock")
-	}
-	select {
 	case err := <-done:
 		require.ErrorIs(t, err, wantErr)
 	case <-time.After(time.Second):
-		t.Fatal("refresh did not cancel the blocked checkpoint after the fetch failed")
+		t.Fatal("refresh did not return after the fetch failed with a checkpoint pending")
 	}
 }
 

--- a/internal/ledger/service/online_delete_refresh_test.go
+++ b/internal/ledger/service/online_delete_refresh_test.go
@@ -305,7 +305,7 @@ func TestService_RefreshValidatedStateRunsInWalkCheckpoint(t *testing.T) {
 
 	wantErr := errors.New("checkpoint stopped traversal")
 	checks := 0
-	refreshedSeq, err := svc.RefreshValidatedState(ctx, seq, func(time.Duration) error {
+	refreshedSeq, err := svc.RefreshValidatedState(ctx, seq, func(context.Context, time.Duration) error {
 		checks++
 		return wantErr
 	})
@@ -321,7 +321,7 @@ func TestService_RefreshValidatedStateRunsInWalkCheckpoint(t *testing.T) {
 	recovered := make(chan struct{})
 	done := make(chan refreshResult, 1)
 	go func() {
-		seq, err := svc.RefreshValidatedState(ctx, seq, func(time.Duration) error {
+		seq, err := svc.RefreshValidatedState(ctx, seq, func(context.Context, time.Duration) error {
 			select {
 			case checkpointReached <- struct{}{}:
 			default:
@@ -350,7 +350,7 @@ func TestService_RefreshValidatedStateRunsInWalkCheckpoint(t *testing.T) {
 	cancelReached := make(chan struct{})
 	done = make(chan refreshResult, 1)
 	go func() {
-		seq, err := svc.RefreshValidatedState(cancelCtx, seq, func(time.Duration) error {
+		seq, err := svc.RefreshValidatedState(cancelCtx, seq, func(context.Context, time.Duration) error {
 			close(cancelReached)
 			<-cancelCtx.Done()
 			return cancelCtx.Err()
@@ -405,13 +405,194 @@ func TestService_RefreshValidatedStateChecksHealthByElapsedWork(t *testing.T) {
 	db.promotionFetches.Store(0)
 	db.promotionDelay = 2 * time.Millisecond
 	wantErr := errors.New("health checkpoint reached")
-	refreshedSeq, err := svc.RefreshValidatedState(ctx, seq, func(time.Duration) error {
+	refreshedSeq, err := svc.RefreshValidatedState(ctx, seq, func(context.Context, time.Duration) error {
 		return wantErr
 	})
 	require.ErrorIs(t, err, wantErr)
 	require.Zero(t, refreshedSeq)
 	require.Positive(t, db.promotionFetches.Load())
 	require.Less(t, db.promotionFetches.Load(), int64(refreshHealthCheckInterval))
+}
+
+func TestService_ConcurrentRefreshChecksHealthDuringFrontierBuild(t *testing.T) {
+	svc, db, _ := newRotatingRefreshFixture(t, 256)
+	root, err := svc.GetValidatedLedger().StateMapHash()
+	require.NoError(t, err)
+
+	startedAt := time.Date(2026, time.August, 23, 12, 0, 0, 0, time.UTC)
+	var clockAdvanced atomic.Bool
+	now := func() time.Time {
+		if clockAdvanced.Load() {
+			return startedAt.Add(refreshHealthCheckPeriod)
+		}
+		return startedAt
+	}
+	firstFetchStarted := make(chan struct{})
+	firstFetchRelease := make(chan struct{})
+	var fetches atomic.Int64
+	fetch := func(ctx context.Context, hash nodestore.Hash256) (*nodestore.Node, error) {
+		if fetches.Add(1) == 1 {
+			close(firstFetchStarted)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-firstFetchRelease:
+			}
+		}
+		return db.FetchForPromotion(ctx, hash)
+	}
+	checkpointTicks := make(chan time.Time)
+	wantErr := errors.New("frontier health checkpoint")
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.walkStoredSHAMapConcurrentWithFetch(
+			t.Context(),
+			root,
+			shamap.TypeState,
+			fetch,
+			resolveOnlineDeleteRefreshWorkers(),
+			storedSHAMapWalkControl{
+				progress: newOnlineDeleteRefreshProgress(
+					svc.logger,
+					svc.nodeStore,
+					root,
+					shamap.TypeState,
+					svc.GetValidatedLedger().Sequence(),
+					startedAt,
+				),
+				checkpoint:      func(context.Context, time.Duration) error { return wantErr },
+				checkpointTicks: checkpointTicks,
+				now:             now,
+			},
+			nil,
+		)
+	}()
+	<-firstFetchStarted
+	clockAdvanced.Store(true)
+	checkpointTicks <- startedAt.Add(refreshHealthCheckPeriod)
+	time.Sleep(20 * time.Millisecond)
+	close(firstFetchRelease)
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, wantErr)
+	case <-time.After(time.Second):
+		t.Fatal("frontier health checkpoint did not stop the refresh")
+	}
+	require.Equal(t, int64(1), fetches.Load())
+}
+
+func TestService_ConcurrentRefreshCancelsBlockedCheckpointAfterFetchError(t *testing.T) {
+	svc, _, _ := newRotatingRefreshFixture(t, 16)
+	root, err := svc.GetValidatedLedger().StateMapHash()
+	require.NoError(t, err)
+
+	startedAt := time.Date(2026, time.August, 23, 12, 0, 0, 0, time.UTC)
+	var clockAdvanced atomic.Bool
+	now := func() time.Time {
+		if clockAdvanced.Load() {
+			return startedAt.Add(refreshHealthCheckPeriod)
+		}
+		return startedAt
+	}
+	fetchStarted := make(chan struct{})
+	fetchRelease := make(chan struct{})
+	wantErr := errors.New("fetch failed")
+	fetch := func(context.Context, nodestore.Hash256) (*nodestore.Node, error) {
+		close(fetchStarted)
+		<-fetchRelease
+		return nil, wantErr
+	}
+	checkpointTicks := make(chan time.Time)
+	checkpointStarted := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.walkStoredSHAMapConcurrentWithFetch(
+			t.Context(),
+			root,
+			shamap.TypeState,
+			fetch,
+			resolveOnlineDeleteRefreshWorkers(),
+			storedSHAMapWalkControl{
+				progress: newOnlineDeleteRefreshProgress(
+					svc.logger,
+					svc.nodeStore,
+					root,
+					shamap.TypeState,
+					svc.GetValidatedLedger().Sequence(),
+					startedAt,
+				),
+				checkpoint: func(ctx context.Context, _ time.Duration) error {
+					close(checkpointStarted)
+					<-ctx.Done()
+					return context.Cause(ctx)
+				},
+				checkpointTicks: checkpointTicks,
+				now:             now,
+			},
+			nil,
+		)
+	}()
+	<-fetchStarted
+	clockAdvanced.Store(true)
+	checkpointTicks <- startedAt.Add(refreshHealthCheckPeriod)
+	time.Sleep(20 * time.Millisecond)
+	close(fetchRelease)
+
+	select {
+	case <-checkpointStarted:
+	case <-time.After(time.Second):
+		t.Fatal("checkpoint did not start after the failed fetch released its read lock")
+	}
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, wantErr)
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not cancel the blocked checkpoint after the fetch failed")
+	}
+}
+
+func TestService_ConcurrentRefreshChecksHealthBeforeCompletion(t *testing.T) {
+	svc, db, _ := newRotatingRefreshFixture(t, 16)
+	validated := svc.GetValidatedLedger()
+	root, err := validated.StateMapHash()
+	require.NoError(t, err)
+
+	startedAt := time.Date(2026, time.August, 23, 12, 0, 0, 0, time.UTC)
+	var nowCalls atomic.Int64
+	now := func() time.Time {
+		if nowCalls.Add(1) == 1 {
+			return startedAt
+		}
+		return startedAt.Add(refreshHealthCheckPeriod)
+	}
+	wantErr := errors.New("terminal health checkpoint")
+	checks := 0
+	err = svc.walkStoredSHAMapConcurrentWithFetch(
+		t.Context(),
+		root,
+		shamap.TypeState,
+		db.FetchForPromotion,
+		resolveOnlineDeleteRefreshWorkers(),
+		storedSHAMapWalkControl{
+			progress: newOnlineDeleteRefreshProgress(
+				svc.logger,
+				svc.nodeStore,
+				root,
+				shamap.TypeState,
+				validated.Sequence(),
+				startedAt,
+			),
+			checkpoint: func(context.Context, time.Duration) error {
+				checks++
+				return wantErr
+			},
+			now: now,
+		},
+		nil,
+	)
+	require.ErrorIs(t, err, wantErr)
+	require.Equal(t, 1, checks)
 }
 
 func TestService_RefreshValidatedStateUsesBoundedConcurrencyAndReportsProgress(t *testing.T) {

--- a/internal/ledger/service/persistence.go
+++ b/internal/ledger/service/persistence.go
@@ -524,7 +524,7 @@ func (s *Service) refreshGenerationState(
 	root [32]byte,
 	sequence uint32,
 	generations nodestore.GenerationDatabase,
-	checkpoint func(time.Duration) error,
+	checkpoint func(context.Context, time.Duration) error,
 ) (err error) {
 	startedAt := time.Now()
 	progress := newOnlineDeleteRefreshProgress(
@@ -575,7 +575,7 @@ func (s *Service) refreshGenerationState(
 func (s *Service) RefreshValidatedState(
 	ctx context.Context,
 	minimumSeq uint32,
-	checkpoint func(time.Duration) error,
+	checkpoint func(context.Context, time.Duration) error,
 ) (uint32, error) {
 	s.mu.RLock()
 	validated := s.validatedLedger
@@ -644,7 +644,7 @@ func (s *Service) RefreshValidatedState(
 		work := time.Since(checkpointStarted)
 		if checkpoint != nil &&
 			(visited%refreshHealthCheckInterval == 0 || work >= refreshHealthCheckPeriod) {
-			if err := checkpoint(work); err != nil {
+			if err := checkpoint(ctx, work); err != nil {
 				return err
 			}
 			checkpointStarted = time.Now()

--- a/internal/ledger/service/persistence.go
+++ b/internal/ledger/service/persistence.go
@@ -519,6 +519,55 @@ const (
 	refreshHealthCheckPeriod   = 10 * time.Millisecond
 )
 
+func (s *Service) refreshGenerationState(
+	ctx context.Context,
+	root [32]byte,
+	sequence uint32,
+	generations nodestore.GenerationDatabase,
+	checkpoint func(time.Duration) error,
+) (err error) {
+	startedAt := time.Now()
+	progress := newOnlineDeleteRefreshProgress(
+		s.logger,
+		s.nodeStore,
+		root,
+		shamap.TypeState,
+		sequence,
+		startedAt,
+	)
+	defer func() { progress.finish(time.Now(), err) }()
+
+	progressTicker := time.NewTicker(storedSHAMapVerificationLogInterval)
+	defer progressTicker.Stop()
+	var checkpointTicker *time.Ticker
+	var checkpointTicks <-chan time.Time
+	if checkpoint != nil {
+		checkpointTicker = time.NewTicker(refreshHealthCheckPeriod)
+		checkpointTicks = checkpointTicker.C
+		defer checkpointTicker.Stop()
+	}
+
+	err = s.walkStoredSHAMapConcurrentWithFetch(
+		ctx,
+		root,
+		shamap.TypeState,
+		generations.FetchForPromotion,
+		resolveOnlineDeleteRefreshWorkers(),
+		storedSHAMapWalkControl{
+			progress:        progress,
+			progressTicks:   progressTicker.C,
+			checkpoint:      checkpoint,
+			checkpointTicks: checkpointTicks,
+			now:             time.Now,
+		},
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+	return s.nodeStore.Sync(ctx)
+}
+
 // RefreshValidatedState preserves the complete live state tree before online
 // deletion retires older node-store records. Rotating stores promote archive
 // reads into their writable generation; legacy stores re-stamp records in place.
@@ -554,30 +603,7 @@ func (s *Service) RefreshValidatedState(
 		if err != nil {
 			return 0, err
 		}
-		visited := 0
-		checkpointStarted := time.Now()
-		err = s.walkStoredSHAMapWithFetch(
-			ctx,
-			root,
-			shamap.TypeState,
-			generations.FetchForPromotion,
-			func(_ [32]byte, _ *nodestore.Node) error {
-				visited++
-				work := time.Since(checkpointStarted)
-				if checkpoint != nil &&
-					(visited%refreshHealthCheckInterval == 0 || work >= refreshHealthCheckPeriod) {
-					if err := checkpoint(work); err != nil {
-						return err
-					}
-					checkpointStarted = time.Now()
-				}
-				return nil
-			},
-		)
-		if err != nil {
-			return 0, err
-		}
-		if err := s.nodeStore.Sync(ctx); err != nil {
+		if err := s.refreshGenerationState(ctx, root, seq, generations, checkpoint); err != nil {
 			return 0, err
 		}
 		return seq, nil

--- a/internal/ledger/shamapstore/rotation.go
+++ b/internal/ledger/shamapstore/rotation.go
@@ -43,9 +43,9 @@ type RelationalPruner interface {
 
 // StateRefresh preserves the live state at or above minimumSeq. Rotating stores
 // promote it into the writable generation; legacy stores re-stamp it in place.
-// checkpoint must be called periodically while walking the state tree. The
+// checkpoint must be called periodically with the active walk context. The
 // returned sequence identifies the validated ledger that was preserved.
-type StateRefresh func(ctx context.Context, minimumSeq uint32, checkpoint func(time.Duration) error) (uint32, error)
+type StateRefresh func(ctx context.Context, minimumSeq uint32, checkpoint func(context.Context, time.Duration) error) (uint32, error)
 
 // RotationConfig carries the node_db online-delete settings the rotator needs.
 type RotationConfig struct {
@@ -409,9 +409,7 @@ func (r *Rotator) rotate(ctx context.Context, validatedSeq, lastRotated uint32) 
 	if advance != nil {
 		advance(minimumOnline)
 	}
-	refreshedSeq, err := refresh(ctx, validatedSeq, func(work time.Duration) error {
-		return r.refreshCheckpoint(ctx, work)
-	})
+	refreshedSeq, err := refresh(ctx, validatedSeq, r.refreshCheckpoint)
 	if err != nil {
 		if ctx.Err() == nil {
 			r.logger.Warn("online delete: live-state refresh failed", "seq", validatedSeq, "err", err)

--- a/internal/ledger/shamapstore/rotation_integration_test.go
+++ b/internal/ledger/shamapstore/rotation_integration_test.go
@@ -109,7 +109,9 @@ func TestRotation_ReclaimsNodeStoreSpace(t *testing.T) {
 	if rot == nil {
 		t.Fatal("NewRotator returned nil")
 	}
-	rot.SetStateRefresh(func(_ context.Context, seq uint32, _ func(time.Duration) error) (uint32, error) { return seq, nil }, nil, nil)
+	rot.SetStateRefresh(func(_ context.Context, seq uint32, _ func(context.Context, time.Duration) error) (uint32, error) {
+		return seq, nil
+	}, nil, nil)
 
 	// Build 25 ledgers, notifying the rotator synchronously per ledger via the
 	// internal predicate path so the assertions are deterministic.
@@ -197,7 +199,7 @@ func TestRotation_RotatingPebblePromotesLiveStateAndRetiresHistory(t *testing.T)
 	)
 	liveHashes := make([]nodestore.Hash256, 0, 2)
 	liveHashes = append(liveHashes, live.Hash)
-	rot.SetStateRefresh(func(ctx context.Context, seq uint32, _ func(time.Duration) error) (uint32, error) {
+	rot.SetStateRefresh(func(ctx context.Context, seq uint32, _ func(context.Context, time.Duration) error) (uint32, error) {
 		for _, hash := range liveHashes {
 			node, err := db.FetchForPromotion(ctx, hash)
 			if err != nil {
@@ -295,7 +297,7 @@ func TestRotation_RealGenerationPreservesHigherExistingFloor(t *testing.T) {
 		nil,
 	)
 	rot.SetStateRefresh(
-		func(_ context.Context, seq uint32, _ func(time.Duration) error) (uint32, error) {
+		func(_ context.Context, seq uint32, _ func(context.Context, time.Duration) error) (uint32, error) {
 			return seq, db.Sync(ctx)
 		},
 		nil,
@@ -335,7 +337,7 @@ func TestRotation_AdvancesAcquisitionFloorBeforeLiveStateRefresh(t *testing.T) {
 	}
 	rot := shamapstore.NewRotator(store, db, nil,
 		shamapstore.RotationConfig{DeleteInterval: 256}, nil)
-	rot.SetStateRefresh(func(_ context.Context, seq uint32, _ func(time.Duration) error) (uint32, error) {
+	rot.SetStateRefresh(func(_ context.Context, seq uint32, _ func(context.Context, time.Duration) error) (uint32, error) {
 		err := family.StoreBatch(ctx, []shamap.FlushEntry{{
 			Hash: hash, Data: data, LedgerSeq: 150, MapType: shamap.TypeState,
 		}})

--- a/internal/ledger/shamapstore/rotation_test.go
+++ b/internal/ledger/shamapstore/rotation_test.go
@@ -50,7 +50,7 @@ func (f *fakeGenerationPruner) GenerationState() (uint32, uint32) {
 
 func TestRotate_RefreshFailureAbortsDeletion(t *testing.T) {
 	r, nodes, rel := newTestRotator(t, false, 256)
-	r.SetStateRefresh(func(context.Context, uint32, func(time.Duration) error) (uint32, error) {
+	r.SetStateRefresh(func(context.Context, uint32, func(context.Context, time.Duration) error) (uint32, error) {
 		return 0, errors.New("missing live node")
 	}, nil, nil)
 	r.maybeRotate(context.Background(), 500)
@@ -97,10 +97,10 @@ func TestRotate_RefreshCheckpointWaitsForHealthRecovery(t *testing.T) {
 	healthy.Store(true)
 	r.SetHealthCheck(healthy.Load, time.Millisecond)
 	checkpointReached := make(chan struct{})
-	r.SetStateRefresh(func(_ context.Context, seq uint32, checkpoint func(time.Duration) error) (uint32, error) {
+	r.SetStateRefresh(func(ctx context.Context, seq uint32, checkpoint func(context.Context, time.Duration) error) (uint32, error) {
 		healthy.Store(false)
 		close(checkpointReached)
-		if err := checkpoint(time.Millisecond); err != nil {
+		if err := checkpoint(ctx, time.Millisecond); err != nil {
 			return 0, err
 		}
 		return seq, nil
@@ -134,10 +134,10 @@ func TestRotate_RefreshCheckpointHonorsCancellation(t *testing.T) {
 	healthy.Store(true)
 	r.SetHealthCheck(healthy.Load, time.Millisecond)
 	checkpointReached := make(chan struct{})
-	r.SetStateRefresh(func(_ context.Context, seq uint32, checkpoint func(time.Duration) error) (uint32, error) {
+	r.SetStateRefresh(func(ctx context.Context, seq uint32, checkpoint func(context.Context, time.Duration) error) (uint32, error) {
 		healthy.Store(false)
 		close(checkpointReached)
-		if err := checkpoint(time.Millisecond); err != nil {
+		if err := checkpoint(ctx, time.Millisecond); err != nil {
 			return 0, err
 		}
 		return seq, nil
@@ -173,9 +173,9 @@ func TestRotate_RefreshPacingHonorsCancellation(t *testing.T) {
 	healthy.Store(true)
 	r.SetHealthCheck(healthy.Load, time.Millisecond)
 	checkpointReached := make(chan struct{})
-	r.SetStateRefresh(func(_ context.Context, seq uint32, checkpoint func(time.Duration) error) (uint32, error) {
+	r.SetStateRefresh(func(ctx context.Context, seq uint32, checkpoint func(context.Context, time.Duration) error) (uint32, error) {
 		close(checkpointReached)
-		if err := checkpoint(time.Hour); err != nil {
+		if err := checkpoint(ctx, time.Hour); err != nil {
 			return 0, err
 		}
 		return seq, nil
@@ -206,7 +206,7 @@ func TestRotator_LongRefreshPersistsActualSequenceAndCoalescesQueuedNotification
 	r, nodes, _ := newTestRotator(t, false, 256)
 	refreshRequests := make(chan uint32, 3)
 	resumeRefresh := make(chan struct{})
-	r.SetStateRefresh(func(_ context.Context, requested uint32, _ func(time.Duration) error) (uint32, error) {
+	r.SetStateRefresh(func(_ context.Context, requested uint32, _ func(context.Context, time.Duration) error) (uint32, error) {
 		refreshRequests <- requested
 		if requested == 800 {
 			<-resumeRefresh
@@ -264,7 +264,9 @@ func TestRotate_PartialPruneResetsCacheWithoutAdvancing(t *testing.T) {
 	nodes.deleted = 3
 	nodes.err = errors.New("partial prune")
 	locked, unlocked := 0, 0
-	r.SetStateRefresh(func(_ context.Context, seq uint32, _ func(time.Duration) error) (uint32, error) { return seq, nil }, nil, func() func() {
+	r.SetStateRefresh(func(_ context.Context, seq uint32, _ func(context.Context, time.Duration) error) (uint32, error) {
+		return seq, nil
+	}, nil, func() func() {
 		locked++
 		return func() { unlocked++ }
 	})
@@ -315,7 +317,9 @@ func newTestRotator(t *testing.T, advisory bool, interval uint32) (*Rotator, *fa
 	if r == nil {
 		t.Fatal("NewRotator returned nil")
 	}
-	r.SetStateRefresh(func(_ context.Context, seq uint32, _ func(time.Duration) error) (uint32, error) { return seq, nil }, nil, nil)
+	r.SetStateRefresh(func(_ context.Context, seq uint32, _ func(context.Context, time.Duration) error) (uint32, error) {
+		return seq, nil
+	}, nil, nil)
 	return r, nodes, rel
 }
 
@@ -383,7 +387,7 @@ func TestRotate_PrefersGenerationRotationOverSequencePruning(t *testing.T) {
 	}
 	nodes := &fakeGenerationPruner{committed: true}
 	r := NewRotator(store, nodes, nil, RotationConfig{DeleteInterval: 256}, nil)
-	r.SetStateRefresh(func(_ context.Context, seq uint32, _ func(time.Duration) error) (uint32, error) {
+	r.SetStateRefresh(func(_ context.Context, seq uint32, _ func(context.Context, time.Duration) error) (uint32, error) {
 		return seq, nil
 	}, nil, nil)
 
@@ -411,7 +415,7 @@ func TestRotate_CommittedGenerationAdvancesDespiteCleanupError(t *testing.T) {
 		rotateErr: errors.New("retired directory cleanup failed"),
 	}
 	r := NewRotator(store, nodes, nil, RotationConfig{DeleteInterval: 256}, nil)
-	r.SetStateRefresh(func(_ context.Context, seq uint32, _ func(time.Duration) error) (uint32, error) {
+	r.SetStateRefresh(func(_ context.Context, seq uint32, _ func(context.Context, time.Duration) error) (uint32, error) {
 		return seq, nil
 	}, nil, nil)
 
@@ -505,7 +509,7 @@ func TestRotator_ReconcileFailureBlocksAnotherGenerationRotation(t *testing.T) {
 	}
 	nodes := &fakeGenerationPruner{committed: true}
 	r := NewRotator(store, nodes, nil, RotationConfig{DeleteInterval: 256}, nil)
-	r.SetStateRefresh(func(_ context.Context, seq uint32, _ func(time.Duration) error) (uint32, error) {
+	r.SetStateRefresh(func(_ context.Context, seq uint32, _ func(context.Context, time.Duration) error) (uint32, error) {
 		return seq, nil
 	}, nil, nil)
 
@@ -588,7 +592,7 @@ func TestRotator_StateRefreshHooksCanBeUpdatedConcurrently(t *testing.T) {
 	refresh := func(
 		_ context.Context,
 		seq uint32,
-		_ func(time.Duration) error,
+		_ func(context.Context, time.Duration) error,
 	) (uint32, error) {
 		return seq, nil
 	}
@@ -621,7 +625,7 @@ func TestRotator_StateRefreshUsesConsistentHookSnapshot(t *testing.T) {
 		func(
 			_ context.Context,
 			seq uint32,
-			_ func(time.Duration) error,
+			_ func(context.Context, time.Duration) error,
 		) (uint32, error) {
 			close(entered)
 			<-release
@@ -640,7 +644,7 @@ func TestRotator_StateRefreshUsesConsistentHookSnapshot(t *testing.T) {
 	}()
 	<-entered
 	r.SetStateRefresh(
-		func(_ context.Context, seq uint32, _ func(time.Duration) error) (uint32, error) {
+		func(_ context.Context, seq uint32, _ func(context.Context, time.Duration) error) (uint32, error) {
 			return seq, nil
 		},
 		func(uint32) {},
@@ -754,7 +758,9 @@ func TestRotate_TolerantOfNilRelationalPruner(t *testing.T) {
 	if r == nil {
 		t.Fatal("rotator nil with valid node pruner")
 	}
-	r.SetStateRefresh(func(_ context.Context, seq uint32, _ func(time.Duration) error) (uint32, error) { return seq, nil }, nil, nil)
+	r.SetStateRefresh(func(_ context.Context, seq uint32, _ func(context.Context, time.Duration) error) (uint32, error) {
+		return seq, nil
+	}, nil, nil)
 	r.maybeRotate(context.Background(), 500)
 	r.maybeRotate(context.Background(), 800)
 	if nc := nodes.calls(); len(nc) != 1 || nc[0] != 500 {

--- a/storage/kvstore/pebble/rotating.go
+++ b/storage/kvstore/pebble/rotating.go
@@ -22,6 +22,7 @@ const legacyGenerationStateVersion = 1
 const generationStateVersion = 2
 const generationMarkerName = ".goxrpl-generation.json"
 const generationMarkerVersion = 1
+const rotatingStoreMutationStripes = 256
 
 var errGenerationNotOwned = errors.New("kvstore/pebble: generation is not owned by this store")
 
@@ -126,8 +127,11 @@ func validateGenerationBoundaries(lastRotated, minimumOnline uint32) error {
 // one archive generation on reads. Promote explicitly copies an archive record
 // into the writable generation for online-delete preservation.
 type RotatingStore struct {
-	mu       sync.RWMutex
-	rotateMu sync.Mutex
+	// Operations pin the generation pair with mu before locking mutation
+	// stripes. Multi-key operations acquire stripes in ascending order.
+	mu        sync.RWMutex
+	rotateMu  sync.Mutex
+	mutations [rotatingStoreMutationStripes]sync.Mutex
 
 	basePath              string
 	statePath             string
@@ -531,12 +535,49 @@ func (r *RotatingStore) CanRotateWithoutRefresh() (canRotate bool, resultErr err
 
 // Promote fetches key and copies an archive hit into the writable generation.
 func (r *RotatingStore) Promote(key []byte) ([]byte, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	if r.closed {
 		return nil, kvstore.ErrClosed
 	}
+	mutation := &r.mutations[mutationStripe(key)]
+	mutation.Lock()
+	defer mutation.Unlock()
 	return r.getLocked(key, true)
+}
+
+func (r *RotatingStore) lockMutations(keys [][]byte) [rotatingStoreMutationStripes]bool {
+	var selected [rotatingStoreMutationStripes]bool
+	for _, key := range keys {
+		selected[mutationStripe(key)] = true
+	}
+	for index := range selected {
+		if selected[index] {
+			r.mutations[index].Lock()
+		}
+	}
+	return selected
+}
+
+func (r *RotatingStore) unlockMutations(selected *[rotatingStoreMutationStripes]bool) {
+	for index := len(selected) - 1; index >= 0; index-- {
+		if selected[index] {
+			r.mutations[index].Unlock()
+		}
+	}
+}
+
+func mutationStripe(key []byte) int {
+	const (
+		offset = uint32(2166136261)
+		prime  = uint32(16777619)
+	)
+	hash := offset
+	for _, value := range key {
+		hash ^= uint32(value)
+		hash *= prime
+	}
+	return int(hash % rotatingStoreMutationStripes)
 }
 
 func (r *RotatingStore) getLocked(key []byte, promote bool) ([]byte, error) {
@@ -566,6 +607,9 @@ func (r *RotatingStore) Put(key []byte, value []byte) error {
 	if r.closed {
 		return kvstore.ErrClosed
 	}
+	mutation := &r.mutations[mutationStripe(key)]
+	mutation.Lock()
+	defer mutation.Unlock()
 	return r.writable.Put(key, value)
 }
 
@@ -1159,11 +1203,17 @@ func (b *rotatingBatch) Write() (resultErr error) {
 	if b.closed {
 		return kvstore.ErrClosed
 	}
-	b.store.mu.Lock()
-	defer b.store.mu.Unlock()
+	keys := make([][]byte, len(b.ops))
+	for index := range b.ops {
+		keys[index] = b.ops[index].key
+	}
+	b.store.mu.RLock()
+	defer b.store.mu.RUnlock()
 	if b.store.closed {
 		return kvstore.ErrClosed
 	}
+	lockedMutations := b.store.lockMutations(keys)
+	defer b.store.unlockMutations(&lockedMutations)
 	writableBatch, err := b.store.writable.NewBatch()
 	if err != nil {
 		return err

--- a/storage/kvstore/pebble/rotating_internal_test.go
+++ b/storage/kvstore/pebble/rotating_internal_test.go
@@ -262,6 +262,41 @@ func TestPromoteDoesNotOverwriteConcurrentPut(t *testing.T) {
 	require.Equal(t, []byte("new"), value)
 }
 
+func TestPromoteDoesNotBlockUnrelatedPut(t *testing.T) {
+	store := newPromoteRaceStore(t)
+	otherKey := []byte("other")
+	require.NotEqual(t, mutationStripe([]byte("key")), mutationStripe(otherKey))
+
+	store.archive.mu.Lock()
+	archiveLocked := true
+	defer func() {
+		if archiveLocked {
+			store.archive.mu.Unlock()
+		}
+	}()
+	promoteDone := make(chan error, 1)
+	go func() {
+		_, err := store.Promote([]byte("key"))
+		promoteDone <- err
+	}()
+	waitForLocked(t, &store.mu)
+
+	putDone := make(chan error, 1)
+	go func() {
+		putDone <- store.Put(otherKey, []byte("new"))
+	}()
+	select {
+	case err := <-putDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("unrelated Put blocked behind promotion")
+	}
+
+	store.archive.mu.Unlock()
+	archiveLocked = false
+	require.NoError(t, <-promoteDone)
+}
+
 func TestPromoteDoesNotResurrectConcurrentDelete(t *testing.T) {
 	store := newPromoteRaceStore(t)
 	batch, err := store.NewBatch()


### PR DESCRIPTION
## Summary
- replace store-wide exclusive promotion locking with generation-pinning read locks and ordered per-key mutation stripes
- refresh the validated state through a conservative four-worker SHAMap frontier while coordinating health/backoff checkpoints across all workers
- expose structured refresh lifecycle and throughput logs, document restart cost, and add concurrency, cancellation, and benchmark coverage

## Test plan
- [x] `go test ./...`
- [x] `go test -race ./storage/kvstore/pebble ./storage/nodestore ./internal/ledger/service -run 'TestPromote|TestRotatingStoreExplicitPromotion|TestRotatingKVDatabase|TestService_RefreshValidatedState|TestService_RefreshSnapshotsValidatedLedger' -count=1`
- [x] `just vet`
- [x] `just lint`
- [x] `go test ./internal/ledger/service -run '^$' -bench '^BenchmarkService_RefreshValidatedState$' -benchtime=1x -count=1` (271,360 nodes/s, 4 workers on Apple M3 Pro)

Fixes #1678
