### PR TITLE
fix: preserve CheckCash payment issuer in metadata

### DIFF
--- a/internal/testing/check/check_cash_flow_deleted_line_test.go
+++ b/internal/testing/check/check_cash_flow_deleted_line_test.go
@@ -38,6 +38,56 @@ func TestCheckCashExactAmountSkipsRestoreWhenFlowDeletesTrustLine(t *testing.T) 
 	})
 }
 
+func TestCheckCashToIssuerTweaksSourceTrustLine(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	issuer := jtx.NewAccount("check-cash-line-issuer")
+	source := jtx.NewAccount("check-cash-line-casher")
+	require.Greater(t, state.CompareAccountIDs(source.ID, issuer.ID), 0)
+	env.Fund(issuer, source)
+	env.Close()
+
+	xrp := tx.NewXRPAmount(10_000)
+	issuerUSD := tx.NewIssuedAmountFromFloat64(900, "USD", issuer.Address)
+	jtx.RequireTxSuccess(t, env.Submit(offer.OfferCreate(source, issuerUSD, xrp).Build()))
+	env.Close()
+	jtx.RequireTxSuccess(t, env.Submit(offer.OfferCreate(issuer, xrp, issuerUSD).Build()))
+	env.Close()
+
+	lineKey := keylet.Line(source.ID, issuer.ID, "USD")
+	jtx.RequireLedgerEntryExists(t, env, lineKey)
+	jtx.RequireIOUBalance(t, env, source, issuer, "USD", 900)
+	jtx.RequireOwnerDirectoryContains(t, env, source, lineKey.Key, true)
+	jtx.RequireOwnerDirectoryContains(t, env, issuer, lineKey.Key, true)
+	jtx.RequireOwnerCount(t, env, source, 1)
+	jtx.RequireOwnerCount(t, env, issuer, 0)
+
+	checkSequence := env.Seq(source)
+	checkKey := keylet.Check(source.ID, checkSequence)
+	checkID := strings.ToUpper(hex.EncodeToString(checkKey.Key[:]))
+	jtx.RequireTxSuccess(t, env.Submit(checkbuilder.CheckCreate(source, issuer, issuerUSD).Build()))
+	env.Close()
+	jtx.RequireOwnerCount(t, env, source, 2)
+
+	result := env.Submit(checkbuilder.CheckCashAmount(issuer, checkID, issuerUSD).Build())
+	jtx.RequireTxSuccess(t, result)
+	requireDeliveredAmount(t, result, issuerUSD)
+
+	deletedLine := requireDeletedLedgerNode(t, result, "RippleState", lineKey)
+	limit, ok := deletedLine.FinalFields["HighLimit"].(map[string]any)
+	require.True(t, ok, "HighLimit must be an issued amount")
+	require.Equal(t, "9999999999999999e80", limit["value"])
+	require.Equal(t, "USD", limit["currency"])
+	require.Equal(t, issuer.Address, limit["issuer"])
+	jtx.RequireLedgerEntryNotExists(t, env, checkKey)
+	jtx.RequireLedgerEntryNotExists(t, env, lineKey)
+	jtx.RequireOwnerDirectoryContains(t, env, source, checkKey.Key, false)
+	jtx.RequireOwnerDirectoryContains(t, env, issuer, checkKey.Key, false)
+	jtx.RequireOwnerDirectoryContains(t, env, source, lineKey.Key, false)
+	jtx.RequireOwnerDirectoryContains(t, env, issuer, lineKey.Key, false)
+	jtx.RequireOwnerCount(t, env, source, 0)
+	jtx.RequireOwnerCount(t, env, issuer, 0)
+}
+
 func testCheckCashFlowDeletedLine(t *testing.T, issuerSeed, casherSeed, limitField, metadataSHA, expectedStateRoot, txRoot string) {
 	t.Helper()
 	env := jtx.NewTestEnv(t)

--- a/internal/testing/check/check_cash_flow_deleted_line_test.go
+++ b/internal/testing/check/check_cash_flow_deleted_line_test.go
@@ -38,7 +38,7 @@ func TestCheckCashExactAmountSkipsRestoreWhenFlowDeletesTrustLine(t *testing.T) 
 	})
 }
 
