### PR TITLE
fix: reject acquired leaves at wrong paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           version: "34.1"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install protoc-gen-go
         run: go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
       - name: Re-run go generate

--- a/internal/consensus/adaptor/router_txset_wire_test.go
+++ b/internal/consensus/adaptor/router_txset_wire_test.go
@@ -289,25 +289,7 @@ func TestRouter_LedgerData_TsCandidate_FeedsEngine(t *testing.T) {
 	ctx := t.Context()
 	go router.Run(ctx)
 
-	// Build a real SHAMap of TypeTransaction containing two tx blobs.
-	// Real tx blobs are >= 12 bytes (SHAMap leaf min — see shamap
-	// leaf.go); use 16-byte synthetic blobs that satisfy the floor.
-	blobs := [][]byte{
-		bytes.Repeat([]byte{0x11}, 16),
-		bytes.Repeat([]byte{0x55}, 16),
-	}
-	txMap := shamap.New(shamap.TypeTransaction)
-	for i, blob := range blobs {
-		var key [32]byte
-		key[0] = byte(0x10 + i) // distinct keys to land in different branches
-		require.NoError(t,
-			txMap.PutWithNodeType(key, blob, shamap.NodeTypeTransactionNoMeta),
-			"PutWithNodeType")
-	}
-	id, err := txMap.Hash()
-	require.NoError(t, err, "Hash")
-	wireNodes, err := txMap.WalkWireNodes()
-	require.NoError(t, err, "WalkWireNodes")
+	_, id, wireNodes := buildTxSetForTest(t, 2)
 	require.NotEmpty(t, wireNodes, "expected at least the root + leaves")
 
 	// Convert WalkWireNodes output → LedgerData node entries. Pre-order

--- a/internal/ledger/inbound/tracker_test.go
+++ b/internal/ledger/inbound/tracker_test.go
@@ -82,11 +82,15 @@ func buildSourceMap(t *testing.T, mapType shamap.Type) (rootHash [32]byte, rootD
 	for branch := range byte(4) {
 		for sub := range byte(4) {
 			for i := range byte(4) {
+				data := []byte{branch, sub, i, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99}
 				var key [32]byte
 				key[0] = (branch << 4) | sub
 				key[1] = i << 4
 				key[31] = 0xA5
-				if err := source.Put(key, []byte{branch, sub, i, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99}); err != nil {
+				if mapType == shamap.TypeTransaction {
+					key = sha512half.Sum(protocol.HashPrefixTransactionID().Bytes(), data)
+				}
+				if err := source.Put(key, data); err != nil {
 					t.Fatalf("put: %v", err)
 				}
 			}

--- a/shamap/attach_outoforder_test.go
+++ b/shamap/attach_outoforder_test.go
@@ -13,7 +13,7 @@ import (
 // fat-reply / off-frontier nodes must follow rippled's "attach-or-re-request"
 // instead of flooding the reject log with ErrParentNotInTree.
 func TestAddKnownNodeByID_OutOfOrderConverges(t *testing.T) {
-	source := New(TypeTransaction)
+	source := New(TypeState)
 
 	// Three keys sharing the first two bytes force a deep (depth>=3) chain;
 	// the spread keys give the tree breadth so gaps appear at several levels.
@@ -72,7 +72,7 @@ func TestAddKnownNodeByID_OutOfOrderConverges(t *testing.T) {
 	// Deepest-first: every node arrives before its parent — the worst case.
 	sort.SliceStable(list, func(i, j int) bool { return list[i].id.Depth() > list[j].id.Depth() })
 
-	dest := New(TypeTransaction)
+	dest := New(TypeState)
 	if err := dest.StartSync(); err != nil {
 		t.Fatalf("StartSync: %v", err)
 	}

--- a/shamap/node_placement_test.go
+++ b/shamap/node_placement_test.go
@@ -47,7 +47,7 @@ func (f *nodePlacementTestFamily) FetchForNodePlacement(ctx context.Context, has
 }
 
 func TestAddKnownNodeByIDHydratesRequiredAncestorForPlacement(t *testing.T) {
-	source := New(TypeTransaction)
+	source := New(TypeState)
 	for branch := range byte(4) {
 		for sub := range byte(4) {
 			var key [32]byte
@@ -90,7 +90,7 @@ func TestAddKnownNodeByIDHydratesRequiredAncestorForPlacement(t *testing.T) {
 		if bytes.Equal(wire[i].NodeID, target.NodeID) {
 			continue
 		}
-		entry, entryErr := FlushEntryFromWire(wire[i].Data, 1, TypeTransaction)
+		entry, entryErr := FlushEntryFromWire(wire[i].Data, 1, TypeState)
 		if entryErr != nil {
 			t.Fatalf("FlushEntryFromWire: %v", entryErr)
 		}
@@ -99,7 +99,7 @@ func TestAddKnownNodeByIDHydratesRequiredAncestorForPlacement(t *testing.T) {
 		}
 	}
 
-	dest, err := NewBacked(TypeTransaction, family)
+	dest, err := NewBacked(TypeState, family)
 	if err != nil {
 		t.Fatalf("NewBacked: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestAddKnownNodeByIDHydratesRequiredAncestorForPlacement(t *testing.T) {
 	if result != NodeUseful {
 		t.Fatalf("result = %v, want NodeUseful", result)
 	}
-	wantEntry, err := FlushEntryFromWire(target.Data, 1, TypeTransaction)
+	wantEntry, err := FlushEntryFromWire(target.Data, 1, TypeState)
 	if err != nil {
 		t.Fatalf("target FlushEntryFromWire: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestAddKnownNodeByIDHydratesRequiredAncestorForPlacement(t *testing.T) {
 }
 
 func TestAddKnownNodeByIDPlacementHonorsContextCancellation(t *testing.T) {
-	source := New(TypeTransaction)
+	source := New(TypeState)
 	var first, second [32]byte
 	first[0], second[0] = 0x10, 0x11
 	if err := source.Put(first, []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}); err != nil {
@@ -170,7 +170,7 @@ func TestAddKnownNodeByIDPlacementHonorsContextCancellation(t *testing.T) {
 
 	family := newNodePlacementTestFamily()
 	for i := range wire {
-		entry, entryErr := FlushEntryFromWire(wire[i].Data, 1, TypeTransaction)
+		entry, entryErr := FlushEntryFromWire(wire[i].Data, 1, TypeState)
 		if entryErr != nil {
 			t.Fatalf("FlushEntryFromWire: %v", entryErr)
 		}
@@ -178,7 +178,7 @@ func TestAddKnownNodeByIDPlacementHonorsContextCancellation(t *testing.T) {
 			t.Fatalf("StoreBatch: %v", err)
 		}
 	}
-	dest, err := NewBacked(TypeTransaction, family)
+	dest, err := NewBacked(TypeState, family)
 	if err != nil {
 		t.Fatalf("NewBacked: %v", err)
 	}

--- a/shamap/sync_acquire.go
+++ b/shamap/sync_acquire.go
@@ -104,8 +104,8 @@ func (sm *SHAMap) addKnownNodeFromPrefix(ctx context.Context, nodeID NodeID, dat
 //   - NodeReRequest, nil when an ancestor on the path is still a hash-only
 //     stub: not a reject, re-requested by the next getMissingNodes walk
 //   - NodeInvalid with ErrEmptyBranchOnPath (path into a branch this map does
-//     not reference), ErrNodeHashMismatch, ErrUnexpectedNode (inner where only
-//     a leaf may live), or ErrSyncNotInProgress / ErrInvalidNodeData on misuse
+//     not reference), ErrNodeHashMismatch, ErrUnexpectedNode (wrong node type
+//     or leaf path), or ErrSyncNotInProgress / ErrInvalidNodeData on misuse
 func (sm *SHAMap) AddKnownNodeByID(nodeID NodeID, data []byte) (AddNodeResult, error) {
 	result, _, err := sm.addKnownNodeByID(context.Background(), nodeID, data, false)
 	return result, err
@@ -153,8 +153,9 @@ func (sm *SHAMap) addKnownNodeByID(ctx context.Context, nodeID NodeID, data []by
 }
 
 // attachKnownNodeAt descends along nodeID's path and attaches the node
-// produced by deserialize at the first hash-only slot, after verifying its
-// hash against the parent's stored child hash. deserialize runs only once the
+// produced by deserialize at the first hash-only slot, after verifying its hash
+// against the parent's stored child and any leaf's key against the requested path.
+// deserialize runs only once the
 // target slot is known to be empty, so a duplicate (slot already populated, or
 // a consolidated leaf mid-path) short-circuits without parsing the peer's
 // data. Reaching a hash-only ancestor before the target depth is NodeReRequest,
@@ -204,6 +205,15 @@ func (sm *SHAMap) attachKnownNodeAt(ctx context.Context, access *familyAccess, n
 			}
 			if newNode.Hash() != childHash {
 				return NodeInvalid, errNodeHashMismatch
+			}
+			if leaf, ok := newNode.(mapLeaf); ok {
+				expectedNodeID, err := createNodeID(nodeID.Depth(), leaf.Item().Key())
+				if err != nil {
+					return NodeInvalid, fmt.Errorf("%w: %w", ErrInvalidNodeData, err)
+				}
+				if expectedNodeID != nodeID {
+					return NodeInvalid, errUnexpectedNode
+				}
 			}
 			if parent.SetChildIfNil(branch, newNode) != newNode {
 				return NodeDuplicate, nil

--- a/shamap/sync_attachment_behavior_test.go
+++ b/shamap/sync_attachment_behavior_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestSme_AddKnownNodeUnchecked(t *testing.T) {
-	source := New(TypeTransaction)
+	source := New(TypeState)
 	k := sme_keyFromByte(0x01)
 	if err := source.Put(k, []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}); err != nil {
 		t.Fatalf("Put: %v", err)
@@ -26,7 +26,7 @@ func TestSme_AddKnownNodeUnchecked(t *testing.T) {
 		t.Fatalf("WalkWireNodes: %v", err)
 	}
 
-	dest1 := New(TypeTransaction)
+	dest1 := New(TypeState)
 	someID, err := newRootNodeID().childNodeID(0)
 	if err != nil {
 		t.Fatalf("ChildNodeID: %v", err)
@@ -35,7 +35,7 @@ func TestSme_AddKnownNodeUnchecked(t *testing.T) {
 		t.Errorf("AddKnownNodeByID not-syncing: want ErrSyncNotInProgress, got %v", err)
 	}
 
-	dest2 := New(TypeTransaction)
+	dest2 := New(TypeState)
 	if err := dest2.StartSync(); err != nil {
 		t.Fatalf("StartSync: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestSme_AddKnownNodeUnchecked(t *testing.T) {
 		t.Errorf("AddKnownNodeByID nil data: want ErrInvalidNodeData, got %v", err)
 	}
 
-	dest3 := New(TypeTransaction)
+	dest3 := New(TypeState)
 	if err := dest3.StartSync(); err != nil {
 		t.Fatalf("StartSync: %v", err)
 	}

--- a/shamap/sync_leaf_position_test.go
+++ b/shamap/sync_leaf_position_test.go
@@ -1,0 +1,117 @@
+package shamap
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestKnownNodeAcquisitionRejectsLeafAtWrongNodeID(t *testing.T) {
+	actualKey := sme_keyFromByte(0x13)
+	leaf, err := newAccountStateLeafNode(NewItem(actualKey, sme_data12(1)))
+	if err != nil {
+		t.Fatalf("newAccountStateLeafNode: %v", err)
+	}
+
+	inner := newInnerNode()
+	if err := inner.SetChild(3, leaf); err != nil {
+		t.Fatalf("inner SetChild: %v", err)
+	}
+	root := newInnerNode()
+	if err := root.SetChild(2, inner); err != nil {
+		t.Fatalf("root SetChild: %v", err)
+	}
+
+	rootData, err := root.SerializeForWire()
+	if err != nil {
+		t.Fatalf("root SerializeForWire: %v", err)
+	}
+	innerWire, err := inner.SerializeForWire()
+	if err != nil {
+		t.Fatalf("inner SerializeForWire: %v", err)
+	}
+	innerPrefix, err := inner.SerializeWithPrefix()
+	if err != nil {
+		t.Fatalf("inner SerializeWithPrefix: %v", err)
+	}
+	leafWire, err := leaf.SerializeForWire()
+	if err != nil {
+		t.Fatalf("leaf SerializeForWire: %v", err)
+	}
+	leafPrefix, err := leaf.SerializeWithPrefix()
+	if err != nil {
+		t.Fatalf("leaf SerializeWithPrefix: %v", err)
+	}
+
+	claimedInnerID, err := createNodeID(1, sme_keyFromByte(0x20))
+	if err != nil {
+		t.Fatalf("create inner NodeID: %v", err)
+	}
+	claimedLeafID, err := createNodeID(2, sme_keyFromByte(0x23))
+	if err != nil {
+		t.Fatalf("create leaf NodeID: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		innerData []byte
+		leafData  []byte
+		add       func(*SHAMap, NodeID, []byte) (AddNodeResult, FlushEntry, error)
+	}{
+		{
+			name:      "wire",
+			innerData: innerWire,
+			leafData:  leafWire,
+			add: func(sm *SHAMap, nodeID NodeID, data []byte) (AddNodeResult, FlushEntry, error) {
+				return sm.AddKnownNodeByIDWithEntryContext(context.Background(), nodeID, data)
+			},
+		},
+		{
+			name:      "prefix",
+			innerData: innerPrefix,
+			leafData:  leafPrefix,
+			add:       (*SHAMap).AddKnownNodeFromPrefixWithEntry,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dest := New(TypeState)
+			if err := dest.StartSync(); err != nil {
+				t.Fatalf("StartSync: %v", err)
+			}
+			if err := dest.AddRootNode(root.Hash(), rootData); err != nil {
+				t.Fatalf("AddRootNode: %v", err)
+			}
+
+			result, entry, err := test.add(dest, claimedInnerID, test.innerData)
+			if err != nil || result != NodeUseful || len(entry.Data) == 0 {
+				t.Fatalf("attach inner: got (%v, data=%d, %v), want (NodeUseful, non-empty, nil)", result, len(entry.Data), err)
+			}
+
+			result, entry, err = test.add(dest, claimedLeafID, test.leafData)
+			if result != NodeInvalid || !errors.Is(err, errUnexpectedNode) {
+				t.Fatalf("attach mismatched leaf: got (%v, %v), want (NodeInvalid, errUnexpectedNode)", result, err)
+			}
+			if entry.Hash != ([32]byte{}) || entry.Data != nil || entry.LedgerSeq != 0 || entry.MapType != 0 {
+				t.Fatalf("rejected leaf returned FlushEntry: %+v", entry)
+			}
+
+			dest.tree.mu.RLock()
+			state := dest.tree.state
+			loadedInner, _, isSet := dest.tree.root.LoadChild(2)
+			dest.tree.mu.RUnlock()
+			if state != stateSyncing {
+				t.Fatalf("map state = %v, want stateSyncing", state)
+			}
+			attachedInner, ok := loadedInner.(*innerNode)
+			if !isSet || !ok {
+				t.Fatalf("branch 2 = (%T, set=%v), want loaded inner", loadedInner, isSet)
+			}
+			attachedLeaf, childHash, isSet := attachedInner.LoadChild(3)
+			if !isSet || attachedLeaf != nil || childHash != leaf.Hash() {
+				t.Fatalf("branch 3 = (%T, %x, set=%v), want hash-only leaf %x", attachedLeaf, childHash, isSet, leaf.Hash())
+			}
+		})
+	}
+}

--- a/shamap/sync_test.go
+++ b/shamap/sync_test.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/LeJamon/go-xrpl/crypto/sha512half"
+	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 func (sm *SHAMap) addKnownNodeFromPrefixForTest(nodeID NodeID, data []byte) (AddNodeResult, error) {
@@ -372,10 +375,9 @@ func TestAddKnownNodeByID_RippledStyleReconstruct(t *testing.T) {
 	for branch := range byte(4) {
 		for sub := range byte(4) {
 			for i := range byte(4) {
-				var key [32]byte
-				key[0] = (branch << 4) | sub
-				key[1] = i << 4
-				if err := source.Put(key, []byte{branch, sub, i, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66}); err != nil {
+				data := []byte{branch, sub, i, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
+				key := sha512half.Sum(protocol.HashPrefixTransactionID().Bytes(), data)
+				if err := source.Put(key, data); err != nil {
 					t.Fatalf("Put: %v", err)
 				}
 			}
@@ -676,7 +678,7 @@ func TestAddKnownNodeByID_SentinelErrors(t *testing.T) {
 // Mirrors rippled SHAMapSync.cpp:597,671-672: a leaf encountered mid-path
 // is the canonical content at that slot — return duplicate (nil), not error.
 func TestAddKnownNodeByID_LeafMidPathReturnsDuplicate(t *testing.T) {
-	source := New(TypeTransaction)
+	source := New(TypeState)
 	// Single key → root has a single leaf child at the path's first
 	// nibble, consolidated at depth 1.
 	var k [32]byte
@@ -698,7 +700,7 @@ func TestAddKnownNodeByID_LeafMidPathReturnsDuplicate(t *testing.T) {
 		t.Fatalf("WalkWireNodes: %v", err)
 	}
 
-	dest := New(TypeTransaction)
+	dest := New(TypeState)
 	if err := dest.StartSync(); err != nil {
 		t.Fatalf("StartSync: %v", err)
 	}
@@ -721,7 +723,10 @@ func TestAddKnownNodeByID_LeafMidPathReturnsDuplicate(t *testing.T) {
 	// Synthesize a depth-2 NodeID on the same path as the consolidated
 	// leaf. The peer's data here is irrelevant — descent must short-
 	// circuit on the leaf and return nil.
-	deepNID := NodeID{depth: 2, id: k}
+	deepNID, err := createNodeID(2, k)
+	if err != nil {
+		t.Fatalf("create deep NodeID: %v", err)
+	}
 	res, err := dest.AddKnownNodeByID(deepNID, []byte{0xFF})
 	if err != nil {
 		t.Fatalf("leaf-mid-path: want nil (duplicate), got %v", err)
@@ -739,10 +744,9 @@ func TestPrefixAcquisitionDirect(t *testing.T) {
 	source := New(TypeTransaction)
 	for branch := range byte(3) {
 		for sub := range byte(3) {
-			var key [32]byte
-			key[0] = (branch << 4) | sub
-			key[1] = 0x99
-			if err := source.Put(key, []byte{branch, sub, 0xCA, 0xFE, 0xBA, 0xBE, 0xDE, 0xAD, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66}); err != nil {
+			data := []byte{branch, sub, 0xCA, 0xFE, 0xBA, 0xBE, 0xDE, 0xAD, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
+			key := sha512half.Sum(protocol.HashPrefixTransactionID().Bytes(), data)
+			if err := source.Put(key, data); err != nil {
 				t.Fatalf("Put: %v", err)
 			}
 		}


### PR DESCRIPTION
## Summary
- reject hash-valid acquired leaves whose key-derived NodeID does not match the requested attachment path
- enforce the invariant for wire and prefix acquisition before attachment or persistence
- add malformed-leaf coverage and correct transaction acquisition fixtures to use canonical keys

## Test plan
- [x] `go test ./shamap -run '<acquisition matrix>' -count=20`
- [x] focused SHAMap, inbound-ledger, and consensus-adaptor race tests
- [x] `just test-libs`
- [x] `just test`
- [x] `just build-all`
- [x] `just vet`
- [x] `just lint`

Fixes #1688
