### PR TITLE
fix: correct LoanPay broker fee routing

### DIFF
--- a/internal/testing/lending/loan_pay_fee_routing_test.go
+++ b/internal/testing/lending/loan_pay_fee_routing_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	mpttest "github.com/LeJamon/go-xrpl/internal/testing/mpt"
 	"github.com/LeJamon/go-xrpl/internal/tx/lending"
 	txsign "github.com/LeJamon/go-xrpl/internal/tx/sign"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -14,9 +15,9 @@ import (
 
 const loanPayServiceFee = int64(100)
 
-func setupLoanPayFeeRouting(t *testing.T, kind string) (*loanSetAssetFixture, string, *jtx.Account) {
+func setupLoanPayFeeRouting(t *testing.T, kind string, mptCreateFlags ...uint32) (*loanSetAssetFixture, string, *jtx.Account) {
 	t.Helper()
-	f := newLoanSetAssetFixture(t, kind)
+	f := newLoanSetAssetFixture(t, kind, mptCreateFlags...)
 	f.createHolding(f.owner)
 
 	loanSet := lending.NewLoanSet(f.borrower.Address, f.brokerID, "1000")
@@ -129,10 +130,41 @@ func TestLoanPayMissingBrokerOwnerHoldingRoutesFeeToCover(t *testing.T) {
 }
 
 func TestLoanPayDeepFrozenBrokerOwnerAndPseudoFails(t *testing.T) {
-	f, loanID, pseudo := setupLoanPayFeeRouting(t, "IOU")
-	deepFreezeLoanSetTrustLine(t, f, f.owner.AccountID())
-	deepFreezeLoanSetTrustLine(t, f, pseudo.AccountID())
+	tests := []struct {
+		name           string
+		kind           string
+		mptCreateFlags []uint32
+		freeze         func(*testing.T, *loanSetAssetFixture, *jtx.Account)
+		want           string
+	}{
+		{
+			name: "IOU",
+			kind: "IOU",
+			freeze: func(t *testing.T, f *loanSetAssetFixture, pseudo *jtx.Account) {
+				deepFreezeLoanSetTrustLine(t, f, f.owner.AccountID())
+				deepFreezeLoanSetTrustLine(t, f, pseudo.AccountID())
+			},
+			want: jtx.TecFROZEN,
+		},
+		{
+			name:           "MPT",
+			kind:           "MPT",
+			mptCreateFlags: []uint32{mpttest.TfMPTCanLock},
+			freeze: func(_ *testing.T, f *loanSetAssetFixture, pseudo *jtx.Account) {
+				f.token.Set(mpttest.SetOpts{Holder: f.owner, Flags: mpttest.TfMPTLock})
+				f.token.Set(mpttest.SetOpts{Holder: pseudo, Flags: mpttest.TfMPTLock})
+			},
+			want: jtx.TecLOCKED,
+		},
+	}
 
-	jtx.RequireTxClaimed(t, f.env.Submit(loanPayFee(f, loanID)), jtx.TecFROZEN)
-	requireLoanPayFeeBalances(t, f, pseudo, 0, 0)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f, loanID, pseudo := setupLoanPayFeeRouting(t, test.kind, test.mptCreateFlags...)
+			test.freeze(t, f, pseudo)
+
+			jtx.RequireTxClaimed(t, f.env.Submit(loanPayFee(f, loanID)), test.want)
+			requireLoanPayFeeBalances(t, f, pseudo, 0, 0)
+		})
+	}
 }

--- a/internal/testing/lending/loan_pay_fee_routing_test.go
+++ b/internal/testing/lending/loan_pay_fee_routing_test.go
@@ -44,13 +44,17 @@ func setupLoanPayFeeRouting(t *testing.T, kind string) (*loanSetAssetFixture, st
 	return f, loanID, pseudo
 }
 