-func TestCheckCashToIssuerTweaksSourceTrustLine(t *testing.T) {
+func TestCheckCashToIssuerRestoresSourceTrustLine(t *testing.T) {
 	env := jtx.NewTestEnv(t)
 	issuer := jtx.NewAccount("check-cash-line-issuer")
 	source := jtx.NewAccount("check-cash-line-casher")
@@ -72,19 +72,23 @@ func TestCheckCashToIssuerTweaksSourceTrustLine(t *testing.T) {
 	jtx.RequireTxSuccess(t, result)
 	requireDeliveredAmount(t, result, issuerUSD)
 
-	deletedLine := requireDeletedLedgerNode(t, result, "RippleState", lineKey)
-	limit, ok := deletedLine.FinalFields["HighLimit"].(map[string]any)
-	require.True(t, ok, "HighLimit must be an issued amount")
-	require.Equal(t, "9999999999999999e80", limit["value"])
-	require.Equal(t, "USD", limit["currency"])
-	require.Equal(t, issuer.Address, limit["issuer"])
+	modifiedLine := metadata.FindNode(result.Metadata, "ModifiedNode", "RippleState")
+	require.NotNil(t, modifiedLine, "modified RippleState metadata")
+	require.Equal(t, strings.ToUpper(hex.EncodeToString(lineKey.Key[:])), modifiedLine.LedgerIndex)
 	jtx.RequireLedgerEntryNotExists(t, env, checkKey)
-	jtx.RequireLedgerEntryNotExists(t, env, lineKey)
+	jtx.RequireLedgerEntryExists(t, env, lineKey)
+	jtx.RequireIOUBalance(t, env, source, issuer, "USD", 0)
+	lineData, err := env.LedgerEntry(lineKey)
+	require.NoError(t, err)
+	line, err := state.ParseRippleState(lineData)
+	require.NoError(t, err)
+	require.True(t, line.HighLimit.IsZero())
+	require.Equal(t, source.Address, line.HighLimit.Issuer)
 	jtx.RequireOwnerDirectoryContains(t, env, source, checkKey.Key, false)
 	jtx.RequireOwnerDirectoryContains(t, env, issuer, checkKey.Key, false)
-	jtx.RequireOwnerDirectoryContains(t, env, source, lineKey.Key, false)
-	jtx.RequireOwnerDirectoryContains(t, env, issuer, lineKey.Key, false)
-	jtx.RequireOwnerCount(t, env, source, 0)
+	jtx.RequireOwnerDirectoryContains(t, env, source, lineKey.Key, true)
+	jtx.RequireOwnerDirectoryContains(t, env, issuer, lineKey.Key, true)
+	jtx.RequireOwnerCount(t, env, source, 1)
 	jtx.RequireOwnerCount(t, env, issuer, 0)
 }
 

--- a/internal/testing/check/check_cash_flow_deleted_line_test.go
+++ b/internal/testing/check/check_cash_flow_deleted_line_test.go
@@ -17,15 +17,32 @@ import (
 )
 
 const (
-	checkCashFlowDeletedLineMetadataSHA256 = "B464AAAEC99A18A9CB14DC6087A696BBED6F425D8E31D08BEFF4DB4140C60022"
-	checkCashFlowDeletedLineStateRoot      = "D6761E1369188ABEDC67AD0CEF8173EEA25F806C4CAEF92F92236EDAA5896225"
-	checkCashFlowDeletedLineTxRoot         = "666A42DCCC9A798FF82619D0D5A117E283401D37D407B26C0920014803084675"
+	checkCashFlowDeletedHighMetadataSHA256 = "49B8E61D7371B1E32FA5B55BB365685B1DAFDE118DF17863A9FEE970369717C8"
+	checkCashFlowDeletedHighStateRoot      = "D6761E1369188ABEDC67AD0CEF8173EEA25F806C4CAEF92F92236EDAA5896225"
+	checkCashFlowDeletedHighTxRoot         = "3DA8C496A5EEE71529D01118B69B8D976AFDBFEE5A46CAA4522DC86248E2D825"
+	checkCashFlowDeletedLowMetadataSHA256  = "96E73BC07AAD7F7033A853052B8A38C19872E023109E89E07D50E7D2000DA0DB"
+	checkCashFlowDeletedLowStateRoot       = "264D98529D8E669076AFAB9F5AC8DD8DCC3A2C3A0B827F626B09FEE4F76F6A08"
+	checkCashFlowDeletedLowTxRoot          = "E434097AF3DE53DE2A81EF1CBF6740481E1387770D9C76A05B60867F56F9C69C"
 )
 
 func TestCheckCashExactAmountSkipsRestoreWhenFlowDeletesTrustLine(t *testing.T) {
+	t.Run("high limit", func(t *testing.T) {
+		testCheckCashFlowDeletedLine(t,
+			"check-cash-line-issuer", "check-cash-line-casher", "HighLimit",
+			checkCashFlowDeletedHighMetadataSHA256, checkCashFlowDeletedHighStateRoot, checkCashFlowDeletedHighTxRoot)
+	})
+	t.Run("low limit", func(t *testing.T) {
+		testCheckCashFlowDeletedLine(t,
+			"check-cash-line-casher", "check-cash-line-issuer", "LowLimit",
+			checkCashFlowDeletedLowMetadataSHA256, checkCashFlowDeletedLowStateRoot, checkCashFlowDeletedLowTxRoot)
+	})
+}
+
+func testCheckCashFlowDeletedLine(t *testing.T, issuerSeed, casherSeed, limitField, metadataSHA, expectedStateRoot, txRoot string) {
+	t.Helper()
 	env := jtx.NewTestEnv(t)
-	issuer := jtx.NewAccount("check-cash-line-issuer")
-	casher := jtx.NewAccount("check-cash-line-casher")
+	issuer := jtx.NewAccount(issuerSeed)
+	casher := jtx.NewAccount(casherSeed)
 	env.Fund(issuer, casher)
 	env.Close()
 
@@ -73,7 +90,17 @@ func TestCheckCashExactAmountSkipsRestoreWhenFlowDeletesTrustLine(t *testing.T) 
 	requireDeliveredAmount(t, result, issuerUSD)
 
 	requireDeletedLedgerNode(t, result, "Check", checkKey)
-	requireDeletedLedgerNode(t, result, "RippleState", lineKey)
+	deletedLine := requireDeletedLedgerNode(t, result, "RippleState", lineKey)
+	if limitField == "LowLimit" {
+		require.Less(t, state.CompareAccountIDs(casher.ID, issuer.ID), 0)
+	} else {
+		require.Greater(t, state.CompareAccountIDs(casher.ID, issuer.ID), 0)
+	}
+	limit, ok := deletedLine.FinalFields[limitField].(map[string]any)
+	require.True(t, ok, "%s must be an issued amount", limitField)
+	require.Equal(t, "9999999999999999e80", limit["value"])
+	require.Equal(t, "USD", limit["currency"])
+	require.Equal(t, issuer.Address, limit["issuer"])
 	jtx.RequireLedgerEntryNotExists(t, env, checkKey)
 	jtx.RequireLedgerEntryNotExists(t, env, lineKey)
 	jtx.RequireOwnerDirectoryContains(t, env, issuer, checkKey.Key, false)
@@ -93,9 +120,9 @@ func TestCheckCashExactAmountSkipsRestoreWhenFlowDeletesTrustLine(t *testing.T) 
 	require.NoError(t, err)
 	transactionRoot, err := env.LastClosedLedger().TxMapHash()
 	require.NoError(t, err)
-	require.Equal(t, checkCashFlowDeletedLineMetadataSHA256, strings.ToUpper(hex.EncodeToString(metadataHash[:])))
-	require.Equal(t, checkCashFlowDeletedLineStateRoot, strings.ToUpper(hex.EncodeToString(stateRoot[:])))
-	require.Equal(t, checkCashFlowDeletedLineTxRoot, strings.ToUpper(hex.EncodeToString(transactionRoot[:])))
+	require.Equal(t, metadataSHA, strings.ToUpper(hex.EncodeToString(metadataHash[:])))
+	require.Equal(t, expectedStateRoot, strings.ToUpper(hex.EncodeToString(stateRoot[:])))
+	require.Equal(t, txRoot, strings.ToUpper(hex.EncodeToString(transactionRoot[:])))
 }
 
 func requireEmptyOwnerDirectory(t *testing.T, env *jtx.TestEnv, owner *jtx.Account) {
@@ -112,9 +139,10 @@ func requireEmptyOwnerDirectory(t *testing.T, env *jtx.TestEnv, owner *jtx.Accou
 	require.Zero(t, directory.IndexPrevious)
 }
 
-func requireDeletedLedgerNode(t *testing.T, result jtx.TxResult, entryType string, key keylet.Keylet) {
+func requireDeletedLedgerNode(t *testing.T, result jtx.TxResult, entryType string, key keylet.Keylet) *tx.AffectedNode {
 	t.Helper()
 	node := metadata.FindNode(result.Metadata, "DeletedNode", entryType)
 	require.NotNil(t, node, "deleted %s metadata", entryType)
 	require.Equal(t, strings.ToUpper(hex.EncodeToString(key.Key[:])), node.LedgerIndex)
+	return node
 }

--- a/internal/tx/applystate/apply_state_table.go
+++ b/internal/tx/applystate/apply_state_table.go
@@ -647,10 +647,10 @@ func (t *ApplyStateTable) applyThreading() {
 			}
 
 		case ActionErase:
-			// Thread owner accounts (the entry itself is being deleted)
-			data := w.entry.Current
+			// Ownership is defined by the entry before any in-transaction mutations.
+			data := w.entry.Original
 			if data == nil {
-				data = w.entry.Original
+				data = w.entry.Current
 			}
 			t.threadOwners(w.key, data, entryType)
 		}

--- a/internal/tx/applystate/erased_owner_threading_test.go
+++ b/internal/tx/applystate/erased_owner_threading_test.go
@@ -1,0 +1,81 @@
+package applystate
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+func TestEraseThreadsOwnersFromOriginalEntry(t *testing.T) {
+	lowID := [20]byte{1}
+	highID := [20]byte{2}
+	lowAddress := state.EncodeAccountIDSafe(lowID)
+	highAddress := state.EncodeAccountIDSafe(highID)
+
+	base := newMockBaseView()
+	for _, account := range []struct {
+		id      [20]byte
+		address string
+	}{
+		{id: lowID, address: lowAddress},
+		{id: highID, address: highAddress},
+	} {
+		data, err := state.SerializeAccountRoot(&state.AccountRoot{
+			Account:  account.address,
+			Balance:  100_000_000,
+			Sequence: 1,
+		})
+		if err != nil {
+			t.Fatalf("serialize account root: %v", err)
+		}
+		base.data[keylet.Account(account.id).Key] = data
+	}
+
+	lineKey := keylet.Line(lowID, highID, "USD")
+	original := &state.RippleState{
+		Balance:   state.NewIssuedAmountFromValue(0, state.MinExponent, "USD", state.AccountOneAddress),
+		LowLimit:  state.NewIssuedAmountFromValue(0, state.MinExponent, "USD", lowAddress),
+		HighLimit: state.NewIssuedAmountFromValue(0, state.MinExponent, "USD", highAddress),
+	}
+	originalData, err := state.SerializeRippleState(original)
+	if err != nil {
+		t.Fatalf("serialize original ripple state: %v", err)
+	}
+	base.data[lineKey.Key] = originalData
+
+	current := *original
+	current.HighLimit = state.NewIssuedAmountFromValue(state.MaxMantissa, state.MaxExponent, "USD", lowAddress)
+	currentData, err := state.SerializeRippleState(&current)
+	if err != nil {
+		t.Fatalf("serialize current ripple state: %v", err)
+	}
+
+	txHash := [32]byte{0xaa}
+	const ledgerSequence = uint32(123)
+	table := NewApplyStateTable(base, txHash, ledgerSequence, amendment.AllSupportedRules())
+	if err := table.Update(lineKey, currentData); err != nil {
+		t.Fatalf("update ripple state: %v", err)
+	}
+	if err := table.Erase(lineKey); err != nil {
+		t.Fatalf("erase ripple state: %v", err)
+	}
+	if _, err := table.Apply(); err != nil {
+		t.Fatalf("apply state table: %v", err)
+	}
+
+	for _, id := range [][20]byte{lowID, highID} {
+		data := base.data[keylet.Account(id).Key]
+		account, err := state.ParseAccountRoot(data)
+		if err != nil {
+			t.Fatalf("parse threaded account root: %v", err)
+		}
+		if account.PreviousTxnID != txHash {
+			t.Fatalf("account %s previous transaction = %x, want %x", account.Account, account.PreviousTxnID, txHash)
+		}
+		if account.PreviousTxnLgrSeq != ledgerSequence {
+			t.Fatalf("account %s previous ledger sequence = %d, want %d", account.Account, account.PreviousTxnLgrSeq, ledgerSequence)
+		}
+	}
+}

--- a/internal/tx/check/check_cash.go
+++ b/internal/tx/check/check_cash.go
@@ -697,8 +697,11 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 	// Reference: CashCheck.cpp L252-end
 
 	// Auto-create the destination's trust line if it does not yet exist.
-	// Determine the trust line key for destination ↔ issuer
 	destLow := state.CompareAccountIDs(issuerID, accountID) > 0
+	trustLineAccountID := accountID
+	if accountID == issuerID {
+		trustLineAccountID = srcID
+	}
 
 	if accountID != issuerID {
 		trustLineKey := keylet.Line(accountID, issuerID, sendMax.Currency)
@@ -727,37 +730,35 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 	// CashCheck.cpp L418-439 - saves the limit, sets it to max, runs flow,
 	// then restores it via scope_exit.
 	// Reference: CashCheck.cpp L422-439
-	var savedLimit *state.Amount
-	if accountID != issuerID {
-		trustLineKey := keylet.Line(accountID, issuerID, sendMax.Currency)
-		trustLineData, err := ctx.View.Read(trustLineKey)
-		if err != nil {
-			return ter.TefINTERNAL
-		}
-		rs, err := state.ParseRippleState(trustLineData)
-		if err != nil {
-			return ter.TefINTERNAL
-		}
+	trustLineKey := keylet.Line(trustLineAccountID, issuerID, sendMax.Currency)
+	trustLineData, err := ctx.View.Read(trustLineKey)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if trustLineData == nil {
+		return ter.TecNO_LINE
+	}
+	rs, err := state.ParseRippleState(trustLineData)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
 
-		// Save and tweak the destination's limit
-		bigLimit := state.NewIssuedAmountFromValue(state.MaxMantissa, state.MaxExponent, sendMax.Currency, sendMax.Issuer)
-		if destLow {
-			saved := rs.LowLimit
-			savedLimit = &saved
-			rs.LowLimit = bigLimit
-		} else {
-			saved := rs.HighLimit
-			savedLimit = &saved
-			rs.HighLimit = bigLimit
-		}
+	var savedLimit state.Amount
+	bigLimit := state.NewIssuedAmountFromValue(state.MaxMantissa, state.MaxExponent, sendMax.Currency, sendMax.Issuer)
+	if destLow {
+		savedLimit = rs.LowLimit
+		rs.LowLimit = bigLimit
+	} else {
+		savedLimit = rs.HighLimit
+		rs.HighLimit = bigLimit
+	}
 
-		updatedData, err := state.SerializeRippleState(rs)
-		if err != nil {
-			return ter.TefINTERNAL
-		}
-		if err := ctx.View.Update(trustLineKey, updatedData); err != nil {
-			return ter.TefINTERNAL
-		}
+	updatedData, err := state.SerializeRippleState(rs)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if err := ctx.View.Update(trustLineKey, updatedData); err != nil {
+		return ter.TefINTERNAL
 	}
 
 	// Determine flow parameters
@@ -791,10 +792,8 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 	if flowResult != ter.TesSUCCESS && flowResult != ter.TecPATH_PARTIAL {
 		ctx.Log.Warn("check cash: flow failed", "result", flowResult)
 		// Restore the trust line limit before returning
-		if savedLimit != nil {
-			if result := restoreTrustLineLimit(ctx, accountID, issuerID, sendMax.Currency, destLow, *savedLimit); result != ter.TesSUCCESS {
-				return result
-			}
+		if result := restoreTrustLineLimit(ctx, trustLineAccountID, issuerID, sendMax.Currency, destLow, savedLimit); result != ter.TesSUCCESS {
+			return result
 		}
 		return flowResult
 	}
@@ -806,10 +805,8 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 		if actualOutAmount.Compare(requestedAmount) < 0 {
 			ctx.Log.Warn("check cash: flow did not produce DeliverMin", "actual", actualOutAmount, "deliverMin", requestedAmount)
 			// Restore the trust line limit before returning
-			if savedLimit != nil {
-				if result := restoreTrustLineLimit(ctx, accountID, issuerID, sendMax.Currency, destLow, *savedLimit); result != ter.TesSUCCESS {
-					return result
-				}
+			if result := restoreTrustLineLimit(ctx, trustLineAccountID, issuerID, sendMax.Currency, destLow, savedLimit); result != ter.TesSUCCESS {
+				return result
 			}
 			return ter.TecPATH_PARTIAL
 		}
@@ -818,10 +815,8 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 	// For exact Amount, flow must have succeeded
 	if !isDeliverMin && flowResult != ter.TesSUCCESS {
 		// Restore the trust line limit before returning
-		if savedLimit != nil {
-			if result := restoreTrustLineLimit(ctx, accountID, issuerID, sendMax.Currency, destLow, *savedLimit); result != ter.TesSUCCESS {
-				return result
-			}
+		if result := restoreTrustLineLimit(ctx, trustLineAccountID, issuerID, sendMax.Currency, destLow, savedLimit); result != ter.TesSUCCESS {
+			return result
 		}
 		return ter.TecPATH_PARTIAL
 	}
@@ -837,10 +832,8 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 	// The flow engine may have modified the balance, but we need to
 	// restore the original limit that was tweaked.
 	// Reference: CashCheck.cpp scope_exit at L426-429
-	if savedLimit != nil {
-		if result := restoreTrustLineLimit(ctx, accountID, issuerID, sendMax.Currency, destLow, *savedLimit); result != ter.TesSUCCESS {
-			return result
-		}
+	if result := restoreTrustLineLimit(ctx, trustLineAccountID, issuerID, sendMax.Currency, destLow, savedLimit); result != ter.TesSUCCESS {
+		return result
 	}
 
 	// Set the delivered amount metadata in all cases, not just for DeliverMin.
@@ -939,8 +932,8 @@ func createTrustLineForCheckCash(ctx *tx.ApplyContext, destID, issuerID [20]byte
 
 // restoreTrustLineLimit restores the original trust line limit after flow.
 // Reference: CashCheck.cpp scope_exit at L426-429
-func restoreTrustLineLimit(ctx *tx.ApplyContext, destID, issuerID [20]byte, currency string, destLow bool, savedLimit state.Amount) ter.Result {
-	trustLineKey := keylet.Line(destID, issuerID, currency)
+func restoreTrustLineLimit(ctx *tx.ApplyContext, lineAccountID, issuerID [20]byte, currency string, destLow bool, savedLimit state.Amount) ter.Result {
+	trustLineKey := keylet.Line(lineAccountID, issuerID, currency)
 	trustLineData, err := ctx.View.Read(trustLineKey)
 	if err != nil {
 		return ter.TefINTERNAL

--- a/internal/tx/check/check_cash.go
+++ b/internal/tx/check/check_cash.go
@@ -740,14 +740,15 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 		}
 
 		// Save and tweak the destination's limit
+		bigLimit := state.NewIssuedAmountFromValue(state.MaxMantissa, state.MaxExponent, sendMax.Currency, sendMax.Issuer)
 		if destLow {
 			saved := rs.LowLimit
 			savedLimit = &saved
-			rs.LowLimit = state.NewIssuedAmountFromValue(state.MaxMantissa, state.MaxExponent, sendMax.Currency, rs.LowLimit.Issuer)
+			rs.LowLimit = bigLimit
 		} else {
 			saved := rs.HighLimit
 			savedLimit = &saved
-			rs.HighLimit = state.NewIssuedAmountFromValue(state.MaxMantissa, state.MaxExponent, sendMax.Currency, rs.HighLimit.Issuer)
+			rs.HighLimit = bigLimit
 		}
 
 		updatedData, err := state.SerializeRippleState(rs)

--- a/internal/tx/check/check_cash.go
+++ b/internal/tx/check/check_cash.go
@@ -698,10 +698,7 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 
 	// Auto-create the destination's trust line if it does not yet exist.
 	destLow := state.CompareAccountIDs(issuerID, accountID) > 0
-	trustLineAccountID := accountID
-	if accountID == issuerID {
-		trustLineAccountID = srcID
-	}
+	trustLineAccountID := checkCashTrustLineAccount(srcID, accountID, issuerID)
 
 	if accountID != issuerID {
 		trustLineKey := keylet.Line(accountID, issuerID, sendMax.Currency)
@@ -928,6 +925,13 @@ func createTrustLineForCheckCash(ctx *tx.ApplyContext, destID, issuerID [20]byte
 	}
 
 	return ter.TesSUCCESS
+}
+
+func checkCashTrustLineAccount(srcID, destID, issuerID [20]byte) [20]byte {
+	if destID == issuerID {
+		return srcID
+	}
+	return destID
 }
 
 // restoreTrustLineLimit restores the original trust line limit after flow.

--- a/internal/tx/check/handler_integrity_test.go
+++ b/internal/tx/check/handler_integrity_test.go
@@ -112,6 +112,19 @@ func TestRestoreTrustLineLimitDistinguishesAbsenceFromFailure(t *testing.T) {
 	}
 }
 
+func TestCheckCashTrustLineAccount(t *testing.T) {
+	sourceID := checkMPTAccountID(0x41)
+	destinationID := checkMPTAccountID(0x42)
+	issuerID := checkMPTAccountID(0x43)
+
+	if got := checkCashTrustLineAccount(sourceID, destinationID, issuerID); got != destinationID {
+		t.Fatalf("non-issuer destination selected %x, want %x", got, destinationID)
+	}
+	if got := checkCashTrustLineAccount(sourceID, issuerID, issuerID); got != sourceID {
+		t.Fatalf("issuer destination selected %x, want source %x", got, sourceID)
+	}
+}
+
 type checkUpdateFailView struct {
 	*checkMPTView
 }


### PR DESCRIPTION
## Summary
- build CheckCash's temporary trust-line maximum from the delivered payment issue so deleted-line metadata matches rippled
- cover both canonical account orderings and pin the resulting metadata, state, and transaction roots

## Test plan
- [x] `go test ./internal/tx/check ./internal/testing/check -count=1`
- [x] focused CheckCash regressions under `go test -race`
- [x] focused integration regression with `-count=20`
- [x] `just test`
- [x] `just build-all`
- [x] `just vet`
- [x] `just lint`

Fixes #1702
