### PR TITLE
fix: handle flow-deleted CheckCash trust lines

### DIFF
--- a/internal/testing/check/check_cash_flow_deleted_line_test.go
+++ b/internal/testing/check/check_cash_flow_deleted_line_test.go
@@ -1,0 +1,120 @@
+package check_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	checkbuilder "github.com/LeJamon/go-xrpl/internal/testing/check"
+	"github.com/LeJamon/go-xrpl/internal/testing/metadata"
+	"github.com/LeJamon/go-xrpl/internal/testing/offer"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	checkCashFlowDeletedLineMetadataSHA256 = "B464AAAEC99A18A9CB14DC6087A696BBED6F425D8E31D08BEFF4DB4140C60022"
+	checkCashFlowDeletedLineStateRoot      = "D6761E1369188ABEDC67AD0CEF8173EEA25F806C4CAEF92F92236EDAA5896225"
+	checkCashFlowDeletedLineTxRoot         = "666A42DCCC9A798FF82619D0D5A117E283401D37D407B26C0920014803084675"
+)
+
+func TestCheckCashExactAmountSkipsRestoreWhenFlowDeletesTrustLine(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	issuer := jtx.NewAccount("check-cash-line-issuer")
+	casher := jtx.NewAccount("check-cash-line-casher")
+	env.Fund(issuer, casher)
+	env.Close()
+
+	xrp := tx.NewXRPAmount(10_000)
+	casherUSD := tx.NewIssuedAmountFromFloat64(900, "USD", casher.Address)
+	jtx.RequireTxSuccess(t, env.Submit(offer.OfferCreate(issuer, casherUSD, xrp).Build()))
+	env.Close()
+	jtx.RequireTxSuccess(t, env.Submit(offer.OfferCreate(casher, xrp, casherUSD).Build()))
+	env.Close()
+
+	lineKey := keylet.Line(casher.ID, issuer.ID, "USD")
+	jtx.RequireLedgerEntryExists(t, env, lineKey)
+	lineData, err := env.LedgerEntry(lineKey)
+	require.NoError(t, err)
+	line, err := state.ParseRippleState(lineData)
+	require.NoError(t, err)
+	require.True(t, line.HasLowNode)
+	require.True(t, line.HasHighNode)
+	require.Zero(t, line.LowNode)
+	require.Zero(t, line.HighNode)
+	jtx.RequireOwnerDirectoryContains(t, env, issuer, lineKey.Key, true)
+	jtx.RequireOwnerDirectoryContains(t, env, casher, lineKey.Key, true)
+	jtx.RequireOwnerCount(t, env, issuer, 1)
+	jtx.RequireOwnerCount(t, env, casher, 0)
+
+	issuerUSD := tx.NewIssuedAmountFromFloat64(900, "USD", issuer.Address)
+	checkSequence := env.Seq(issuer)
+	checkKey := keylet.Check(issuer.ID, checkSequence)
+	checkID := strings.ToUpper(hex.EncodeToString(checkKey.Key[:]))
+	jtx.RequireTxSuccess(t, env.Submit(checkbuilder.CheckCreate(issuer, casher, issuerUSD).Build()))
+	env.Close()
+	checkData, err := env.LedgerEntry(checkKey)
+	require.NoError(t, err)
+	storedCheck, err := state.ParseCheck(checkData)
+	require.NoError(t, err)
+	require.Zero(t, storedCheck.OwnerNode)
+	require.True(t, storedCheck.HasDestNode)
+	require.Zero(t, storedCheck.DestinationNode)
+	jtx.RequireOwnerDirectoryContains(t, env, issuer, checkKey.Key, true)
+	jtx.RequireOwnerDirectoryContains(t, env, casher, checkKey.Key, true)
+	jtx.RequireOwnerCount(t, env, issuer, 2)
+
+	result := env.Submit(checkbuilder.CheckCashAmount(casher, checkID, issuerUSD).Build())
+	jtx.RequireTxSuccess(t, result)
+	requireDeliveredAmount(t, result, issuerUSD)
+
+	requireDeletedLedgerNode(t, result, "Check", checkKey)
+	requireDeletedLedgerNode(t, result, "RippleState", lineKey)
+	jtx.RequireLedgerEntryNotExists(t, env, checkKey)
+	jtx.RequireLedgerEntryNotExists(t, env, lineKey)
+	jtx.RequireOwnerDirectoryContains(t, env, issuer, checkKey.Key, false)
+	jtx.RequireOwnerDirectoryContains(t, env, casher, checkKey.Key, false)
+	jtx.RequireOwnerDirectoryContains(t, env, issuer, lineKey.Key, false)
+	jtx.RequireOwnerDirectoryContains(t, env, casher, lineKey.Key, false)
+	jtx.RequireOwnerCount(t, env, issuer, 0)
+	jtx.RequireOwnerCount(t, env, casher, 0)
+	requireEmptyOwnerDirectory(t, env, issuer)
+	requireEmptyOwnerDirectory(t, env, casher)
+
+	metadataBlob, err := tx.SerializeMetadata(result.Metadata)
+	require.NoError(t, err)
+	metadataHash := sha256.Sum256(metadataBlob)
+	env.Close()
+	stateRoot, err := env.LastClosedLedger().StateMapHash()
+	require.NoError(t, err)
+	transactionRoot, err := env.LastClosedLedger().TxMapHash()
+	require.NoError(t, err)
+	require.Equal(t, checkCashFlowDeletedLineMetadataSHA256, strings.ToUpper(hex.EncodeToString(metadataHash[:])))
+	require.Equal(t, checkCashFlowDeletedLineStateRoot, strings.ToUpper(hex.EncodeToString(stateRoot[:])))
+	require.Equal(t, checkCashFlowDeletedLineTxRoot, strings.ToUpper(hex.EncodeToString(transactionRoot[:])))
+}
+
+func requireEmptyOwnerDirectory(t *testing.T, env *jtx.TestEnv, owner *jtx.Account) {
+	t.Helper()
+	directoryKey := keylet.OwnerDir(owner.ID)
+	data, err := env.LedgerEntry(directoryKey)
+	require.NoError(t, err)
+	directory, err := state.ParseDirectoryNode(data)
+	require.NoError(t, err)
+	require.Equal(t, owner.ID, directory.Owner)
+	require.Equal(t, directoryKey.Key, directory.RootIndex)
+	require.Empty(t, directory.Indexes)
+	require.Zero(t, directory.IndexNext)
+	require.Zero(t, directory.IndexPrevious)
+}
+
+func requireDeletedLedgerNode(t *testing.T, result jtx.TxResult, entryType string, key keylet.Keylet) {
+	t.Helper()
+	node := metadata.FindNode(result.Metadata, "DeletedNode", entryType)
+	require.NotNil(t, node, "deleted %s metadata", entryType)
+	require.Equal(t, strings.ToUpper(hex.EncodeToString(key.Key[:])), node.LedgerIndex)
+}

