### PR TITLE
fix: preserve noCurrency in binary parsing

### DIFF
--- a/codec/binarycodec/types/amount.go
+++ b/codec/binarycodec/types/amount.go
@@ -78,11 +78,6 @@ var (
 
 	zeroByteArray = make([]byte, 20)
 
-	// standardXRPBytes is the standard-form spelling of the system code: zero
-	// padding with the ASCII chars "XRP" at bytes 12-14. rippled forbids it as
-	// an issued-currency code.
-	standardXRPBytes = []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'X', 'R', 'P', 0, 0, 0, 0, 0}
-
 	errAmountMissingValue            = errors.New("amount missing value field")
 	errInvalidAmountValue            = errors.New("invalid amount value")
 	errInvalidCurrencyValue          = errors.New("invalid currency value")
@@ -323,14 +318,7 @@ func deserializeValue(data []byte) (string, error) {
 	return d.GetScaledValue(), nil
 }
 
-// deserializeCurrencyCode decodes an amount/path-step currency. It rejects the
-// standard-form system code (zero-padded "XRP" chars): rippled's to_string
-// renders those bytes as hex, but the amount encoder explicitly refuses that
-// hex form, so accepting it on decode would break the round-trip invariant.
 func deserializeCurrencyCode(data []byte) (string, error) {
-	if bytes.Equal(data, standardXRPBytes) {
-		return "", errInvalidCurrencyCode
-	}
 	return decodeCurrencyCode(data)
 }
 
