### PR TITLE
fix: enforce Vault-backed MPT payment auth

### DIFF
--- a/internal/testing/vault/vault_payment_test.go
+++ b/internal/testing/vault/vault_payment_test.go
@@ -1,0 +1,104 @@
+package vault_test
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	paybuilder "github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mpt"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/vault"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVaultSharePaymentRequiresUnderlyingIOUAuthorization(t *testing.T) {
+	env := newVaultEnv(t)
+	env.DisableFeature("MPTokensV2")
+	env.Close()
+	issuer := jtx.NewAccount("issuer")
+	owner := jtx.NewAccount("owner")
+	destination := jtx.NewAccount("destination")
+	env.Fund(issuer, owner, destination)
+	env.EnableRequireAuth(issuer)
+
+	const currency = "USD"
+	limit := tx.NewIssuedAmountFromFloat64(1_000, currency, issuer.Address)
+	env.Trust(owner, limit)
+	env.AuthorizeTrustLine(issuer, owner, currency)
+	env.PayIOU(issuer, owner, issuer, currency, 100)
+
+	sequence := env.Seq(owner)
+	create := vault.NewVaultCreate(owner.Address, tx.Asset{Currency: currency, Issuer: issuer.Address})
+	create.Common.Fee = createFee
+	jtx.RequireTxSuccess(t, env.Submit(create))
+
+	vaultKey := keylet.Vault(owner.AccountID(), sequence)
+	vaultInfo, err := vault.ReadVaultInfo(env.Ledger(), vaultKey)
+	require.NoError(t, err)
+	require.NotNil(t, vaultInfo)
+	shareID := mptutil.EncodeID(vaultInfo.ShareMPTID)
+
+	deposit := vault.NewVaultDeposit(
+		owner.Address,
+		vaultID(owner, sequence),
+		tx.NewIssuedAmountFromFloat64(100, currency, issuer.Address),
+	)
+	jtx.RequireTxSuccess(t, env.Submit(deposit))
+	jtx.RequireTxSuccess(t, env.Submit(mpt.NewMPTokenAuthorize(destination.Address, shareID)))
+
+	shareAmount := state.NewMPTAmountWithIssuanceID(10, "", shareID)
+	payment := func() tx.Transaction {
+		return paybuilder.PayIssued(owner, destination, shareAmount).Build()
+	}
+	ownerShares := vaultShareBalance(t, env, vaultInfo.ShareMPTID, owner)
+	destinationShares := vaultShareBalance(t, env, vaultInfo.ShareMPTID, destination)
+	require.Greater(t, ownerShares, uint64(10))
+	require.Zero(t, destinationShares)
+
+	ownerXRP := env.Balance(owner)
+	missingLineResult := env.Submit(payment())
+	requireFeeOnlyPaymentClaim(t, env, missingLineResult, jtx.TecNO_LINE)
+	require.Equal(t, ownerXRP-env.BaseFee(), env.Balance(owner))
+	require.False(t, env.TrustLineExists(destination, issuer, currency))
+	require.Equal(t, ownerShares, vaultShareBalance(t, env, vaultInfo.ShareMPTID, owner))
+	require.Equal(t, destinationShares, vaultShareBalance(t, env, vaultInfo.ShareMPTID, destination))
+
+	env.Trust(destination, limit)
+	ownerXRP = env.Balance(owner)
+	unauthorizedResult := env.Submit(payment())
+	requireFeeOnlyPaymentClaim(t, env, unauthorizedResult, jtx.TecNO_AUTH)
+	require.Equal(t, ownerXRP-env.BaseFee(), env.Balance(owner))
+	require.Equal(t, ownerShares, vaultShareBalance(t, env, vaultInfo.ShareMPTID, owner))
+	require.Equal(t, destinationShares, vaultShareBalance(t, env, vaultInfo.ShareMPTID, destination))
+
+	env.AuthorizeTrustLine(issuer, destination, currency)
+	ownerXRP = env.Balance(owner)
+	jtx.RequireTxSuccess(t, env.Submit(payment()))
+	require.Equal(t, ownerXRP-env.BaseFee(), env.Balance(owner))
+	require.Equal(t, ownerShares-10, vaultShareBalance(t, env, vaultInfo.ShareMPTID, owner))
+	require.Equal(t, destinationShares+10, vaultShareBalance(t, env, vaultInfo.ShareMPTID, destination))
+}
+
+func requireFeeOnlyPaymentClaim(t *testing.T, env *jtx.TestEnv, result jtx.TxResult, code string) {
+	t.Helper()
+	jtx.RequireTxClaimed(t, result, code)
+	require.True(t, result.Applied)
+	require.Equal(t, env.BaseFee(), result.Fee)
+	require.NotNil(t, result.Metadata)
+	require.Len(t, result.Metadata.AffectedNodes, 1)
+	require.Equal(t, "ModifiedNode", result.Metadata.AffectedNodes[0].NodeType)
+	require.Equal(t, "AccountRoot", result.Metadata.AffectedNodes[0].LedgerEntryType)
+}
+
+func vaultShareBalance(t *testing.T, env *jtx.TestEnv, issuanceID [24]byte, holder *jtx.Account) uint64 {
+	t.Helper()
+	raw, err := env.Ledger().Read(keylet.MPTokenByID(issuanceID, holder.AccountID()))
+	require.NoError(t, err)
+	require.NotNil(t, raw)
+	token, err := state.ParseMPToken(raw)
+	require.NoError(t, err)
+	return token.MPTAmount
+}

