### PR TITLE
fix: honor reference-backed MPT freezes

### DIFF
--- a/internal/testing/vault/vault_payment_test.go
+++ b/internal/testing/vault/vault_payment_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	paybuilder "github.com/LeJamon/go-xrpl/internal/testing/payment"
+	trustbuilder "github.com/LeJamon/go-xrpl/internal/testing/trustset"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/mpt"
 	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
@@ -16,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestVaultSharePaymentRequiresUnderlyingIOUAuthorization(t *testing.T) {
+func TestVaultSharePaymentInheritsUnderlyingIOUChecks(t *testing.T) {
 	env := newVaultEnv(t)
 	env.DisableFeature("MPTokensV2")
 	env.Close()
@@ -41,6 +42,7 @@ func TestVaultSharePaymentRequiresUnderlyingIOUAuthorization(t *testing.T) {
 	vaultInfo, err := vault.ReadVaultInfo(env.Ledger(), vaultKey)
 	require.NoError(t, err)
 	require.NotNil(t, vaultInfo)
+	require.NotNil(t, vaultShareIssuance(t, env, vaultInfo.ShareMPTID).ReferenceHolding)
 	shareID := mptutil.EncodeID(vaultInfo.ShareMPTID)
 
 	deposit := vault.NewVaultDeposit(
@@ -77,6 +79,26 @@ func TestVaultSharePaymentRequiresUnderlyingIOUAuthorization(t *testing.T) {
 	require.Equal(t, destinationShares, vaultShareBalance(t, env, vaultInfo.ShareMPTID, destination))
 
 	env.AuthorizeTrustLine(issuer, destination, currency)
+	jtx.RequireTxSuccess(t, env.Submit(trustbuilder.TrustLine(issuer, currency, owner, "0").NoRipple().Build()))
+	jtx.RequireTxSuccess(t, env.Submit(trustbuilder.TrustLine(issuer, currency, destination, "0").NoRipple().Build()))
+	require.True(t, env.HasNoRipple(issuer, owner, currency))
+	require.True(t, env.HasNoRipple(issuer, destination, currency))
+
+	ownerXRP = env.Balance(owner)
+	ownerSequence := env.Seq(owner)
+	noRippleResult := env.Submit(payment())
+	jtx.RequireTxFail(t, noRippleResult, jtx.TerNO_RIPPLE)
+	require.False(t, noRippleResult.Applied)
+	require.False(t, noRippleResult.Queued)
+	require.Zero(t, noRippleResult.Fee)
+	require.Nil(t, noRippleResult.Metadata)
+	require.Equal(t, ownerXRP, env.Balance(owner))
+	require.Equal(t, ownerSequence, env.Seq(owner))
+	require.Equal(t, ownerShares, vaultShareBalance(t, env, vaultInfo.ShareMPTID, owner))
+	require.Equal(t, destinationShares, vaultShareBalance(t, env, vaultInfo.ShareMPTID, destination))
+
+	jtx.RequireTxSuccess(t, env.Submit(trustbuilder.TrustLine(issuer, currency, destination, "0").ClearNoRipple().Build()))
+	require.False(t, env.HasNoRipple(issuer, destination, currency))
 	ownerXRP = env.Balance(owner)
 	jtx.RequireTxSuccess(t, env.Submit(payment()))
 	require.Equal(t, ownerXRP-env.BaseFee(), env.Balance(owner))

--- a/internal/testing/vault/vault_payment_test.go
+++ b/internal/testing/vault/vault_payment_test.go
@@ -1,6 +1,7 @@
 package vault_test
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
@@ -11,6 +12,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/vault"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -82,6 +84,85 @@ func TestVaultSharePaymentRequiresUnderlyingIOUAuthorization(t *testing.T) {
 	require.Equal(t, destinationShares+10, vaultShareBalance(t, env, vaultInfo.ShareMPTID, destination))
 }
 
+func TestVaultSharePaymentRejectsFrozenReferenceHolding(t *testing.T) {
+	env := newVaultEnv(t)
+	env.DisableFeature("MPTokensV2")
+	env.Close()
+	issuer := jtx.NewAccount("issuer")
+	owner := jtx.NewAccount("owner")
+	destination := jtx.NewAccount("destination")
+	env.Fund(issuer, owner, destination)
+	env.EnableRequireAuth(issuer)
+
+	const currency = "USD"
+	limit := tx.NewIssuedAmountFromFloat64(1_000, currency, issuer.Address)
+	env.Trust(owner, limit)
+	env.AuthorizeTrustLine(issuer, owner, currency)
+	env.PayIOU(issuer, owner, issuer, currency, 100)
+
+	sequence := env.Seq(owner)
+	create := vault.NewVaultCreate(owner.Address, tx.Asset{Currency: currency, Issuer: issuer.Address})
+	create.Common.Fee = createFee
+	jtx.RequireTxSuccess(t, env.Submit(create))
+
+	vaultKey := keylet.Vault(owner.AccountID(), sequence)
+	vaultInfo, err := vault.ReadVaultInfo(env.Ledger(), vaultKey)
+	require.NoError(t, err)
+	require.NotNil(t, vaultInfo)
+	shareID := mptutil.EncodeID(vaultInfo.ShareMPTID)
+
+	deposit := vault.NewVaultDeposit(
+		owner.Address,
+		vaultID(owner, sequence),
+		tx.NewIssuedAmountFromFloat64(100, currency, issuer.Address),
+	)
+	jtx.RequireTxSuccess(t, env.Submit(deposit))
+	env.Trust(destination, limit)
+	env.AuthorizeTrustLine(issuer, destination, currency)
+	jtx.RequireTxSuccess(t, env.Submit(mpt.NewMPTokenAuthorize(destination.Address, shareID)))
+
+	pseudoAddress, err := state.EncodeAccountID(vaultInfo.Account)
+	require.NoError(t, err)
+	pseudo := jtx.NewAccountWithAddress("vault", pseudoAddress)
+	env.FreezeTrustLine(issuer, pseudo, currency)
+
+	issuance := vaultShareIssuance(t, env, vaultInfo.ShareMPTID)
+	require.NotNil(t, issuance.ReferenceHolding)
+	require.Zero(t, issuance.Flags&entry.LsfMPTLocked)
+	require.Zero(t, vaultShareHolding(t, env, vaultInfo.ShareMPTID, owner).Flags&entry.LsfMPTLocked)
+	require.Zero(t, vaultShareHolding(t, env, vaultInfo.ShareMPTID, destination).Flags&entry.LsfMPTLocked)
+
+	ownerXRP := env.Balance(owner)
+	ownerSequence := env.Seq(owner)
+	ownerCount := env.AccountInfo(owner).OwnerCount
+	destinationXRP := env.Balance(destination)
+	destinationSequence := env.Seq(destination)
+	ownerShares := vaultShareBalance(t, env, vaultInfo.ShareMPTID, owner)
+	destinationShares := vaultShareBalance(t, env, vaultInfo.ShareMPTID, destination)
+
+	amount := state.NewMPTAmountWithIssuanceID(10, "", shareID)
+	result := env.Submit(paybuilder.PayIssued(owner, destination, amount).Build())
+	requireFeeOnlyPaymentClaim(t, env, result, jtx.TecLOCKED)
+
+	accountNode := result.Metadata.AffectedNodes[0]
+	require.Equal(t, map[string]any{
+		"Balance":  strconv.FormatUint(ownerXRP, 10),
+		"Sequence": ownerSequence,
+	}, accountNode.PreviousFields)
+	require.Equal(t, owner.Address, accountNode.FinalFields["Account"])
+	require.Equal(t, strconv.FormatUint(ownerXRP-env.BaseFee(), 10), accountNode.FinalFields["Balance"])
+	require.Equal(t, ownerSequence+1, accountNode.FinalFields["Sequence"])
+	require.Equal(t, ownerCount, accountNode.FinalFields["OwnerCount"])
+
+	require.Equal(t, ownerXRP-env.BaseFee(), env.Balance(owner))
+	require.Equal(t, ownerSequence+1, env.Seq(owner))
+	require.Equal(t, ownerCount, env.AccountInfo(owner).OwnerCount)
+	require.Equal(t, destinationXRP, env.Balance(destination))
+	require.Equal(t, destinationSequence, env.Seq(destination))
+	require.Equal(t, ownerShares, vaultShareBalance(t, env, vaultInfo.ShareMPTID, owner))
+	require.Equal(t, destinationShares, vaultShareBalance(t, env, vaultInfo.ShareMPTID, destination))
+}
+
 func requireFeeOnlyPaymentClaim(t *testing.T, env *jtx.TestEnv, result jtx.TxResult, code string) {
 	t.Helper()
 	jtx.RequireTxClaimed(t, result, code)
@@ -95,10 +176,25 @@ func requireFeeOnlyPaymentClaim(t *testing.T, env *jtx.TestEnv, result jtx.TxRes
 
 func vaultShareBalance(t *testing.T, env *jtx.TestEnv, issuanceID [24]byte, holder *jtx.Account) uint64 {
 	t.Helper()
+	return vaultShareHolding(t, env, issuanceID, holder).MPTAmount
+}
+
+func vaultShareHolding(t *testing.T, env *jtx.TestEnv, issuanceID [24]byte, holder *jtx.Account) *state.MPTokenData {
+	t.Helper()
 	raw, err := env.Ledger().Read(keylet.MPTokenByID(issuanceID, holder.AccountID()))
 	require.NoError(t, err)
 	require.NotNil(t, raw)
 	token, err := state.ParseMPToken(raw)
 	require.NoError(t, err)
-	return token.MPTAmount
+	return token
+}
+
+func vaultShareIssuance(t *testing.T, env *jtx.TestEnv, issuanceID [24]byte) *state.MPTokenIssuanceData {
+	t.Helper()
+	raw, err := env.Ledger().Read(keylet.MPTIssuance(issuanceID))
+	require.NoError(t, err)
+	require.NotNil(t, raw)
+	issuance, err := state.ParseMPTokenIssuance(raw)
+	require.NoError(t, err)
+	return issuance
 }

--- a/internal/tx/payment/payment_mpt.go
+++ b/internal/tx/payment/payment_mpt.go
@@ -102,26 +102,9 @@ func (p *Payment) applyMPTPayment(ctx *tx.ApplyContext) ter.Result {
 	// rate is in QUALITY_ONE format: 1_000_000_000 = 1.0
 	rate := uint64(mptRateOne)
 	if !senderIsIssuer && !destIsIssuer {
-		// Check frozen (globally or individually locked)
-		if issuance.Flags&entry.LsfMPTLocked != 0 {
+		if mptutil.IsFrozen(ctx.View, mptID, ctx.AccountID) ||
+			mptutil.IsFrozen(ctx.View, mptID, destAccountID) {
 			return ter.TecLOCKED
-		}
-		// Check individual locks on sender and destination
-		senderTokenKey := keylet.MPToken(issuanceKey.Key, ctx.AccountID)
-		senderTokenRaw, _ := ctx.View.Read(senderTokenKey)
-		if senderTokenRaw != nil {
-			senderToken, _ := state.ParseMPToken(senderTokenRaw)
-			if senderToken != nil && senderToken.Flags&entry.LsfMPTLocked != 0 {
-				return ter.TecLOCKED
-			}
-		}
-		destTokenKey := keylet.MPToken(issuanceKey.Key, destAccountID)
-		destTokenRaw, _ := ctx.View.Read(destTokenKey)
-		if destTokenRaw != nil {
-			destToken, _ := state.ParseMPToken(destTokenRaw)
-			if destToken != nil && destToken.Flags&entry.LsfMPTLocked != 0 {
-				return ter.TecLOCKED
-			}
 		}
 
 		// Transfer fee: rate = 1_000_000_000 + 10_000 * TransferFee

--- a/internal/tx/payment/payment_mpt.go
+++ b/internal/tx/payment/payment_mpt.go
@@ -11,7 +11,6 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
-	"github.com/LeJamon/go-xrpl/ledger/entry"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
 
@@ -76,13 +75,8 @@ func (p *Payment) applyMPTPayment(ctx *tx.ApplyContext) ter.Result {
 	senderIsIssuer := ctx.AccountID == issuerID
 	destIsIssuer := destAccountID == issuerID
 
-	// canTransfer: holder-to-holder requires CanTransfer flag.
-	// Checked BEFORE deposit preauth, matching rippled's ordering.
-	// Reference: rippled Payment.cpp:526-529
-	if !senderIsIssuer && !destIsIssuer {
-		if issuance.Flags&entry.LsfMPTCanTransfer == 0 {
-			return ter.TecNO_AUTH
-		}
+	if result := mptutil.CanTransfer(ctx.View, mptID, ctx.AccountID, destAccountID); result != ter.TesSUCCESS {
+		return result
 	}
 
 	// Verify deposit preauth


### PR DESCRIPTION
## Summary
- route holder-to-holder direct MPT Payments through the shared reference-aware freeze helper
- return `tecLOCKED` for frozen Vault/reference-backed issuances while preserving raw lock and issuer-bypass behavior
- add an end-to-end regression covering fee-only metadata and unchanged MPT balances

## Test plan
- [x] `go test ./internal/testing/vault -run '^TestVaultSharePaymentRejectsFrozenReferenceHolding$' -count=20`
- [x] `go test -race ./internal/testing/vault -run '^TestVaultSharePaymentRejectsFrozenReferenceHolding$' -count=1`
- [x] `just test-tx`
- [x] `just test-integration`
- [x] `just test`
- [x] `just build-all`
- [x] `just vet`
- [x] `just lint`

Fixes #1721