-func submitLoanPayFee(t *testing.T, f *loanSetAssetFixture, loanID string) {
-	t.Helper()
-	jtx.RequireTxSuccess(t, f.env.Submit(lending.NewLoanPay(
+func loanPayFee(f *loanSetAssetFixture, loanID string) *lending.LoanPay {
+	return lending.NewLoanPay(
 		f.borrower.Address,
 		loanID,
 		f.amount(1000+loanPayServiceFee),
-	)))
+	)
+}
+
+func submitLoanPayFee(t *testing.T, f *loanSetAssetFixture, loanID string) {
+	t.Helper()
+	jtx.RequireTxSuccess(t, f.env.Submit(loanPayFee(f, loanID)))
 }
 
 func requireLoanPayFeeBalances(t *testing.T, f *loanSetAssetFixture, pseudo *jtx.Account, owner, cover int64) {
@@ -122,4 +126,13 @@ func TestLoanPayMissingBrokerOwnerHoldingRoutesFeeToCover(t *testing.T) {
 			requireLoanPayFeeBalances(t, f, pseudo, 0, loanPayServiceFee)
 		})
 	}
+}
+
+func TestLoanPayDeepFrozenBrokerOwnerAndPseudoFails(t *testing.T) {
+	f, loanID, pseudo := setupLoanPayFeeRouting(t, "IOU")
+	deepFreezeLoanSetTrustLine(t, f, f.owner.AccountID())
+	deepFreezeLoanSetTrustLine(t, f, pseudo.AccountID())
+
+	jtx.RequireTxClaimed(t, f.env.Submit(loanPayFee(f, loanID)), jtx.TecFROZEN)
+	requireLoanPayFeeBalances(t, f, pseudo, 0, 0)
 }

--- a/internal/testing/lending/loan_pay_fee_routing_test.go
+++ b/internal/testing/lending/loan_pay_fee_routing_test.go
@@ -1,0 +1,125 @@
+package lending_test
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/tx/lending"
+	txsign "github.com/LeJamon/go-xrpl/internal/tx/sign"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+const loanPayServiceFee = int64(100)
+
+func setupLoanPayFeeRouting(t *testing.T, kind string) (*loanSetAssetFixture, string, *jtx.Account) {
+	t.Helper()
+	f := newLoanSetAssetFixture(t, kind)
+	f.createHolding(f.owner)
+
+	loanSet := lending.NewLoanSet(f.borrower.Address, f.brokerID, "1000")
+	loanSet.Counterparty = f.owner.Address
+	serviceFee := "100"
+	loanSet.LoanServiceFee = &serviceFee
+	loanSet.GetCommon().Fee = "20"
+	loanSet.GetCommon().SigningPubKey = strings.ToUpper(f.borrower.PublicKeyHex())
+	signature, err := txsign.SignCounterparty(
+		loanSet,
+		strings.ToUpper(f.owner.PublicKeyHex()),
+		"00"+strings.ToUpper(f.owner.PrivateKeyHex()),
+	)
+	if err != nil {
+		t.Fatalf("sign LoanSet counterparty: %v", err)
+	}
+	loanSet.GetCommon().CounterpartySignature = signature
+	jtx.RequireTxSuccess(t, f.env.Submit(loanSet))
+	f.fundHolding(f.borrower, loanPayServiceFee)
+
+	loanKey := keylet.Loan(f.brokerKey, 1)
+	loanID := strings.ToUpper(hex.EncodeToString(loanKey.Key[:]))
+	pseudoID := loanBrokerPseudoAccount(t, f)
+	pseudo := jtx.NewAccountWithAddress("broker-pseudo", state.EncodeAccountIDSafe(pseudoID))
+	return f, loanID, pseudo
+}
+
+func submitLoanPayFee(t *testing.T, f *loanSetAssetFixture, loanID string) {
+	t.Helper()
+	jtx.RequireTxSuccess(t, f.env.Submit(lending.NewLoanPay(
+		f.borrower.Address,
+		loanID,
+		f.amount(1000+loanPayServiceFee),
+	)))
+}
+
+func requireLoanPayFeeBalances(t *testing.T, f *loanSetAssetFixture, pseudo *jtx.Account, owner, cover int64) {
+	t.Helper()
+	if f.asset.IsMPT() {
+		f.token.RequireMPTokenAmount(f.owner, owner)
+		f.token.RequireMPTokenAmount(pseudo, cover)
+	} else {
+		jtx.RequireIOUBalance(t, f.env, f.owner, f.issuer, "USD", float64(owner))
+		jtx.RequireIOUBalance(t, f.env, pseudo, f.issuer, "USD", float64(cover))
+	}
+
+	broker := decodeLendingEntry(t, f.env, keylet.LoanBrokerByID(f.brokerKey))
+	if cover == 0 {
+		if value, present := broker["CoverAvailable"]; present && value != "0" {
+			t.Fatalf("LoanBroker CoverAvailable = %v, want zero", value)
+		}
+		return
+	}
+	assertLendingField(t, "LoanBroker", broker, "CoverAvailable", "100")
+}
+
+func TestLoanPayBrokerOwnerFreezeRouting(t *testing.T) {
+	tests := []struct {
+		name     string
+		freeze   func(*testing.T, *loanSetAssetFixture)
+		ownerFee int64
+		coverFee int64
+	}{
+		{
+			name: "ordinary freeze sends fee to owner",
+			freeze: func(_ *testing.T, f *loanSetAssetFixture) {
+				f.env.FreezeTrustLine(f.issuer, f.owner, "USD")
+			},
+			ownerFee: loanPayServiceFee,
+		},
+		{
+			name: "deep freeze sends fee to cover",
+			freeze: func(t *testing.T, f *loanSetAssetFixture) {
+				deepFreezeLoanSetTrustLine(t, f, f.owner.AccountID())
+			},
+			coverFee: loanPayServiceFee,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f, loanID, pseudo := setupLoanPayFeeRouting(t, "IOU")
+			test.freeze(t, f)
+			submitLoanPayFee(t, f, loanID)
+			requireLoanPayFeeBalances(t, f, pseudo, test.ownerFee, test.coverFee)
+		})
+	}
+}
+
+func TestLoanPayMissingBrokerOwnerHoldingRoutesFeeToCover(t *testing.T) {
+	for _, kind := range []string{"IOU", "MPT"} {
+		t.Run(kind, func(t *testing.T) {
+			f, loanID, pseudo := setupLoanPayFeeRouting(t, kind)
+			f.removeHolding(f.owner)
+			if f.env.LedgerEntryExists(f.holdingKey(f.owner)) {
+				t.Fatal("broker owner holding still exists before LoanPay")
+			}
+
+			submitLoanPayFee(t, f, loanID)
+			if f.env.LedgerEntryExists(f.holdingKey(f.owner)) {
+				t.Fatal("LoanPay recreated the broker owner holding")
+			}
+			requireLoanPayFeeBalances(t, f, pseudo, 0, loanPayServiceFee)
+		})
+	}
+}

