### PR TITLE
amendment: harden voting parity and add package docs

### DIFF
--- a/amendment/README.md
+++ b/amendment/README.md
@@ -1,0 +1,158 @@
+# Amendment
+
+Package `amendment` models XRPL amendment capability, per-ledger activation
+rules, and a node's live amendment policy and observed state.
+
+It does not decode ledger entries, persist operator preferences, or tally
+validator votes. Those integrations live in the ledger, storage, RPC, and
+consensus packages.
+
+## Mental model
+
+The package has three separate layers:
+
+| Layer | Type | Meaning |
+| --- | --- | --- |
+| Registry | `Feature` | Process-wide catalog of known amendments, build capability, and default vote behavior |
+| Ledger rules | `Rules` | Read-only activation snapshot used while processing one ledger |
+| Node state | `Table` | Concurrent mutable state for local vote preferences, validated-ledger observations, majority warnings, and amendment blocking |
+
+These states are independent. A known amendment may be unsupported by this
+binary, a supported amendment may not be enabled on a ledger, and an enabled
+amendment is not necessarily one the local validator voted for.
+
+## Feature states
+
+- **Known** means the amendment is present in the registry and can be found with
+  `FeatureByName` or `FeatureByID`.
+- **Supported** means this binary can execute the amendment's behavior. It does
+  not mean the amendment is active on a particular ledger.
+- **Enabled** means the amendment is active in a particular `Rules` snapshot.
+- **Default yes** and **default no** are local validator vote defaults. Operators
+  may override these for supported, non-obsolete amendments.
+- **Obsolete** is a third vote state. Obsolete amendments remain known and may
+  remain supported, but the node never proposes them.
+- **Retired** amendments are supported and obsolete, and their pre-amendment
+  behavior has been removed. Their IDs form part of the permanent rules
+  baseline even when they are absent from the ledger's Amendments object.
+
+The generated [amendment catalog](../docs/amendments.md) lists the registry's
+current capability, vote behavior, and lifecycle metadata.
+
+## Registry
+
+Amendment IDs are SHA-512Half hashes of their exact, case-sensitive names.
+`FeatureID` performs only that hash; it does not register or validate a name.
+
+```go
+feature := amendment.FeatureByName("XRPFees")
+if feature == nil {
+	return errors.New("unknown amendment")
+}
+
+fmt.Printf("%X supported=%t\n", feature.ID, feature.IsSupported())
+```
+
+`FeatureByName`, `FeatureByID`, `AllFeatures`, `SupportedFeatures`, and
+`DefaultYesFeatures` return copies. Callers cannot mutate the process-wide
+registry through their results. The list functions are ordered by amendment
+ID.
+
+The registry is fixed during package initialization; there is no runtime
+registration API. `ConfidentialTransfer` is a special capability case: it is
+reported as supported only when the optional native MPT cryptography backend is
+available in the current build.
+
+## Rules snapshots
+
+`Rules` is the transaction-processing view of amendment activation. Production
+code obtains it from a ledger's Amendments object and adds the IDs returned by
+`PermanentlyEnabledIDs`. `NewRules` deliberately constructs the exact explicit
+set passed by the caller; it does not add permanent IDs automatically.
+
+```go
+rules := amendment.NewRules([][32]byte{amendment.FeatureXRPFees})
+if rules.Enabled(amendment.FeatureXRPFees) {
+	// Apply XRPFees behavior for this ledger snapshot.
+}
+```
+
+After construction, a `Rules` value is read-only and may be shared by
+concurrent readers. `EnabledIDs` returns the explicitly stored IDs in ID order.
+It does not necessarily enumerate every ID for which `Enabled` returns true:
+`NonFungibleTokensV1_1` logically subsumes `NonFungibleTokensV1`,
+`fixNFTokenNegOffer`, and `fixNFTokenDirV1` for historical replay compatibility.
+
+The presets and `RulesBuilder` are primarily useful in tests:
+
+```go
+rules := amendment.NewRulesBuilder().
+	FromPreset(amendment.PresetGenesis).
+	Enable(amendment.FeatureAMM).
+	Disable(amendment.FeatureXRPFees).
+	Build()
+```
+
+`FromPreset` merges into the builder's current set. `EnableByName` and
+`DisableByName` ignore unknown names, so code handling user input should first
+validate it with `FeatureByName`. `AllSupportedRules` activates every capability
+for testing; it is not a substitute for rules loaded from a real ledger.
+
+## Live node state
+
+`Table` owns four kinds of live state:
+
+- amendments observed as enabled on validated ledgers;
+- local operator vetoes and explicit upvotes;
+- the earliest projected activation time for an unsupported amendment holding
+  majority;
+- sticky unsupported-enabled and amendment-blocked state.
+
+`NewTable` uses the protocol default majority duration of
+`DefaultMajorityTime` (14 days). `NewTableWithMajorityTime` is used for networks
+that configure another duration. The application setting is
+`amendment_majority_time`, expressed as a Go duration such as `"15m"` or
+`"336h"`; values below 15 minutes are rejected.
+
+`NeedValidatedLedger` tells the caller when a validated ledger has crossed a
+256-ledger amendment window. `DoValidatedLedger` then folds the enabled and
+majority sets into the table. Enabled state is monotonic: amendments are added,
+not removed. Only entries whose value is `true` are treated as enabled.
+
+When an unsupported amendment holds majority, the table projects its earliest
+activation by adding the configured majority duration to the XRPL-epoch close
+time. Enabling an unsupported amendment records that fact immediately;
+amendment blocking becomes active when the state is folded from a validated
+ledger. Both flags remain set because a node cannot safely resume validation
+without software that supports the active amendment.
+
+`Desired` returns the ID-sorted, supported, non-obsolete amendments selected by
+the local default and operator preferences. It is used when constructing a
+fresh genesis ledger. The consensus package performs the actual validator vote
+tally and stores its latest counts in `LastVote` for RPC inspection.
+
+## Concurrency and ownership
+
+- The registry is immutable after package initialization, and lookup results
+  are copies.
+- `Rules` is immutable through its public API and safe for concurrent reads.
+- `RulesBuilder` is mutable, supports its zero value, and should have one owner.
+- `Table` supports its zero value and serializes access internally. Its slice
+  results, `LastVote`, and `Clone` are independent copies.
+
+Avoid copying a `Table` value after first use because it contains a mutex. Share
+its pointer or use `Clone` when an independent snapshot is required.
+
+## Verification
+
+From the module root:
+
+```sh
+just test-pkg ./amendment/...
+go test -race ./amendment/...
+go vet ./amendment/...
+```
+
+The tests cover registry IDs and metadata, rule construction and historical
+subsumption, deterministic enumeration, vote preferences, validated-ledger
+windowing, majority projections, defensive copies, and amendment blocking.

