### PR TITLE
fix: enforce LoanSet MPT authorization

### DIFF
--- a/internal/testing/lending/loan_pay_owner_count_test.go
+++ b/internal/testing/lending/loan_pay_owner_count_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestLoanPayDeletingSourceTrustLinePersistsOwnerCount(t *testing.T) {
 	f := newLoanSetAssetFixture(t, "IOU")
+	f.createHolding(f.owner)
 	jtx.RequireTxSuccess(t, f.env.Submit(accounttest.AccountSet(f.borrower).
 		ClearFlag(accounttx.AccountSetFlagDefaultRipple).
 		Build()))

--- a/internal/testing/lending/loan_set_auth_test.go
+++ b/internal/testing/lending/loan_set_auth_test.go
@@ -1,0 +1,134 @@
+package lending_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	mpttest "github.com/LeJamon/go-xrpl/internal/testing/mpt"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+func TestLoanSetMPTAuthorization(t *testing.T) {
+	tests := []struct {
+		name              string
+		authorizeBorrower bool
+		originationFee    bool
+		ownerSubmits      bool
+		unauthorized      func(*loanSetAssetFixture) *jtx.Account
+	}{
+		{
+			name:         "borrower submits",
+			unauthorized: func(f *loanSetAssetFixture) *jtx.Account { return f.borrower },
+		},
+		{
+			name:         "broker owner submits for unauthorized borrower",
+			ownerSubmits: true,
+			unauthorized: func(f *loanSetAssetFixture) *jtx.Account { return f.borrower },
+		},
+		{
+			name:              "origination fee recipient",
+			authorizeBorrower: true,
+			originationFee:    true,
+			unauthorized:      func(f *loanSetAssetFixture) *jtx.Account { return f.owner },
+		},
+		{
+			name:              "broker owner without origination fee",
+			authorizeBorrower: true,
+			unauthorized:      func(f *loanSetAssetFixture) *jtx.Account { return f.owner },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newLoanSetAssetFixture(t, "MPT", mpttest.TfMPTRequireAuth)
+			if tc.authorizeBorrower {
+				f.createHolding(f.borrower)
+			}
+			submitter, counterparty := f.borrower, f.owner
+			if tc.ownerSubmits {
+				submitter, counterparty = counterparty, submitter
+			}
+
+			beforeState := loanSetLedgerState(t, f.env)
+			beforeBalance := f.env.Balance(submitter)
+			beforeSequence := f.env.Seq(submitter)
+			beforeBorrowerOwners := f.env.OwnerCount(f.borrower)
+			beforeOwnerOwners := f.env.OwnerCount(f.owner)
+
+			result := submitLoanSet(t, f, submitter, counterparty, tc.originationFee)
+			jtx.RequireTxClaimed(t, result, jtx.TecNO_AUTH)
+			if !result.Applied || result.Fee != 20 {
+				t.Fatalf("applied/fee = %v/%d, want true/20", result.Applied, result.Fee)
+			}
+			if result.Metadata == nil || result.Metadata.TransactionResult.String() != jtx.TecNO_AUTH {
+				t.Fatalf("metadata result = %v, want %s", result.Metadata, jtx.TecNO_AUTH)
+			}
+			if len(result.Metadata.AffectedNodes) != 1 {
+				t.Fatalf("affected nodes = %d, want 1", len(result.Metadata.AffectedNodes))
+			}
+			node := result.Metadata.AffectedNodes[0]
+			accountKey := keylet.Account(submitter.AccountID())
+			wantIndex := strings.ToUpper(hex.EncodeToString(accountKey.Key[:]))
+			if node.NodeType != "ModifiedNode" || node.LedgerEntryType != "AccountRoot" || node.LedgerIndex != wantIndex {
+				t.Fatalf("affected node = %+v, want submitter AccountRoot modification", node)
+			}
+
+			if got := f.env.Balance(submitter); got != beforeBalance-20 {
+				t.Errorf("submitter balance = %d, want %d", got, beforeBalance-20)
+			}
+			if got := f.env.Seq(submitter); got != beforeSequence+1 {
+				t.Errorf("submitter sequence = %d, want %d", got, beforeSequence+1)
+			}
+			if got := f.env.OwnerCount(f.borrower); got != beforeBorrowerOwners {
+				t.Errorf("borrower OwnerCount = %d, want %d", got, beforeBorrowerOwners)
+			}
+			if got := f.env.OwnerCount(f.owner); got != beforeOwnerOwners {
+				t.Errorf("broker owner OwnerCount = %d, want %d", got, beforeOwnerOwners)
+			}
+			if f.env.LedgerEntryExists(f.holdingKey(tc.unauthorized(f))) {
+				t.Error("unauthorized MPToken remained after claimed failure")
+			}
+			if f.env.LedgerEntryExists(keylet.Loan(f.brokerKey, 1)) {
+				t.Error("Loan remained after claimed failure")
+			}
+
+			afterState := loanSetLedgerState(t, f.env)
+			delete(beforeState, accountKey.Key)
+			delete(afterState, accountKey.Key)
+			if len(afterState) != len(beforeState) {
+				t.Fatalf("non-submitter state entry count = %d, want %d", len(afterState), len(beforeState))
+			}
+			for key, want := range beforeState {
+				got, ok := afterState[key]
+				if !ok || !bytes.Equal(got, want) {
+					t.Fatalf("non-submitter ledger entry %X changed after claimed failure", key)
+				}
+			}
+		})
+	}
+
+	t.Run("authorized parties", func(t *testing.T) {
+		f := newLoanSetAssetFixture(t, "MPT", mpttest.TfMPTRequireAuth)
+		f.createHolding(f.borrower)
+		f.createHolding(f.owner)
+		jtx.RequireTxSuccess(t, submitLoanSet(t, f, f.borrower, f.owner, true))
+		if !f.env.LedgerEntryExists(keylet.Loan(f.brokerKey, 1)) {
+			t.Fatal("Loan was not created")
+		}
+	})
+}
+
+func loanSetLedgerState(t *testing.T, env *jtx.TestEnv) map[[32]byte][]byte {
+	t.Helper()
+	entries := make(map[[32]byte][]byte)
+	if err := env.Ledger().ForEach(func(key [32]byte, data []byte) bool {
+		entries[key] = append([]byte(nil), data...)
+		return true
+	}); err != nil {
+		t.Fatalf("snapshot ledger state: %v", err)
+	}
+	return entries
+}