--- a/internal/testing/lending/loan_set_owner_count_test.go
+++ b/internal/testing/lending/loan_set_owner_count_test.go
@@ -19,10 +19,15 @@ import (
 type loanSetAssetFixture struct {
 	env                     *jtx.TestEnv
 	issuer, owner, borrower *jtx.Account
+	asset                   tx.Asset
 	brokerID                string
 	brokerKey               [32]byte
 	holdingKey              func(*jtx.Account) keylet.Keylet
 	createHolding           func(*jtx.Account)
+	removeHolding           func(*jtx.Account)
+	fundHolding             func(*jtx.Account, int64)
+	amount                  func(int64) tx.Amount
+	token                   *mpttest.MPTTester
 }
 
 func newLoanSetAssetFixture(t *testing.T, kind string, mptCreateFlags ...uint32) *loanSetAssetFixture {
@@ -40,6 +45,10 @@ func newLoanSetAssetFixture(t *testing.T, kind string, mptCreateFlags ...uint32)
 	var deposit tx.Amount
 	var holdingKey func(*jtx.Account) keylet.Keylet
 	var createHolding func(*jtx.Account)
+	var removeHolding func(*jtx.Account)
+	var fundHolding func(*jtx.Account, int64)
+	var amount func(int64) tx.Amount
+	var token *mpttest.MPTTester
 	switch kind {
 	case "IOU":
 		asset = tx.Asset{Currency: "USD", Issuer: issuer.Address}
@@ -51,8 +60,18 @@ func newLoanSetAssetFixture(t *testing.T, kind string, mptCreateFlags ...uint32)
 			return keylet.Line(account.AccountID(), issuer.AccountID(), "USD")
 		}
 		createHolding = func(account *jtx.Account) { env.Trust(account, limit) }
+		removeHolding = func(account *jtx.Account) {
+			env.Trust(account, tx.NewIssuedAmountFromFloat64(0, "USD", issuer.Address))
+		}
+		fundHolding = func(account *jtx.Account, value int64) {
+			env.Trust(account, limit)
+			env.PayIOU(issuer, account, issuer, "USD", float64(value))
+		}
+		amount = func(value int64) tx.Amount {
+			return tx.NewIssuedAmountFromFloat64(float64(value), "USD", issuer.Address)
+		}
 	case "MPT":
-		token := mpttest.NewMPTTester(t, env, issuer, mpttest.MPTInit{Holders: []*jtx.Account{depositor}})
+		token = mpttest.NewMPTTester(t, env, issuer, mpttest.MPTInit{Holders: []*jtx.Account{depositor}})
 		flags := mpttest.TfMPTCanTransfer
 		for _, extra := range mptCreateFlags {
 			flags |= extra
@@ -78,6 +97,11 @@ func newLoanSetAssetFixture(t *testing.T, kind string, mptCreateFlags ...uint32)
 			return keylet.MPTokenByID(issuanceID, account.AccountID())
 		}
 		createHolding = authorize
+		removeHolding = func(account *jtx.Account) {
+			token.Authorize(mpttest.AuthorizeOpts{Account: account, Flags: mpttest.TfMPTUnauthorize})
+		}
+		fundHolding = func(account *jtx.Account, value int64) { token.Pay(issuer, account, value) }
+		amount = token.MPTAmount
 	default:
 		t.Fatalf("unsupported asset kind %q", kind)
 	}
@@ -104,10 +128,15 @@ func newLoanSetAssetFixture(t *testing.T, kind string, mptCreateFlags ...uint32)
 		issuer:        issuer,
 		owner:         owner,
 		borrower:      borrower,
+		asset:         asset,
 		brokerID:      brokerID,
 		brokerKey:     brokerKey,
 		holdingKey:    holdingKey,
 		createHolding: createHolding,
+		removeHolding: removeHolding,
+		fundHolding:   fundHolding,
+		amount:        amount,
+		token:         token,
 	}
 }
 

