### PR TITLE
fix: canonicalize AMMClawback exhaustion fraction

### DIFF
--- a/internal/testing/amm/amm_clawback_test.go
+++ b/internal/testing/amm/amm_clawback_test.go
@@ -467,13 +467,14 @@ func TestAMMClawbackRejectsRoundedLPWithdrawalAboveHolderBalance(t *testing.T) {
 	}
 }
 
-func setupAMMClawbackHolderExhaustionPool(t *testing.T, fixAMMv1_3 bool) (*amm.AMMTestEnv, *jtx.Account) {
+func setupAMMClawbackHolderExhaustionPool(t *testing.T, fixAMMv1_3, largeMantissa bool) (*amm.AMMTestEnv, *jtx.Account) {
 	t.Helper()
 
 	env := amm.NewAMMTestEnv(t)
-	// Keep Number in the small-mantissa regime used by the AMMClawback fixture.
-	env.DisableFeature("SingleAssetVault")
-	env.DisableFeature("LendingProtocol")
+	if !largeMantissa {
+		env.DisableFeature("SingleAssetVault")
+		env.DisableFeature("LendingProtocol")
+	}
 	if !fixAMMv1_3 {
 		env.DisableFeature("fixAMMv1_3")
 	}
@@ -534,47 +535,55 @@ func TestAMMClawbackHolderExhaustionUsesSTAmountFraction(t *testing.T) {
 		{name: "WithFixAMMv1_3", fixAMMv1_3: true, poolXRP: 70_710_679},
 		{name: "WithoutFixAMMv1_3", fixAMMv1_3: false, poolXRP: 70_710_678},
 	}
+	mantissaScales := []struct {
+		name  string
+		large bool
+	}{
+		{name: "SmallMantissa", large: false},
+		{name: "LargeMantissa", large: true},
+	}
 	for _, path := range paths {
-		for _, ruleSet := range rules {
-			t.Run(path.name+"/"+ruleSet.name, func(t *testing.T) {
-				env, ammAccount := setupAMMClawbackHolderExhaustionPool(t, ruleSet.fixAMMv1_3)
-				jtx.RequireTxSuccess(t, env.Submit(amm.AMMDeposit(env.Alice, amm.XRP(), env.USD).
-					Amount(amm.IOUAmount(env.GW, "USD", 400)).
-					SingleAsset().
-					Build()))
-				env.Close()
+		for _, mantissaScale := range mantissaScales {
+			for _, ruleSet := range rules {
+				t.Run(path.name+"/"+mantissaScale.name+"/"+ruleSet.name, func(t *testing.T) {
+					env, ammAccount := setupAMMClawbackHolderExhaustionPool(t, ruleSet.fixAMMv1_3, mantissaScale.large)
+					jtx.RequireTxSuccess(t, env.Submit(amm.AMMDeposit(env.Alice, amm.XRP(), env.USD).
+						Amount(amm.IOUAmount(env.GW, "USD", 400)).
+						SingleAsset().
+						Build()))
+					env.Close()
 
-				ammData := env.ReadAMMData(amm.XRP(), env.USD)
-				require.NotNil(t, ammData)
-				require.Equal(t, "282842.712474619", ammData.LPTokenBalance.Value())
-				poolUSDBefore := env.IOUBalance(ammAccount, env.GW, "USD")
-				require.NotNil(t, poolUSDBefore)
-				require.Equal(t, "800", poolUSDBefore.Value())
-				holderLPTokens := env.IOUBalance(env.Alice, ammAccount, ammData.LPTokenBalance.Currency)
-				require.NotNil(t, holderLPTokens)
-				require.Equal(t, "82842.712474619", holderLPTokens.Value())
+					ammData := env.ReadAMMData(amm.XRP(), env.USD)
+					require.NotNil(t, ammData)
+					require.Equal(t, "282842.712474619", ammData.LPTokenBalance.Value())
+					poolUSDBefore := env.IOUBalance(ammAccount, env.GW, "USD")
+					require.NotNil(t, poolUSDBefore)
+					require.Equal(t, "800", poolUSDBefore.Value())
+					holderLPTokens := env.IOUBalance(env.Alice, ammAccount, ammData.LPTokenBalance.Currency)
+					require.NotNil(t, holderLPTokens)
+					require.Equal(t, "82842.712474619", holderLPTokens.Value())
 
-				result := env.Submit(path.build(env))
-				jtx.RequireTxSuccess(t, result)
+					result := env.Submit(path.build(env))
+					jtx.RequireTxSuccess(t, result)
 
-				poolUSD := env.IOUBalance(ammAccount, env.GW, "USD")
-				require.NotNil(t, poolUSD)
-				require.Equal(t, "565.685424949238", poolUSD.Value())
-				require.Equal(t, ruleSet.poolXRP, env.Balance(ammAccount))
-				ammData = env.ReadAMMData(amm.XRP(), env.USD)
-				require.NotNil(t, ammData)
-				require.Equal(t, "200000", ammData.LPTokenBalance.Value())
-				holderLPTokens = env.IOUBalance(env.Alice, ammAccount, ammData.LPTokenBalance.Currency)
-				if holderLPTokens != nil {
-					require.True(t, holderLPTokens.IsZero())
-				}
+					poolUSD := env.IOUBalance(ammAccount, env.GW, "USD")
+					require.NotNil(t, poolUSD)
+					require.Equal(t, "565.685424949238", poolUSD.Value())
+					require.Equal(t, ruleSet.poolXRP, env.Balance(ammAccount))
+					ammData = env.ReadAMMData(amm.XRP(), env.USD)
+					require.NotNil(t, ammData)
+					require.Equal(t, "200000", ammData.LPTokenBalance.Value())
+					holderLPTokens = env.IOUBalance(env.Alice, ammAccount, ammData.LPTokenBalance.Currency)
+					if holderLPTokens != nil {
+						require.True(t, holderLPTokens.IsZero())
+					}
 
-				lineData, err := env.LedgerEntry(keylet.Line(ammAccount.ID, env.GW.ID, "USD"))
-				require.NoError(t, err)
-				lineHex := strings.ToUpper(hex.EncodeToString(lineData))
-				require.Contains(t, lineHex, "62D51418E104164F9C00000000000000000000000055534400000000000000000000000000000000000000000000000001")
-				require.Equal(t, path.expectedLineHex, lineHex)
-			})
+					lineData, err := env.LedgerEntry(keylet.Line(ammAccount.ID, env.GW.ID, "USD"))
+					require.NoError(t, err)
+					lineHex := strings.ToUpper(hex.EncodeToString(lineData))
+					require.Equal(t, path.expectedLineHex, lineHex)
+				})
+			}
 		}
 	}
 }
@@ -602,7 +611,7 @@ func TestAMMClawbackHolderExhaustionRejectsZeroRoundedAsset(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			env, ammAccount := setupAMMClawbackHolderExhaustionPool(t, true)
+			env, ammAccount := setupAMMClawbackHolderExhaustionPool(t, true, true)
 			lpToken := amm.LPTokenAmount(env, amm.XRP(), env.USD, 0)
 			dust := tx.NewIssuedAmount(1, -4, lpToken.Currency, lpToken.Issuer)
 			jtx.RequireTxSuccess(t, env.Submit(amm.AMMDeposit(env.Alice, amm.XRP(), env.USD).

--- a/internal/testing/amm/amm_clawback_test.go
+++ b/internal/testing/amm/amm_clawback_test.go
@@ -527,63 +527,56 @@ func TestAMMClawbackHolderExhaustionUsesSTAmountFraction(t *testing.T) {
 			expectedLineHex: "1100722201010000250000000737000000000000000038000000000000000055457DB1AD99D27B68363B7F986A39923649BC8E27B679F94967458EF90AAF8AF362D51418E104164F9C0000000000000000000000005553440000000000000000000000000000000000000000000000000166800000000000000000000000000000000000000055534400000000008F41242483ADD4D2B69900347812D2B0E68E3D0E6780000000000000000000000000000000000000005553440000000000A407AF5856CCF3C42619DAA925813FC955C72983",
 		},
 	}
-	rules := []struct {
-		name       string
-		fixAMMv1_3 bool
-		poolXRP    uint64
+	contexts := []struct {
+		name          string
+		fixAMMv1_3    bool
+		largeMantissa bool
+		poolXRP       uint64
 	}{
-		{name: "WithFixAMMv1_3", fixAMMv1_3: true, poolXRP: 70_710_679},
-		{name: "WithoutFixAMMv1_3", fixAMMv1_3: false, poolXRP: 70_710_678},
-	}
-	mantissaScales := []struct {
-		name  string
-		large bool
-	}{
-		{name: "SmallMantissa", large: false},
-		{name: "LargeMantissa", large: true},
+		{name: "SmallMantissa/WithFixAMMv1_3", fixAMMv1_3: true, largeMantissa: false, poolXRP: 70_710_679},
+		{name: "SmallMantissa/WithoutFixAMMv1_3", fixAMMv1_3: false, largeMantissa: false, poolXRP: 70_710_678},
+		{name: "LargeMantissa/WithFixAMMv1_3", fixAMMv1_3: true, largeMantissa: true, poolXRP: 70_710_679},
 	}
 	for _, path := range paths {
-		for _, mantissaScale := range mantissaScales {
-			for _, ruleSet := range rules {
-				t.Run(path.name+"/"+mantissaScale.name+"/"+ruleSet.name, func(t *testing.T) {
-					env, ammAccount := setupAMMClawbackHolderExhaustionPool(t, ruleSet.fixAMMv1_3, mantissaScale.large)
-					jtx.RequireTxSuccess(t, env.Submit(amm.AMMDeposit(env.Alice, amm.XRP(), env.USD).
-						Amount(amm.IOUAmount(env.GW, "USD", 400)).
-						SingleAsset().
-						Build()))
-					env.Close()
+		for _, context := range contexts {
+			t.Run(path.name+"/"+context.name, func(t *testing.T) {
+				env, ammAccount := setupAMMClawbackHolderExhaustionPool(t, context.fixAMMv1_3, context.largeMantissa)
+				jtx.RequireTxSuccess(t, env.Submit(amm.AMMDeposit(env.Alice, amm.XRP(), env.USD).
+					Amount(amm.IOUAmount(env.GW, "USD", 400)).
+					SingleAsset().
+					Build()))
+				env.Close()
 
-					ammData := env.ReadAMMData(amm.XRP(), env.USD)
-					require.NotNil(t, ammData)
-					require.Equal(t, "282842.712474619", ammData.LPTokenBalance.Value())
-					poolUSDBefore := env.IOUBalance(ammAccount, env.GW, "USD")
-					require.NotNil(t, poolUSDBefore)
-					require.Equal(t, "800", poolUSDBefore.Value())
-					holderLPTokens := env.IOUBalance(env.Alice, ammAccount, ammData.LPTokenBalance.Currency)
-					require.NotNil(t, holderLPTokens)
-					require.Equal(t, "82842.712474619", holderLPTokens.Value())
+				ammData := env.ReadAMMData(amm.XRP(), env.USD)
+				require.NotNil(t, ammData)
+				require.Equal(t, "282842.712474619", ammData.LPTokenBalance.Value())
+				poolUSDBefore := env.IOUBalance(ammAccount, env.GW, "USD")
+				require.NotNil(t, poolUSDBefore)
+				require.Equal(t, "800", poolUSDBefore.Value())
+				holderLPTokens := env.IOUBalance(env.Alice, ammAccount, ammData.LPTokenBalance.Currency)
+				require.NotNil(t, holderLPTokens)
+				require.Equal(t, "82842.712474619", holderLPTokens.Value())
 
-					result := env.Submit(path.build(env))
-					jtx.RequireTxSuccess(t, result)
+				result := env.Submit(path.build(env))
+				jtx.RequireTxSuccess(t, result)
 
-					poolUSD := env.IOUBalance(ammAccount, env.GW, "USD")
-					require.NotNil(t, poolUSD)
-					require.Equal(t, "565.685424949238", poolUSD.Value())
-					require.Equal(t, ruleSet.poolXRP, env.Balance(ammAccount))
-					ammData = env.ReadAMMData(amm.XRP(), env.USD)
-					require.NotNil(t, ammData)
-					require.Equal(t, "200000", ammData.LPTokenBalance.Value())
-					holderLPTokens = env.IOUBalance(env.Alice, ammAccount, ammData.LPTokenBalance.Currency)
-					if holderLPTokens != nil {
-						require.True(t, holderLPTokens.IsZero())
-					}
+				poolUSD := env.IOUBalance(ammAccount, env.GW, "USD")
+				require.NotNil(t, poolUSD)
+				require.Equal(t, "565.685424949238", poolUSD.Value())
+				require.Equal(t, context.poolXRP, env.Balance(ammAccount))
+				ammData = env.ReadAMMData(amm.XRP(), env.USD)
+				require.NotNil(t, ammData)
+				require.Equal(t, "200000", ammData.LPTokenBalance.Value())
+				holderLPTokens = env.IOUBalance(env.Alice, ammAccount, ammData.LPTokenBalance.Currency)
+				if holderLPTokens != nil {
+					require.True(t, holderLPTokens.IsZero())
+				}
 
-					lineData, err := env.LedgerEntry(keylet.Line(ammAccount.ID, env.GW.ID, "USD"))
-					require.NoError(t, err)
-					lineHex := strings.ToUpper(hex.EncodeToString(lineData))
-					require.Equal(t, path.expectedLineHex, lineHex)
-				})
-			}
+				lineData, err := env.LedgerEntry(keylet.Line(ammAccount.ID, env.GW.ID, "USD"))
+				require.NoError(t, err)
+				lineHex := strings.ToUpper(hex.EncodeToString(lineData))
+				require.Equal(t, path.expectedLineHex, lineHex)
+			})
 		}
 	}
 }

--- a/internal/testing/amm/amm_clawback_test.go
+++ b/internal/testing/amm/amm_clawback_test.go
@@ -3,6 +3,8 @@
 package amm_test
 
 import (
+	"encoding/hex"
+	"strings"
 	"testing"
 
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
@@ -10,6 +12,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/testing/amm"
 	"github.com/LeJamon/go-xrpl/internal/testing/clawback"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/stretchr/testify/require"
 )
 
@@ -461,6 +464,183 @@ func TestAMMClawbackRejectsRoundedLPWithdrawalAboveHolderBalance(t *testing.T) {
 	holderLPAfterWithdrawAll := env.IOUBalance(env.Alice, ammAccount, lpSupplyBefore.Currency)
 	if holderLPAfterWithdrawAll != nil {
 		require.True(t, holderLPAfterWithdrawAll.IsZero())
+	}
+}
+
+func setupAMMClawbackHolderExhaustionPool(t *testing.T, fixAMMv1_3 bool) (*amm.AMMTestEnv, *jtx.Account) {
+	t.Helper()
+
+	env := amm.NewAMMTestEnv(t)
+	// Keep Number in the small-mantissa regime used by the AMMClawback fixture.
+	env.DisableFeature("SingleAssetVault")
+	env.DisableFeature("LendingProtocol")
+	if !fixAMMv1_3 {
+		env.DisableFeature("fixAMMv1_3")
+	}
+	for _, account := range []*jtx.Account{env.GW, env.Alice, env.Bob} {
+		env.FundAmount(account, uint64(jtx.XRP(1_000_000)))
+	}
+	env.Close()
+
+	jtx.RequireTxSuccess(t, env.Submit(accountset.AccountSet(env.GW).AllowClawback().Build()))
+	env.Close()
+
+	for _, holder := range []*jtx.Account{env.Alice, env.Bob} {
+		env.Trust(holder, env.GW, "USD", 1_000)
+		env.PayIOU(env.GW, holder, "USD", 400)
+	}
+	env.Close()
+
+	jtx.RequireTxSuccess(t, env.Submit(amm.AMMCreate(
+		env.Bob,
+		amm.XRPAmount(100),
+		amm.IOUAmount(env.GW, "USD", 400),
+	).Build()))
+	env.Close()
+
+	ammAccount := env.ReadAMMAccount(amm.XRP(), env.USD)
+	require.NotNil(t, ammAccount)
+	return env, ammAccount
+}
+
+func TestAMMClawbackHolderExhaustionUsesSTAmountFraction(t *testing.T) {
+	paths := []struct {
+		name            string
+		build           func(*amm.AMMTestEnv) tx.Transaction
+		expectedLineHex string
+	}{
+		{
+			name: "SpecifiedAmount",
+			build: func(env *amm.AMMTestEnv) tx.Transaction {
+				return amm.AMMClawback(env.GW, env.Alice.Address, env.USD, amm.XRP()).
+					Amount(amm.IOUAmount(env.GW, "USD", 400)).
+					Build()
+			},
+			expectedLineHex: "11007222010100002500000007370000000000000000380000000000000000559FEF63156D4C9F3BE0AC77315FCFF3A8D14D766B3C3397BA489934EC5CAF5F1A62D51418E104164F9C0000000000000000000000005553440000000000000000000000000000000000000000000000000166800000000000000000000000000000000000000055534400000000008F41242483ADD4D2B69900347812D2B0E68E3D0E6780000000000000000000000000000000000000005553440000000000A407AF5856CCF3C42619DAA925813FC955C72983",
+		},
+		{
+			name: "AllHolderTokens",
+			build: func(env *amm.AMMTestEnv) tx.Transaction {
+				return amm.AMMClawback(env.GW, env.Alice.Address, env.USD, amm.XRP()).Build()
+			},
+			expectedLineHex: "1100722201010000250000000737000000000000000038000000000000000055457DB1AD99D27B68363B7F986A39923649BC8E27B679F94967458EF90AAF8AF362D51418E104164F9C0000000000000000000000005553440000000000000000000000000000000000000000000000000166800000000000000000000000000000000000000055534400000000008F41242483ADD4D2B69900347812D2B0E68E3D0E6780000000000000000000000000000000000000005553440000000000A407AF5856CCF3C42619DAA925813FC955C72983",
+		},
+	}
+	rules := []struct {
+		name       string
+		fixAMMv1_3 bool
+		poolXRP    uint64
+	}{
+		{name: "WithFixAMMv1_3", fixAMMv1_3: true, poolXRP: 70_710_679},
+		{name: "WithoutFixAMMv1_3", fixAMMv1_3: false, poolXRP: 70_710_678},
+	}
+	for _, path := range paths {
+		for _, ruleSet := range rules {
+			t.Run(path.name+"/"+ruleSet.name, func(t *testing.T) {
+				env, ammAccount := setupAMMClawbackHolderExhaustionPool(t, ruleSet.fixAMMv1_3)
+				jtx.RequireTxSuccess(t, env.Submit(amm.AMMDeposit(env.Alice, amm.XRP(), env.USD).
+					Amount(amm.IOUAmount(env.GW, "USD", 400)).
+					SingleAsset().
+					Build()))
+				env.Close()
+
+				ammData := env.ReadAMMData(amm.XRP(), env.USD)
+				require.NotNil(t, ammData)
+				require.Equal(t, "282842.712474619", ammData.LPTokenBalance.Value())
+				poolUSDBefore := env.IOUBalance(ammAccount, env.GW, "USD")
+				require.NotNil(t, poolUSDBefore)
+				require.Equal(t, "800", poolUSDBefore.Value())
+				holderLPTokens := env.IOUBalance(env.Alice, ammAccount, ammData.LPTokenBalance.Currency)
+				require.NotNil(t, holderLPTokens)
+				require.Equal(t, "82842.712474619", holderLPTokens.Value())
+
+				result := env.Submit(path.build(env))
+				jtx.RequireTxSuccess(t, result)
+
+				poolUSD := env.IOUBalance(ammAccount, env.GW, "USD")
+				require.NotNil(t, poolUSD)
+				require.Equal(t, "565.685424949238", poolUSD.Value())
+				require.Equal(t, ruleSet.poolXRP, env.Balance(ammAccount))
+				ammData = env.ReadAMMData(amm.XRP(), env.USD)
+				require.NotNil(t, ammData)
+				require.Equal(t, "200000", ammData.LPTokenBalance.Value())
+				holderLPTokens = env.IOUBalance(env.Alice, ammAccount, ammData.LPTokenBalance.Currency)
+				if holderLPTokens != nil {
+					require.True(t, holderLPTokens.IsZero())
+				}
+
+				lineData, err := env.LedgerEntry(keylet.Line(ammAccount.ID, env.GW.ID, "USD"))
+				require.NoError(t, err)
+				lineHex := strings.ToUpper(hex.EncodeToString(lineData))
+				require.Contains(t, lineHex, "62D51418E104164F9C00000000000000000000000055534400000000000000000000000000000000000000000000000001")
+				require.Equal(t, path.expectedLineHex, lineHex)
+			})
+		}
+	}
+}
+
+func TestAMMClawbackHolderExhaustionRejectsZeroRoundedAsset(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(*amm.AMMTestEnv) tx.Transaction
+	}{
+		{
+			name: "SpecifiedAmount",
+			build: func(env *amm.AMMTestEnv) tx.Transaction {
+				return amm.AMMClawback(env.GW, env.Alice.Address, env.USD, amm.XRP()).
+					Amount(amm.IOUAmount(env.GW, "USD", 400)).
+					Build()
+			},
+		},
+		{
+			name: "AllHolderTokens",
+			build: func(env *amm.AMMTestEnv) tx.Transaction {
+				return amm.AMMClawback(env.GW, env.Alice.Address, env.USD, amm.XRP()).Build()
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			env, ammAccount := setupAMMClawbackHolderExhaustionPool(t, true)
+			lpToken := amm.LPTokenAmount(env, amm.XRP(), env.USD, 0)
+			dust := tx.NewIssuedAmount(1, -4, lpToken.Currency, lpToken.Issuer)
+			jtx.RequireTxSuccess(t, env.Submit(amm.AMMDeposit(env.Alice, amm.XRP(), env.USD).
+				LPTokenOut(dust).
+				LPToken().
+				Build()))
+			env.Close()
+
+			poolUSDBefore := env.IOUBalance(ammAccount, env.GW, "USD")
+			require.NotNil(t, poolUSDBefore)
+			poolXRPBefore := env.Balance(ammAccount)
+			ammDataBefore := env.ReadAMMData(amm.XRP(), env.USD)
+			require.NotNil(t, ammDataBefore)
+			holderLPBefore := env.IOUBalance(env.Alice, ammAccount, lpToken.Currency)
+			require.NotNil(t, holderLPBefore)
+			require.Equal(t, "0.0001", holderLPBefore.Value())
+			issuerBalanceBefore := env.Balance(env.GW)
+			issuerSequenceBefore := env.Seq(env.GW)
+
+			result := env.Submit(test.build(env))
+			jtx.RequireTxClaimed(t, result, amm.TecAMM_FAILED)
+			require.Equal(t, env.BaseFee(), result.Fee)
+			require.NotNil(t, result.Metadata)
+			require.Len(t, result.Metadata.AffectedNodes, 1)
+			require.Equal(t, issuerBalanceBefore-env.BaseFee(), env.Balance(env.GW))
+			require.Equal(t, issuerSequenceBefore+1, env.Seq(env.GW))
+
+			poolUSDAfter := env.IOUBalance(ammAccount, env.GW, "USD")
+			require.NotNil(t, poolUSDAfter)
+			require.Zero(t, poolUSDBefore.Compare(*poolUSDAfter))
+			require.Equal(t, poolXRPBefore, env.Balance(ammAccount))
+			ammDataAfter := env.ReadAMMData(amm.XRP(), env.USD)
+			require.NotNil(t, ammDataAfter)
+			require.Zero(t, ammDataBefore.LPTokenBalance.Compare(ammDataAfter.LPTokenBalance))
+			holderLPAfter := env.IOUBalance(env.Alice, ammAccount, lpToken.Currency)
+			require.NotNil(t, holderLPAfter)
+			require.Zero(t, holderLPBefore.Compare(*holderLPAfter))
+		})
 	}
 }
 

--- a/internal/tx/amm/amm_clawback.go
+++ b/internal/tx/amm/amm_clawback.go
@@ -264,9 +264,12 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 			withdrawAmount2 = assetBalance2
 		} else {
 			// Proportional withdrawal
-			frac := math.div(math.fromAmount(holdLPTokens), math.fromAmount(lptAMMBalance), state.RoundToNearest)
+			frac := math.stAmountDiv(holdLPTokens, lptAMMBalance)
 			withdrawAmount1 = getRoundedAsset(math, fixV1_3, assetBalance1, frac, false)
 			withdrawAmount2 = getRoundedAsset(math, fixV1_3, assetBalance2, frac, false)
+			if withdrawAmount1.IsZero() || withdrawAmount2.IsZero() {
+				return ter.TecAMM_FAILED
+			}
 		}
 	} else {
 		// Amount specified - calculate proportional withdrawal.
@@ -288,9 +291,12 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 				withdrawAmount1 = assetBalance1
 				withdrawAmount2 = assetBalance2
 			} else {
-				fallbackFrac := math.div(math.fromAmount(holdLPTokens), math.fromAmount(lptAMMBalance), state.RoundToNearest)
+				fallbackFrac := math.stAmountDiv(holdLPTokens, lptAMMBalance)
 				withdrawAmount1 = getRoundedAsset(math, fixV1_3, assetBalance1, fallbackFrac, false)
 				withdrawAmount2 = getRoundedAsset(math, fixV1_3, assetBalance2, fallbackFrac, false)
+				if withdrawAmount1.IsZero() || withdrawAmount2.IsZero() {
+					return ter.TecAMM_FAILED
+				}
 			}
 		} else {
 			// fixAMMClawbackRounding: use rounded tokens and adjusted fractions


### PR DESCRIPTION
## Why

AMMClawback's holder-exhaustion fallback divided LP tokens as `Number` values. Rippled performs this proportional division as `STAmount`, so the fallback could leave an IOU pool balance one mantissa unit away from the canonical ledger result.

## What changed

- use the existing STAmount division helper in both holder-exhaustion paths
- reject proportional exhaustion with `tecAMM_FAILED` when either pool asset rounds to zero
- cover specified-Amount and no-Amount exhaustion before and after `fixAMMv1_3`
- pin final pool balances, LP-token state, rollback effects, and serialized trust-line bytes

## Verification

- focused regression tests, 20 iterations, and race detector
- `just test`
- `just test-tx`
- `just test-integration`
- `just build-all`
- `just vet`
- `just lint`
- two independent Go-quality and rippled v3.3.0 conformance reviews

Fixes #1725