--- a/internal/testing/lending/loan_set_owner_count_test.go
+++ b/internal/testing/lending/loan_set_owner_count_test.go
@@ -53,7 +53,7 @@ func newLoanSetAssetFixture(t *testing.T, kind string, mptCreateFlags ...uint32)
 		createHolding = func(account *jtx.Account) { env.Trust(account, limit) }
 	case "MPT":
 		token := mpttest.NewMPTTester(t, env, issuer, mpttest.MPTInit{Holders: []*jtx.Account{depositor}})
-		flags := uint32(mpttest.TfMPTCanTransfer)
+		flags := mpttest.TfMPTCanTransfer
 		for _, extra := range mptCreateFlags {
 			flags |= extra
 		}

--- a/internal/testing/lending/loan_set_owner_count_test.go
+++ b/internal/testing/lending/loan_set_owner_count_test.go
@@ -25,7 +25,7 @@ type loanSetAssetFixture struct {
 	createHolding           func(*jtx.Account)
 }
 
-func newLoanSetAssetFixture(t *testing.T, kind string) *loanSetAssetFixture {
+func newLoanSetAssetFixture(t *testing.T, kind string, mptCreateFlags ...uint32) *loanSetAssetFixture {
 	t.Helper()
 	env := newLendingEnv(t)
 	issuer := jtx.NewAccount(kind + "-issuer")
@@ -53,8 +53,18 @@ func newLoanSetAssetFixture(t *testing.T, kind string) *loanSetAssetFixture {
 		createHolding = func(account *jtx.Account) { env.Trust(account, limit) }
 	case "MPT":
 		token := mpttest.NewMPTTester(t, env, issuer, mpttest.MPTInit{Holders: []*jtx.Account{depositor}})
-		token.Create(mpttest.CreateOpts{Flags: mpttest.TfMPTCanTransfer})
-		token.Authorize(mpttest.AuthorizeOpts{Account: depositor})
+		flags := uint32(mpttest.TfMPTCanTransfer)
+		for _, extra := range mptCreateFlags {
+			flags |= extra
+		}
+		token.Create(mpttest.CreateOpts{Flags: flags})
+		authorize := func(account *jtx.Account) {
+			token.Authorize(mpttest.AuthorizeOpts{Account: account})
+			if flags&mpttest.TfMPTRequireAuth != 0 {
+				token.Authorize(mpttest.AuthorizeOpts{Holder: account})
+			}
+		}
+		authorize(depositor)
 		token.Pay(issuer, depositor, 10_000)
 		asset = tx.Asset{MPTIssuanceID: token.IssuanceID()}
 		deposit = token.MPTAmount(10_000)
@@ -67,9 +77,7 @@ func newLoanSetAssetFixture(t *testing.T, kind string) *loanSetAssetFixture {
 		holdingKey = func(account *jtx.Account) keylet.Keylet {
 			return keylet.MPTokenByID(issuanceID, account.AccountID())
 		}
-		createHolding = func(account *jtx.Account) {
-			token.Authorize(mpttest.AuthorizeOpts{Account: account})
-		}
+		createHolding = authorize
 	default:
 		t.Fatalf("unsupported asset kind %q", kind)
 	}
@@ -156,6 +164,7 @@ func assertLoanSetOwnedObjects(t *testing.T, f *loanSetAssetFixture, borrower *j
 func TestLoanSetHoldingOwnerCount(t *testing.T) {
 	t.Run("IOU borrower submits with new holding", func(t *testing.T) {
 		f := newLoanSetAssetFixture(t, "IOU")
+		f.createHolding(f.owner)
 		if got := f.env.OwnerCount(f.borrower); got != 0 {
 			t.Fatalf("initial borrower OwnerCount = %d, want 0", got)
 		}
@@ -168,6 +177,7 @@ func TestLoanSetHoldingOwnerCount(t *testing.T) {
 
 	t.Run("MPT broker owner submits for counterparty borrower", func(t *testing.T) {
 		f := newLoanSetAssetFixture(t, "MPT")
+		f.createHolding(f.owner)
 		ownerCount := f.env.OwnerCount(f.owner)
 		jtx.RequireTxSuccess(t, submitLoanSet(t, f, f.owner, f.borrower, false))
 		if got := f.env.OwnerCount(f.borrower); got != 2 {
@@ -183,6 +193,7 @@ func TestLoanSetHoldingOwnerCount(t *testing.T) {
 		t.Run(kind+" existing holding", func(t *testing.T) {
 			f := newLoanSetAssetFixture(t, kind)
 			f.createHolding(f.borrower)
+			f.createHolding(f.owner)
 			before := f.env.OwnerCount(f.borrower)
 			jtx.RequireTxSuccess(t, submitLoanSet(t, f, f.borrower, f.owner, false))
 			if got := f.env.OwnerCount(f.borrower); got != before+1 {
@@ -223,6 +234,7 @@ func TestLoanSetHoldingReserve(t *testing.T) {
 	} {
 		t.Run(tc.kind, func(t *testing.T) {
 			f := newLoanSetAssetFixture(t, tc.kind)
+			f.createHolding(f.owner)
 			before := f.env.OwnerCount(f.borrower)
 			target := f.env.ReserveBase() + uint64(before+1)*f.env.ReserveIncrement()
 			balance := f.env.Balance(f.borrower)

--- a/internal/tx/lending/loan_set_apply.go
+++ b/internal/tx/lending/loan_set_apply.go
@@ -224,7 +224,7 @@ func (l *LoanSet) Apply(ctx *tx.ApplyContext) ter.Result {
 	if r := applyLoanSetHoldingOwnerCount(ctx, borrower, borrowerHoldingDelta); r != ter.TesSUCCESS {
 		return r
 	}
-	if r := tx.RequireAuth(ctx.View, asset, borrower); r != ter.TesSUCCESS {
+	if r := mptutil.RequireAssetAuthAt(ctx.View, asset, borrower, mptutil.StrongAuth, ctx.Config.ParentCloseTime); r != ter.TesSUCCESS {
 		return r
 	}
 	if originationFee.Signum() != 0 {
@@ -239,9 +239,9 @@ func (l *LoanSet) Apply(ctx *tx.ApplyContext) ter.Result {
 		if r := applyLoanSetHoldingOwnerCount(ctx, b.Owner, ownerHoldingDelta); r != ter.TesSUCCESS {
 			return r
 		}
-		if r := tx.RequireAuth(ctx.View, asset, b.Owner); r != ter.TesSUCCESS {
-			return r
-		}
+	}
+	if r := mptutil.RequireAssetAuthAt(ctx.View, asset, b.Owner, mptutil.StrongAuth, ctx.Config.ParentCloseTime); r != ter.TesSUCCESS {
+		return r
 	}
 
 	// Disburse principal to the borrower and the origination fee to the owner.


### PR DESCRIPTION
## Summary

- enforce asset-aware `StrongAuth` for both LoanSet parties
- preserve rippled's unconditional broker-owner authorization check when no origination fee is charged
- verify `tecNO_AUTH` metadata and complete non-fee ledger rollback for MPT authorization failures

## Test plan

- [x] `just test-pkg './internal/testing/lending -run TestLoanSetMPTAuthorization -count=1'`
- [x] `just test-pkg './internal/testing/lending -count=1'`
- [x] `just test-pkg './internal/tx/lending/... -count=1'`
- [x] `just test-pkg './internal/tx/mptutil/... -count=1'`
- [x] `just test-tx`
- [x] `just test-integration`
- [x] `just vet`
- [x] `just lint`
- [x] `just build-all`

Fixes #1716
