### PR TITLE
Fix delegated multisign replay index drift

### DIFF
--- a/internal/ledger/service/simulate_amm_test.go
+++ b/internal/ledger/service/simulate_amm_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	coreamm "github.com/LeJamon/go-xrpl/internal/tx/amm"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -135,6 +136,9 @@ func TestService_SimulateTransaction_AMMCreateUsesParentHash(t *testing.T) {
 	if !result.Result.IsSuccess() {
 		t.Fatalf("AMMCreate simulate result = %v (%s), want a tes success", result.Result, result.Message)
 	}
+	if result.Applied {
+		t.Fatal("AMMCreate simulate reported applied=true")
+	}
 	if result.Metadata == nil {
 		t.Fatal("simulate returned nil metadata")
 	}
@@ -164,5 +168,43 @@ func TestService_SimulateTransaction_AMMCreateUsesParentHash(t *testing.T) {
 	}
 	if hasZero {
 		t.Errorf("simulated AMMCreate created the AMM pseudo-account at the zero-parent-hash address %s — ParentHash not threaded into the simulate EngineConfig", zeroIdx)
+	}
+}
+
+func TestService_SimulateTransaction_DoesNotAssumeMasterSignature(t *testing.T) {
+	cfg := defaultServiceConfig()
+	cfg.Startup = service.StartupConfig{Mode: service.StartupFresh}
+	svc, err := service.New(cfg)
+	if err != nil {
+		t.Fatalf("service.New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("service.Start: %v", err)
+	}
+	defer svc.Stop()
+
+	env := jtx.NewTestEnv(t)
+	master := jtx.MasterAccount()
+	alice := jtx.NewAccount("alice-simulate-master")
+	masterSeq := accountSeq(t, svc, master.Address)
+	mustApply(t, svc, signedBlob(t, env,
+		payment.Pay(master, alice, 100_000_000).Sequence(masterSeq).Build(), master))
+	closeLedger(t, svc)
+
+	sequence := accountSeq(t, svc, alice.Address)
+	transaction := accountset.AccountSet(alice).
+		NoFreeze().
+		Fee(env.BaseFee()).
+		Sequence(sequence).
+		Build()
+	result, err := svc.SimulateTransaction(transaction)
+	if err != nil {
+		t.Fatalf("SimulateTransaction: %v", err)
+	}
+	if result.Result != ter.TecNEED_MASTER_KEY || result.Applied {
+		t.Fatalf("simulate result = %v, applied = %v; want tecNEED_MASTER_KEY, false", result.Result, result.Applied)
+	}
+	if result.Metadata == nil {
+		t.Fatal("simulate returned nil metadata")
 	}
 }

--- a/internal/ledger/service/simulate_delegate_test.go
+++ b/internal/ledger/service/simulate_delegate_test.go
@@ -20,6 +20,7 @@ func TestService_SimulateDelegatedMultiSignDryRun(t *testing.T) {
 	cfg.GenesisConfig.Amendments = append(
 		cfg.GenesisConfig.Amendments,
 		amendment.FeaturePermissionDelegationV1_1,
+		amendment.FeatureSponsor,
 	)
 	svc, err := service.New(cfg)
 	if err != nil {

--- a/internal/ledger/service/simulate_delegate_test.go
+++ b/internal/ledger/service/simulate_delegate_test.go
@@ -123,4 +123,34 @@ func TestService_SimulateDelegatedMultiSignDryRun(t *testing.T) {
 			t.Fatalf("simulate result = %v, applied = %v; want tefBAD_QUORUM, false", result.Result, result.Applied)
 		}
 	})
+
+	t.Run("empty sponsor signer array reaches quorum check", func(t *testing.T) {
+		simulated := newSimulated()
+		common := simulated.GetCommon()
+		common.Signers = []tx.SignerWrapper{{Signer: tx.Signer{Account: otherSigner.Address}}}
+		common.Sponsor = delegate.Address
+		sponsorFlags := tx.SpfSponsorFee
+		common.SponsorFlags = &sponsorFlags
+		fields, err := simulated.Flatten()
+		if err != nil {
+			t.Fatalf("Flatten: %v", err)
+		}
+		fields["SponsorSignature"] = map[string]any{"Signers": []any{}}
+		encoded, err := json.Marshal(fields)
+		if err != nil {
+			t.Fatalf("json.Marshal: %v", err)
+		}
+		parsed, err := tx.ParseJSON(encoded)
+		if err != nil {
+			t.Fatalf("ParseJSON: %v", err)
+		}
+
+		result, err := svc.SimulateTransaction(parsed)
+		if err != nil {
+			t.Fatalf("SimulateTransaction: %v", err)
+		}
+		if result.Result != ter.TefBAD_QUORUM || result.Applied {
+			t.Fatalf("simulate result = %v, applied = %v; want tefBAD_QUORUM, false", result.Result, result.Applied)
+		}
+	})
 }