--- a/internal/tx/lending/loan_pay_apply.go
+++ b/internal/tx/lending/loan_pay_apply.go
@@ -228,6 +228,8 @@ func (l *LoanPay) Apply(ctx *tx.ApplyContext) ter.Result {
 	brokerPayee := b.Account
 	if sendFeeToOwner {
 		brokerPayee = b.Owner
+	} else if r := mptutil.CheckDeepFrozen(ctx.View, brokerPayee, asset); r != ter.TesSUCCESS {
+		return r
 	}
 
 	// Reverse any impairment before applying the payment.

--- a/internal/tx/lending/loan_pay_apply.go
+++ b/internal/tx/lending/loan_pay_apply.go
@@ -5,6 +5,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/lending/lmath"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/sign"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/internal/tx/vault"
@@ -222,8 +223,8 @@ func (l *LoanPay) Apply(ctx *tx.ApplyContext) ter.Result {
 		minCover = brokerCoverRateAtScale(number(b.DebtTotal), b.CoverRateMinimum, loanScale, integral)
 	}
 	sendFeeToOwner := number(b.CoverAvailable).Cmp(minCover) >= 0 &&
-		tx.AssetFrozen(ctx.View, b.Owner, asset) == ter.TesSUCCESS &&
-		tx.RequireAuth(ctx.View, asset, b.Owner) == ter.TesSUCCESS
+		mptutil.CheckDeepFrozen(ctx.View, b.Owner, asset) == ter.TesSUCCESS &&
+		mptutil.RequireAssetAuthAt(ctx.View, asset, b.Owner, mptutil.StrongAuth, ctx.Config.ParentCloseTime) == ter.TesSUCCESS
 	brokerPayee := b.Account
 	if sendFeeToOwner {
 		brokerPayee = b.Owner


### PR DESCRIPTION
## Summary

- route LoanPay broker fees with deep-freeze and StrongAuth semantics
- preserve ordinary IOU freeze behavior while falling back to cover for deep freeze
- cover missing IOU and MPT broker-owner holdings without recreating them

## Test plan

- [x] `go test ./internal/testing/lending -run 'TestLoanPay(BrokerOwnerFreezeRouting|MissingBrokerOwnerHoldingRoutesFeeToCover)$' -count=20`
- [x] `go test -race ./internal/testing/lending -run 'TestLoanPay(BrokerOwnerFreezeRouting|MissingBrokerOwnerHoldingRoutesFeeToCover)$' -count=1`
- [x] `go test ./internal/tx/lending ./internal/testing/lending`
- [x] `just test-tx`
- [x] `just test-integration`
- [x] `just build`
- [x] `just vet`
- [x] `just lint`

Fixes #1724