--- a/amendment/amendment_test.go
+++ b/amendment/amendment_test.go
@@ -272,6 +272,25 @@ func TestTableDesired(t *testing.T) {
 	if !slices.Contains(table.Desired(), FeatureAMM) {
 		t.Fatal("Desired omitted an explicitly upvoted supported amendment")
 	}
+
+	table.UpVote(FeatureNonFungibleTokensV1)
+	if table.IsUpVoted(FeatureNonFungibleTokensV1) {
+		t.Fatal("obsolete amendment accepted an explicit upvote")
+	}
+	if slices.Contains(table.Desired(), FeatureNonFungibleTokensV1) {
+		t.Fatal("Desired included an obsolete amendment")
+	}
+}
+
+func TestTableZeroValue(t *testing.T) {
+	var table Table
+	table.Enable(FeatureAMM)
+	table.Veto(FeatureXRPFees)
+	table.UpVote(FeatureDID)
+
+	if !table.IsEnabled(FeatureAMM) || !table.IsVetoed(FeatureXRPFees) || !table.IsUpVoted(FeatureDID) {
+		t.Fatal("zero-value Table did not retain mutations")
+	}
 }
 
 func TestRetiredFeaturesVoteObsolete(t *testing.T) {
@@ -437,6 +456,30 @@ func TestRulesBuilder(t *testing.T) {
 	}
 	if rules.Enabled(FeatureFlow) {
 		t.Error("Builder should have disabled Flow")
+	}
+}
+
+func TestRulesBuilderZeroValue(t *testing.T) {
+	var builder RulesBuilder
+	rules := builder.Enable(FeatureAMM).FromPreset(PresetGenesis).Build()
+	if !rules.Enabled(FeatureAMM) || !rules.Enabled(FeatureFlow) {
+		t.Fatal("zero-value RulesBuilder did not retain enabled amendments")
+	}
+}
+
+func TestEnabledIDsAreSorted(t *testing.T) {
+	high := [32]byte{2}
+	low := [32]byte{1}
+	rules := NewRules([][32]byte{high, low})
+	if got := rules.EnabledIDs(); !slices.Equal(got, [][32]byte{low, high}) {
+		t.Fatalf("Rules.EnabledIDs() = %x, want ID order", got)
+	}
+
+	table := NewTable()
+	table.Enable(high)
+	table.Enable(low)
+	if got := table.EnabledIDs(); !slices.Equal(got, [][32]byte{low, high}) {
+		t.Fatalf("Table.EnabledIDs() = %x, want ID order", got)
 	}
 }
 

--- a/amendment/doc.go
+++ b/amendment/doc.go
@@ -1,11 +1,9 @@
-// Package amendment implements the XRPL amendment system for managing protocol
-// feature activation.
+// Package amendment models XRP Ledger amendment metadata, per-ledger activation
+// rules, and a node's live amendment policy and observed state.
 //
-// Amendments are identified by a 256-bit hash derived from their name. Each
-// amendment has a support status (supported or unsupported by this node) and a
-// voting default (yes or no). The Rules type tracks which amendments are
-// currently enabled on a given ledger, allowing transaction processing code to
-// gate behavior behind feature flags.
-//
-// The amendment registry is derived from rippled's features.macro.
+// Feature values describe the process-wide registry and local capability. Rules
+// is a read-only activation snapshot for one ledger. Table is the concurrent,
+// mutable node state used for operator vote preferences, validated-ledger
+// observations, and amendment-block detection. Support, activation, and voting
+// policy are independent states.
 package amendment

--- a/amendment/feature.go
+++ b/amendment/feature.go
@@ -51,21 +51,21 @@ func FeatureID(name string) [32]byte {
 }
 
 // IsSupported returns true if the feature is supported by this code.
