### PR TITLE
fix: preserve tiny initial IOU cover deposits

### DIFF
--- a/internal/ledger/state/lending_number.go
+++ b/internal/ledger/state/lending_number.go
@@ -58,10 +58,10 @@ func (n XRPLNumber) RoundToAssetScale(integral bool, scale int, mode RoundingMod
 
 // AssetExponent returns the decimal exponent of STAmount{asset, n} under mode,
 // used to derive a loan's scale (rippled computeLoanProperties reads
-// amount.exponent()). Integral assets and zero have exponent 0; an IOU reports
-// the exponent of its 16-significant-digit normalization.
+// amount.exponent()). Integral assets have exponent 0; an IOU reports the
+// exponent of its 16-significant-digit normalization, including -100 for zero.
 func (n XRPLNumber) AssetExponent(integral bool, mode RoundingMode) int {
-	if n.IsZero() || integral {
+	if integral {
 		return 0
 	}
 	return newIOUAmountValueRoundedWithContext(

--- a/internal/ledger/state/number_asset_test.go
+++ b/internal/ledger/state/number_asset_test.go
@@ -39,6 +39,14 @@ func TestRoundToAsset_IOU(t *testing.T) {
 	require.True(t, NewXRPLNumberScaled(0, 0, MantissaScaleLarge, RoundToNearest).RoundToAsset(false).IsZero())
 }
 
+func TestAssetExponent_Zero(t *testing.T) {
+	t.Parallel()
+	zero := NewXRPLNumberScaled(0, 0, MantissaScaleLarge, RoundToNearest)
+	require.Equal(t, 0, zero.AssetExponent(true, RoundToNearest))
+	require.Equal(t, zeroExponent, zero.AssetExponent(false, RoundToNearest))
+	require.Equal(t, -15, NewXRPLNumberScaled(25, -1, MantissaScaleLarge, RoundToNearest).AssetExponent(false, RoundToNearest))
+}
+
 func TestAssociateAssetField_Removal(t *testing.T) {
 	t.Parallel()
 	// Integral asset, sub-unit value, soeDEFAULT field -> removed.

--- a/internal/testing/lending/loanbroker_test.go
+++ b/internal/testing/lending/loanbroker_test.go
@@ -13,6 +13,7 @@ import (
 	mpttest "github.com/LeJamon/go-xrpl/internal/testing/mpt"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/lending"
+	"github.com/LeJamon/go-xrpl/internal/tx/payment"
 	txsign "github.com/LeJamon/go-xrpl/internal/tx/sign"
 	"github.com/LeJamon/go-xrpl/internal/tx/vault"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -219,6 +220,52 @@ func TestLoanBroker_CoverDepositInsufficientFunds(t *testing.T) {
 	// Deposit more than the owner can spend.
 	dep := lending.NewLoanBrokerCoverDeposit(owner.Address, bid, tx.NewXRPAmount(1_000_000_000_000))
 	jtx.RequireTxClaimed(t, env.Submit(dep), jtx.TecINSUFFICIENT_FUNDS)
+}
+
+func TestLoanBroker_InitialTinyIOUCoverDeposit(t *testing.T) {
+	env := newLendingEnv(t)
+	issuer := jtx.NewAccount("issuer")
+	owner := jtx.NewAccount("owner")
+	for _, account := range []*jtx.Account{issuer, owner} {
+		env.FundAmount(account, 10_000_000_000)
+	}
+
+	env.Trust(owner, tx.NewIssuedAmountFromFloat64(1, "USD", issuer.Address))
+	tiny := tx.NewIssuedAmount(1_000_000_000_000_000, -30, "USD", issuer.Address)
+	jtx.RequireTxSuccess(t, env.Submit(payment.NewPayment(issuer.Address, owner.Address, tiny)))
+
+	vaultSeq := env.Seq(owner)
+	create := vault.NewVaultCreate(owner.Address, tx.Asset{Currency: "USD", Issuer: issuer.Address})
+	create.Common.Fee = reserveIncrement
+	jtx.RequireTxSuccess(t, env.Submit(create))
+
+	brokerSeq := env.Seq(owner)
+	jtx.RequireTxSuccess(t, env.Submit(lending.NewLoanBrokerSet(owner.Address, vaultID(owner, vaultSeq))))
+	bid := brokerID(owner, brokerSeq)
+	brokerKey := keylet.LoanBroker(owner.AccountID(), brokerSeq)
+	broker := decodeLendingEntry(t, env, brokerKey)
+	if _, present := broker["CoverAvailable"]; present {
+		t.Fatalf("initial LoanBroker CoverAvailable = %v, want absent", broker["CoverAvailable"])
+	}
+	jtx.RequireTxClaimed(t, env.Submit(lending.NewLoanBrokerCoverWithdraw(owner.Address, bid, tiny)), jtx.TecINSUFFICIENT_FUNDS)
+
+	jtx.RequireTxSuccess(t, env.Submit(lending.NewLoanBrokerCoverDeposit(owner.Address, bid, tiny)))
+
+	broker = decodeLendingEntry(t, env, brokerKey)
+	if got := broker["CoverAvailable"]; got != "1e-15" {
+		t.Fatalf("LoanBroker CoverAvailable = %v, want 1e-15", got)
+	}
+	pseudoAddress, ok := broker["Account"].(string)
+	if !ok {
+		t.Fatalf("LoanBroker Account = %v, want address", broker["Account"])
+	}
+	pseudo := jtx.NewAccountWithAddress("broker", pseudoAddress)
+	if got := env.IOUBalance(pseudo, issuer, "USD"); got.Compare(tiny) != 0 {
+		t.Fatalf("broker USD balance = %s, want 1e-15", got.Value())
+	}
+	if got := env.IOUBalance(owner, issuer, "USD").Value(); got != "0" {
+		t.Fatalf("owner USD balance = %s, want 0", got)
+	}
 }
 
 func TestLoanSet_UpwardPaymentCountXRP(t *testing.T) {

--- a/internal/tx/invariants/vault_test.go
+++ b/internal/tx/invariants/vault_test.go
@@ -342,6 +342,9 @@ func TestVaultMinScale_AmendmentGate(t *testing.T) {
 	iou := vvAsset{currency: "USD", issuer: [20]byte{1}}
 	afterIOU := vvVault{asset: iou, assetsTotal: state.NewXRPLNumber(1000000, 0)}
 	iouDelta := iou.makeDelta(state.NewXRPLNumber(0, 0), state.NewXRPLNumber(25, -1))
+	if want := iou.scaleOf(state.NewXRPLNumber(25, -1)); iouDelta.scale != want {
+		t.Fatalf("zero-to-nonzero IOU delta scale = %d, want %d", iouDelta.scale, want)
+	}
 
 	on := (&vvChecker{rules: fixOn}).vaultMinScale(iou, afterIOU, iouDelta)
 	off := (&vvChecker{rules: fixOff}).vaultMinScale(iou, afterIOU, iouDelta)

--- a/internal/tx/lending/cover_test.go
+++ b/internal/tx/lending/cover_test.go
@@ -74,12 +74,16 @@ func TestCanApplyToBrokerCover(t *testing.T) {
 			}
 		})
 	}
+	if got := canApplyToBrokerCover(true, lmath.Zero(), lmath.Num(1, -15), false); got != ter.TesSUCCESS {
+		t.Fatalf("initial tiny IOU cover = %v, want tesSUCCESS", got)
+	}
 }
 
 func TestRoundCoverDeposit(t *testing.T) {
 	cover := lmath.Num(1000000, 0) // IOU, scale -9
 	dust := lmath.Num(5, -12)
 	amt := lmath.Num(25, -1) // 2.5, representable at scale -9
+	tiny := lmath.Num(1, -15)
 
 	// Disabled: amount passes through untouched.
 	if got, res := roundCoverDeposit(false, cover, dust, false); res != ter.TesSUCCESS || !got.Equal(dust) {
@@ -92,6 +96,11 @@ func TestRoundCoverDeposit(t *testing.T) {
 	// Enabled: representable amount is quantized down and preserved.
 	if got, res := roundCoverDeposit(true, cover, amt, false); res != ter.TesSUCCESS || !got.Equal(amt) {
 		t.Fatalf("enabled roundCoverDeposit = (%s,%v), want (2.5,tes)", numStr(got), res)
+	}
+	// An empty IOU cover field has STAmount's canonical zero scale and accepts
+	// every representable positive IOU amount.
+	if got, res := roundCoverDeposit(true, lmath.Zero(), tiny, false); res != ter.TesSUCCESS || !got.Equal(tiny) {
+		t.Fatalf("enabled initial tiny deposit = (%s,%v), want (%s,tes)", numStr(got), res, numStr(tiny))
 	}
 	// Integral: deposit is unchanged (whole units already representable).
 	if got, res := roundCoverDeposit(true, lmath.FromDrops(1000), lmath.FromDrops(7), true); res != ter.TesSUCCESS || !got.Equal(lmath.FromDrops(7)) {


### PR DESCRIPTION
## Summary

- preserve the canonical IOU zero scale when deriving lending asset precision
- accept the first representable tiny IOU cover deposit without changing integral behavior
- cover shared guard, invariant, error-precedence, and exact broker/trust-line state

## Test plan

- [x] focused regression tests, including pre-fix failure proof
- [x] affected package test suites
- [x] focused race and repeated runs
- [x] `just build-all`
- [x] `just test-tx`
- [x] `just test-integration`
- [x] `just vet`
- [x] `just lint`
- [x] independent whole-diff rippled v3.3.0 conformance review

Fixes #1722