--- a/internal/tx/payment/payment_mpt.go
+++ b/internal/tx/payment/payment_mpt.go
@@ -8,6 +8,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/credential"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
@@ -60,15 +61,15 @@ func (p *Payment) applyMPTPayment(ctx *tx.ApplyContext) ter.Result {
 		return ter.TecDST_TAG_NEEDED
 	}
 
-	// requireAuth: check sender is authorized
-	// Reference: rippled View.cpp requireAuth() for MPTIssue + Payment.cpp:518-520
-	if res := requireMPTAuth(ctx, issuance, issuanceKey, ctx.AccountID, issuerID); res != ter.TesSUCCESS {
+	if res := mptutil.RequireAuthWithTypeAt(
+		ctx.View, mptID, ctx.AccountID, mptutil.LegacyAuth, ctx.Config.ParentCloseTime,
+	); res != ter.TesSUCCESS {
 		return res
 	}
 
-	// requireAuth: check destination is authorized
-	// Reference: rippled View.cpp requireAuth() for MPTIssue + Payment.cpp:522-524
-	if res := requireMPTAuth(ctx, issuance, issuanceKey, destAccountID, issuerID); res != ter.TesSUCCESS {
+	if res := mptutil.RequireAuthWithTypeAt(
+		ctx.View, mptID, destAccountID, mptutil.LegacyAuth, ctx.Config.ParentCloseTime,
+	); res != ter.TesSUCCESS {
 		return res
 	}
 
@@ -418,103 +419,4 @@ func mptAmountToUint64(a tx.Amount) uint64 {
 		exp++
 	}
 	return result
-}
-
-// requireMPTAuth checks if an account is authorized for an MPToken issuance.
-// Reference: rippled View.cpp requireAuth() for MPTIssue (lines 2436-2519)
-func requireMPTAuth(ctx *tx.ApplyContext, issuance *state.MPTokenIssuanceData,
-	issuanceKey keylet.Keylet, accountID [20]byte, issuerID [20]byte) ter.Result {
-	// Issuer is always authorized
-	if accountID == issuerID {
-		return ter.TesSUCCESS
-	}
-
-	// Read the MPToken for this account
-	tokenKey := keylet.MPToken(issuanceKey.Key, accountID)
-	tokenRaw, _ := ctx.View.Read(tokenKey)
-	var token *state.MPTokenData
-	if tokenRaw != nil {
-		token, _ = state.ParseMPToken(tokenRaw)
-	}
-
-	// If no MPToken exists, fail (StrongAuth/Legacy path)
-	if token == nil && issuance.Flags&entry.LsfMPTRequireAuth != 0 {
-		// Check domain-based credential authorization first
-		if issuance.DomainID != nil {
-			domainID, err := hex.DecodeString(*issuance.DomainID)
-			if err == nil && len(domainID) == 32 {
-				var did [32]byte
-				copy(did[:], domainID)
-				res := validDomain(ctx, did, accountID)
-				return res // No token → return domain result directly
-			}
-		}
-		return ter.TecNO_AUTH
-	}
-
-	// Check domain-based credential authorization
-	// Reference: rippled View.cpp lines 2494-2511
-	if issuance.DomainID != nil {
-		domainID, err := hex.DecodeString(*issuance.DomainID)
-		if err == nil && len(domainID) == 32 {
-			var did [32]byte
-			copy(did[:], domainID)
-			res := validDomain(ctx, did, accountID)
-			if res == ter.TesSUCCESS {
-				return ter.TesSUCCESS // Authorized by credentials
-			}
-			if token == nil {
-				return res // No token and credentials invalid
-			}
-			// Token exists but credentials invalid — fall through to classic check
-		}
-	}
-
-	// Classic authorization check
-	if issuance.Flags&entry.LsfMPTRequireAuth != 0 {
-		if token == nil || token.Flags&entry.LsfMPTAuthorized == 0 {
-			return ter.TecNO_AUTH
-		}
-	}
-
-	return ter.TesSUCCESS
-}
-
-// validDomain checks if an account has valid credentials for a permissioned domain.
-// Reference: rippled CredentialHelpers.cpp credentials::validDomain()
-func validDomain(ctx *tx.ApplyContext, domainID [32]byte, account [20]byte) ter.Result {
-	domKey := keylet.PermissionedDomainByID(domainID)
-	domData, err := ctx.View.Read(domKey)
-	if err != nil || domData == nil {
-		return ter.TecOBJECT_NOT_FOUND
-	}
-	pd, err := state.ParsePermissionedDomain(domData)
-	if err != nil {
-		return ter.TefINTERNAL
-	}
-
-	foundExpired := false
-	for _, c := range pd.AcceptedCredentials {
-		credKey := keylet.Credential(account, c.Issuer, c.CredentialType)
-		credData, err := ctx.View.Read(credKey)
-		if err != nil || credData == nil {
-			continue
-		}
-		cred, err := credential.ParseCredentialEntry(credData)
-		if err != nil {
-			continue
-		}
-		if credential.CheckCredentialExpired(cred, ctx.Config.ParentCloseTime) {
-			foundExpired = true
-			continue
-		}
-		if cred.IsAccepted() {
-			return ter.TesSUCCESS
-		}
-	}
-
-	if foundExpired {
-		return ter.TecEXPIRED
-	}
-	return ter.TecNO_AUTH
 }


### PR DESCRIPTION
## Summary
- Route legacy direct MPT Payments through the shared `LegacyAuth` implementation so Vault shares recursively enforce authorization for their underlying asset.
- Remove the Payment-local authorization duplicate that skipped Vault recursion and shared TER precedence.
- Add an IOU-backed Vault-share regression covering `tecNO_LINE`, `tecNO_AUTH`, fee-only rollback metadata, and successful balance transfer.

## Test plan
- [x] `go test ./internal/testing/vault -run TestVaultSharePaymentRequiresUnderlyingIOUAuthorization -count=20`
- [x] `go test -race ./internal/testing/vault -run TestVaultSharePaymentRequiresUnderlyingIOUAuthorization -count=1`
- [x] `go test ./internal/tx/payment/... ./internal/tx/mptutil ./internal/testing/mpt ./internal/testing/vault -count=1`
- [x] `just test-tx`
- [x] `just test-integration`
- [x] `just build-all`
- [x] `just vet`
- [x] `just lint`
- [x] `git diff --check`

Fixes #1698
