### PR TITLE
fix: use delegate for multisign structure

### DIFF
--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -494,7 +494,11 @@ func (e *Engine) preflightMultiSignStructure(tx txcore.Transaction, common *txco
 	if n := len(common.Signers); n < sign.MinMultiSigners || n > sign.MaxMultiSigners {
 		return ter.TemINVALID
 	}
-	txAccountID, acctErr := state.DecodeAccountID(common.Account)
+	idAccount := common.Account
+	if common.Delegate != "" {
+		idAccount = common.Delegate
+	}
+	idAccountID, acctErr := state.DecodeAccountID(idAccount)
 	if acctErr != nil {
 		return ter.TemBAD_SRC_ACCOUNT
 	}
@@ -504,8 +508,8 @@ func (e *Engine) preflightMultiSignStructure(tx txcore.Transaction, common *txco
 		if decErr != nil {
 			return ter.TemINVALID
 		}
-		// The account owner may not multisign for themselves.
-		if signerID == txAccountID {
+		// The signing identity may not multisign for itself.
+		if signerID == idAccountID {
 			return ter.TemINVALID
 		}
 		// No duplicate signers allowed.

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -508,7 +508,6 @@ func (e *Engine) preflightMultiSignStructure(tx txcore.Transaction, common *txco
 		if decErr != nil {
 			return ter.TemINVALID
 		}
-		// The signing identity may not multisign for itself.
 		if signerID == idAccountID {
 			return ter.TemINVALID
 		}

--- a/internal/tx/engine/preflight_multisign_structure_test.go
+++ b/internal/tx/engine/preflight_multisign_structure_test.go
@@ -1,0 +1,43 @@
+package engine
+
+import (
+	"testing"
+
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+func TestPreflightMultiSignStructureUsesDelegateIdentity(t *testing.T) {
+	const (
+		account     = "r4aKxtVB6Va8BM4s9LKzEXAuGnxuDh5EME"
+		delegate    = "rBKjMimqYjHX6BUSMNA4CScwRRTXMgRz6W"
+		destination = "r3gYkHRkq7umjZrVmqFb51BYVTGYtFEosH"
+	)
+
+	for _, test := range []struct {
+		name     string
+		delegate string
+		signer   string
+		want     ter.Result
+	}{
+		{name: "delegated account signer", delegate: delegate, signer: account, want: ter.TesSUCCESS},
+		{name: "delegated self signer", delegate: delegate, signer: delegate, want: ter.TemINVALID},
+		{name: "ordinary self signer", signer: account, want: ter.TemINVALID},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			transaction := payment.NewPayment(account, destination, txcore.NewXRPAmount(100_000))
+			transaction.Fee = "30"
+			transaction.SetSequence(1)
+			transaction.SigningPubKey = ""
+			transaction.Delegate = test.delegate
+			transaction.Signers = []txcore.SignerWrapper{{
+				Signer: txcore.Signer{Account: test.signer},
+			}}
+
+			if got := preflightEngine(allRules()).preflight(transaction); got != test.want {
+				t.Fatalf("preflight = %v, want %v", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- use `Delegate` as the effective signing identity for delegated multisign structural self-signer validation
- cover delegated source-account acceptance, delegated self-signer rejection, and ordinary self-signer rejection through full preflight

## Test plan
- [x] `go test ./internal/tx/engine -run TestPreflightMultiSignStructureUsesDelegateIdentity -count=20`
- [x] `go test -race ./internal/tx/engine -run TestPreflightMultiSignStructureUsesDelegateIdentity -count=1`
- [x] `go test ./internal/tx/engine ./internal/tx/sign ./internal/testing/delegate -count=1`
- [x] `just test-tx`
- [x] `just test-integration`
- [x] `just build`
- [x] `just vet`
- [x] `just lint`

## Replay note
- Devnet ledger 4659836 remains available, but exact replay could not complete locally: the original state-compare PostgreSQL capture is unavailable, and full ledger 4659835 state export exceeded bounded 10-minute rippled and 20-minute Clio attempts after Clio delivered more than 409,600 entries. No partial fixture or replay result is claimed.

Fixes #1732