@@ -617,10 +605,10 @@ func SerializeIssuedCurrencyValue(value string) ([]byte, error) {
 
 // serializeIssuedCurrencyCode serializes an issued currency code to its bytes representation.
 // The currency code can be 3 allowed string characters, or 20 bytes of hex.
-// The native code is disallowed in both its ISO and hex spellings.
+// The native code is disallowed in its ISO spelling.
 func serializeIssuedCurrencyCode(currency string) ([]byte, error) {
 	currency = strings.TrimPrefix(currency, "0x")
-	if currency == "XRP" || currency == "0000000000000000000000005852500000000000" {
+	if currency == "XRP" {
 		return nil, &InvalidCodeError{Disallowed: "XRP uppercase"}
 	}
 

--- a/codec/binarycodec/types/amount.go
+++ b/codec/binarycodec/types/amount.go
@@ -629,6 +629,9 @@ func serializeIssuedCurrencyAmount(value, currency, issuer string) ([]byte, erro
 	if err != nil {
 		return nil, err
 	}
+	if bytes.Equal(currencyBytes, zeroByteArray) {
+		return nil, errInvalidCurrencyCode
+	}
 	_, issuerBytes, err := addresscodec.DecodeClassicAddressToAccountID(issuer) // decode the issuer address
 	if err != nil {
 		return nil, err

--- a/codec/binarycodec/types/amount_rippled_test.go
+++ b/codec/binarycodec/types/amount_rippled_test.go
@@ -588,8 +588,7 @@ func TestCurrencyCodeValidation(t *testing.T) {
 		// Valid 40-character hex codes
 		{"hex USD", "0000000000000000000000005553440000000000", false},
 		{"hex EUR", "0000000000000000000000004555520000000000", false},
-		// Invalid hex - XRP code
-		{"hex XRP reserved", "0000000000000000000000005852500000000000", true},
+		{"hex badCurrency", "0000000000000000000000005852500000000000", false},
 	}
 
 	for _, tc := range tests {

--- a/codec/binarycodec/types/amount_test.go
+++ b/codec/binarycodec/types/amount_test.go
@@ -447,6 +447,13 @@ func TestSerializeIssuedCurrencyAmount(t *testing.T) {
 			expectedErr:   addresscodec.ErrInvalidClassicAddress,
 		},
 		{
+			name:          "fail - native currency bytes in issued amount",
+			inputValue:    "1",
+			inputCurrency: "0000000000000000000000000000000000000000",
+			inputIssuer:   "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+			expectedErr:   errInvalidCurrencyCode,
+		},
+		{
 			name:          "pass - valid serialized issued currency amount",
 			inputValue:    "7072.8",
 			inputCurrency: "USD",

--- a/codec/binarycodec/types/amount_test.go
+++ b/codec/binarycodec/types/amount_test.go
@@ -347,10 +347,9 @@ func TestSerializeIssuedCurrencyCode(t *testing.T) {
 			expectedErr: &InvalidCodeError{"XRP uppercase"},
 		},
 		{
-			name:        "fail - disallowed standard currency - XRP - hex",
-			input:       "0000000000000000000000005852500000000000",
-			expected:    nil,
-			expectedErr: &InvalidCodeError{"XRP uppercase"},
+			name:     "pass - badCurrency sentinel - hex",
+			input:    "0000000000000000000000005852500000000000",
+			expected: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x58, 0x52, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00},
 		},
 		{
 			name:        "fail - invalid standard currency - 4 characters",

--- a/codec/binarycodec/types/rippled_protocol_test.go
+++ b/codec/binarycodec/types/rippled_protocol_test.go
@@ -614,13 +614,12 @@ func TestCurrencyCodeEncoding_RippledVectors(t *testing.T) {
 			expectError: true,
 			description: "XRP uppercase is disallowed for IOU",
 		},
-		// XRP hex format is also reserved
 		{
-			name:        "XRP hex reserved",
+			name:        "badCurrency hex",
 			currency:    "0000000000000000000000005852500000000000",
-			expectedHex: "",
-			expectError: true,
-			description: "XRP in hex format is disallowed",
+			expectedHex: "0000000000000000000000005852500000000000",
+			expectError: false,
+			description: "badCurrency retains its raw 160-bit representation",
 		},
 	}
 

--- a/internal/ledger/state/generated_decode_helpers.go
+++ b/internal/ledger/state/generated_decode_helpers.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 )
 
+const decodedNoCurrencyHex = "0000000000000000000000000000000000000001"
+
 func decodeLedgerHex(field, value string, dst []byte) error {
 	decoded, err := hex.DecodeString(value)
 	if err != nil {
@@ -37,13 +39,27 @@ func decodeLedgerAccount(field, value string) ([20]byte, error) {
 }
 
 func decodeLedgerAmount(field string, value any) (Amount, error) {
-	raw, err := json.Marshal(value)
+	decoded := value
+	noCurrency := false
+	if issued, ok := value.(map[string]any); ok && issued["currency"] == "1" {
+		adjusted := make(map[string]any, len(issued))
+		for name, value := range issued {
+			adjusted[name] = value
+		}
+		adjusted["currency"] = decodedNoCurrencyHex
+		decoded = adjusted
+		noCurrency = true
+	}
+	raw, err := json.Marshal(decoded)
 	if err != nil {
 		return Amount{}, fmt.Errorf("%s: marshal decoded amount: %w", field, err)
 	}
 	amount, err := AmountFromJSON(raw)
 	if err != nil {
 		return Amount{}, fmt.Errorf("%s: invalid amount: %w", field, err)
+	}
+	if noCurrency {
+		amount.Currency = "1"
 	}
 	return amount, nil
 }

--- a/internal/ledger/state/generated_decoder_adapters_test.go
+++ b/internal/ledger/state/generated_decoder_adapters_test.go
@@ -58,8 +58,12 @@ func TestParseRippleStatePreservesBinaryBadCurrency(t *testing.T) {
 
 	constructed := *parsed
 	constructed.binaryBadCurrency = false
-	if _, err := SerializeRippleState(&constructed); err == nil {
-		t.Fatal("constructed RippleState writer accepted badCurrency")
+	constructedData, err := SerializeRippleState(&constructed)
+	if err != nil {
+		t.Fatalf("serialize constructed badCurrency RippleState: %v", err)
+	}
+	if !bytes.Equal(constructedData, raw) {
+		t.Fatal("constructed badCurrency RippleState did not round-trip")
 	}
 
 	bad := keylet.BadCurrency()

--- a/internal/testing/trustset/no_currency_binary_test.go
+++ b/internal/testing/trustset/no_currency_binary_test.go
@@ -1,0 +1,173 @@
+package trustset
+
+import (
+	"bytes"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/all"
+	sponsortx "github.com/LeJamon/go-xrpl/internal/tx/sponsor"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	trustsettx "github.com/LeJamon/go-xrpl/internal/tx/trustset"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+const noCurrencyTrustSetBlob = "120014240045CF2A201B0045D0C5204A0000000363D4838D7EA4C680000000000000000000000000000000000000000001F2D3998AF7133840529595D2D80FFA90B670AD0D68400000000000000C7321ED5067639DE601D7043EA9EDAC37CF7CB9A5DC8E51268F3B4ABC2C61009B1F34017440673215C69AB49B2C1305A5D87E589E1DE61F0FCAE16EE1AC05E9A900E171F3489688E6739866F29919FF8F219B01EA375FAFDA1D5B6E37005D0DC019A007910B811426E613343B8F39EAD2216786FBBE891A9DB6609A801B1491CBEE1263AF5B8A4B253F68561611150D27064D"
+
+func TestTrustSetNoCurrencyBinaryReplay(t *testing.T) {
+	all.RegisterAll()
+	raw, err := hex.DecodeString(noCurrencyTrustSetBlob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transaction, err := txcore.ParseFromBinary(raw)
+	if err != nil {
+		t.Fatalf("ParseFromBinary: %v", err)
+	}
+	parsed, ok := transaction.(*trustsettx.TrustSet)
+	if !ok {
+		t.Fatalf("parsed transaction = %T, want *trustset.TrustSet", transaction)
+	}
+	if parsed.LimitAmount.Currency != "1" {
+		t.Fatalf("LimitAmount currency = %q, want canonical noCurrency string", parsed.LimitAmount.Currency)
+	}
+	if got := keylet.CurrencyBytes(parsed.LimitAmount.Currency); got != keylet.NoCurrency() {
+		t.Fatalf("LimitAmount currency bytes = %X, want %X", got, keylet.NoCurrency())
+	}
+	reencoded, err := txcore.SerializeTransaction(transaction)
+	if err != nil {
+		t.Fatalf("SerializeTransaction: %v", err)
+	}
+	if !bytes.Equal(reencoded, raw) {
+		t.Fatalf("canonical re-encoding changed transaction\nwant %X\n got %X", raw, reencoded)
+	}
+	flattened, err := transaction.Flatten()
+	if err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+	flattenedBinary, err := binarycodec.EncodeBytes(flattened)
+	if err != nil {
+		t.Fatalf("encode flattened transaction: %v", err)
+	}
+	if !bytes.Equal(flattenedBinary, raw) {
+		t.Fatalf("field re-encoding changed transaction\nwant %X\n got %X", raw, flattenedBinary)
+	}
+	if !bytes.Equal(transaction.GetRawBytes(), raw) {
+		t.Fatal("parsed transaction did not retain the canonical binary")
+	}
+	if matches, err := txcore.CurrentFieldsMatchRaw(transaction); err != nil || !matches {
+		t.Fatalf("CurrentFieldsMatchRaw = %v, %v", matches, err)
+	}
+
+	jsonTransaction := []byte(`{"TransactionType":"TrustSet","Account":"rhYgJBYvKE7ZoxMsWGK1RDeVYgLY9BfuSG","Fee":"12","Sequence":4575018,"LimitAmount":{"currency":"1","issuer":"rP3xrdjhZUneSig4yaswidJZV2FCEqV98K","value":"1"}}`)
+	if _, err := txcore.ParseJSON(jsonTransaction); err == nil {
+		t.Fatal(`ParseJSON accepted user-supplied currency "1"`)
+	}
+
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("Sponsor")
+	account := jtx.NewAccountWithAddress("account", parsed.Account)
+	issuer := jtx.NewAccountWithAddress("issuer", parsed.LimitAmount.Issuer)
+	sponsor := jtx.NewAccountWithAddress("sponsor", parsed.Sponsor)
+	env.FundAmountNoRipple(account, uint64(jtx.XRP(1_000)))
+	env.FundAmountNoRipple(issuer, uint64(jtx.XRP(1_000)))
+	env.FundAmountNoRipple(sponsor, uint64(jtx.XRP(1_000)))
+	env.Close()
+
+	feeBudget := txcore.NewXRPAmount(100)
+	ownerBudget := int32(1)
+	sponsorship := sponsortx.NewSponsorshipSet(sponsor.Address)
+	sponsorship.Sponsee = account.Address
+	sponsorship.FeeAmountDelta = &feeBudget
+	sponsorship.RemainingOwnerCountDelta = &ownerBudget
+	created := env.SubmitWithOptions(sponsorship, jtx.SubmitOptions{SkipSignature: true})
+	if created.Code != "tesSUCCESS" {
+		t.Fatalf("create Sponsorship = %s, want tesSUCCESS", created.Code)
+	}
+
+	setAccountSequence(t, env, account, *parsed.Sequence)
+	result := env.SubmitWithOptions(transaction, jtx.SubmitOptions{SkipSignature: true})
+	if result.Code != "tesSUCCESS" || result.Result != ter.TesSUCCESS || !result.Applied {
+		t.Fatalf("captured TrustSet = %s, result %s, applied %v", result.Code, result.Result, result.Applied)
+	}
+	if result.Metadata == nil || result.Metadata.TransactionResult != ter.TesSUCCESS {
+		t.Fatalf("metadata result = %#v, want tesSUCCESS", result.Metadata)
+	}
+
+	lineKey := keylet.Line(account.ID, issuer.ID, parsed.LimitAmount.Currency)
+	lineIndex := strings.ToUpper(hex.EncodeToString(lineKey.Key[:]))
+	if lineIndex != "5CFD7BB1F51D068978B8DF15D0A9A276643169A72781AF081CA5A45CD0A44688" {
+		t.Fatalf("RippleState index = %s", lineIndex)
+	}
+	var createdNode map[string]any
+	for _, node := range result.Metadata.AffectedNodes {
+		if node.NodeType == "CreatedNode" && node.LedgerEntryType == "RippleState" && node.LedgerIndex == lineIndex {
+			createdNode = node.NewFields
+			break
+		}
+	}
+	if createdNode == nil {
+		t.Fatal("metadata does not contain the created noCurrency RippleState")
+	}
+	assertNoCurrencyAmounts(t, createdNode)
+
+	lineData, err := env.LedgerEntry(lineKey)
+	if err != nil {
+		t.Fatalf("read RippleState: %v", err)
+	}
+	if lineData == nil {
+		t.Fatal("captured TrustSet did not create the noCurrency RippleState")
+	}
+	decoded, err := binarycodec.DecodeBytes(lineData)
+	if err != nil {
+		t.Fatalf("decode RippleState: %v", err)
+	}
+	assertNoCurrencyAmounts(t, decoded)
+	line, err := state.ParseRippleState(lineData)
+	if err != nil {
+		t.Fatalf("ParseRippleState: %v", err)
+	}
+	for name, amount := range map[string]txcore.Amount{
+		"Balance": line.Balance, "LowLimit": line.LowLimit, "HighLimit": line.HighLimit,
+	} {
+		if amount.Currency != "1" || keylet.CurrencyBytes(amount.Currency) != keylet.NoCurrency() {
+			t.Fatalf("%s currency = %q, want noCurrency", name, amount.Currency)
+		}
+	}
+}
+
+func assertNoCurrencyAmounts(t *testing.T, fields map[string]any) {
+	t.Helper()
+	for _, name := range []string{"Balance", "LowLimit", "HighLimit"} {
+		amount, ok := fields[name].(map[string]any)
+		if !ok || amount["currency"] != "1" {
+			t.Fatalf("%s = %#v, want currency 1", name, fields[name])
+		}
+	}
+}
+
+func setAccountSequence(t *testing.T, env *jtx.TestEnv, account *jtx.Account, sequence uint32) {
+	t.Helper()
+	accountKey := keylet.Account(account.ID)
+	data, err := env.LedgerEntry(accountKey)
+	if err != nil {
+		t.Fatalf("read AccountRoot: %v", err)
+	}
+	root, err := state.ParseAccountRoot(data)
+	if err != nil {
+		t.Fatalf("parse AccountRoot: %v", err)
+	}
+	root.Sequence = sequence
+	encoded, err := state.SerializeAccountRoot(root)
+	if err != nil {
+		t.Fatalf("serialize AccountRoot: %v", err)
+	}
+	if err := env.Ledger().Update(accountKey, encoded); err != nil {
+		t.Fatalf("update AccountRoot: %v", err)
+	}
+}

--- a/internal/testing/trustset/no_currency_binary_test.go
+++ b/internal/testing/trustset/no_currency_binary_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
@@ -18,6 +19,51 @@ import (
 )
 
 const noCurrencyTrustSetBlob = "120014240045CF2A201B0045D0C5204A0000000363D4838D7EA4C680000000000000000000000000000000000000000001F2D3998AF7133840529595D2D80FFA90B670AD0D68400000000000000C7321ED5067639DE601D7043EA9EDAC37CF7CB9A5DC8E51268F3B4ABC2C61009B1F34017440673215C69AB49B2C1305A5D87E589E1DE61F0FCAE16EE1AC05E9A900E171F3489688E6739866F29919FF8F219B01EA375FAFDA1D5B6E37005D0DC019A007910B811426E613343B8F39EAD2216786FBBE891A9DB6609A801B1491CBEE1263AF5B8A4B253F68561611150D27064D"
+
+func TestTrustSetBadCurrencyBinaryPreflight(t *testing.T) {
+	all.RegisterAll()
+	raw, err := hex.DecodeString(noCurrencyTrustSetBlob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	noCurrency := keylet.NoCurrency()
+	badCurrency := keylet.BadCurrency()
+	offset := bytes.Index(raw, noCurrency[:])
+	if offset < 0 || bytes.Index(raw[offset+len(noCurrency):], noCurrency[:]) >= 0 {
+		t.Fatal("captured TrustSet does not contain exactly one noCurrency field")
+	}
+	copy(raw[offset:offset+len(badCurrency)], badCurrency[:])
+
+	transaction, err := txcore.ParseFromBinary(raw)
+	if err != nil {
+		t.Fatalf("ParseFromBinary: %v", err)
+	}
+	parsed, ok := transaction.(*trustsettx.TrustSet)
+	if !ok {
+		t.Fatalf("parsed transaction = %T, want *trustset.TrustSet", transaction)
+	}
+	if parsed.LimitAmount.Currency != "0000000000000000000000005852500000000000" {
+		t.Fatalf("LimitAmount currency = %q, want badCurrency", parsed.LimitAmount.Currency)
+	}
+	reencoded, err := txcore.SerializeTransaction(transaction)
+	if err != nil {
+		t.Fatalf("SerializeTransaction: %v", err)
+	}
+	if !bytes.Equal(reencoded, raw) {
+		t.Fatalf("canonical re-encoding changed transaction\nwant %X\n got %X", raw, reencoded)
+	}
+	if err := parsed.PreflightWithRules(amendment.AllSupportedRules()); err == nil || err.Error() != "temBAD_CURRENCY: invalid currency" {
+		t.Fatalf("PreflightWithRules = %v, want temBAD_CURRENCY", err)
+	}
+	parsed.SetFlags(trustsettx.TrustSetFlagSetDeepFreeze)
+	rules := amendment.NewRulesBuilder().
+		FromPreset(amendment.PresetAllSupported).
+		DisableByName("DeepFreeze").
+		Build()
+	if err := parsed.PreflightWithRules(rules); err == nil || err.Error() != "temINVALID_FLAG: deep freeze flags require the DeepFreeze amendment" {
+		t.Fatalf("PreflightWithRules without DeepFreeze = %v, want temINVALID_FLAG", err)
+	}
+}
 
 func TestTrustSetNoCurrencyBinaryReplay(t *testing.T) {
 	all.RegisterAll()

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -39,6 +39,9 @@ type RawTransactionData struct {
 }
 
 func (r *RawTransactionData) UnmarshalJSON(data []byte) error {
+	if _, err := tx.ParseJSON(data); err != nil {
+		return fmt.Errorf("parse inner transaction JSON: %w", err)
+	}
 	var innerMap map[string]any
 	if err := json.Unmarshal(data, &innerMap); err != nil {
 		return err

--- a/internal/tx/batch/batch_test.go
+++ b/internal/tx/batch/batch_test.go
@@ -17,11 +17,13 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx/lending"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	trustsettx "github.com/LeJamon/go-xrpl/internal/tx/trustset"
 )
 
 func TestMain(m *testing.M) {
 	Register()
 	payment.Register()
+	trustsettx.Register()
 	os.Exit(m.Run())
 }
 
@@ -73,6 +75,43 @@ func TestBatchBinaryRoundTripPreservesInnerTransactions(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, originalHash, parsedHash)
 	}
+}
+
+func TestBatchNoCurrencyJSONBoundary(t *testing.T) {
+	outer := NewBatch(testOuter)
+	outer.Fee = "40"
+	outer.SetSequence(1)
+	outer.SetFlags(BatchFlagAllOrNothing)
+
+	sequence := uint32(2)
+	flags := tx.TfInnerBatchTxn
+	inner := trustsettx.NewTrustSet(testOuter, tx.NewIssuedAmountFromFloat64(1, "1", testSigner1))
+	inner.Fee = "0"
+	inner.Sequence = &sequence
+	inner.Flags = &flags
+	outer.AddInnerTransaction(inner)
+	outer.AddInnerTransaction(makeTestPayment())
+
+	fields, err := outer.Flatten()
+	require.NoError(t, err)
+	jsonBlob, err := json.Marshal(fields)
+	require.NoError(t, err)
+	_, err = tx.ParseJSON(jsonBlob)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "currency")
+
+	encoded, err := binarycodec.Encode(fields)
+	require.NoError(t, err)
+	blob, err := hex.DecodeString(encoded)
+	require.NoError(t, err)
+	parsed, err := tx.ParseFromBinary(blob)
+	require.NoError(t, err)
+	parsedBatch := parsed.(*Batch)
+	parsedInner := parsedBatch.RawTransactions[0].RawTransaction.InnerTx.(*trustsettx.TrustSet)
+	require.Equal(t, "1", parsedInner.LimitAmount.Currency)
+	reencoded, err := tx.SerializeTransaction(parsed)
+	require.NoError(t, err)
+	require.Equal(t, blob, reencoded)
 }
 
 func TestBatchBinaryRoundTripPreservesEmptyNestedSignature(t *testing.T) {

--- a/internal/tx/parse.go
+++ b/internal/tx/parse.go
@@ -136,6 +136,9 @@ func parseFromBinaryUnbound(blob []byte) (Transaction, map[string]any, []byte, e
 	jsonFields := jsonMap
 	if parsed != nil {
 		jsonFields = binaryAmountJSONFields(parsed, jsonMap)
+		if parsed.TxType() == TypeBatch {
+			jsonFields = binaryBatchJSONFields(jsonFields)
+		}
 	}
 	jsonBytes, err := json.Marshal(jsonFields)
 	if err != nil {
@@ -191,6 +194,52 @@ func binaryAmountJSONFields(transaction Transaction, fields map[string]any) map[
 	if adjusted == nil {
 		return fields
 	}
+	return adjusted
+}
+
+func binaryBatchJSONFields(fields map[string]any) map[string]any {
+	rawTransactions, ok := fields["RawTransactions"].([]any)
+	if !ok {
+		return fields
+	}
+	adjustedTransactions := make([]any, len(rawTransactions))
+	copy(adjustedTransactions, rawTransactions)
+	changed := false
+	for i, raw := range rawTransactions {
+		wrapper, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		innerFields, ok := wrapper["RawTransaction"].(map[string]any)
+		if !ok {
+			continue
+		}
+		typeName, _ := innerFields["TransactionType"].(string)
+		txType, ok := TypeFromName(typeName)
+		if !ok {
+			continue
+		}
+		inner, err := NewFromType(txType)
+		if err != nil {
+			continue
+		}
+		adjustedInner := binaryAmountJSONFields(inner, innerFields)
+		adjustedWrapper := make(map[string]any, len(wrapper))
+		for name, value := range wrapper {
+			adjustedWrapper[name] = value
+		}
+		adjustedWrapper["RawTransaction"] = adjustedInner
+		adjustedTransactions[i] = adjustedWrapper
+		changed = true
+	}
+	if !changed {
+		return fields
+	}
+	adjusted := make(map[string]any, len(fields))
+	for name, value := range fields {
+		adjusted[name] = value
+	}
+	adjusted["RawTransactions"] = adjustedTransactions
 	return adjusted
 }
 

--- a/internal/tx/parse.go
+++ b/internal/tx/parse.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
@@ -122,12 +123,6 @@ func parseFromBinaryUnbound(blob []byte) (Transaction, map[string]any, []byte, e
 		}
 	}
 
-	// Convert map to JSON bytes
-	jsonBytes, err := json.Marshal(jsonMap)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to marshal decoded transaction: %w", err)
-	}
-
 	// The TransactionType is already known from the decoded map, so build the
 	// concrete transaction and unmarshal in one pass, skipping the redundant
 	// TransactionType re-parse FromJSON performs. Unknown or unregistered
@@ -135,11 +130,22 @@ func parseFromBinaryUnbound(blob []byte) (Transaction, map[string]any, []byte, e
 	var parsed Transaction
 	if knownType {
 		if t, nerr := NewFromType(txType); nerr == nil {
-			if err := json.Unmarshal(jsonBytes, t); err != nil {
-				return nil, nil, nil, fmt.Errorf("failed to parse transaction: %w", err)
-			}
 			parsed = t
 		}
+	}
+	jsonFields := jsonMap
+	if parsed != nil {
+		jsonFields = binaryAmountJSONFields(parsed, jsonMap)
+	}
+	jsonBytes, err := json.Marshal(jsonFields)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to marshal decoded transaction: %w", err)
+	}
+	if parsed != nil {
+		if err := json.Unmarshal(jsonBytes, parsed); err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to parse transaction: %w", err)
+		}
+		restoreBinaryNoCurrency(parsed, jsonMap)
 	}
 	if parsed == nil {
 		parsed, err = ParseJSON(jsonBytes)
@@ -151,4 +157,63 @@ func parseFromBinaryUnbound(blob []byte) (Transaction, map[string]any, []byte, e
 	parsed.GetCommon().SetPresentFields(presentFields)
 
 	return parsed, jsonMap, canonical, nil
+}
+
+const noCurrencyHex = "0000000000000000000000000000000000000001"
+
+func binaryAmountJSONFields(transaction Transaction, fields map[string]any) map[string]any {
+	value := reflect.ValueOf(transaction)
+	if value.Kind() == reflect.Pointer {
+		value = value.Elem()
+	}
+	var adjusted map[string]any
+	for _, field := range getFlattenInfo(value.Type()).fields {
+		if !field.isAmount {
+			continue
+		}
+		amount, ok := fields[field.name].(map[string]any)
+		if !ok || amount["currency"] != "1" {
+			continue
+		}
+		if adjusted == nil {
+			adjusted = make(map[string]any, len(fields))
+			for name, value := range fields {
+				adjusted[name] = value
+			}
+		}
+		adjustedAmount := make(map[string]any, len(amount))
+		for name, value := range amount {
+			adjustedAmount[name] = value
+		}
+		adjustedAmount["currency"] = noCurrencyHex
+		adjusted[field.name] = adjustedAmount
+	}
+	if adjusted == nil {
+		return fields
+	}
+	return adjusted
+}
+
+func restoreBinaryNoCurrency(transaction Transaction, fields map[string]any) {
+	value := reflect.ValueOf(transaction)
+	if value.Kind() == reflect.Pointer {
+		value = value.Elem()
+	}
+	for _, field := range getFlattenInfo(value.Type()).fields {
+		if !field.isAmount {
+			continue
+		}
+		encoded, ok := fields[field.name].(map[string]any)
+		if !ok || encoded["currency"] != "1" {
+			continue
+		}
+		amountField := value.Field(field.index)
+		if amountField.Kind() == reflect.Pointer {
+			if !amountField.IsNil() {
+				amountField.Interface().(*Amount).Currency = "1"
+			}
+			continue
+		}
+		amountField.Addr().Interface().(*Amount).Currency = "1"
+	}
 }

--- a/internal/tx/trustset/trustset.go
+++ b/internal/tx/trustset/trustset.go
@@ -73,14 +73,21 @@ func (t *TrustSet) TxType() tx.Type {
 // Reference: rippled STAmount::cMaxNativeN / isLegalNet.
 const cMaxNativeN int64 = 100_000_000_000_000_000
 
-// Validate runs the rules-independent structural checks of rippled's
-// SetTrust::preflight body. The flag mask lives in GetFlagsMask (preflight0),
-// the amendment-gated deep-freeze rejection in PreflightRules, and the
-// self-issuer check is a ledger-stage preclaim check (see Apply) — not preflight.
-// Reference: rippled SetTrust.cpp preflight().
 func (t *TrustSet) Validate() error {
+	return t.validate(nil)
+}
+
+func (t *TrustSet) PreflightWithRules(rules *amendment.Rules) error {
+	return t.validate(rules)
+}
+
+func (t *TrustSet) validate(rules *amendment.Rules) error {
 	if err := t.BaseTx.Validate(); err != nil {
 		return err
+	}
+	if rules != nil && !rules.DeepFreezeEnabled() &&
+		t.GetFlags()&(TrustSetFlagSetDeepFreeze|TrustSetFlagClearDeepFreeze) != 0 {
+		return ter.Errorf(ter.TemINVALID_FLAG, "deep freeze flags require the DeepFreeze amendment")
 	}
 
 	// isLegalNet: a native limit whose magnitude exceeds the total XRP supply is
@@ -108,6 +115,9 @@ func (t *TrustSet) Validate() error {
 	if t.LimitAmount.Currency == "XRP" {
 		return ter.Errorf(ter.TemBAD_CURRENCY, "cannot use XRP as IOU currency")
 	}
+	if keylet.CurrencyBytes(t.LimitAmount.Currency) == keylet.BadCurrency() {
+		return ter.Errorf(ter.TemBAD_CURRENCY, "invalid currency")
+	}
 
 	// Negative limit is not allowed
 	if t.LimitAmount.IsNegative() {
@@ -124,26 +134,8 @@ func (t *TrustSet) Validate() error {
 	return nil
 }
 
-// GetFlagsMask reports the invalid-flag mask (rippled SetTrust::getFlagsMask =
-// tfTrustSetMask). The deep-freeze bits are valid in this mask; their amendment
-// gating is the separate preflight-body check in PreflightRules, so the mask is
-// unconditional. The engine rejects flags intersecting it at preflight0.
 func (t *TrustSet) GetFlagsMask(rules *amendment.Rules) uint32 {
 	return TrustSetFlagMask
-}
-
-// PreflightRules runs the amendment-gated deep-freeze rejection at rippled's
-// position: the first statement of SetTrust::preflight's body, after preflight1's
-// fee/account/key checks. The deep-freeze flag bits are valid within
-// tfTrustSetMask, so the flag mask never rejects them; only this
-// amendment-conditional check does.
-// Reference: rippled SetTrust.cpp preflight() (featureDeepFreeze gate).
-func (t *TrustSet) PreflightRules(rules *amendment.Rules) error {
-	if !rules.DeepFreezeEnabled() &&
-		t.GetFlags()&(TrustSetFlagSetDeepFreeze|TrustSetFlagClearDeepFreeze) != 0 {
-		return ter.Errorf(ter.TemINVALID_FLAG, "deep freeze flags require the DeepFreeze amendment")
-	}
-	return nil
 }
 
 func (t *TrustSet) Flatten() (map[string]any, error) {
@@ -342,7 +334,7 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) ter.Result {
 	bNoFreeze := (ctx.Account.Flags & state.LsfNoFreeze) != 0
 
 	// Deep freeze preclaim invariants. The amendment-disabled flag rejection is a
-	// preflight check (PreflightRules); only these ledger-state invariants remain.
+	// preflight check; only these ledger-state invariants remain.
 	// Reference: rippled SetTrust.cpp preclaim() freeze/deep-freeze checks.
 	if ctx.Rules().DeepFreezeEnabled() {
 		// Check #1: Cannot freeze if account has lsfNoFreeze set.

--- a/internal/tx/trustset/trustset_test.go
+++ b/internal/tx/trustset/trustset_test.go
@@ -3,6 +3,7 @@ package trustset
 import (
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 )
 
@@ -95,6 +96,23 @@ func TestTrustSetValidation(t *testing.T) {
 			},
 			expectError: true,
 			errorMsg:    "temBAD_CURRENCY: cannot use XRP as IOU currency",
+		},
+		{
+			name: "noCurrency sentinel from binary - passes preflight",
+			trustSet: &TrustSet{
+				BaseTx:      *tx.NewBaseTx(tx.TypeTrustSet, "rAlice"),
+				LimitAmount: tx.NewIssuedAmountFromFloat64(100, "1", "rGateway"),
+			},
+			expectError: false,
+		},
+		{
+			name: "badCurrency sentinel - should fail",
+			trustSet: &TrustSet{
+				BaseTx:      *tx.NewBaseTx(tx.TypeTrustSet, "rAlice"),
+				LimitAmount: tx.NewIssuedAmountFromFloat64(100, "0000000000000000000000005852500000000000", "rGateway"),
+			},
+			expectError: true,
+			errorMsg:    "temBAD_CURRENCY: invalid currency",
 		},
 		{
 			name: "negative limit - should fail",
@@ -202,6 +220,21 @@ func TestTrustSetValidation(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestTrustSetDeepFreezeGatePrecedesBadCurrency(t *testing.T) {
+	trustSet := NewTrustSet("rAlice", tx.NewIssuedAmountFromFloat64(
+		100, "0000000000000000000000005852500000000000", "rGateway"))
+	trustSet.SetFlags(TrustSetFlagSetDeepFreeze)
+	rules := amendment.NewRulesBuilder().
+		FromPreset(amendment.PresetAllSupported).
+		DisableByName("DeepFreeze").
+		Build()
+
+	err := trustSet.PreflightWithRules(rules)
+	if err == nil || err.Error() != "temINVALID_FLAG: deep freeze flags require the DeepFreeze amendment" {
+		t.Fatalf("preflight result = %v, want temINVALID_FLAG", err)
 	}
 }
 

--- a/ledger/entry/bad_currency_test.go
+++ b/ledger/entry/bad_currency_test.go
@@ -37,8 +37,13 @@ func TestRippleStateDecodeAllowsBinaryBadCurrency(t *testing.T) {
 	if amountOffset < 0 {
 		t.Fatal("badCurrency amount not found")
 	}
-	if _, err := newStreamReader(raw[amountOffset:]).readAmountAny(); err == nil {
-		t.Fatal("generic amount decoder accepted badCurrency")
+	generic, err := newStreamReader(raw[amountOffset:]).readAmountAny()
+	if err != nil {
+		t.Fatalf("generic amount decoder: %v", err)
+	}
+	genericAmount, ok := generic.(map[string]any)
+	if !ok || genericAmount["currency"] != badCurrencyHex {
+		t.Fatalf("generic amount = %#v, want badCurrency", generic)
 	}
 
 	var decoded RippleState
@@ -71,7 +76,11 @@ func TestRippleStateDecodeAllowsBinaryBadCurrency(t *testing.T) {
 	fresh.SetBalance(badAmount)
 	fresh.SetLowLimit(badAmount)
 	fresh.SetHighLimit(badAmount)
-	if _, err := fresh.Encode(); err == nil {
-		t.Fatal("fresh RippleState writer accepted badCurrency")
+	freshData, err := fresh.Encode()
+	if err != nil {
+		t.Fatalf("encode fresh badCurrency RippleState: %v", err)
+	}
+	if count := bytes.Count(freshData, badCurrencyBytes); count != 3 {
+		t.Fatalf("fresh badCurrency payload count = %d, want 3", count)
 	}
 }


### PR DESCRIPTION
## Summary

- preserve the protocol `noCurrency()` sentinel when parsing canonical transaction binary without relaxing public JSON currency validation
- preserve the same sentinel while decoding ledger amounts, allowing the resulting RippleState entry and invariant checks to succeed
- align TrustSet `badCurrency()` validation and DeepFreeze-disabled TER precedence with rippled v3.3.0
- replay the reported historical TrustSet blob end to end, including exact re-encoding, application, metadata, and stored ledger state

## Testing

- `just test-tx`
- `just test-integration`
- `go test -race ./internal/testing/trustset ./internal/tx/trustset ./internal/ledger/state`
- `just build-all`
- `just vet`
- `just lint`

Fixes #1700