--- a/internal/tx/check/check_cash.go
+++ b/internal/tx/check/check_cash.go
@@ -944,6 +944,9 @@ func restoreTrustLineLimit(ctx *tx.ApplyContext, destID, issuerID [20]byte, curr
 	if err != nil {
 		return ter.TefINTERNAL
 	}
+	if trustLineData == nil {
+		return ter.TesSUCCESS
+	}
 	rs, err := state.ParseRippleState(trustLineData)
 	if err != nil {
 		return ter.TefINTERNAL

--- a/internal/tx/check/handler_integrity_test.go
+++ b/internal/tx/check/handler_integrity_test.go
@@ -70,6 +70,56 @@ func TestCheckCashReadFailuresAreNotAbsence(t *testing.T) {
 	}
 }
 
+func TestRestoreTrustLineLimitDistinguishesAbsenceFromFailure(t *testing.T) {
+	destinationID := checkMPTAccountID(0x43)
+	issuerID := checkMPTAccountID(0x44)
+	lineKey := keylet.Line(destinationID, issuerID, "USD")
+	view := newCheckMPTView()
+	ctx := checkMPTContext(view, nil, destinationID)
+
+	if got := restoreTrustLineLimit(ctx, destinationID, issuerID, "USD", true, state.Amount{}); got != ter.TesSUCCESS {
+		t.Fatalf("missing trust line: got %v, want tesSUCCESS", got)
+	}
+
+	view.readErrors[lineKey.Key] = errors.New("storage failure")
+	if got := restoreTrustLineLimit(ctx, destinationID, issuerID, "USD", true, state.Amount{}); got != ter.TefINTERNAL {
+		t.Fatalf("trust line read failure: got %v, want tefINTERNAL", got)
+	}
+	delete(view.readErrors, lineKey.Key)
+
+	view.data[lineKey.Key] = []byte{0x00}
+	if got := restoreTrustLineLimit(ctx, destinationID, issuerID, "USD", true, state.Amount{}); got != ter.TefINTERNAL {
+		t.Fatalf("malformed trust line: got %v, want tefINTERNAL", got)
+	}
+
+	destinationAddress := state.EncodeAccountIDSafe(destinationID)
+	issuerAddress := state.EncodeAccountIDSafe(issuerID)
+	line := &state.RippleState{
+		Balance:     state.NewIssuedAmountFromFloat64(0, "USD", state.AccountOneAddress),
+		LowLimit:    state.NewIssuedAmountFromFloat64(0, "USD", destinationAddress),
+		HighLimit:   state.NewIssuedAmountFromFloat64(0, "USD", issuerAddress),
+		HasLowNode:  true,
+		HasHighNode: true,
+	}
+	lineData, err := state.SerializeRippleState(line)
+	if err != nil {
+		t.Fatal(err)
+	}
+	view.data[lineKey.Key] = lineData
+	ctx.View = &checkUpdateFailView{checkMPTView: view}
+	if got := restoreTrustLineLimit(ctx, destinationID, issuerID, "USD", true, line.LowLimit); got != ter.TefINTERNAL {
+		t.Fatalf("trust line update failure: got %v, want tefINTERNAL", got)
+	}
+}
+
+type checkUpdateFailView struct {
+	*checkMPTView
+}
+
+func (v *checkUpdateFailView) Update(keylet.Keylet, []byte) error {
+	return errors.New("storage failure")
+}
+
 func TestCheckCancelCreatorReadFailureIsInternal(t *testing.T) {
 	sourceID := checkMPTAccountID(0x51)
 	destinationID := checkMPTAccountID(0x52)


### PR DESCRIPTION
## Summary

- Treat a trust line erased by successful CheckCash flow as a valid restoration no-op, matching rippled v3.3.0.
- Preserve `tefINTERNAL` for actual storage, decoding, serialization, and update failures.
- Add a Devnet-shaped exact-amount regression covering trust-line and check deletion, page-zero owner directories, owner counts, metadata, state root, and transaction root.

## Test plan

- [x] `go test ./internal/tx/check ./internal/testing/check -count=1`
- [x] Focused regression under `go test -race`
- [x] Focused integration regression with `-count=20`
- [x] `just test`
- [x] `just build-all`
- [x] `just vet`
- [x] `just lint`

Fixes #1702
