### PR TITLE
fix: enforce LoanSet broker deep freeze

### DIFF
--- a/internal/testing/lending/loan_set_freeze_test.go
+++ b/internal/testing/lending/loan_set_freeze_test.go
@@ -1,0 +1,94 @@
+package lending_test
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+func loanBrokerPseudoAccount(t *testing.T, f *loanSetAssetFixture) [20]byte {
+	t.Helper()
+	data, err := f.env.LedgerEntry(keylet.LoanBrokerByID(f.brokerKey))
+	if err != nil {
+		t.Fatalf("read LoanBroker: %v", err)
+	}
+	fields, err := binarycodec.DecodeBytes(data)
+	if err != nil {
+		t.Fatalf("decode LoanBroker: %v", err)
+	}
+	address, ok := fields["Account"].(string)
+	if !ok {
+		t.Fatalf("LoanBroker Account = %#v, want address", fields["Account"])
+	}
+	account, err := state.DecodeAccountID(address)
+	if err != nil {
+		t.Fatalf("decode LoanBroker Account: %v", err)
+	}
+	return account
+}
+
+func deepFreezeLoanSetTrustLine(t *testing.T, f *loanSetAssetFixture, account [20]byte) {
+	t.Helper()
+	lineKey := keylet.Line(account, f.issuer.AccountID(), "USD")
+	data, err := f.env.LedgerEntry(lineKey)
+	if err != nil {
+		t.Fatalf("read trust line: %v", err)
+	}
+	line, err := state.ParseRippleState(data)
+	if err != nil {
+		t.Fatalf("parse trust line: %v", err)
+	}
+	if state.CompareAccountIDs(f.issuer.AccountID(), account) > 0 {
+		line.Flags |= state.LsfHighFreeze | state.LsfHighDeepFreeze
+	} else {
+		line.Flags |= state.LsfLowFreeze | state.LsfLowDeepFreeze
+	}
+	data, err = state.SerializeRippleState(line)
+	if err != nil {
+		t.Fatalf("serialize trust line: %v", err)
+	}
+	if err := f.env.Ledger().Update(lineKey, data); err != nil {
+		t.Fatalf("update trust line: %v", err)
+	}
+}
+
+func TestLoanSetBrokerDeepFreeze(t *testing.T) {
+	tests := []struct {
+		name   string
+		target func(*testing.T, *loanSetAssetFixture) [20]byte
+	}{
+		{
+			name: "owner",
+			target: func(_ *testing.T, f *loanSetAssetFixture) [20]byte {
+				return f.owner.AccountID()
+			},
+		},
+		{
+			name:   "pseudo-account",
+			target: loanBrokerPseudoAccount,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := newLoanSetAssetFixture(t, "IOU")
+			f.createHolding(f.owner)
+			deepFreezeLoanSetTrustLine(t, f, test.target(t, f))
+
+			jtx.RequireTxClaimed(t, submitLoanSet(t, f, f.borrower, f.owner, false), jtx.TecFROZEN)
+			if f.env.LedgerEntryExists(keylet.Loan(f.brokerKey, 1)) || f.env.LedgerEntryExists(f.holdingKey(f.borrower)) {
+				t.Fatal("deep-frozen LoanSet committed loan-related state")
+			}
+		})
+	}
+
+	t.Run("unfrozen", func(t *testing.T) {
+		f := newLoanSetAssetFixture(t, "IOU")
+		f.createHolding(f.owner)
+		jtx.RequireTxSuccess(t, submitLoanSet(t, f, f.borrower, f.owner, false))
+		assertLoanSetOwnedObjects(t, f, f.borrower)
+	})
+}

--- a/internal/tx/lending/loan_set_apply.go
+++ b/internal/tx/lending/loan_set_apply.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/lending/lmath"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/sign"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/internal/tx/vault"
@@ -115,7 +116,13 @@ func (l *LoanSet) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Resul
 	if r := tx.AssetFrozen(view, vinfo.Account, asset); r != ter.TesSUCCESS {
 		return r
 	}
+	if r := mptutil.CheckDeepFrozen(view, b.Account, asset); r != ter.TesSUCCESS {
+		return r
+	}
 	if r := tx.AssetFrozen(view, borrower, asset); r != ter.TesSUCCESS {
+		return r
+	}
+	if r := mptutil.CheckDeepFrozen(view, b.Owner, asset); r != ter.TesSUCCESS {
 		return r
 	}
 	return ter.TesSUCCESS

--- a/internal/tx/mptutil/mpt.go
+++ b/internal/tx/mptutil/mpt.go
@@ -250,7 +250,7 @@ func CheckWithdrawFreeze(view state.LedgerView, pseudoAcct, submitterAcct, dstAc
 			return result
 		}
 	}
-	if result := checkDeepFrozen(view, dstAcct, asset); result != ter.TesSUCCESS {
+	if result := CheckDeepFrozen(view, dstAcct, asset); result != ter.TesSUCCESS {
 		return result
 	}
 	return checkPseudoAccountBackingFreeze(view, pseudoAcct, asset)
@@ -319,7 +319,11 @@ func checkIndividualFrozen(view state.LedgerView, account [20]byte, asset tx.Ass
 	return ter.TesSUCCESS
 }
 
-func checkDeepFrozen(view state.LedgerView, account [20]byte, asset tx.Asset) ter.Result {
+// CheckDeepFrozen returns whether an account is unable to receive an asset.
+func CheckDeepFrozen(view state.LedgerView, account [20]byte, asset tx.Asset) ter.Result {
+	if asset.IsNative() {
+		return ter.TesSUCCESS
+	}
 	if asset.IsMPT() {
 		id, err := DecodeID(asset.MPTIssuanceID)
 		if err != nil {


### PR DESCRIPTION
## Summary
- reject `LoanSet` when the broker pseudo-account or broker owner is deep-frozen for the vault asset
- preserve rippled's preclaim ordering and cover both frozen identities plus the unfrozen path with stateful regressions

## Test plan
- [x] `just test-pkg './internal/testing/lending/... -run TestLoanSetBrokerDeepFreeze'`
- [x] `just test-pkg ./internal/tx/lending/...`
- [x] `just test-pkg ./internal/tx/mptutil/...`
- [x] `just test-pkg ./internal/testing/lending/...`
- [x] `just vet`
- [x] `just build`
- [x] `just lint`

Fixes #1703