--- a/internal/ledger/service/simulate_delegate_test.go
+++ b/internal/ledger/service/simulate_delegate_test.go
@@ -1,0 +1,126 @@
+package service_test
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	delegatetx "github.com/LeJamon/go-xrpl/internal/tx/delegate"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+func TestService_SimulateDelegatedMultiSignDryRun(t *testing.T) {
+	cfg := defaultServiceConfig()
+	cfg.Startup = service.StartupConfig{Mode: service.StartupFresh}
+	cfg.GenesisConfig.Amendments = append(
+		cfg.GenesisConfig.Amendments,
+		amendment.FeaturePermissionDelegationV1_1,
+	)
+	svc, err := service.New(cfg)
+	if err != nil {
+		t.Fatalf("service.New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("service.Start: %v", err)
+	}
+	defer svc.Stop()
+
+	env := jtx.NewTestEnv(t)
+	master := jtx.MasterAccount()
+	owner := jtx.NewAccount("owner")
+	delegate := jtx.NewAccount("delegate")
+	destination := jtx.NewAccount("destination")
+	otherSigner := jtx.NewAccount("other-signer")
+
+	masterSeq := accountSeq(t, svc, master.Address)
+	for i, account := range []*jtx.Account{owner, delegate, destination, otherSigner} {
+		fund := payment.Pay(master, account, 100_000_000).Sequence(masterSeq + uint32(i)).Build()
+		mustApply(t, svc, signedBlob(t, env, fund, master))
+	}
+	closeLedger(t, svc)
+
+	ownerSeq := accountSeq(t, svc, owner.Address)
+	delegateSet := delegatetx.NewDelegateSet(owner.Address)
+	delegateSet.Authorize = delegate.Address
+	delegateSet.Permissions = append(delegateSet.Permissions, delegatetx.NewPermission("Payment"))
+	delegateSet.Fee = strconv.FormatUint(env.BaseFee(), 10)
+	delegateSet.Sequence = &ownerSeq
+	mustApply(t, svc, signedBlob(t, env, delegateSet, owner))
+
+	delegateSeq := accountSeq(t, svc, delegate.Address)
+	signerList := jtx.NewSignerListSetTx(delegate, 1, []jtx.TestSigner{{Account: otherSigner, Weight: 1}})
+	signerList.GetCommon().Fee = strconv.FormatUint(env.BaseFee(), 10)
+	signerList.GetCommon().Sequence = &delegateSeq
+	mustApply(t, svc, signedBlob(t, env, signerList, delegate))
+	closeLedger(t, svc)
+
+	newSimulated := func() tx.Transaction {
+		txn := payment.Pay(owner, destination, 1_000).Build()
+		common := txn.GetCommon()
+		common.Delegate = delegate.Address
+		common.Fee = strconv.FormatUint(2*env.BaseFee(), 10)
+		sequence := accountSeq(t, svc, owner.Address)
+		common.Sequence = &sequence
+		return txn
+	}
+
+	t.Run("delegate self-signer reaches authorization", func(t *testing.T) {
+		simulated := newSimulated()
+		simulated.GetCommon().Signers = []tx.SignerWrapper{{Signer: tx.Signer{Account: delegate.Address}}}
+
+		result, err := svc.SimulateTransaction(simulated)
+		if err != nil {
+			t.Fatalf("SimulateTransaction: %v", err)
+		}
+		if result.Result != ter.TefBAD_SIGNATURE || result.Applied {
+			t.Fatalf("simulate result = %v, applied = %v; want tefBAD_SIGNATURE, false", result.Result, result.Applied)
+		}
+	})
+
+	t.Run("single and multi-signing is invalid", func(t *testing.T) {
+		simulated := newSimulated()
+		common := simulated.GetCommon()
+		common.SigningPubKey = owner.PublicKeyHex()
+		common.Signers = []tx.SignerWrapper{{Signer: tx.Signer{Account: otherSigner.Address}}}
+
+		result, err := svc.SimulateTransaction(simulated)
+		if err != nil {
+			t.Fatalf("SimulateTransaction: %v", err)
+		}
+		if result.Result != ter.TemINVALID || result.Applied {
+			t.Fatalf("simulate result = %v, applied = %v; want temINVALID, false", result.Result, result.Applied)
+		}
+	})
+
+	t.Run("empty signer array reaches quorum check", func(t *testing.T) {
+		simulated := newSimulated()
+		fields, err := simulated.Flatten()
+		if err != nil {
+			t.Fatalf("Flatten: %v", err)
+		}
+		fields["Signers"] = []any{}
+		fields["SigningPubKey"] = ""
+		fields["TxnSignature"] = ""
+		encoded, err := json.Marshal(fields)
+		if err != nil {
+			t.Fatalf("json.Marshal: %v", err)
+		}
+		parsed, err := tx.ParseJSON(encoded)
+		if err != nil {
+			t.Fatalf("ParseJSON: %v", err)
+		}
+
+		result, err := svc.SimulateTransaction(parsed)
+		if err != nil {
+			t.Fatalf("SimulateTransaction: %v", err)
+		}
+		if result.Result != ter.TefBAD_QUORUM || result.Applied {
+			t.Fatalf("simulate result = %v, applied = %v; want tefBAD_QUORUM, false", result.Result, result.Applied)
+		}
+	})
+}

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -875,17 +875,17 @@ func (s *Service) SimulateTransaction(transaction tx.Transaction) (*SubmitResult
 
 	// Create engine config from current state
 	engineConfig := tx.EngineConfig{
-		BaseFee:                   simBaseFee,
-		ReserveBase:               simReserveBase,
-		ReserveIncrement:          simReserveIncrement,
-		LedgerSequence:            s.openLedger.Sequence(),
-		ParentHash:                s.openLedger.ParentHash(),
-		SkipSignatureVerification: true, // Skip signatures for simulation
-		OpenLedger:                true, // Check fee adequacy for simulation
-		NetworkID:                 s.config.NetworkID,
-		Logger:                    s.config.Logger,
-		Rules:                     rulesFromLedger(s.closedLedger, s.logger),
-		FeeTrack:                  s.feeTrack,
+		BaseFee:          simBaseFee,
+		ReserveBase:      simReserveBase,
+		ReserveIncrement: simReserveIncrement,
+		LedgerSequence:   s.openLedger.Sequence(),
+		ParentHash:       s.openLedger.ParentHash(),
+		OpenLedger:       true, // Check fee adequacy for simulation
+		ApplyFlags:       tx.TapDRY_RUN,
+		NetworkID:        s.config.NetworkID,
+		Logger:           s.config.Logger,
+		Rules:            rulesFromLedger(s.closedLedger, s.logger),
+		FeeTrack:         s.feeTrack,
 	}
 
 	// Create engine with the snapshot view

--- a/internal/replaytool/replay_execute.go
+++ b/internal/replaytool/replay_execute.go
@@ -149,17 +149,29 @@ func executeBlock(ctx context.Context, input blockExecution) (*executedBlock, er
 			return nil, fmt.Errorf("tx %d processor hash %x does not match validated hash %x", transaction.Index, blockTxResult.Hash, transaction.Hash)
 		}
 		applyResult := blockTxResult.ApplyResult
+		if !applyResult.Applied {
+			return nil, fmt.Errorf("tx %d was not applied: %s", transaction.Index, applyResult.Result)
+		}
+		if applyResult.Metadata == nil {
+			return nil, fmt.Errorf("tx %d execution returned nil metadata", transaction.Index)
+		}
+		if applyResult.Metadata.TransactionIndex != uint32(transaction.Index) {
+			return nil, fmt.Errorf(
+				"tx %d TransactionIndex mismatch: execution produced %d, captured ledger has %d",
+				transaction.Index,
+				applyResult.Metadata.TransactionIndex,
+				transaction.Index,
+			)
+		}
 		txInfo.Result = applyResult.Result.String()
 		txInfo.ResultCode = int(applyResult.Result)
 		txInfo.Applied = applyResult.Applied
 		txInfo.Fee = applyResult.Fee
-		if applyResult.Applied {
-			_, metadata, err := tx.SplitTxWithMetaBlobStrict(blockTxResult.TxWithMetaBlob)
-			if err != nil {
-				return nil, fmt.Errorf("tx %d extracting applied metadata: %w", transaction.Index, err)
-			}
-			txInfo.MetaBlob = metadata
+		_, metadata, err := tx.SplitTxWithMetaBlobStrict(blockTxResult.TxWithMetaBlob)
+		if err != nil {
+			return nil, fmt.Errorf("tx %d extracting applied metadata: %w", transaction.Index, err)
 		}
+		txInfo.MetaBlob = metadata
 		result.TxResults = append(result.TxResults, txInfo)
 		expectedBatchInners = append(expectedBatchInners, applyResult.AppliedInnerTransactions...)
 	}
@@ -199,11 +211,31 @@ func executeBlock(ctx context.Context, input blockExecution) (*executedBlock, er
 }
 
 func fillExpectedBatchInner(info *txApplyInfo, input blockTransaction, expected tx.AppliedInnerTransaction) error {
-	expectedHash, hashErr := tx.ComputeTransactionHash(expected.Transaction)
-	if hashErr != nil || expectedHash != input.Hash || expected.Metadata == nil ||
-		expected.Metadata.TransactionIndex != uint32(input.Index) ||
-		expected.Metadata.ParentBatchID == nil {
-		return fmt.Errorf("tx %d batch inner does not match outer execution", input.Index)
+	expectedHash, err := tx.ComputeTransactionHash(expected.Transaction)
+	if err != nil {
+		return fmt.Errorf("tx %d computing batch inner hash from outer execution: %w", input.Index, err)
+	}
+	if expectedHash != input.Hash {
+		return fmt.Errorf(
+			"tx %d batch inner hash mismatch: outer execution produced %X, captured ledger has %X",
+			input.Index,
+			expectedHash,
+			input.Hash,
+		)
+	}
+	if expected.Metadata == nil {
+		return fmt.Errorf("tx %d batch inner outer execution returned nil metadata", input.Index)
+	}
+	if expected.Metadata.TransactionIndex != uint32(input.Index) {
+		return fmt.Errorf(
+			"tx %d batch inner TransactionIndex mismatch: outer execution produced %d, captured ledger has %d",
+			input.Index,
+			expected.Metadata.TransactionIndex,
+			input.Index,
+		)
+	}
+	if expected.Metadata.ParentBatchID == nil {
+		return fmt.Errorf("tx %d batch inner metadata from outer execution is missing ParentBatchID", input.Index)
 	}
 	metadata, err := tx.SerializeMetadata(expected.Metadata)
 	if err != nil {

--- a/internal/replaytool/replay_execute_test.go
+++ b/internal/replaytool/replay_execute_test.go
@@ -3,6 +3,8 @@ package replaytool
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -45,20 +47,113 @@ func TestFillExpectedBatchInnerValidatesCanonicalLeaf(t *testing.T) {
 		t.Fatalf("inner result not synthesized from outer execution: %+v", info)
 	}
 
-	badHash := input
-	badHash.Hash[0] ^= 0xff
-	if err := fillExpectedBatchInner(&txApplyInfo{}, badHash, expected); err == nil {
-		t.Fatal("hash mismatch accepted")
+	t.Run("hash computation", func(t *testing.T) {
+		malformed := tx.NewBaseTx(tx.TypeClawback, inner.Account)
+		malformed.SetRawBytes([]byte{0})
+		badExpected := expected
+		badExpected.Transaction = malformed
+		err := fillExpectedBatchInner(&txApplyInfo{}, input, badExpected)
+		if err == nil || !strings.Contains(err.Error(), "tx 3 computing batch inner hash from outer execution:") {
+			t.Fatalf("hash computation error = %v", err)
+		}
+	})
+
+	t.Run("hash mismatch", func(t *testing.T) {
+		badInput := input
+		badInput.Hash[0] ^= 0xff
+		want := fmt.Sprintf(
+			"tx 3 batch inner hash mismatch: outer execution produced %X, captured ledger has %X",
+			hash,
+			badInput.Hash,
+		)
+		if err := fillExpectedBatchInner(&txApplyInfo{}, badInput, expected); err == nil || err.Error() != want {
+			t.Fatalf("hash mismatch error = %v, want %q", err, want)
+		}
+	})
+
+	t.Run("nil metadata", func(t *testing.T) {
+		badExpected := expected
+		badExpected.Metadata = nil
+		want := "tx 3 batch inner outer execution returned nil metadata"
+		if err := fillExpectedBatchInner(&txApplyInfo{}, input, badExpected); err == nil || err.Error() != want {
+			t.Fatalf("nil metadata error = %v, want %q", err, want)
+		}
+	})
+
+	t.Run("index mismatch", func(t *testing.T) {
+		badInput := input
+		badInput.Index++
+		want := "tx 4 batch inner TransactionIndex mismatch: outer execution produced 3, captured ledger has 4"
+		if err := fillExpectedBatchInner(&txApplyInfo{}, badInput, expected); err == nil || err.Error() != want {
+			t.Fatalf("index mismatch error = %v, want %q", err, want)
+		}
+	})
+
+	t.Run("missing parent", func(t *testing.T) {
+		badExpected := expected
+		metadata := *expected.Metadata
+		metadata.ParentBatchID = nil
+		badExpected.Metadata = &metadata
+		want := "tx 3 batch inner metadata from outer execution is missing ParentBatchID"
+		if err := fillExpectedBatchInner(&txApplyInfo{}, input, badExpected); err == nil || err.Error() != want {
+			t.Fatalf("missing parent error = %v, want %q", err, want)
+		}
+	})
+}
+
+func TestExecuteBlockRejectsCanonicalTransactionDivergence(t *testing.T) {
+	seed, err := genesis.Create(genesis.DefaultConfig())
+	if err != nil {
+		t.Fatal(err)
 	}
-	badIndex := input
-	badIndex.Index++
-	if err := fillExpectedBatchInner(&txApplyInfo{}, badIndex, expected); err == nil {
-		t.Fatal("index mismatch accepted")
+	makeInput := func(t *testing.T, sequence uint32, index int) blockTransaction {
+		t.Helper()
+		transaction := account.NewAccountSet(seed.GenesisAddress)
+		transaction.Fee = "10"
+		transaction.SetSequence(sequence)
+		blob, err := tx.SerializeTransaction(transaction)
+		if err != nil {
+			t.Fatal(err)
+		}
+		hash, err := tx.ComputeTransactionHash(transaction)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return blockTransaction{Index: index, Hash: hash, Blob: blob, Transaction: transaction}
 	}
-	expected.Metadata.ParentBatchID = nil
-	if err := fillExpectedBatchInner(&txApplyInfo{}, input, expected); err == nil {
-		t.Fatal("missing ParentBatchID accepted")
+	execute := func(transaction blockTransaction) error {
+		stateMap, err := seed.StateMap.SnapshotMutable()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = executeBlock(context.Background(), blockExecution{
+			StateMap:            stateMap,
+			LedgerIndex:         2,
+			ParentCloseTime:     time.Unix(10, 0),
+			CloseTime:           time.Unix(20, 0),
+			CloseTimeResolution: 10,
+			TotalCoins:          seed.Header.Drops,
+			Fees:                drops.DefaultFees(),
+			Rules:               amendment.AllSupportedRules(),
+			Transactions:        []blockTransaction{transaction},
+		})
+		return err
 	}
+
+	t.Run("not applied", func(t *testing.T) {
+		err := execute(makeInput(t, 2, 0))
+		if err == nil || err.Error() != "tx 0 was not applied: terPRE_SEQ" {
+			t.Fatalf("non-applied error = %v", err)
+		}
+	})
+
+	t.Run("metadata index", func(t *testing.T) {
+		err := execute(makeInput(t, 1, 1))
+		want := "tx 1 TransactionIndex mismatch: execution produced 0, captured ledger has 1"
+		if err == nil || err.Error() != want {
+			t.Fatalf("metadata index error = %v, want %q", err, want)
+		}
+	})
 }
 
 func TestExecuteBlockSkipsRecordedBatchInnerLeaves(t *testing.T) {

--- a/internal/testing/batch/open_ledger_test.go
+++ b/internal/testing/batch/open_ledger_test.go
@@ -11,6 +11,7 @@ import (
 	batchtx "github.com/LeJamon/go-xrpl/internal/tx/batch"
 	"github.com/LeJamon/go-xrpl/internal/tx/check"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	sponsortx "github.com/LeJamon/go-xrpl/internal/tx/sponsor"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/internal/txq"
 	"github.com/stretchr/testify/require"
@@ -404,6 +405,90 @@ func TestClosedLedgerIndexesBatchInnerTransactions(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, innerHash, storedHash)
 	}
+}
+
+func TestClosedLedgerIndexesSponsoredBatchAfterDelegatedMultiSign(t *testing.T) {
+	env := newBatchEnv(t)
+	alice := jtx.NewAccount("alice")
+	delegate := jtx.NewAccount("delegate")
+	destination := jtx.NewAccount("destination")
+	otherSigner := jtx.NewAccount("other-signer")
+	sponsor := jtx.NewAccount("sponsor")
+	env.Fund(alice, delegate, destination, otherSigner, sponsor)
+	env.Close()
+
+	env.SetDelegate(alice, delegate, []string{"Payment"})
+	env.SetSignerList(delegate, 2, []jtx.TestSigner{
+		{Account: alice, Weight: 1},
+		{Account: otherSigner, Weight: 1},
+	})
+	sponsorship := sponsortx.NewSponsorshipSet(sponsor.Address)
+	sponsorship.Sponsee = alice.Address
+	feeBudget := tx.NewXRPAmount(1_000)
+	sponsorship.FeeAmountDelta = &feeBudget
+	jtx.RequireTxSuccess(t, env.Submit(sponsorship))
+	env.Close()
+
+	transactions := make([]tx.Transaction, 0, 8)
+	delegated := payment.NewPayment(alice.Address, destination.Address, tx.NewXRPAmount(1))
+	delegated.Delegate = delegate.Address
+	jtx.RequireTxSuccess(t, env.SubmitMultiSigned(delegated, []*jtx.Account{alice, otherSigner}))
+	transactions = append(transactions, delegated)
+	for range 4 {
+		noop := accounttx.NewAccountSet(alice.Address)
+		jtx.RequireTxSuccess(t, env.Submit(noop))
+		transactions = append(transactions, noop)
+	}
+
+	aliceSeq := env.Seq(alice)
+	batch := NewBatchBuilder(alice, aliceSeq, CalcBatchFeeFromEnv(env, 0, 2), batchtx.BatchFlagAllOrNothing).
+		AddInnerTx(MakeInnerPaymentXRP(alice, destination, 1, aliceSeq+1)).
+		AddInnerTx(MakeInnerPaymentXRP(alice, destination, 2, aliceSeq+2)).
+		MustBuild()
+	batch.Sponsor = sponsor.Address
+	sponsorFlags := tx.SpfSponsorFee
+	batch.SponsorFlags = &sponsorFlags
+	jtx.RequireTxSuccess(t, env.Submit(batch))
+	transactions = append(transactions, batch)
+	for i := range batch.RawTransactions {
+		transactions = append(transactions, batch.RawTransactions[i].RawTransaction.InnerTx)
+	}
+
+	hashes := make([][32]byte, len(transactions))
+	for i, transaction := range transactions {
+		var err error
+		hashes[i], err = tx.ComputeTransactionHash(transaction)
+		require.NoError(t, err)
+	}
+	outerHash := hashes[5]
+
+	env.Close()
+	closed := env.LastClosedLedger()
+	require.Equal(t, uint32(8), closed.TxCount())
+	for index, hash := range hashes {
+		raw, found, err := closed.GetTransaction(hash)
+		require.NoError(t, err)
+		require.True(t, found, "transaction %d is missing from the closed ledger", index)
+		accepted := ledgerservice.ParseAcceptedTransaction(raw)
+		require.NoError(t, accepted.ParseError())
+		require.Equal(t, ter.TesSUCCESS, accepted.Result())
+		storedIndex, ok := accepted.TransactionIndex()
+		require.True(t, ok)
+		require.Equal(t, uint32(index), storedIndex)
+		parsed, err := tx.ParseFromBinary(accepted.TransactionBlob())
+		require.NoError(t, err)
+		storedHash, err := tx.ComputeTransactionHash(parsed)
+		require.NoError(t, err)
+		require.Equal(t, hash, storedHash)
+		if index >= 6 {
+			require.Equal(t, fmt.Sprintf("%X", outerHash[:]), accepted.Metadata()["ParentBatchID"])
+		}
+	}
+
+	txRoot, err := closed.TxMapHash()
+	require.NoError(t, err)
+	require.Equal(t, closed.Header().TxHash, txRoot)
+	require.Equal(t, "BD76A302261EC77B227F1DC8FCAE86C9CA58D8FD6A8E1397872744551ACA17B1", fmt.Sprintf("%X", txRoot[:]))
 }
 
 // makeSmallQueueConfig creates a TxQ config matching rippled's Batch_test

--- a/internal/testing/delegate/delegate_test.go
+++ b/internal/testing/delegate/delegate_test.go
@@ -39,6 +39,63 @@ func payDelegated(env *jtx.TestEnv, owner, delegate, dest *jtx.Account, amount t
 	return env.SubmitSignedWith(p, delegate)
 }
 
+func TestDelegate_MultiSignUsesDelegateAsInitiator(t *testing.T) {
+	newEnv := func(t *testing.T) (*jtx.TestEnv, *jtx.Account, *jtx.Account, *jtx.Account, *jtx.Account) {
+		t.Helper()
+		env := jtx.NewTestEnv(t)
+		owner := jtx.NewAccount("owner")
+		delegate := jtx.NewAccount("delegate")
+		destination := jtx.NewAccount("destination")
+		otherSigner := jtx.NewAccount("other-signer")
+		env.Fund(owner, delegate, destination, otherSigner)
+		env.Close()
+		return env, owner, delegate, destination, otherSigner
+	}
+
+	t.Run("delegator may sign for delegate", func(t *testing.T) {
+		env, owner, delegate, destination, otherSigner := newEnv(t)
+		env.SetDelegate(owner, delegate, []string{"Payment"})
+		env.SetSignerList(delegate, 2, []jtx.TestSigner{
+			{Account: owner, Weight: 1},
+			{Account: otherSigner, Weight: 1},
+		})
+		env.Close()
+
+		payment := paymenttx.NewPayment(owner.Address, destination.Address, tx.NewXRPAmount(1_000))
+		payment.Delegate = delegate.Address
+		result := env.SubmitMultiSigned(payment, []*jtx.Account{owner, otherSigner})
+		jtx.RequireTxSuccess(t, result)
+	})
+
+	t.Run("delegate may not sign for itself", func(t *testing.T) {
+		env, owner, delegate, destination, otherSigner := newEnv(t)
+		env.SetDelegate(owner, delegate, []string{"Payment"})
+		env.SetSignerList(delegate, 2, []jtx.TestSigner{
+			{Account: owner, Weight: 1},
+			{Account: otherSigner, Weight: 1},
+		})
+		env.Close()
+
+		payment := paymenttx.NewPayment(owner.Address, destination.Address, tx.NewXRPAmount(1_000))
+		payment.Delegate = delegate.Address
+		result := env.SubmitMultiSigned(payment, []*jtx.Account{owner, delegate})
+		jtx.RequireTxFail(t, result, "temINVALID")
+	})
+
+	t.Run("ordinary account may not sign for itself", func(t *testing.T) {
+		env, owner, delegate, destination, otherSigner := newEnv(t)
+		env.SetSignerList(owner, 2, []jtx.TestSigner{
+			{Account: delegate, Weight: 1},
+			{Account: otherSigner, Weight: 1},
+		})
+		env.Close()
+
+		payment := paymenttx.NewPayment(owner.Address, destination.Address, tx.NewXRPAmount(1_000))
+		result := env.SubmitMultiSigned(payment, []*jtx.Account{owner, otherSigner})
+		jtx.RequireTxFail(t, result, "temINVALID")
+	})
+}
+
 // TestDelegate_FeatureDisabled confirms a DelegateSet is rejected with
 // temDISABLED until PermissionDelegationV1_1 is enabled.
 // Reference: rippled Delegate_test.cpp testFeatureDisabled.

--- a/internal/tx/applystate/apply_atomicity_test.go
+++ b/internal/tx/applystate/apply_atomicity_test.go
@@ -124,6 +124,35 @@ func applyTestAccountRootFields() map[string]any {
 	}
 }
 
+func TestPreviewBuildsMetadataWithoutMutatingBase(t *testing.T) {
+	base := newRecordingBaseView()
+	accountKey := keylet.Keylet{Key: [32]byte{1}}
+	original := encodeApplyTestEntry(t, applyTestAccountRootFields())
+	base.data[accountKey.Key] = original
+
+	table := NewApplyStateTable(base, [32]byte{2}, 3, amendment.AllSupportedRules())
+	updatedFields := applyTestAccountRootFields()
+	updatedFields["Balance"] = "999990"
+	updated := encodeApplyTestEntry(t, updatedFields)
+	if err := table.Update(accountKey, updated); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	metadata, err := table.Preview()
+	if err != nil {
+		t.Fatalf("Preview: %v", err)
+	}
+	if len(metadata.AffectedNodes) != 1 {
+		t.Fatalf("AffectedNodes = %d, want 1", len(metadata.AffectedNodes))
+	}
+	if !bytes.Equal(base.data[accountKey.Key], original) {
+		t.Fatal("Preview mutated the base entry")
+	}
+	if len(base.mutations) != 0 {
+		t.Fatalf("Preview recorded %d base mutations", len(base.mutations))
+	}
+}
+
 func TestApplyMetadataBuildErrorDoesNotMutateBase(t *testing.T) {
 	valid := encodeApplyTestEntry(t, applyTestAccountRootFields())
 	invalidFields := applyTestAccountRootFields()

--- a/internal/tx/applystate/apply_atomicity_test.go
+++ b/internal/tx/applystate/apply_atomicity_test.go
@@ -127,11 +127,16 @@ func applyTestAccountRootFields() map[string]any {
 func TestPreviewBuildsMetadataWithoutMutatingBase(t *testing.T) {
 	base := newRecordingBaseView()
 	accountKey := keylet.Keylet{Key: [32]byte{1}}
-	original := encodeApplyTestEntry(t, applyTestAccountRootFields())
+	originalFields := applyTestAccountRootFields()
+	originalFields["PreviousTxnID"] = hex.EncodeToString(make([]byte, 32))
+	originalFields["PreviousTxnLgrSeq"] = uint32(1)
+	original := encodeApplyTestEntry(t, originalFields)
 	base.data[accountKey.Key] = original
 
 	table := NewApplyStateTable(base, [32]byte{2}, 3, amendment.AllSupportedRules())
 	updatedFields := applyTestAccountRootFields()
+	updatedFields["PreviousTxnID"] = hex.EncodeToString(make([]byte, 32))
+	updatedFields["PreviousTxnLgrSeq"] = uint32(1)
 	updatedFields["Balance"] = "999990"
 	updated := encodeApplyTestEntry(t, updatedFields)
 	if err := table.Update(accountKey, updated); err != nil {

--- a/internal/tx/applystate/apply_state_table.go
+++ b/internal/tx/applystate/apply_state_table.go
@@ -424,6 +424,17 @@ func (t *ApplyStateTable) Apply() (*tx.Metadata, error) {
 	return metadata, nil
 }
 
+// Preview generates the same metadata as Apply without mutating the base view.
+func (t *ApplyStateTable) Preview() (*tx.Metadata, error) {
+	staged := t.clone()
+	staged.applyThreading()
+	return staged.applyOrdered(
+		nil,
+		sortedLedgerKeys(staged.items),
+		sortedLedgerKeys(staged.threadOnlyOwners),
+	)
+}
+
 // ApplyUnthreaded commits changes that were already threaded by child
 // transaction state tables.
 func (t *ApplyStateTable) ApplyUnthreaded() error {
@@ -520,6 +531,10 @@ func (t *ApplyStateTable) applyOrdered(
 			}
 			metadata.AffectedNodes = append(metadata.AffectedNodes, node)
 		}
+	}
+
+	if atomicBase == nil {
+		return metadata, nil
 	}
 
 	// Metadata builders may fail; keep the base unchanged until all succeed.

--- a/internal/tx/engine/apply.go
+++ b/internal/tx/engine/apply.go
@@ -206,9 +206,17 @@ func (e *Engine) applyWithContext(
 
 	// The charged fee was committed atomically with the state table.
 	if applied {
-		metadata.TransactionIndex = e.txCount.Add(1) - 1
+		if e.config.ApplyFlags&txcore.TapDRY_RUN != 0 {
+			metadata.TransactionIndex = e.txCount.Load()
+		} else {
+			metadata.TransactionIndex = e.txCount.Add(1) - 1
+		}
 	} else {
 		metadata = nil
+	}
+	// Dry-run still builds metadata from the snapshot but is never reported as applied.
+	if e.config.ApplyFlags&txcore.TapDRY_RUN != 0 {
+		applied = false
 	}
 
 	e.logger.Debug("apply result",
@@ -565,7 +573,7 @@ func (e *Engine) commitPreclaimTec(ctx context.Context, tx txcore.Transaction, t
 	if err := tecTable.AdjustDropsDestroyed(drops.XRPAmount(st.chargedFee)); err != nil {
 		return ter.TefINTERNAL, 0
 	}
-	generatedMeta, applyErr := tecTable.Apply()
+	generatedMeta, applyErr := e.applyTable(tecTable)
 	if applyErr != nil {
 		return ter.TefINTERNAL, 0
 	}

--- a/internal/tx/engine/do_apply.go
+++ b/internal/tx/engine/do_apply.go
@@ -206,7 +206,7 @@ func (e *Engine) doApply(ctx context.Context, tx txcore.Transaction, metadata *t
 	if err := table.AdjustDropsDestroyed(drops.XRPAmount(st.chargedFee)); err != nil {
 		return ter.TefINTERNAL, 0
 	}
-	generatedMeta, err := table.Apply()
+	generatedMeta, err := e.applyTable(table)
 	if err != nil {
 		return ter.TefINTERNAL, 0
 	}
@@ -464,7 +464,7 @@ func (e *Engine) applyTecRecovery(st *applyState, result ter.Result) ter.Result 
 	if err := tecTable.AdjustDropsDestroyed(drops.XRPAmount(st.chargedFee)); err != nil {
 		return ter.TefINTERNAL
 	}
-	generatedMeta, applyErr := tecTable.Apply()
+	generatedMeta, applyErr := e.applyTable(tecTable)
 	if applyErr != nil {
 		return ter.TefINTERNAL
 	}
@@ -925,11 +925,18 @@ func (e *Engine) applyInvariantViolation(st *applyState, txDeclaredFee uint64) (
 	if err := invTecTable.AdjustDropsDestroyed(drops.XRPAmount(st.chargedFee)); err != nil {
 		return ter.TefINTERNAL
 	}
-	generatedMeta, applyErr := invTecTable.Apply()
+	generatedMeta, applyErr := e.applyTable(invTecTable)
 	if applyErr != nil {
 		return ter.TefINTERNAL
 	}
 	st.metadata.AffectedNodes = generatedMeta.AffectedNodes
 
 	return ter.TecINVARIANT_FAILED
+}
+
+func (e *Engine) applyTable(table *applystate.ApplyStateTable) (*txcore.Metadata, error) {
+	if e.config.ApplyFlags&txcore.TapDRY_RUN != 0 {
+		return table.Preview()
+	}
+	return table.Apply()
 }

--- a/internal/tx/engine/preclaim.go
+++ b/internal/tx/engine/preclaim.go
@@ -424,8 +424,9 @@ func (e *Engine) checkSign(tx txcore.Transaction, common *txcore.Common) ter.Res
 	if result := e.checkPseudoAccountSign(common); result != ter.TesSUCCESS {
 		return result
 	}
+	hasSigners := len(common.Signers) > 0 || common.HasField("Signers")
 	if e.config.ApplyFlags&txcore.TapDRY_RUN != 0 &&
-		common.SigningPubKey == "" && !common.HasField("Signers") {
+		common.SigningPubKey == "" && !hasSigners {
 		return ter.TesSUCCESS
 	}
 	if sponsor := common.SponsorSignature; sponsor != nil {
@@ -436,9 +437,10 @@ func (e *Engine) checkSign(tx txcore.Transaction, common *txcore.Common) ter.Res
 		// have already failed crypto verification in preflight.
 		skipSignatureVerification := e.config.SkipSignatureVerification ||
 			e.config.ApplyFlags&txcore.TapDRY_RUN != 0
+		sponsorHasSigners := len(sponsor.Signers) > 0 || sponsor.HasField("Signers")
 		if !(skipSignatureVerification &&
-			sponsor.SigningPubKey == "" && len(sponsor.Signers) == 0) {
-			if len(sponsor.Signers) > 0 {
+			sponsor.SigningPubKey == "" && !sponsorHasSigners) {
+			if sponsorHasSigners {
 				if result := e.checkMultiSignForAccount(common.Sponsor, sponsor.Signers); result != ter.TesSUCCESS {
 					return result
 				}
@@ -448,7 +450,7 @@ func (e *Engine) checkSign(tx txcore.Transaction, common *txcore.Common) ter.Res
 		}
 	}
 	if sign.IsMultiSigned(tx) ||
-		(e.config.ApplyFlags&txcore.TapDRY_RUN != 0 && common.HasField("Signers")) {
+		(e.config.ApplyFlags&txcore.TapDRY_RUN != 0 && hasSigners) {
 		return e.checkMultiSign(common)
 	}
 	if common.SigningPubKey != "" {

--- a/internal/tx/engine/preclaim.go
+++ b/internal/tx/engine/preclaim.go
@@ -415,21 +415,28 @@ func (e *Engine) checkSponsor(common *txcore.Common) ter.Result {
 	return ter.TesSUCCESS
 }
 
-// checkSign performs sponsor authorization first, then the transaction's
-// ordinary single- or multi-sign authorization.
+// checkSign validates the effective initiator, applies the dry-run unsigned
+// shortcut, then checks sponsor and transaction signature authorization.
 // Reference: rippled Transactor::checkSign in Transactor.cpp.
 // When a delegate is present, the idAccount for signature checking is the
-// delegate. Reference: rippled line 602:
-//
-//	auto const idAccount = ctx.tx[~sfDelegate].value_or(ctx.tx[sfAccount]);
+// delegate.
 func (e *Engine) checkSign(tx txcore.Transaction, common *txcore.Common) ter.Result {
+	if result := e.checkPseudoAccountSign(common); result != ter.TesSUCCESS {
+		return result
+	}
+	if e.config.ApplyFlags&txcore.TapDRY_RUN != 0 &&
+		common.SigningPubKey == "" && !common.HasField("Signers") {
+		return ter.TesSUCCESS
+	}
 	if sponsor := common.SponsorSignature; sponsor != nil {
 		if result := e.checkPseudoAccount(common.Sponsor); result != ter.TesSUCCESS {
 			return result
 		}
 		// Dry-run/test mode permits an empty signature object. Real submissions
 		// have already failed crypto verification in preflight.
-		if !(e.config.SkipSignatureVerification &&
+		skipSignatureVerification := e.config.SkipSignatureVerification ||
+			e.config.ApplyFlags&txcore.TapDRY_RUN != 0
+		if !(skipSignatureVerification &&
 			sponsor.SigningPubKey == "" && len(sponsor.Signers) == 0) {
 			if len(sponsor.Signers) > 0 {
 				if result := e.checkMultiSignForAccount(common.Sponsor, sponsor.Signers); result != ter.TesSUCCESS {
@@ -440,10 +447,8 @@ func (e *Engine) checkSign(tx txcore.Transaction, common *txcore.Common) ter.Res
 			}
 		}
 	}
-	if result := e.checkPseudoAccountSign(common); result != ter.TesSUCCESS {
-		return result
-	}
-	if sign.IsMultiSigned(tx) {
+	if sign.IsMultiSigned(tx) ||
+		(e.config.ApplyFlags&txcore.TapDRY_RUN != 0 && common.HasField("Signers")) {
 		return e.checkMultiSign(common)
 	}
 	if common.SigningPubKey != "" {

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -40,11 +40,10 @@ func (e *Engine) preflight(tx txcore.Transaction) (result ter.Result) {
 	rules := e.rules()
 	currentTxID, currentTxIDErr := txcore.ComputeCurrentTransactionHash(tx)
 
-	// Structural preflight is ledger-state-independent, so its verdict is
-	// memoised on the transaction and a re-preflight under the same rules skips
-	// the repeat (see Common.preflightedRules). Signature verification stays out
-	// of the memo and always runs below, so a multi-signed tx's view-dependent
-	// signer-list check is never cached.
+	// Non-signature structural preflight is ledger-state-independent, so its
+	// verdict is memoised on the transaction and a re-preflight under the same
+	// rules skips the repeat (see Common.preflightedRules). Signature structure
+	// and verification stay out of the memo and always run below.
 	if currentTxIDErr != nil || !common.PreflightVerified(rules, currentTxID) {
 		if result := e.preflightStructure(tx, common); result != ter.TesSUCCESS {
 			return result
@@ -52,6 +51,9 @@ func (e *Engine) preflight(tx txcore.Transaction) (result ter.Result) {
 		if currentTxIDErr == nil {
 			common.MarkPreflightVerified(rules, currentTxID)
 		}
+	}
+	if result := e.preflightSignatureStructure(tx, common); result != ter.TesSUCCESS {
+		return result
 	}
 
 	// preflight2 — cryptographic signature verification runs LAST, after the
@@ -79,11 +81,10 @@ func (e *Engine) preflight(tx txcore.Transaction) (result ter.Result) {
 
 // preflightStructure runs the ledger-state-independent preflight checks in
 // rippled's invokePreflight order: the amendment gate and T::checkExtraFeatures,
-// then preflight1 (which invokes preflight0), then the per-type preflight body,
-// then the preflight2 structural (multi-sign) checks. Signature verification
-// itself runs separately in verifySignatures. This is a pure function of the
-// transaction fields and the active rules, which is what makes its verdict safe
-// to memoise (see Common.PreflightVerified).
+// then preflight1 (which invokes preflight0), then the per-type preflight body.
+// Signature-dependent structure and cryptographic verification run separately
+// below. This is a pure function of the transaction fields and the active rules,
+// which is what makes its verdict safe to memoise (see Common.PreflightVerified).
 // Reference: rippled Transactor.h Transactor::invokePreflight<T>.
 func (e *Engine) preflightStructure(tx txcore.Transaction, common *txcore.Common) ter.Result {
 	rules := e.rules()
@@ -130,20 +131,41 @@ func (e *Engine) preflightStructure(tx txcore.Transaction, common *txcore.Common
 		}
 	}
 
-	// preflight2 structural stage — the multi-sign structural rules run after
-	// T::preflight (rippled STTx::multiSignHelper reached via checkValidity) and
-	// a violation is Validity::SigBad → temINVALID. The per-signer cryptographic
-	// verification runs later in verifySignatures.
+	return ter.TesSUCCESS
+}
+
+// preflightSignatureStructure runs the non-cryptographic parts of checkValidity.
+// rippled bypasses all of checkValidity for TapDryRun and performs signer-list
+// authorization later in preclaim.
+func (e *Engine) preflightSignatureStructure(tx txcore.Transaction, common *txcore.Common) ter.Result {
+	if e.config.ApplyFlags&txcore.TapDRY_RUN != 0 {
+		return preflightSimulateKeys(common)
+	}
 	if result := e.preflightMultiSignStructure(tx, common); result != ter.TesSUCCESS {
 		return result
 	}
 	if result := e.preflightSponsorSignStructure(common); result != ter.TesSUCCESS {
 		return result
 	}
-	if result := e.preflightBatchSignerStructure(tx); result != ter.TesSUCCESS {
-		return result
-	}
+	return e.preflightBatchSignerStructure(tx)
+}
 
+func preflightSimulateKeys(common *txcore.Common) ter.Result {
+	if common.TxnSignature != "" {
+		return ter.TemINVALID
+	}
+	hasSigners := len(common.Signers) > 0 || common.HasField("Signers")
+	if !hasSigners {
+		return ter.TesSUCCESS
+	}
+	for _, signer := range common.Signers {
+		if signer.Signer.TxnSignature != "" {
+			return ter.TemINVALID
+		}
+	}
+	if common.SigningPubKey != "" {
+		return ter.TemINVALID
+	}
 	return ter.TesSUCCESS
 }
 
@@ -483,12 +505,15 @@ func (e *Engine) preflightSequence(common *txcore.Common) ter.Result {
 // (bounds, sort, uniqueness, self-sign rejection). rippled runs these inside
 // STTx::multiSignHelper, reached via checkValidity in preflight2 — AFTER the
 // per-type preflight body — and a violation is Validity::SigBad → temINVALID
-// (NOT temBAD_SIGNATURE, which the submission layer reports separately). It runs
-// regardless of SkipSignatureVerification.
+// (NOT temBAD_SIGNATURE, which the submission layer reports separately).
 // Reference: rippled STTx.cpp multiSignHelper() + Transactor::preflight2.
 func (e *Engine) preflightMultiSignStructure(tx txcore.Transaction, common *txcore.Common) ter.Result {
-	if !sign.IsMultiSigned(tx) {
+	hasSigners := len(common.Signers) > 0 || common.HasField("Signers")
+	if !hasSigners {
 		return ter.TesSUCCESS
+	}
+	if common.SigningPubKey != "" || common.TxnSignature != "" || common.HasField("TxnSignature") {
+		return ter.TemINVALID
 	}
 	// The signer array must lie within the multi-signer bounds.
 	if n := len(common.Signers); n < sign.MinMultiSigners || n > sign.MaxMultiSigners {
@@ -525,7 +550,7 @@ func (e *Engine) preflightMultiSignStructure(tx txcore.Transaction, common *txco
 }
 
 // preflightSponsorSignStructure enforces the signature-object shape even when
-// cryptographic verification is disabled (simulation and the test harness).
+// generic cryptographic verification is disabled.
 // Nested multisigners are ordered and unique by binary AccountID, but unlike
 // top-level Signers they are not compared with the transaction Account.
 func (e *Engine) preflightSponsorSignStructure(common *txcore.Common) ter.Result {
@@ -533,13 +558,14 @@ func (e *Engine) preflightSponsorSignStructure(common *txcore.Common) ter.Result
 	if sponsor == nil {
 		return ter.TesSUCCESS
 	}
+	hasSigners := len(sponsor.Signers) > 0 || sponsor.HasField("Signers")
 	if sponsor.SigningPubKey != "" {
-		if len(sponsor.Signers) != 0 {
+		if hasSigners {
 			return ter.TemINVALID
 		}
 		return ter.TesSUCCESS
 	}
-	if len(sponsor.Signers) == 0 {
+	if !hasSigners {
 		if sponsor.TxnSignature != "" {
 			return ter.TemINVALID
 		}
@@ -547,7 +573,7 @@ func (e *Engine) preflightSponsorSignStructure(common *txcore.Common) ter.Result
 		// The crypto verifier rejects it on a normal submission.
 		return ter.TesSUCCESS
 	}
-	if sponsor.TxnSignature != "" {
+	if sponsor.TxnSignature != "" || sponsor.HasField("TxnSignature") {
 		return ter.TemINVALID
 	}
 	if n := len(sponsor.Signers); n < sign.MinMultiSigners || n > sign.MaxMultiSigners {
@@ -569,10 +595,8 @@ func (e *Engine) preflightSponsorSignStructure(common *txcore.Common) ter.Result
 
 // preflightBatchSignerStructure enforces the upper bound on each
 // multi-signed BatchSigner's nested Signers array. rippled checks this inside
-// multiSignHelper (called from Batch::preflight with ctx.rules); an out-of-range
-// array there is a bad-signature validity result and surfaces as temINVALID. The
-// crypto verification of those signers lives in Batch.Validate(), which has no
-// rules access, so the rules-dependent size bound is enforced here in preflight.
+// multiSignHelper through STTx::checkBatchSign; an out-of-range array is a
+// bad-signature validity result and surfaces as temINVALID.
 func (e *Engine) preflightBatchSignerStructure(tx txcore.Transaction) ter.Result {
 	bsp, ok := tx.(txcore.BatchSignerProvider)
 	if !ok {
@@ -596,7 +620,7 @@ func (e *Engine) preflightBatchSignerStructure(tx txcore.Transaction) ter.Result
 // when SkipSignatureVerification is false. Authorization checks (master/regular
 // key) live in preclaim.
 func (e *Engine) verifySignatures(tx txcore.Transaction) ter.Result {
-	if e.config.SkipSignatureVerification {
+	if e.config.SkipSignatureVerification || e.config.ApplyFlags&txcore.TapDRY_RUN != 0 {
 		return ter.TesSUCCESS
 	}
 	if matches, err := txcore.CurrentFieldsMatchRaw(tx); err != nil || !matches {

--- a/internal/tx/engine_config.go
+++ b/internal/tx/engine_config.go
@@ -36,9 +36,10 @@ type ApplyFlags uint32
 
 const (
 	TapNONE      ApplyFlags = 0x00
-	TapFAIL_HARD ApplyFlags = 0x10  // Local tx with fail_hard flag
-	TapRETRY     ApplyFlags = 0x20  // Not the tx's last pass — tec from preclaim is not applied
-	TapUNLIMITED ApplyFlags = 0x400 // Privileged source
+	TapFAIL_HARD ApplyFlags = 0x10   // Local tx with fail_hard flag
+	TapRETRY     ApplyFlags = 0x20   // Not the tx's last pass — tec from preclaim is not applied
+	TapUNLIMITED ApplyFlags = 0x400  // Privileged source
+	TapDRY_RUN   ApplyFlags = 0x1000 // Simulation; bypasses signature validity in preflight2
 )
 
 // EngineConfig holds configuration for the transaction engine
@@ -123,7 +124,8 @@ type EngineConfig struct {
 	// ApplyFlags controls transaction application behavior.
 	// TapRETRY means this is not the tx's last pass: tec results from
 	// preclaim are not applied (likelyToClaimFee = false), allowing the
-	// tx to be retried on the next pass.
+	// tx to be retried on the next pass. TapDRY_RUN marks simulation and
+	// bypasses preflight2 signature validity while retaining authorization.
 	// Reference: rippled Transactor.cpp / BuildLedger.cpp
 	ApplyFlags ApplyFlags
 

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -473,11 +473,10 @@ type Common struct {
 	txIDCached bool
 
 	// preflightedRules records the amendment rules under which this
-	// transaction's structural preflight last succeeded. Structural preflight
-	// (everything except the view-dependent signature check) is a pure function
-	// of the transaction fields and the active rules, so when the engine
-	// re-preflights the same parsed transaction under the identical rules — as
-	// the open-ledger apply strand does, preflighting once in TxQ.Apply and
+	// transaction's non-signature structural preflight last succeeded. This stage
+	// is a pure function of the transaction fields and the active rules, so when
+	// the engine re-preflights the same parsed transaction under identical rules —
+	// as the open-ledger apply strand does, preflighting once in TxQ.Apply and
 	// again in Engine.Apply under modifyMu — the second run skips the repeat.
 	// The rules pointer keys the verdict: a later ledger rebuilds rules, so a
 	// pointer mismatch forces a recompute and the verdict never outlives an


### PR DESCRIPTION
Closes #1731

## Summary

- treat `Delegate` as the effective signing identity for multisign structural validation
- fail closed-ledger replay at the first non-applied transaction or metadata-index drift
- report predicate-specific Batch-inner hash, metadata, index, and parent errors
- add delegated multisign and sponsored `tfAllOrNothing` closed-ledger regressions

## Root cause

Devnet transaction 0 is a delegated multisigned Payment whose source account participates in the delegate's signer list. goXRPL compared every multisigner with `Account`, rejected that valid transaction as `temINVALID`, and therefore generated every later metadata index one slot early. The Batch arithmetic itself was correct; its first inner exposed the earlier counter drift.

Rippled 3.3.0 uses `STTx::getInitiator()` for this self-signer check, selecting `Delegate` when present. The source account may therefore sign for the delegate, while the delegate itself remains forbidden.

## Verification

- `just build`
- `just vet`
- `just lint` (`0 issues`)
- `just test-tx`
- `just test-integration`
- targeted race tests for delegate, Batch, and replay paths
- sponsored Batch regression repeated 10 times with stable transaction SHAMap root `BD76A302261EC77B227F1DC8FCAE86C9CA58D8FD6A8E1397872744551ACA17B1`

Oracle: rippled `3.3.0` (`00a178fb92ca49521b937ae1a99d863765ea8a90`).
