### PR TITLE
fix: allow larger STATE checkpoints

### DIFF
--- a/internal/statecompare/client_test.go
+++ b/internal/statecompare/client_test.go
@@ -414,6 +414,41 @@ func TestSQLManifestSnapshotLoadsTrustMetadata(t *testing.T) {
 	}
 }
 
+func TestSQLManifestAcceptsLargeCheckpoint(t *testing.T) {
+	const objectCount int64 = 34_258_888
+	row := scannerFunc(func(dest ...any) error {
+		*(dest[0].(*int64)) = 10
+		*(dest[1].(*string)) = "state/ckpt-10.pack"
+		*(dest[2].(*[]byte)) = make([]byte, 32)
+		*(dest[3].(*int64)) = objectCount
+		*(dest[4].(*int64)) = observedDevnetStatePackBytes
+		return nil
+	})
+	manifest := &sqlManifest{db: fakeManifestDB{row: row}}
+	checkpoint, err := manifest.checkpoint(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	if checkpoint.objectCount != uint32(objectCount) || checkpoint.sizeBytes != observedDevnetStatePackBytes {
+		t.Fatalf("checkpoint count/size = %d/%d", checkpoint.objectCount, checkpoint.sizeBytes)
+	}
+}
+
+func TestSQLManifestRejectsOversizedCheckpoint(t *testing.T) {
+	row := scannerFunc(func(dest ...any) error {
+		*(dest[0].(*int64)) = 10
+		*(dest[1].(*string)) = "state/ckpt-10.pack"
+		*(dest[2].(*[]byte)) = make([]byte, 32)
+		*(dest[3].(*int64)) = 1
+		*(dest[4].(*int64)) = maxStatePackBytes + 1
+		return nil
+	})
+	manifest := &sqlManifest{db: fakeManifestDB{row: row}}
+	if _, err := manifest.checkpoint(context.Background(), 10); err == nil {
+		t.Fatal("oversized checkpoint accepted")
+	}
+}
+
 func TestSQLManifestRejectsImpossibleCheckpoint(t *testing.T) {
 	row := scannerFunc(func(dest ...any) error {
 		*(dest[0].(*int64)) = 10

--- a/internal/statecompare/pack.go
+++ b/internal/statecompare/pack.go
@@ -28,7 +28,7 @@ const (
 	minLedgerRecordLen  = 8 + 4 + header.SizeBase + 4
 	minTransactionEntry = hashLen + 4 + minTransactionBytes + 4 + 1
 
-	maxStatePackBytes   int64  = 4 << 30
+	maxStatePackBytes   int64  = 8 << 30
 	maxLedgerPackBytes  int64  = 512 << 20
 	maxStateEntryBytes  uint32 = 16 << 20
 	minTransactionBytes        = 32

--- a/internal/statecompare/pack_test.go
+++ b/internal/statecompare/pack_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 )
 
+const observedDevnetStatePackBytes int64 = 5_918_719_233
+
 func encodeStatePack(seq uint32, entries []StateEntry) []byte {
 	var out bytes.Buffer
 	out.WriteString(packMagic)
@@ -45,6 +47,41 @@ func TestUnpackStateStreamValidatesBeforeCallback(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("unpackStateStream: %v", err)
+	}
+}
+
+func TestUnpackStateStreamAcceptsLargeDeclaredSize(t *testing.T) {
+	data := encodeStatePack(10, []StateEntry{{Index: [32]byte{1}, Data: []byte{2}}})
+	sentinel := errors.New("stop after first entry")
+	called := false
+	err := unpackStateStream(
+		context.Background(),
+		bytes.NewReader(data),
+		statePackExpectation{seq: 10, count: 1, size: observedDevnetStatePackBytes},
+		func([32]byte, []byte) error {
+			called = true
+			return sentinel
+		},
+	)
+	if !errors.Is(err, sentinel) || !called {
+		t.Fatalf("unpackStateStream error=%v callback=%t", err, called)
+	}
+}
+
+func TestUnpackStateStreamRejectsOversizedPack(t *testing.T) {
+	data := encodeStatePack(10, []StateEntry{{Index: [32]byte{1}, Data: []byte{2}}})
+	called := false
+	err := unpackStateStream(
+		context.Background(),
+		bytes.NewReader(data),
+		statePackExpectation{seq: 10, count: 1, size: maxStatePackBytes + 1},
+		func([32]byte, []byte) error {
+			called = true
+			return nil
+		},
+	)
+	if !errors.Is(err, errPack) || called {
+		t.Fatalf("unpackStateStream error=%v callback=%t", err, called)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Raise the streamed STATE pack ceiling to 8 GiB so current Devnet checkpoints can seed replay while retaining an explicit ingestion work bound.
- Cover the observed 5,918,719,233-byte checkpoint and preserve fail-closed rejection above the new ceiling in both manifest and streaming paths.

## Test plan
- [x] `go test ./internal/statecompare/...`
- [x] `go test ./internal/statecompare -run 'Test(UnpackStateStream|SQLManifest)' -count=20`
- [x] `go test -race ./internal/statecompare ./internal/replaytool`
- [x] `env GOCACHE=/private/tmp/goxrpl-issue-1689-gocache just test`
- [x] `just vet`
- [x] `just lint`
- [x] `just build-all`
- [x] `git diff --check origin/main...HEAD`

Fixes #1689
