### PR TITLE
fix: reject wrong-type NFT offer keys

### DIFF
--- a/internal/testing/nft/nftoken_cancel_wrong_type_test.go
+++ b/internal/testing/nft/nftoken_cancel_wrong_type_test.go
@@ -56,7 +56,7 @@ func TestNFTokenCancelOfferWrongType(t *testing.T) {
 		sequenceBefore := env.Seq(alice)
 		ownerCountBefore := env.OwnerCount(alice)
 
-		result := env.Submit(nft.NFTokenCancelOffer(alice, wrongTypeID, offerID).Build())
+		result := env.Submit(nft.NFTokenCancelOffer(alice, offerID, wrongTypeID).Build())
 
 		jtx.RequireTxClaimed(t, result, jtx.TecNO_PERMISSION)
 		require.True(t, result.Applied)

--- a/internal/testing/nft/nftoken_cancel_wrong_type_test.go
+++ b/internal/testing/nft/nftoken_cancel_wrong_type_test.go
@@ -1,0 +1,69 @@
+package nft_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/nft"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/nftoken"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNFTokenCancelOfferWrongType(t *testing.T) {
+	t.Run("AccountRoot", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		env.Fund(alice)
+		env.Close()
+
+		accountKey := keylet.Account(alice.ID)
+		wrongTypeID := hex.EncodeToString(accountKey.Key[:])
+		balanceBefore := env.Balance(alice)
+		sequenceBefore := env.Seq(alice)
+
+		result := env.Submit(nft.NFTokenCancelOffer(alice, wrongTypeID).Build())
+
+		jtx.RequireTxClaimed(t, result, jtx.TecNO_PERMISSION)
+		require.True(t, result.Applied)
+		require.Equal(t, env.BaseFee(), result.Fee)
+		require.Equal(t, balanceBefore-env.BaseFee(), env.Balance(alice))
+		require.Equal(t, sequenceBefore+1, env.Seq(alice))
+		require.True(t, env.LedgerEntryExists(accountKey))
+	})
+
+	t.Run("MixedListIsAtomic", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		env.Fund(alice)
+		env.Close()
+
+		nftID := nft.GetNextNFTokenID(env, alice, 0, nftoken.NFTokenFlagTransferable, 0)
+		jtx.RequireTxSuccess(t, env.Submit(nft.NFTokenMint(alice, 0).Transferable().Build()))
+		env.Close()
+
+		offerKey := keylet.NFTokenOffer(alice.ID, env.Seq(alice))
+		jtx.RequireTxSuccess(t, env.Submit(
+			nft.NFTokenCreateSellOffer(alice, nftID, tx.NewXRPAmount(0)).Build()))
+		env.Close()
+
+		accountKey := keylet.Account(alice.ID)
+		wrongTypeID := hex.EncodeToString(accountKey.Key[:])
+		offerID := hex.EncodeToString(offerKey.Key[:])
+		balanceBefore := env.Balance(alice)
+		sequenceBefore := env.Seq(alice)
+		ownerCountBefore := env.OwnerCount(alice)
+
+		result := env.Submit(nft.NFTokenCancelOffer(alice, wrongTypeID, offerID).Build())
+
+		jtx.RequireTxClaimed(t, result, jtx.TecNO_PERMISSION)
+		require.True(t, result.Applied)
+		require.Equal(t, env.BaseFee(), result.Fee)
+		require.Equal(t, balanceBefore-env.BaseFee(), env.Balance(alice))
+		require.Equal(t, sequenceBefore+1, env.Seq(alice))
+		require.Equal(t, ownerCountBefore, env.OwnerCount(alice))
+		require.True(t, env.LedgerEntryExists(offerKey))
+	})
+}

--- a/internal/tx/nftoken/nftoken_cancel_offer.go
+++ b/internal/tx/nftoken/nftoken_cancel_offer.go
@@ -127,7 +127,7 @@ func (n *NFTokenCancelOffer) Apply(ctx *tx.ApplyContext) ter.Result {
 
 		var offerKeyBytes [32]byte
 		copy(offerKeyBytes[:], offerIDBytes)
-		offerKey := keylet.Keylet{Type: entry.TypeNFTokenOffer, Key: offerKeyBytes}
+		offerKey := keylet.Child(offerKeyBytes)
 
 		offerData, err := ctx.View.Read(offerKey)
 		if err != nil || offerData == nil {


### PR DESCRIPTION
## Summary
- use a child keylet during `NFTokenCancelOffer` preclaim so existing non-offer ledger entries return `tecNO_PERMISSION`
- preserve typed offer deletion and add regression coverage for AccountRoot IDs and atomic mixed lists

## Test plan
- [x] `just test-pkg ./internal/tx/nftoken/...`
- [x] `just test-pkg ./internal/testing/nft/...`
- [x] `just test-tx`
- [x] `just test-integration`
- [x] `just vet`
- [x] `just lint`
- [x] `just build`

Fixes #1699