-func (f *Feature) IsSupported() bool {
+func (f Feature) IsSupported() bool {
 	return f.Supported == SupportedYes
 }
 
 // IsDefaultYes returns true if the feature should be voted for by default.
-func (f *Feature) IsDefaultYes() bool {
+func (f Feature) IsDefaultYes() bool {
 	return f.Vote == VoteDefaultYes
 }
 
 // IsObsolete returns true if the feature is obsolete.
-func (f *Feature) IsObsolete() bool {
+func (f Feature) IsObsolete() bool {
 	return f.Vote == VoteObsolete
 }
 
 // String returns the feature name.
-func (f *Feature) String() string {
+func (f Feature) String() string {
 	return f.Name
 }

--- a/amendment/rules.go
+++ b/amendment/rules.go
@@ -4,6 +4,11 @@
 
 package amendment
 
+import (
+	"bytes"
+	"sort"
+)
+
 // Rules provides a read-only view of which amendments are enabled for
 // transaction processing and validation. It is typically loaded from
 // the Amendments entry in a specific ledger.
@@ -48,12 +53,16 @@ func (r *Rules) EnabledCount() int {
 	return len(r.enabled)
 }
 
-// EnabledIDs returns a slice of all enabled amendment IDs.
+// EnabledIDs returns all explicitly enabled amendment IDs in ID order.
+// It does not include amendments enabled only through protocol subsumption.
 func (r *Rules) EnabledIDs() [][32]byte {
 	result := make([][32]byte, 0, len(r.enabled))
 	for id := range r.enabled {
 		result = append(result, id)
 	}
+	sort.Slice(result, func(i, j int) bool {
+		return bytes.Compare(result[i][:], result[j][:]) < 0
+	})
 	return result
 }
 
@@ -71,8 +80,8 @@ func GenesisRules() *Rules {
 	return NewRules(enabledIDs)
 }
 
-// PermanentlyEnabledIDs returns the retired amendments, which are always
-// enabled regardless of a ledger's Amendments object.
+// PermanentlyEnabledIDs returns the retired amendments that ledger-loading
+// callers must add to the IDs stored in a ledger's Amendments object.
 func PermanentlyEnabledIDs() [][32]byte {
 	ids := make([][32]byte, 0)
 	for _, f := range AllFeatures() {
@@ -113,7 +122,8 @@ const (
 	PresetAllSupported
 )
 
-// RulesForPreset returns Rules for the given preset.
+// RulesForPreset returns Rules for the given preset. Unknown presets produce
+// an empty rule set.
 func RulesForPreset(preset Preset) *Rules {
 	switch preset {
 	case PresetEmpty:
@@ -132,6 +142,12 @@ type RulesBuilder struct {
 	enabled map[[32]byte]bool
 }
 
+func (b *RulesBuilder) initEnabled() {
+	if b.enabled == nil {
+		b.enabled = make(map[[32]byte]bool)
+	}
+}
+
 // NewRulesBuilder creates a new RulesBuilder.
 func NewRulesBuilder() *RulesBuilder {
 	return &RulesBuilder{
@@ -141,15 +157,17 @@ func NewRulesBuilder() *RulesBuilder {
 
 // Enable adds an amendment to the enabled set.
 func (b *RulesBuilder) Enable(featureID [32]byte) *RulesBuilder {
+	b.initEnabled()
 	b.enabled[featureID] = true
 	return b
 }
 
-// EnableByName adds an amendment by name to the enabled set.
+// EnableByName adds a registered amendment by name to the enabled set.
+// Unknown names are ignored.
 func (b *RulesBuilder) EnableByName(name string) *RulesBuilder {
 	f := FeatureByName(name)
 	if f != nil {
-		b.enabled[f.ID] = true
+		b.Enable(f.ID)
 	}
 	return b
 }
@@ -160,7 +178,8 @@ func (b *RulesBuilder) Disable(featureID [32]byte) *RulesBuilder {
 	return b
 }
 
-// DisableByName removes an amendment by name from the enabled set.
+// DisableByName removes a registered amendment by name from the enabled set.
+// Unknown names are ignored.
 func (b *RulesBuilder) DisableByName(name string) *RulesBuilder {
 	f := FeatureByName(name)
 	if f != nil {
@@ -169,11 +188,11 @@ func (b *RulesBuilder) DisableByName(name string) *RulesBuilder {
 	return b
 }
 
-// FromPreset initializes the builder from a preset.
+// FromPreset adds the amendments in a preset to the builder's current set.
 func (b *RulesBuilder) FromPreset(preset Preset) *RulesBuilder {
 	rules := RulesForPreset(preset)
 	for id := range rules.enabled {
-		b.enabled[id] = true
+		b.Enable(id)
 	}
 	return b
 }

--- a/amendment/table.go
+++ b/amendment/table.go
@@ -9,12 +9,12 @@ import (
 	"maps"
 	"sort"
 	"sync"
+	"time"
 )
 
-// majorityTimeSeconds is the duration an amendment must hold majority before it
-// is enabled (14 days). Mirrors rippled's DEFAULT_AMENDMENT_MAJORITY_TIME used
-// to project firstUnsupportedExpected.
-const majorityTimeSeconds uint32 = 14 * 24 * 60 * 60
+// DefaultMajorityTime is how long an amendment must hold majority before it can
+// be enabled when the operator does not configure another duration.
+const DefaultMajorityTime = 14 * 24 * time.Hour
 
 // Table tracks which amendments are enabled and manages voting.
 // This is the central data structure for amendment management in the node.
@@ -29,6 +29,8 @@ type Table struct {
 
 	// upVoted tracks amendments explicitly voted for by the operator
 	upVoted map[[32]byte]bool
+
+	majorityTime time.Duration
 
 	// unsupportedEnabled is set once an amendment this build does not support
 	// becomes enabled. Cached counterpart of HasUnsupportedEnabled.
@@ -69,10 +71,32 @@ type LastVote struct {
 
 // NewTable creates a new Table with no enabled amendments.
 func NewTable() *Table {
+	return NewTableWithMajorityTime(DefaultMajorityTime)
+}
+
+// NewTableWithMajorityTime creates a Table using majorityTime for activation
+// projections. A non-positive duration uses DefaultMajorityTime.
+func NewTableWithMajorityTime(majorityTime time.Duration) *Table {
+	if majorityTime <= 0 {
+		majorityTime = DefaultMajorityTime
+	}
 	return &Table{
-		enabled: make(map[[32]byte]bool),
-		vetoed:  make(map[[32]byte]bool),
-		upVoted: make(map[[32]byte]bool),
+		enabled:      make(map[[32]byte]bool),
+		vetoed:       make(map[[32]byte]bool),
+		upVoted:      make(map[[32]byte]bool),
+		majorityTime: majorityTime,
+	}
+}
+
+func (t *Table) initMaps() {
+	if t.enabled == nil {
+		t.enabled = make(map[[32]byte]bool)
+	}
+	if t.vetoed == nil {
+		t.vetoed = make(map[[32]byte]bool)
+	}
+	if t.upVoted == nil {
+		t.upVoted = make(map[[32]byte]bool)
 	}
 }
 
@@ -101,6 +125,7 @@ func (t *Table) IsSupported(featureID [32]byte) bool {
 func (t *Table) Enable(featureID [32]byte) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	t.initMaps()
 	t.enabled[featureID] = true
 	if !isSupported(featureID) {
 		t.unsupportedEnabled = true
@@ -114,7 +139,7 @@ func (t *Table) Disable(featureID [32]byte) {
 	delete(t.enabled, featureID)
 }
 
-// EnabledIDs returns a slice of all enabled amendment IDs.
+// EnabledIDs returns all enabled amendment IDs in ID order.
 func (t *Table) EnabledIDs() [][32]byte {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -123,13 +148,20 @@ func (t *Table) EnabledIDs() [][32]byte {
 	for id := range t.enabled {
 		result = append(result, id)
 	}
+	sort.Slice(result, func(i, j int) bool {
+		return bytes.Compare(result[i][:], result[j][:]) < 0
+	})
 	return result
 }
 
 // Veto marks an amendment as vetoed, preventing this node from voting for it.
 func (t *Table) Veto(featureID [32]byte) {
+	if f := FeatureByID(featureID); f != nil && f.IsObsolete() {
+		return
+	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	t.initMaps()
 	t.vetoed[featureID] = true
 	delete(t.upVoted, featureID)
 }
@@ -143,8 +175,12 @@ func (t *Table) Unveto(featureID [32]byte) {
 
 // UpVote explicitly votes for an amendment.
 func (t *Table) UpVote(featureID [32]byte) {
+	if f := FeatureByID(featureID); f != nil && f.IsObsolete() {
+		return
+	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	t.initMaps()
 	t.upVoted[featureID] = true
 	delete(t.vetoed, featureID)
 }
@@ -170,7 +206,7 @@ func (t *Table) Desired() [][32]byte {
 
 	result := make([][32]byte, 0)
 	for _, feature := range AllFeatures() {
-		if feature.Supported != SupportedYes || t.vetoed[feature.ID] {
+		if feature.Supported != SupportedYes || feature.IsObsolete() || t.vetoed[feature.ID] {
 			continue
 		}
 		if t.upVoted[feature.ID] ||
@@ -195,8 +231,8 @@ func (t *Table) HasUnsupportedEnabled() bool {
 	return t.unsupportedEnabled
 }
 
-// UnsupportedEnabledIDs returns a slice of enabled amendment IDs that are
-// not supported by this node.
+// UnsupportedEnabledIDs returns the enabled amendment IDs that are not
+// supported by this node, in ID order.
 func (t *Table) UnsupportedEnabledIDs() [][32]byte {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -208,6 +244,9 @@ func (t *Table) UnsupportedEnabledIDs() [][32]byte {
 			result = append(result, id)
 		}
 	}
+	sort.Slice(result, func(i, j int) bool {
+		return bytes.Compare(result[i][:], result[j][:]) < 0
+	})
 	return result
 }
 
@@ -281,15 +320,17 @@ func (t *Table) NeedValidatedLedger(seq uint32) bool {
 	return ((seq - 1) / 256) != ((t.lastUpdateSeq - 1) / 256)
 }
 
-// DoValidatedLedger re-syncs the in-memory table from a validated flag ledger:
-// it enables every amendment in `enabled` and recomputes
+// DoValidatedLedger folds a validated flag ledger into the in-memory table. It
+// adds each amendment whose value in enabled is true and recomputes
 // firstUnsupportedExpected from `majorities` (amendment hash → majority close
 // time in XRPL epoch seconds). Blocking is engaged once an unsupported
 // amendment is enabled. Mirrors AmendmentTableImpl::doValidatedLedger.
 func (t *Table) DoValidatedLedger(seq uint32, enabled map[[32]byte]bool, majorities map[[32]byte]uint32) {
 	// enable() locks internally; run it before taking the lock, as rippled does.
-	for id := range enabled {
-		t.Enable(id)
+	for id, isEnabled := range enabled {
+		if isEnabled {
+			t.Enable(id)
+		}
 	}
 
 	t.mu.Lock()
@@ -312,7 +353,11 @@ func (t *Table) DoValidatedLedger(seq uint32, enabled map[[32]byte]bool, majorit
 		}
 	}
 	if haveEarliest {
-		projected := earliest + majorityTimeSeconds
+		majorityTime := t.majorityTime
+		if majorityTime <= 0 {
+			majorityTime = DefaultMajorityTime
+		}
+		projected := earliest + uint32(majorityTime/time.Second)
 		t.firstUnsupportedExpected = &projected
 	} else {
 		t.firstUnsupportedExpected = nil
@@ -348,6 +393,7 @@ func (t *Table) Clone() *Table {
 	clone.unsupportedEnabled = t.unsupportedEnabled
 	clone.blocked = t.blocked
 	clone.lastUpdateSeq = t.lastUpdateSeq
+	clone.majorityTime = t.majorityTime
 	if t.firstUnsupportedExpected != nil {
 		v := *t.firstUnsupportedExpected
 		clone.firstUnsupportedExpected = &v

--- a/amendment/table_resync_test.go
+++ b/amendment/table_resync_test.go
@@ -4,7 +4,10 @@
 
 package amendment
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 // unknownAmendment is a hash not present in the registry.
 var unknownAmendment = [32]byte{0xDE, 0xAD, 0xBE, 0xEF}
@@ -54,6 +57,14 @@ func TestDoValidatedLedger_EnablesAndBlocks(t *testing.T) {
 	}
 }
 
+func TestDoValidatedLedger_IgnoresFalseEntries(t *testing.T) {
+	tbl := NewTable()
+	tbl.DoValidatedLedger(256, map[[32]byte]bool{FeatureDID: false}, nil)
+	if tbl.IsEnabled(FeatureDID) {
+		t.Fatal("false entry in enabled set activated an amendment")
+	}
+}
+
 func TestDoValidatedLedger_FirstUnsupportedExpected(t *testing.T) {
 	tbl := NewTable()
 
@@ -68,7 +79,7 @@ func TestDoValidatedLedger_FirstUnsupportedExpected(t *testing.T) {
 	if !ok {
 		t.Fatal("expected firstUnsupportedExpected to be set for an unsupported majority")
 	}
-	if want := unsupportedMajorityTime + majorityTimeSeconds; exp != want {
+	if want := unsupportedMajorityTime + uint32(DefaultMajorityTime/time.Second); exp != want {
 		t.Fatalf("firstUnsupportedExpected = %d, want %d (majority time + 14d)", exp, want)
 	}
 	if tbl.IsBlocked() {
@@ -83,6 +94,17 @@ func TestDoValidatedLedger_FirstUnsupportedExpected(t *testing.T) {
 	}
 	if !tbl.IsBlocked() {
 		t.Fatal("node must be blocked after the unsupported amendment activates")
+	}
+}
+
+func TestDoValidatedLedger_ConfiguredMajorityTime(t *testing.T) {
+	tbl := NewTableWithMajorityTime(15 * time.Minute)
+	const majorityClose uint32 = 1_000_000
+	tbl.DoValidatedLedger(256, nil, map[[32]byte]uint32{unknownAmendment: majorityClose})
+
+	got, ok := tbl.FirstUnsupportedExpected()
+	if !ok || got != majorityClose+15*60 {
+		t.Fatalf("FirstUnsupportedExpected() = (%d, %t), want (%d, true)", got, ok, majorityClose+15*60)
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/amendment"
 )
 
 // Config represents the complete goxrpl configuration.
@@ -56,6 +59,9 @@ type Config struct {
 
 	// Amendments holds the operator's amendment voting preferences.
 	Amendments AmendmentsConfig `toml:"amendments" mapstructure:"amendments"`
+	// AmendmentMajorityTime is how long an amendment must continuously hold
+	// majority before activation. Zero uses amendment.DefaultMajorityTime.
+	AmendmentMajorityTime time.Duration `toml:"amendment_majority_time" mapstructure:"amendment_majority_time"`
 
 	// 9. Misc Settings
 	NodeSize   string `toml:"node_size" mapstructure:"node_size"` // optional; "" = default ("medium")
@@ -77,6 +83,15 @@ type Config struct {
 
 	// Validators configuration (loaded from separate file)
 	Validators ValidatorsConfig `toml:"-" mapstructure:"-"`
+}
+
+// EffectiveAmendmentMajorityTime returns the configured duration or the
+// protocol default when it is unset.
+func (c *Config) EffectiveAmendmentMajorityTime() time.Duration {
+	if c.AmendmentMajorityTime <= 0 {
+		return amendment.DefaultMajorityTime
+	}
+	return c.AmendmentMajorityTime
 }
 
 // Paths holds the paths to configuration files

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -134,6 +135,21 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, 8080, portConfig.Port)
 	assert.Equal(t, "127.0.0.1", portConfig.IP)
 	assert.Equal(t, "http", portConfig.Protocol)
+}
+
+func TestLoadConfig_AmendmentMajorityTime(t *testing.T) {
+	tempDir := t.TempDir()
+	contents := strings.Replace(
+		completeTestConfig(),
+		"database_path = \"/tmp/test/db\"",
+		"database_path = \"/tmp/test/db\"\namendment_majority_time = \"15m\"",
+		1,
+	)
+	path := writeConfig(t, tempDir, "majority-time.toml", contents)
+
+	cfg, err := LoadConfig(Paths{Main: path, SkipValidators: true})
+	require.NoError(t, err)
+	assert.Equal(t, 15*time.Minute, cfg.EffectiveAmendmentMajorityTime())
 }
 
 func TestNodeDBConfigPebbleResourcesValidation(t *testing.T) {
@@ -849,6 +865,17 @@ func TestConfigValidation_CompleteConfig(t *testing.T) {
 	assert.NoError(t, ValidateConfig(validCompleteConfig()))
 }
 
+func TestConfigValidation_AmendmentMajorityTime(t *testing.T) {
+	cfg := validCompleteConfig()
+	cfg.AmendmentMajorityTime = 14 * time.Minute
+	err := ValidateConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "amendment_majority_time must be at least 15m")
+
+	cfg.AmendmentMajorityTime = 15 * time.Minute
+	assert.NoError(t, ValidateConfig(cfg))
+}
+
 func TestConfigValidation_InvalidPort(t *testing.T) {
 	config := validCompleteConfig()
 	config.Ports = map[string]PortConfig{
@@ -969,6 +996,7 @@ func TestConfigHelperMethods_Defaults(t *testing.T) {
 	assert.Equal(t, 256, config.ResolvedLedgerHistory())
 	assert.Equal(t, DefaultLedgerCacheSize, config.ResolvedLedgerCacheSize())
 	assert.Equal(t, defaultFetchDepth, config.ResolvedFetchDepth())
+	assert.Equal(t, 14*24*time.Hour, config.EffectiveAmendmentMajorityTime())
 }
 
 func TestLoadConfigLedgerCacheSize(t *testing.T) {

--- a/config/examples/goxrpl.toml
+++ b/config/examples/goxrpl.toml
@@ -30,6 +30,9 @@ relay_validations = "all"        # all, trusted, drop_untrusted (case-insensitiv
 ledger_history = 256             # integer, "full", or "none"
 ledger_cache_size = 256          # recent ledger/tx indexes and persisted-ledger lookups (1-384)
 fetch_depth = "full"             # integer, "full", or "none" (values < 10 are clamped to 10)
+# How long an amendment must continuously hold majority before activation.
+# Uses Go duration syntax, defaults to 336h (14 days), and must be at least 15m.
+# amendment_majority_time = "336h"
 
 # Network: "main", "testnet", "devnet", or integer
 network_id = "main"

--- a/config/validation.go
+++ b/config/validation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/protocol"
@@ -64,6 +65,9 @@ func ValidateConfig(config *Config) error {
 	}
 	if err := config.Amendments.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("amendments: %w", err))
+	}
+	if config.AmendmentMajorityTime != 0 && config.AmendmentMajorityTime < 15*time.Minute {
+		errs = append(errs, errors.New("amendment_majority_time must be at least 15m"))
 	}
 
 	// 8. Validate misc settings

--- a/docs/amendments.md
+++ b/docs/amendments.md
@@ -4,120 +4,121 @@
 
 XRPL amendments known to this node, generated from the amendment registry
 (`amendment`). **Supported** means this implementation can apply the
-amendment's behavior; **Default vote** is whether the node votes for it by
-default (operators override via the `[amendments]` config section).
+amendment's behavior; it does not mean the amendment is enabled on a ledger.
+Operators may override default yes/no voting for supported amendments, but
+obsolete and retired amendments are never proposed.
 
 Total: 110 amendments.
 
-| Amendment | Supported | Default vote |
-|-----------|-----------|--------------|
-| `AMM` | yes | no |
-| `AMMClawback` | yes | no |
-| `BatchV1_1` | yes | no |
-| `CheckCashMakesTrustLine` | yes | no |
-| `Checks` | yes | no |
-| `Clawback` | yes | no |
-| `ConfidentialTransfer` | no | no |
-| `Credentials` | yes | no |
-| `CryptoConditions` | yes | no |
-| `CryptoConditionsSuite` | yes | no |
-| `DID` | yes | no |
-| `DeepFreeze` | yes | no |
-| `DeletableAccounts` | yes | no |
-| `DepositAuth` | yes | no |
-| `DepositPreauth` | yes | no |
-| `DisallowIncoming` | yes | no |
-| `DynamicMPT` | yes | no |
-| `DynamicNFT` | yes | no |
-| `EnforceInvariants` | yes | no |
-| `Escrow` | yes | no |
-| `ExpandedSignerList` | yes | no |
-| `FeeEscalation` | yes | no |
-| `Flow` | yes | no |
-| `FlowCross` | yes | no |
-| `FlowSortStrands` | yes | no |
-| `HardenedValidations` | yes | no |
-| `ImmediateOfferKilled` | yes | no |
-| `InvariantsV1_1` | no | no |
-| `LendingProtocol` | yes | no |
-| `LendingProtocolV1_1` | no | no |
-| `MPTokensV1` | yes | no |
-| `MPTokensV2` | no | no |
-| `MultiSign` | yes | no |
-| `MultiSignReserve` | yes | no |
-| `NFTokenMintOffer` | yes | no |
-| `NegativeUNL` | yes | no |
-| `NonFungibleTokensV1` | yes | no |
-| `NonFungibleTokensV1_1` | yes | no |
-| `PayChan` | yes | no |
-| `PermissionDelegationV1_1` | yes | no |
-| `PermissionedDEX` | yes | no |
-| `PermissionedDomains` | yes | no |
-| `PriceOracle` | yes | no |
-| `RequireFullyCanonicalSig` | yes | no |
-| `SingleAssetVault` | yes | no |
-| `SortedDirectories` | yes | no |
-| `Sponsor` | yes | no |
-| `TickSize` | yes | no |
-| `TicketBatch` | yes | no |
-| `TokenEscrow` | yes | no |
-| `TrustSetAuth` | yes | no |
-| `XChainBridge` | no | no |
-| `XRPFees` | yes | no |
-| `fix1201` | yes | no |
-| `fix1368` | yes | no |
-| `fix1373` | yes | no |
-| `fix1512` | yes | no |
-| `fix1513` | yes | no |
-| `fix1515` | yes | no |
-| `fix1523` | yes | no |
-| `fix1528` | yes | no |
-| `fix1543` | yes | no |
-| `fix1571` | yes | no |
-| `fix1578` | yes | no |
-| `fix1623` | yes | no |
-| `fix1781` | yes | no |
-| `fixAMMClawbackRounding` | yes | no |
-| `fixAMMOverflowOffer` | yes | yes |
-| `fixAMMv1_1` | yes | no |
-| `fixAMMv1_2` | yes | no |
-| `fixAMMv1_3` | yes | no |
-| `fixAmendmentMajorityCalc` | yes | no |
-| `fixCheckThreading` | yes | no |
-| `fixCleanup3_1_3` | yes | yes |
-| `fixCleanup3_2_0` | yes | no |
-| `fixCleanup3_3_0` | yes | no |
-| `fixDirectoryLimit` | yes | no |
-| `fixDisallowIncomingV1` | yes | no |
-| `fixEmptyDID` | yes | no |
-| `fixEnforceNFTokenTrustline` | yes | no |
-| `fixEnforceNFTokenTrustlineV2` | yes | no |
-| `fixFillOrKill` | yes | no |
-| `fixFrozenLPTokenTransfer` | yes | no |
-| `fixIncludeKeyletFields` | yes | no |
-| `fixInnerObjTemplate` | yes | no |
-| `fixInnerObjTemplate2` | yes | no |
-| `fixInvalidTxFlags` | yes | no |
-| `fixMPTDeliveredAmount` | yes | no |
-| `fixMasterKeyAsRegularKey` | yes | no |
-| `fixNFTokenDirV1` | yes | no |
-| `fixNFTokenNegOffer` | yes | no |
-| `fixNFTokenPageLinks` | yes | no |
-| `fixNFTokenRemint` | yes | no |
-| `fixNFTokenReserve` | yes | no |
-| `fixNonFungibleTokensV1_2` | yes | no |
-| `fixPayChanCancelAfter` | yes | no |
-| `fixPayChanRecipientOwnerDir` | yes | no |
-| `fixPreviousTxnID` | yes | no |
-| `fixPriceOracleOrder` | yes | no |
-| `fixQualityUpperBound` | yes | no |
-| `fixReducedOffersV1` | yes | no |
-| `fixReducedOffersV2` | yes | no |
-| `fixRemoveNFTokenAutoTrustLine` | yes | yes |
-| `fixRmSmallIncreasedQOffers` | yes | no |
-| `fixSTAmountCanonicalize` | yes | no |
-| `fixTakerDryOfferRemoval` | yes | no |
-| `fixTokenEscrowV1` | yes | no |
-| `fixTrustLinesToSelf` | yes | no |
-| `fixUniversalNumber` | yes | no |
-| `fixXChainRewardRounding` | yes | no |
+| Amendment | Supported | Vote behavior | Lifecycle |
+|-----------|-----------|---------------|-----------|
+| `AMM` | yes | default no | active |
+| `AMMClawback` | yes | default no | active |
+| `BatchV1_1` | yes | default no | active |
+| `CheckCashMakesTrustLine` | yes | obsolete | retired |
+| `Checks` | yes | obsolete | retired |
+| `Clawback` | yes | obsolete | retired |
+| `ConfidentialTransfer` | no | default no | active |
+| `Credentials` | yes | default no | active |
+| `CryptoConditions` | yes | obsolete | retired |
+| `CryptoConditionsSuite` | yes | obsolete | retired |
+| `DID` | yes | default no | active |
+| `DeepFreeze` | yes | default no | active |
+| `DeletableAccounts` | yes | obsolete | retired |
+| `DepositAuth` | yes | obsolete | retired |
+| `DepositPreauth` | yes | obsolete | retired |
+| `DisallowIncoming` | yes | obsolete | retired |
+| `DynamicMPT` | yes | default no | active |
+| `DynamicNFT` | yes | default no | active |
+| `EnforceInvariants` | yes | obsolete | retired |
+| `Escrow` | yes | obsolete | retired |
+| `ExpandedSignerList` | yes | obsolete | retired |
+| `FeeEscalation` | yes | obsolete | retired |
+| `Flow` | yes | obsolete | retired |
+| `FlowCross` | yes | obsolete | retired |
+| `FlowSortStrands` | yes | obsolete | retired |
+| `HardenedValidations` | yes | obsolete | retired |
+| `ImmediateOfferKilled` | yes | obsolete | retired |
+| `InvariantsV1_1` | no | default no | active |
+| `LendingProtocol` | yes | default no | active |
+| `LendingProtocolV1_1` | no | default no | active |
+| `MPTokensV1` | yes | default no | active |
+| `MPTokensV2` | no | default no | active |
+| `MultiSign` | yes | obsolete | retired |
+| `MultiSignReserve` | yes | obsolete | retired |
+| `NFTokenMintOffer` | yes | default no | active |
+| `NegativeUNL` | yes | obsolete | retired |
+| `NonFungibleTokensV1` | yes | obsolete | obsolete |
+| `NonFungibleTokensV1_1` | yes | obsolete | retired |
+| `PayChan` | yes | obsolete | retired |
+| `PermissionDelegationV1_1` | yes | default no | active |
+| `PermissionedDEX` | yes | default no | active |
+| `PermissionedDomains` | yes | default no | active |
+| `PriceOracle` | yes | default no | active |
+| `RequireFullyCanonicalSig` | yes | obsolete | retired |
+| `SingleAssetVault` | yes | default no | active |
+| `SortedDirectories` | yes | obsolete | retired |
+| `Sponsor` | yes | default no | active |
+| `TickSize` | yes | obsolete | retired |
+| `TicketBatch` | yes | obsolete | retired |
+| `TokenEscrow` | yes | default no | active |
+| `TrustSetAuth` | yes | obsolete | retired |
+| `XChainBridge` | no | default no | active |
+| `XRPFees` | yes | default no | active |
+| `fix1201` | yes | obsolete | retired |
+| `fix1368` | yes | obsolete | retired |
+| `fix1373` | yes | obsolete | retired |
+| `fix1512` | yes | obsolete | retired |
+| `fix1513` | yes | obsolete | retired |
+| `fix1515` | yes | obsolete | retired |
+| `fix1523` | yes | obsolete | retired |
+| `fix1528` | yes | obsolete | retired |
+| `fix1543` | yes | obsolete | retired |
+| `fix1571` | yes | obsolete | retired |
+| `fix1578` | yes | obsolete | retired |
+| `fix1623` | yes | obsolete | retired |
+| `fix1781` | yes | obsolete | retired |
+| `fixAMMClawbackRounding` | yes | default no | active |
+| `fixAMMOverflowOffer` | yes | default yes | active |
+| `fixAMMv1_1` | yes | default no | active |
+| `fixAMMv1_2` | yes | default no | active |
+| `fixAMMv1_3` | yes | default no | active |
+| `fixAmendmentMajorityCalc` | yes | obsolete | retired |
+| `fixCheckThreading` | yes | obsolete | retired |
+| `fixCleanup3_1_3` | yes | default yes | active |
+| `fixCleanup3_2_0` | yes | default no | active |
+| `fixCleanup3_3_0` | yes | default no | active |
+| `fixDirectoryLimit` | yes | default no | active |
+| `fixDisallowIncomingV1` | yes | obsolete | retired |
+| `fixEmptyDID` | yes | default no | active |
+| `fixEnforceNFTokenTrustline` | yes | default no | active |
+| `fixEnforceNFTokenTrustlineV2` | yes | default no | active |
+| `fixFillOrKill` | yes | default no | active |
+| `fixFrozenLPTokenTransfer` | yes | default no | active |
+| `fixIncludeKeyletFields` | yes | default no | active |
+| `fixInnerObjTemplate` | yes | obsolete | retired |
+| `fixInnerObjTemplate2` | yes | default no | active |
+| `fixInvalidTxFlags` | yes | default no | active |
+| `fixMPTDeliveredAmount` | yes | default no | active |
+| `fixMasterKeyAsRegularKey` | yes | obsolete | retired |
+| `fixNFTokenDirV1` | yes | obsolete | obsolete |
+| `fixNFTokenNegOffer` | yes | obsolete | obsolete |
+| `fixNFTokenPageLinks` | yes | default no | active |
+| `fixNFTokenRemint` | yes | obsolete | retired |
+| `fixNFTokenReserve` | yes | obsolete | retired |
+| `fixNonFungibleTokensV1_2` | yes | obsolete | retired |
+| `fixPayChanCancelAfter` | yes | default no | active |
+| `fixPayChanRecipientOwnerDir` | yes | obsolete | retired |
+| `fixPreviousTxnID` | yes | default no | active |
+| `fixPriceOracleOrder` | yes | default no | active |
+| `fixQualityUpperBound` | yes | obsolete | retired |
+| `fixReducedOffersV1` | yes | obsolete | retired |
+| `fixReducedOffersV2` | yes | default no | active |
+| `fixRemoveNFTokenAutoTrustLine` | yes | default yes | active |
+| `fixRmSmallIncreasedQOffers` | yes | obsolete | retired |
+| `fixSTAmountCanonicalize` | yes | obsolete | retired |
+| `fixTakerDryOfferRemoval` | yes | obsolete | retired |
+| `fixTokenEscrowV1` | yes | default no | active |
+| `fixTrustLinesToSelf` | yes | obsolete | retired |
+| `fixUniversalNumber` | yes | obsolete | retired |
+| `fixXChainRewardRounding` | yes | default no | active |

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -327,6 +327,9 @@ omit one to use rippled's `TxQ::Setup` default, or set it explicitly
   an amendment (rippled's `[amendments]` stanza); `veto` refuses to vote for it
   (rippled's `[veto_amendments]`). Names match the amendment registry; an amendment
   must not appear in both lists.
+- **`amendment_majority_time`** — duration an amendment must continuously hold
+  majority before activation. It uses Go duration syntax, defaults to `"336h"`
+  (14 days), and must be at least `"15m"`.
 
 Before deploying to a public network, manually compare that network's amendment
 state with this build's registry:

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -122,7 +122,8 @@ type Adaptor struct {
 	// sources vote stances from each round (so operator veto/upvote changes
 	// take effect without restart) and stashes per-round tallies into. nil
 	// falls back to the construction-time amendmentStances map.
-	amendmentTable *amendment.Table
+	amendmentTable        *amendment.Table
+	amendmentMajorityTime time.Duration
 
 	// trustedVotes caches per-validator amendment votes for 24h to dampen
 	// flapping when a flaky validator drops briefly.
@@ -296,6 +297,9 @@ type Config struct {
 	// abstain, upvoted → up) over registry defaults. Shared with the ledger
 	// service, which folds validated flag ledgers in via DoValidatedLedger.
 	Table *amendment.Table
+	// AmendmentMajorityTime is how long majority must hold before activation.
+	// Zero uses amendment.DefaultMajorityTime.
+	AmendmentMajorityTime time.Duration
 	// RelayValidations is the operator's [relay_validations] stance; the
 	// zero value relays untrusted validations (rippled's default).
 	RelayValidations RelayValidationsPolicy
@@ -364,6 +368,10 @@ func New(cfg Config) *Adaptor {
 
 	logger := slog.Default().With("component", "consensus-adaptor")
 	amendmentStances := seedAmendmentStances(cfg.AmendmentVote, logger)
+	amendmentMajorityTime := cfg.AmendmentMajorityTime
+	if amendmentMajorityTime <= 0 {
+		amendmentMajorityTime = amendment.DefaultMajorityTime
+	}
 
 	// Seed the amendment-vote cache with the initial UNL so
 	// recordVotes accepts validations from round one. Re-call
@@ -413,29 +421,30 @@ func New(cfg Config) *Adaptor {
 	}
 
 	a := &Adaptor{
-		ledgerService:     cfg.LedgerService,
-		txLookup:          txLookup,
-		sender:            sender,
-		identity:          cfg.Identity,
-		trustedValidators: cfg.Validators,
-		trustedSet:        trustedSet,
-		trustedMasterKeys: trustedMasterKeys,
-		operatingMode:     consensus.OpModeDisconnected,
-		stateAcct:         newStateAccounting(consensus.OpModeDisconnected, time.Now),
-		negUNLVoter:       negUNLVoter,
-		txSetCache:        newTxSetCache(),
-		peerLCLs:          make(map[uint64]consensus.LedgerID),
-		reqLedgerLast:     make(map[consensus.LedgerID]time.Time),
-		announcedSets:     make(map[consensus.TxSetID]struct{}),
-		onTxSetBuilt:      cfg.OnTxSetBuilt,
-		maxDisallowedSeq:  maxDisallowedSeq,
-		cookie:            cookie,
-		feeVote:           feeVote,
-		amendmentStances:  amendmentStances,
-		amendmentTable:    cfg.Table,
-		trustedVotes:      trustedVotes,
-		relayValidations:  cfg.RelayValidations,
-		logger:            logger,
+		ledgerService:         cfg.LedgerService,
+		txLookup:              txLookup,
+		sender:                sender,
+		identity:              cfg.Identity,
+		trustedValidators:     cfg.Validators,
+		trustedSet:            trustedSet,
+		trustedMasterKeys:     trustedMasterKeys,
+		operatingMode:         consensus.OpModeDisconnected,
+		stateAcct:             newStateAccounting(consensus.OpModeDisconnected, time.Now),
+		negUNLVoter:           negUNLVoter,
+		txSetCache:            newTxSetCache(),
+		peerLCLs:              make(map[uint64]consensus.LedgerID),
+		reqLedgerLast:         make(map[consensus.LedgerID]time.Time),
+		announcedSets:         make(map[consensus.TxSetID]struct{}),
+		onTxSetBuilt:          cfg.OnTxSetBuilt,
+		maxDisallowedSeq:      maxDisallowedSeq,
+		cookie:                cookie,
+		feeVote:               feeVote,
+		amendmentStances:      amendmentStances,
+		amendmentTable:        cfg.Table,
+		amendmentMajorityTime: amendmentMajorityTime,
+		trustedVotes:          trustedVotes,
+		relayValidations:      cfg.RelayValidations,
+		logger:                logger,
 	}
 	if cfg.LedgerService != nil {
 		cfg.LedgerService.SetValidatedLedgerAgeClock(a.Now)

--- a/internal/consensus/adaptor/flag_ledger_vote.go
+++ b/internal/consensus/adaptor/flag_ledger_vote.go
@@ -16,11 +16,6 @@ import (
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
-// amendmentMajorityTimeout is how long an amendment must hold
-// majority on the ledger before it's enabled. Mainnet config:
-// 14 days.
-const amendmentMajorityTimeout = 14 * 24 * time.Hour
-
 // readAmendmentsSLE pulls the parent ledger's Amendments SLE
 // (enabled set + majorities array) once at the producer boundary.
 // Both runners consume the result, and the enabled set doubles as
@@ -221,18 +216,16 @@ func (a *Adaptor) runAmendmentVote(
 
 	stances := a.currentAmendmentStances()
 
-	// Restrict the vote walk to amendments this server supports,
-	// mirroring rippled's doVoting over amendmentMap_, which is seeded
-	// from the supported (Supported::yes) set only. Two divergences this
-	// closes: an amendment recorded only in the parent ledger's
-	// sfMajorities but unknown to this binary (a newer protocol
-	// amendment), and a compile-time-known but unsupported amendment —
-	// either would otherwise wrongly emit a LostMajority pseudo-tx,
-	// forking the flag-ledger tx set from the rest of the network.
+	// Rippled walks every supported amendment plus amendments discovered in
+	// the ledger majority set. The latter must remain in the domain even when
+	// this build does not recognize them so a lost majority is cleared.
 	supported := amendment.SupportedFeatures()
-	known := make(map[amendmentvote.Amendment]bool, len(supported))
+	known := make(map[amendmentvote.Amendment]bool, len(supported)+len(majority))
 	for _, f := range supported {
 		known[f.ID] = true
+	}
+	for id := range majority {
+		known[id] = true
 	}
 
 	// Stash this round's tallies for `feature` RPC introspection.
@@ -249,7 +242,7 @@ func (a *Adaptor) runAmendmentVote(
 	in := amendmentvote.Inputs{
 		UpcomingSeq:        upcomingSeq,
 		CloseTime:          closeTime,
-		MajorityTimeout:    amendmentMajorityTimeout,
+		MajorityTimeout:    a.amendmentMajorityTime,
 		TrustedValidations: available,
 		Votes:              votes,
 		Enabled:            enabled,

--- a/internal/consensus/adaptor/flag_ledger_vote_test.go
+++ b/internal/consensus/adaptor/flag_ledger_vote_test.go
@@ -428,6 +428,33 @@ func TestGenerateFlagLedgerPseudoTxs_UnsupportedAmendmentNotWalked(t *testing.T)
 	}
 }
 
+func TestRunAmendmentVote_MajorityOnlyAmendmentCanLoseMajority(t *testing.T) {
+	a := newTestAdaptorWithConfig(t, FeeVoteStance{}, nil)
+	prev := a.ledgerService.GetClosedLedger()
+	require.NotNil(t, prev)
+	target := amendment.FeatureID("unknown-majority-amendment")
+
+	blobs := a.runAmendmentVote(
+		prev,
+		prev.Sequence()+1,
+		nil,
+		map[[32]byte]bool{},
+		map[[32]byte]time.Time{target: time.Unix(1_000_000, 0)},
+	)
+
+	var found bool
+	for _, blob := range blobs {
+		stx := decodeTx(t, blob)
+		if stx["TransactionType"] == "EnableAmendment" &&
+			stringFold(stx["Amendment"]) == hex.EncodeToString(target[:]) &&
+			asUint(stx["Flags"]) == uint64(amendmentvote.TfLostMajority) {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "majority-only amendment must emit LostMajority after validator support disappears")
+}
+
 // TestAmendmentStances_SeededFromRegistry verifies the constructor
 // walks amendment.AllFeatures() and seeds the stance map from each
 // feature's registered VoteBehavior, mirroring rippled's

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -493,7 +493,8 @@ func NewFromConfig(
 		// Source vote stances from the same amendment table the ledger service
 		// resyncs from validated ledgers, so operator veto/upvote ([amendments]
 		// config) drives consensus voting.
-		Table: ledgerSvc.Table(),
+		Table:                 ledgerSvc.Table(),
+		AmendmentMajorityTime: appCfg.EffectiveAmendmentMajorityTime(),
 		// The operator's [voting] stanza.
 		FeeVote:          feeVoteFromConfig(appCfg.Voting, appCfg.FeeDefault),
 		RelayValidations: parseRelayValidationsPolicy(appCfg.RelayValidations),

--- a/internal/consensus/amendmentvote/vote.go
+++ b/internal/consensus/amendmentvote/vote.go
@@ -65,10 +65,10 @@ type Inputs struct {
 	// this server's per-amendment stance; absent defaults to VoteAbstain
 	Stances map[Amendment]Stance
 
-	// amendments this server supports — the walk domain for Decide.
-	// Includes DefaultYes/DefaultNo/Obsolete but not unsupported, so a
-	// supported-but-down amendment can still emit LostMajority. Nil walks
-	// the union of Stances/Votes/Majority (test-only; inputs assumed known).
+	// amendments tracked by this server — the walk domain for Decide. Callers
+	// include supported amendments and every amendment in the ledger majority
+	// set, including unknown amendments that may need LostMajority emitted. Nil
+	// walks the union of Stances, Votes, and Majority.
 	Known map[Amendment]bool
 }
 

--- a/internal/consensus/amendmentvote/vote_test.go
+++ b/internal/consensus/amendmentvote/vote_test.go
@@ -180,15 +180,10 @@ func TestDecide_LostMajorityFiresEvenForAbstain(t *testing.T) {
 	assert.Equal(t, TfLostMajority, got[0].Flags)
 }
 
-// TestDecide_UnknownAmendmentInMajorityIgnored pins C3: when Known is
-// supplied, an amendment recorded in the parent ledger's sfMajorities
-// (in.Majority) but absent from Known — one this server doesn't
-// recognize, e.g. a newer protocol amendment — must NEVER emit a
-// pseudo-tx, even with lost validator support. Rippled's doVoting walks
-// only amendmentMap_ (Table.cpp:875), so it emits nothing for
-// such an amendment; emitting a spurious LostMajority would fork the
-// flag-ledger tx set from the rest of the network.
-func TestDecide_UnknownAmendmentInMajorityIgnored(t *testing.T) {
+// TestDecide_AmendmentOutsideWalkDomainIgnored verifies that Known is the
+// authoritative walk domain. Production callers include majority-only
+// amendments in Known so they can emit LostMajority.
+func TestDecide_AmendmentOutsideWalkDomainIgnored(t *testing.T) {
 	known := makeAmendment(0x01)
 	unknown := makeAmendment(0x02) // recorded on the ledger, but not compiled in
 	in := Inputs{
@@ -202,8 +197,7 @@ func TestDecide_UnknownAmendmentInMajorityIgnored(t *testing.T) {
 		Known:              map[Amendment]bool{known: true},
 	}
 	got := Decide(in)
-	assert.Empty(t, got,
-		"an amendment absent from Known must never emit a pseudo-tx, even with ledger majority + lost support")
+	assert.Empty(t, got, "an amendment absent from Known must not emit a pseudo-tx")
 }
 
 // TestDecide_KnownAbstainAmendmentLostMajorityFires is the companion to

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -664,8 +664,8 @@ func applyValidatorReloadContextWithGate(
 // DB takes precedence over the config stanzas. Unknown names are logged and
 // ignored. The returned table owns operator veto/upvote and the enabled/blocked
 // state, and is shared between the ledger service and the consensus adaptor.
-func buildTable(ctx context.Context, cfg config.AmendmentsConfig, repo relationaldb.RepositoryManager, log xrpllog.Logger) *amendment.Table {
-	t := amendment.NewTable()
+func buildTable(ctx context.Context, cfg config.AmendmentsConfig, majorityTime time.Duration, repo relationaldb.RepositoryManager, log xrpllog.Logger) *amendment.Table {
+	t := amendment.NewTableWithMajorityTime(majorityTime)
 	for _, name := range cfg.Upvote {
 		f := amendment.FeatureByName(name)
 		if f == nil {

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -223,7 +223,7 @@ func (r *nodeRuntime) configureLedger() error {
 	// One instance is shared between the ledger service (which folds validated
 	// flag ledgers into it) and the consensus adaptor (which sources vote
 	// stances from it).
-	amendmentTable := buildTable(ctx, r.appConfig.Amendments, r.repo, r.serverLog)
+	amendmentTable := buildTable(ctx, r.appConfig.Amendments, r.appConfig.EffectiveAmendmentMajorityTime(), r.repo, r.serverLog)
 	if err := context.Cause(ctx); err != nil {
 		return err
 	}

--- a/scripts/docsgen/registries/main.go
+++ b/scripts/docsgen/registries/main.go
@@ -52,6 +52,29 @@ func yesNo(v bool) string {
 	return "no"
 }
 
+func amendmentVote(v amendment.VoteBehavior) string {
+	switch v {
+	case amendment.VoteDefaultNo:
+		return "default no"
+	case amendment.VoteDefaultYes:
+		return "default yes"
+	case amendment.VoteObsolete:
+		return "obsolete"
+	default:
+		return "unknown"
+	}
+}
+
+func amendmentLifecycle(f *amendment.Feature) string {
+	if f.Retired {
+		return "retired"
+	}
+	if f.IsObsolete() {
+		return "obsolete"
+	}
+	return "active"
+}
+
 func writeAmendments() error {
 	feats := amendment.AllFeatures()
 	sort.Slice(feats, func(i, j int) bool { return feats[i].Name < feats[j].Name })
@@ -61,13 +84,14 @@ func writeAmendments() error {
 	b.WriteString("# Amendments\n\n")
 	b.WriteString("XRPL amendments known to this node, generated from the amendment registry\n")
 	b.WriteString("(`amendment`). **Supported** means this implementation can apply the\n")
-	b.WriteString("amendment's behavior; **Default vote** is whether the node votes for it by\n")
-	b.WriteString("default (operators override via the `[amendments]` config section).\n\n")
+	b.WriteString("amendment's behavior; it does not mean the amendment is enabled on a ledger.\n")
+	b.WriteString("Operators may override default yes/no voting for supported amendments, but\n")
+	b.WriteString("obsolete and retired amendments are never proposed.\n\n")
 	fmt.Fprintf(&b, "Total: %d amendments.\n\n", len(feats))
-	b.WriteString("| Amendment | Supported | Default vote |\n")
-	b.WriteString("|-----------|-----------|--------------|\n")
+	b.WriteString("| Amendment | Supported | Vote behavior | Lifecycle |\n")
+	b.WriteString("|-----------|-----------|---------------|-----------|\n")
 	for _, f := range feats {
-		fmt.Fprintf(&b, "| `%s` | %s | %s |\n", f.Name, yesNo(f.IsSupported()), yesNo(f.IsDefaultYes()))
+		fmt.Fprintf(&b, "| `%s` | %s | %s | %s |\n", f.Name, yesNo(f.IsSupported()), amendmentVote(f.Vote), amendmentLifecycle(f))
 	}
 	return os.WriteFile("docs/amendments.md", []byte(b.String()), 0o644) //nolint:gosec // G306: generated docs artifact, world-readable by intent
 }


### PR DESCRIPTION
## Summary

- add a package README explaining the registry, ledger rule snapshots, live table state, voting policy, lifecycle states, concurrency, and configuration
- make the public amendment helpers deterministic and zero-value safe, and prevent obsolete amendments from being explicitly proposed
- match rippled amendment voting by retaining majority-only amendments for LostMajority decisions and honoring configurable majority timing
- expand the generated amendment catalog to distinguish support, vote behavior, and lifecycle

## Rippled parity

Reviewed against the local rippled 3.3.0 oracle at commit `00a178fb92ca49521b937ae1a99d863765ea8a90`.

## Verification

- `go test` on amendment, config, amendmentvote, adaptor, node, and docs generator packages
- `go test -race ./amendment ./internal/consensus/amendmentvote`
- focused `go vet`
- `just build`
- `just vet`
- `just lint` (0 issues)
- `just test`
- regenerated registry documentation and confirmed a clean `git diff --check`