### PR TITLE
fix: parse XChain UInt64 binary fields

### DIFF
--- a/internal/testing/xchain/xchain_test.go
+++ b/internal/testing/xchain/xchain_test.go
@@ -78,7 +78,7 @@ func signClaimAttestation(t *testing.T, att *xchaintx.XChainAddClaimAttestation,
 		"WasLockingChainSend":      uint8(0),
 		"XChainBridge":             bridgeJSON(att.XChainBridge),
 	}
-	if att.WasLockingChainSend {
+	if att.WasLockingChainSend != 0 {
 		fields["WasLockingChainSend"] = uint8(1)
 	}
 	if att.Destination != "" {
@@ -95,7 +95,7 @@ func signClaimAttestation(t *testing.T, att *xchaintx.XChainAddClaimAttestation,
 func signCreateAttestation(t *testing.T, att *xchaintx.XChainAddAccountCreateAttestation, witness *jtx.Account) {
 	t.Helper()
 	locking := uint8(0)
-	if att.WasLockingChainSend {
+	if att.WasLockingChainSend != 0 {
 		locking = 1
 	}
 	message, err := binarycodec.EncodeBytes(map[string]any{
@@ -130,7 +130,7 @@ func newClaimAttestation(
 	att.AttestationRewardAccount = witness.Address
 	att.AttestationSignerAccount = witness.Address
 	att.Destination = destination
-	att.WasLockingChainSend = false
+	att.WasLockingChainSend = 0
 	signClaimAttestation(t, att, witness)
 	return att
 }
@@ -151,7 +151,7 @@ func newCreateAttestation(
 	att.SignatureReward = reward
 	att.AttestationRewardAccount = witness.Address
 	att.AttestationSignerAccount = witness.Address
-	att.WasLockingChainSend = false
+	att.WasLockingChainSend = 0
 	att.XChainAccountCreateCount = count
 	signCreateAttestation(t, att, witness)
 	return att

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -1,7 +1,6 @@
 package batch
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/bits"
@@ -39,7 +38,8 @@ type RawTransactionData struct {
 }
 
 func (r *RawTransactionData) UnmarshalJSON(data []byte) error {
-	if _, err := tx.ParseJSON(data); err != nil {
+	parsed, err := tx.ParseJSON(data)
+	if err != nil {
 		return fmt.Errorf("parse inner transaction JSON: %w", err)
 	}
 	var innerMap map[string]any
@@ -53,13 +53,9 @@ func (r *RawTransactionData) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("validate inner transaction: %w", err)
 		}
 	}
-	encoded, err := binarycodec.Encode(innerMap)
+	raw, err := tx.SerializeTransaction(parsed)
 	if err != nil {
 		return fmt.Errorf("encode inner transaction: %w", err)
-	}
-	raw, err := hex.DecodeString(encoded)
-	if err != nil {
-		return fmt.Errorf("decode inner transaction: %w", err)
 	}
 	inner, err := tx.ParseFromBinary(raw)
 	if err != nil {

--- a/internal/tx/flatten.go
+++ b/internal/tx/flatten.go
@@ -38,7 +38,6 @@ type flattenField struct {
 	omitempty bool
 	isAmount  bool // use flattenAmount converter
 	isAsset   bool // use flattenAsset converter for Asset/Issue fields
-	boolint   bool // convert bool to int (0 or 1)
 	baseTen   bool // UInt64 field rippled emits as decimal (sMD_BaseTen)
 }
 
@@ -51,11 +50,11 @@ type flattenInfo struct {
 var flattenCache sync.Map // map[reflect.Type]*flattenInfo
 
 // parseXRPLTag parses an xrpl struct tag.
-// Format: "FieldName,opt1,opt2" where options are: omitempty, amount, asset, boolint
+// Format: "FieldName,opt1,opt2" where options are: omitempty, amount, asset
 // Returns ("", false) for tags that should be skipped ("-").
-func parseXRPLTag(tag string) (name string, omitempty bool, isAmount bool, isAsset bool, boolint bool, skip bool) {
+func parseXRPLTag(tag string) (name string, omitempty bool, isAmount bool, isAsset bool, skip bool) {
 	if tag == "" || tag == "-" {
-		return "", false, false, false, false, true
+		return "", false, false, false, true
 	}
 	parts := strings.Split(tag, ",")
 	name = parts[0]
@@ -67,11 +66,9 @@ func parseXRPLTag(tag string) (name string, omitempty bool, isAmount bool, isAss
 			isAmount = true
 		case "asset":
 			isAsset = true
-		case "boolint":
-			boolint = true
 		}
 	}
-	return name, omitempty, isAmount, isAsset, boolint, false
+	return name, omitempty, isAmount, isAsset, false
 }
 
 // getFlattenInfo returns the cached flattenInfo for a struct type.
@@ -96,7 +93,7 @@ func getFlattenInfo(t reflect.Type) *flattenInfo {
 		}
 
 		tag := field.Tag.Get("xrpl")
-		name, omitempty, isAmount, isAsset, boolint, skip := parseXRPLTag(tag)
+		name, omitempty, isAmount, isAsset, skip := parseXRPLTag(tag)
 		if skip {
 			continue
 		}
@@ -107,7 +104,6 @@ func getFlattenInfo(t reflect.Type) *flattenInfo {
 			omitempty: omitempty,
 			isAmount:  isAmount,
 			isAsset:   isAsset,
-			boolint:   boolint,
 			baseTen:   definitions.IsBaseTenUInt64FieldName(name),
 		})
 	}
@@ -190,13 +186,6 @@ func ReflectFlatten(tx Transaction) (map[string]any, error) {
 				asset = val.Interface().(Asset)
 			}
 			m[f.name] = flattenAsset(asset)
-		} else if f.boolint {
-			// Convert bool to int (0 or 1) for XRPL protocol
-			if val.Bool() {
-				m[f.name] = 1
-			} else {
-				m[f.name] = 0
-			}
 		} else {
 			// Default: dereference pointers and convert struct slices
 			if val.Kind() == reflect.Pointer {

--- a/internal/tx/parse.go
+++ b/internal/tx/parse.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strconv"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
@@ -135,7 +136,7 @@ func parseFromBinaryUnbound(blob []byte) (Transaction, map[string]any, []byte, e
 	}
 	jsonFields := jsonMap
 	if parsed != nil {
-		jsonFields = binaryAmountJSONFields(parsed, jsonMap)
+		jsonFields = binaryTransactionJSONFields(parsed, jsonMap)
 		if parsed.TxType() == TypeBatch {
 			jsonFields = binaryBatchJSONFields(jsonFields)
 		}
@@ -164,37 +165,74 @@ func parseFromBinaryUnbound(blob []byte) (Transaction, map[string]any, []byte, e
 
 const noCurrencyHex = "0000000000000000000000000000000000000001"
 
-func binaryAmountJSONFields(transaction Transaction, fields map[string]any) map[string]any {
+func binaryTransactionJSONFields(transaction Transaction, fields map[string]any) map[string]any {
 	value := reflect.ValueOf(transaction)
 	if value.Kind() == reflect.Pointer {
 		value = value.Elem()
 	}
 	var adjusted map[string]any
 	for _, field := range getFlattenInfo(value.Type()).fields {
-		if !field.isAmount {
+		if field.isAmount {
+			amount, ok := fields[field.name].(map[string]any)
+			if !ok || amount["currency"] != "1" {
+				continue
+			}
+			if adjusted == nil {
+				adjusted = cloneFields(fields)
+			}
+			adjustedAmount := cloneFields(amount)
+			adjustedAmount["currency"] = noCurrencyHex
+			adjusted[field.name] = adjustedAmount
 			continue
 		}
-		amount, ok := fields[field.name].(map[string]any)
-		if !ok || amount["currency"] != "1" {
+		if field.boolint {
+			encoded, ok := fields[field.name].(int)
+			if !ok {
+				continue
+			}
+			if adjusted == nil {
+				adjusted = cloneFields(fields)
+			}
+			adjusted[field.name] = encoded != 0
+			continue
+		}
+
+		fieldType := value.Type().Field(field.index).Type
+		if fieldType.Kind() == reflect.Pointer {
+			fieldType = fieldType.Elem()
+		}
+		if fieldType.Kind() != reflect.Uint64 {
+			continue
+		}
+		encoded, ok := fields[field.name].(string)
+		if !ok {
+			continue
+		}
+		base := 16
+		if field.baseTen {
+			base = 10
+		}
+		decoded, err := strconv.ParseUint(encoded, base, 64)
+		if err != nil {
 			continue
 		}
 		if adjusted == nil {
-			adjusted = make(map[string]any, len(fields))
-			for name, value := range fields {
-				adjusted[name] = value
-			}
+			adjusted = cloneFields(fields)
 		}
-		adjustedAmount := make(map[string]any, len(amount))
-		for name, value := range amount {
-			adjustedAmount[name] = value
-		}
-		adjustedAmount["currency"] = noCurrencyHex
-		adjusted[field.name] = adjustedAmount
+		adjusted[field.name] = decoded
 	}
 	if adjusted == nil {
 		return fields
 	}
 	return adjusted
+}
+
+func cloneFields(fields map[string]any) map[string]any {
+	cloned := make(map[string]any, len(fields))
+	for name, value := range fields {
+		cloned[name] = value
+	}
+	return cloned
 }
 
 func binaryBatchJSONFields(fields map[string]any) map[string]any {
@@ -223,7 +261,7 @@ func binaryBatchJSONFields(fields map[string]any) map[string]any {
 		if err != nil {
 			continue
 		}
-		adjustedInner := binaryAmountJSONFields(inner, innerFields)
+		adjustedInner := binaryTransactionJSONFields(inner, innerFields)
 		adjustedWrapper := make(map[string]any, len(wrapper))
 		for name, value := range wrapper {
 			adjustedWrapper[name] = value

--- a/internal/tx/parse.go
+++ b/internal/tx/parse.go
@@ -185,18 +185,6 @@ func binaryTransactionJSONFields(transaction Transaction, fields map[string]any)
 			adjusted[field.name] = adjustedAmount
 			continue
 		}
-		if field.boolint {
-			encoded, ok := fields[field.name].(int)
-			if !ok {
-				continue
-			}
-			if adjusted == nil {
-				adjusted = cloneFields(fields)
-			}
-			adjusted[field.name] = encoded != 0
-			continue
-		}
-
 		fieldType := value.Type().Field(field.index).Type
 		if fieldType.Kind() == reflect.Pointer {
 			fieldType = fieldType.Elem()

--- a/internal/tx/xchain/attestations.go
+++ b/internal/tx/xchain/attestations.go
@@ -206,7 +206,7 @@ func storedClaimMap(x *XChainAddClaimAttestation) map[string]any {
 		"PublicKey":                x.PublicKey,
 		"Amount":                   mustAmountAny(x.Amount),
 		"AttestationRewardAccount": x.AttestationRewardAccount,
-		"WasLockingChainSend":      boolInt(x.WasLockingChainSend),
+		"WasLockingChainSend":      boolInt(x.WasLockingChainSend != 0),
 	}
 	if x.Destination != "" {
 		fields["Destination"] = x.Destination
@@ -221,7 +221,7 @@ func storedCreateMap(x *XChainAddAccountCreateAttestation) map[string]any {
 		"Amount":                   mustAmountAny(x.Amount),
 		"SignatureReward":          mustAmountAny(x.SignatureReward),
 		"AttestationRewardAccount": x.AttestationRewardAccount,
-		"WasLockingChainSend":      boolInt(x.WasLockingChainSend),
+		"WasLockingChainSend":      boolInt(x.WasLockingChainSend != 0),
 		"Destination":              x.Destination,
 	}}
 }
@@ -294,7 +294,7 @@ func createQuorum(
 		}
 		valid = append(valid, value)
 		if !amountEqual(att.amount, x.Amount) || !amountEqual(att.reward, x.SignatureReward) ||
-			att.lockingSend != x.WasLockingChainSend || att.destination != x.Destination {
+			att.lockingSend != (x.WasLockingChainSend != 0) || att.destination != x.Destination {
 			continue
 		}
 		weight += uint64(signers.weights[att.signerAccount])
@@ -555,7 +555,7 @@ func (x *XChainAddClaimAttestation) Apply(ctx *tx.ApplyContext) ter.Result {
 	if claim.OtherChainSource != x.OtherChainSource {
 		return ter.TecXCHAIN_SENDING_ACCOUNT_MISMATCH
 	}
-	if destinationChain(x.WasLockingChainSend) != dstChain {
+	if destinationChain(x.WasLockingChainSend != 0) != dstChain {
 		return ter.TecXCHAIN_WRONG_CHAIN
 	}
 	values := append([]any(nil), claim.XChainClaimAttestations...)
@@ -567,7 +567,7 @@ func (x *XChainAddClaimAttestation) Apply(ctx *tx.ApplyContext) ter.Result {
 		values = addOrReplaceClaim(values, x)
 		didModify = true
 	}
-	values, rewards, quorum := claimQuorum(outer, values, signers, x.Amount, x.WasLockingChainSend, x.Destination, true)
+	values, rewards, quorum := claimQuorum(outer, values, signers, x.Amount, x.WasLockingChainSend != 0, x.Destination, true)
 	claim.SetXChainClaimAttestations(values)
 	data, encodeResult := encodeEntry(&claim)
 	if encodeResult != ter.TesSUCCESS {
@@ -617,7 +617,7 @@ func (x *XChainAddAccountCreateAttestation) Apply(ctx *tx.ApplyContext) ter.Resu
 		return result
 	}
 	srcChain := otherChain(dstChain)
-	if destinationChain(x.WasLockingChainSend) != dstChain {
+	if destinationChain(x.WasLockingChainSend != 0) != dstChain {
 		return ter.TecXCHAIN_WRONG_CHAIN
 	}
 	signers, result := loadSignerSet(outer, bridge)

--- a/internal/tx/xchain/binary_parse_test.go
+++ b/internal/tx/xchain/binary_parse_test.go
@@ -1,0 +1,143 @@
+package xchain
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestXChainUInt64BinaryRoundTrip(t *testing.T) {
+	const (
+		account      = "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"
+		otherAccount = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+		publicKey    = "ED0000000000000000000000000000000000000000000000000000000000000000"
+		wireValue    = "ABCDEF1234567890"
+		value        = uint64(0xABCDEF1234567890)
+	)
+	bridge := bridgeMap(XChainBridge{
+		LockingChainDoor:  account,
+		LockingChainIssue: tx.Asset{Currency: "XRP"},
+		IssuingChainDoor:  otherAccount,
+		IssuingChainIssue: tx.Asset{Currency: "XRP"},
+	})
+	attestationFields := func(transactionType string) map[string]any {
+		return map[string]any{
+			"Account":                  account,
+			"TransactionType":          transactionType,
+			"XChainBridge":             bridge,
+			"OtherChainSource":         otherAccount,
+			"Amount":                   "1000000",
+			"AttestationRewardAccount": account,
+			"AttestationSignerAccount": account,
+			"PublicKey":                publicKey,
+			"Signature":                "00",
+			"WasLockingChainSend":      1,
+		}
+	}
+
+	tests := []struct {
+		name      string
+		wireField string
+		fields    map[string]any
+		assert    func(*testing.T, tx.Transaction)
+	}{
+		{
+			name:      "commit claim ID",
+			wireField: "XChainClaimID",
+			fields: map[string]any{
+				"Account":         account,
+				"TransactionType": tx.TypeXChainCommit.String(),
+				"XChainBridge":    bridge,
+				"XChainClaimID":   wireValue,
+				"Amount":          "1000000",
+			},
+			assert: func(t *testing.T, transaction tx.Transaction) {
+				t.Helper()
+				parsed, ok := transaction.(*XChainCommit)
+				require.True(t, ok)
+				require.Equal(t, value, parsed.XChainClaimID)
+			},
+		},
+		{
+			name:      "claim claim ID",
+			wireField: "XChainClaimID",
+			fields: map[string]any{
+				"Account":         account,
+				"TransactionType": tx.TypeXChainClaim.String(),
+				"XChainBridge":    bridge,
+				"XChainClaimID":   wireValue,
+				"Destination":     otherAccount,
+				"Amount":          "1000000",
+			},
+			assert: func(t *testing.T, transaction tx.Transaction) {
+				t.Helper()
+				parsed, ok := transaction.(*XChainClaim)
+				require.True(t, ok)
+				require.Equal(t, value, parsed.XChainClaimID)
+			},
+		},
+		{
+			name:      "claim attestation claim ID",
+			wireField: "XChainClaimID",
+			fields: func() map[string]any {
+				fields := attestationFields(tx.TypeXChainAddClaimAttestation.String())
+				fields["XChainClaimID"] = wireValue
+				return fields
+			}(),
+			assert: func(t *testing.T, transaction tx.Transaction) {
+				t.Helper()
+				parsed, ok := transaction.(*XChainAddClaimAttestation)
+				require.True(t, ok)
+				require.Equal(t, value, parsed.XChainClaimID)
+			},
+		},
+		{
+			name:      "account-create attestation count",
+			wireField: "XChainAccountCreateCount",
+			fields: func() map[string]any {
+				fields := attestationFields(tx.TypeXChainAddAccountCreateAttest.String())
+				fields["XChainAccountCreateCount"] = wireValue
+				fields["Destination"] = otherAccount
+				fields["SignatureReward"] = "10"
+				return fields
+			}(),
+			assert: func(t *testing.T, transaction tx.Transaction) {
+				t.Helper()
+				parsed, ok := transaction.(*XChainAddAccountCreateAttestation)
+				require.True(t, ok)
+				require.Equal(t, value, parsed.XChainAccountCreateCount)
+			},
+		},
+	}
+
+	Register()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.fields["Sequence"] = uint32(1)
+			test.fields["Fee"] = "12"
+			test.fields["SigningPubKey"] = publicKey
+			blob, err := binarycodec.EncodeBytes(test.fields)
+			require.NoError(t, err)
+
+			decoded, err := binarycodec.DecodeBytes(blob)
+			require.NoError(t, err)
+			require.Equal(t, "abcdef1234567890", decoded[test.wireField])
+
+			parsed, err := tx.ParseFromBinary(blob)
+			require.NoError(t, err)
+			test.assert(t, parsed)
+			require.Equal(t, blob, parsed.GetRawBytes())
+			matches, err := tx.CurrentFieldsMatchRaw(parsed)
+			require.NoError(t, err)
+			require.True(t, matches)
+
+			flattened, err := parsed.Flatten()
+			require.NoError(t, err)
+			roundTripped, err := binarycodec.EncodeBytes(flattened)
+			require.NoError(t, err)
+			require.Equal(t, blob, roundTripped)
+		})
+	}
+}

--- a/internal/tx/xchain/binary_parse_test.go
+++ b/internal/tx/xchain/binary_parse_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/batch"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,7 +34,7 @@ func TestXChainUInt64BinaryRoundTrip(t *testing.T) {
 			"AttestationSignerAccount": account,
 			"PublicKey":                publicKey,
 			"Signature":                "00",
-			"WasLockingChainSend":      1,
+			"WasLockingChainSend":      2,
 		}
 	}
 
@@ -91,6 +92,7 @@ func TestXChainUInt64BinaryRoundTrip(t *testing.T) {
 				parsed, ok := transaction.(*XChainAddClaimAttestation)
 				require.True(t, ok)
 				require.Equal(t, value, parsed.XChainClaimID)
+				require.Equal(t, uint8(2), parsed.WasLockingChainSend)
 			},
 		},
 		{
@@ -108,6 +110,7 @@ func TestXChainUInt64BinaryRoundTrip(t *testing.T) {
 				parsed, ok := transaction.(*XChainAddAccountCreateAttestation)
 				require.True(t, ok)
 				require.Equal(t, value, parsed.XChainAccountCreateCount)
+				require.Equal(t, uint8(2), parsed.WasLockingChainSend)
 			},
 		},
 	}
@@ -140,4 +143,76 @@ func TestXChainUInt64BinaryRoundTrip(t *testing.T) {
 			require.Equal(t, blob, roundTripped)
 		})
 	}
+}
+
+func TestXChainUInt64BatchBinaryRoundTrip(t *testing.T) {
+	const (
+		account      = "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"
+		otherAccount = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+		publicKey    = "ED0000000000000000000000000000000000000000000000000000000000000000"
+		wireValue    = "ABCDEF1234567890"
+		value        = uint64(0xABCDEF1234567890)
+	)
+	bridge := bridgeMap(XChainBridge{
+		LockingChainDoor:  account,
+		LockingChainIssue: tx.Asset{Currency: "XRP"},
+		IssuingChainDoor:  otherAccount,
+		IssuingChainIssue: tx.Asset{Currency: "XRP"},
+	})
+	inner := func(transactionType string, sequence uint32) map[string]any {
+		fields := map[string]any{
+			"Account":         account,
+			"TransactionType": transactionType,
+			"XChainBridge":    bridge,
+			"XChainClaimID":   wireValue,
+			"Amount":          "1000000",
+			"Sequence":        sequence,
+			"Fee":             "0",
+			"SigningPubKey":   "",
+			"Flags":           tx.TfInnerBatchTxn,
+		}
+		if transactionType == tx.TypeXChainClaim.String() {
+			fields["Destination"] = otherAccount
+		}
+		return fields
+	}
+	fields := map[string]any{
+		"Account":         account,
+		"TransactionType": tx.TypeBatch.String(),
+		"Sequence":        uint32(1),
+		"Fee":             "40",
+		"SigningPubKey":   publicKey,
+		"Flags":           batch.BatchFlagAllOrNothing,
+		"RawTransactions": []any{
+			map[string]any{"RawTransaction": inner(tx.TypeXChainCommit.String(), 2)},
+			map[string]any{"RawTransaction": inner(tx.TypeXChainClaim.String(), 3)},
+		},
+	}
+
+	Register()
+	batch.Register()
+	blob, err := binarycodec.EncodeBytes(fields)
+	require.NoError(t, err)
+
+	parsedTransaction, err := tx.ParseFromBinary(blob)
+	require.NoError(t, err)
+	parsed, ok := parsedTransaction.(*batch.Batch)
+	require.True(t, ok)
+	require.Len(t, parsed.RawTransactions, 2)
+	commit, ok := parsed.RawTransactions[0].RawTransaction.InnerTx.(*XChainCommit)
+	require.True(t, ok)
+	require.Equal(t, value, commit.XChainClaimID)
+	claim, ok := parsed.RawTransactions[1].RawTransaction.InnerTx.(*XChainClaim)
+	require.True(t, ok)
+	require.Equal(t, value, claim.XChainClaimID)
+	require.Equal(t, blob, parsed.GetRawBytes())
+	matches, err := tx.CurrentFieldsMatchRaw(parsed)
+	require.NoError(t, err)
+	require.True(t, matches)
+
+	flattened, err := parsed.Flatten()
+	require.NoError(t, err)
+	roundTripped, err := binarycodec.EncodeBytes(flattened)
+	require.NoError(t, err)
+	require.Equal(t, blob, roundTripped)
 }

--- a/internal/tx/xchain/binary_parse_test.go
+++ b/internal/tx/xchain/binary_parse_test.go
@@ -1,6 +1,7 @@
 package xchain
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
@@ -8,6 +9,15 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx/batch"
 	"github.com/stretchr/testify/require"
 )
+
+var registerBinaryParseTypes sync.Once
+
+func registerBinaryParseTransactionTypes() {
+	registerBinaryParseTypes.Do(func() {
+		Register()
+		batch.Register()
+	})
+}
 
 func TestXChainUInt64BinaryRoundTrip(t *testing.T) {
 	const (
@@ -115,7 +125,7 @@ func TestXChainUInt64BinaryRoundTrip(t *testing.T) {
 		},
 	}
 
-	Register()
+	registerBinaryParseTransactionTypes()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			test.fields["Sequence"] = uint32(1)
@@ -189,8 +199,7 @@ func TestXChainUInt64BatchBinaryRoundTrip(t *testing.T) {
 		},
 	}
 
-	Register()
-	batch.Register()
+	registerBinaryParseTransactionTypes()
 	blob, err := binarycodec.EncodeBytes(fields)
 	require.NoError(t, err)
 

--- a/internal/tx/xchain/helpers.go
+++ b/internal/tx/xchain/helpers.go
@@ -374,7 +374,7 @@ func claimAttestationMessage(x *XChainAddClaimAttestation) ([]byte, error) {
 		"Amount":                   amount,
 		"OtherChainSource":         x.OtherChainSource,
 		"AttestationRewardAccount": x.AttestationRewardAccount,
-		"WasLockingChainSend":      boolInt(x.WasLockingChainSend),
+		"WasLockingChainSend":      boolInt(x.WasLockingChainSend != 0),
 		"XChainBridge":             bridgeMap(x.XChainBridge),
 	}
 	if x.Destination != "" {
@@ -399,7 +399,7 @@ func createAccountAttestationMessage(x *XChainAddAccountCreateAttestation) ([]by
 		"Destination":              x.Destination,
 		"OtherChainSource":         x.OtherChainSource,
 		"AttestationRewardAccount": x.AttestationRewardAccount,
-		"WasLockingChainSend":      boolInt(x.WasLockingChainSend),
+		"WasLockingChainSend":      boolInt(x.WasLockingChainSend != 0),
 		"XChainBridge":             bridgeMap(x.XChainBridge),
 	})
 }
@@ -419,7 +419,7 @@ func validateClaimAttestation(x *XChainAddClaimAttestation) error {
 	message, err := claimAttestationMessage(x)
 	if err != nil || !verifyAttestationSignature(x.PublicKey, x.Signature, message) ||
 		!isLegalNet(x.Amount) || x.Amount.Signum() <= 0 ||
-		!assetEqual(assetOf(x.Amount), x.XChainBridge.issue(sourceChain(x.WasLockingChainSend))) {
+		!assetEqual(assetOf(x.Amount), x.XChainBridge.issue(sourceChain(x.WasLockingChainSend != 0))) {
 		return ter.Errorf(ter.TemXCHAIN_BAD_PROOF, "invalid claim attestation proof")
 	}
 	return nil
@@ -436,7 +436,7 @@ func validateCreateAccountAttestation(x *XChainAddAccountCreateAttestation) erro
 	message, err := createAccountAttestationMessage(x)
 	if err != nil || !verifyAttestationSignature(x.PublicKey, x.Signature, message) ||
 		!isLegalNet(x.Amount) || !isLegalNet(x.SignatureReward) || x.Amount.Signum() <= 0 ||
-		!assetEqual(assetOf(x.Amount), x.XChainBridge.issue(sourceChain(x.WasLockingChainSend))) {
+		!assetEqual(assetOf(x.Amount), x.XChainBridge.issue(sourceChain(x.WasLockingChainSend != 0))) {
 		return ter.Errorf(ter.TemXCHAIN_BAD_PROOF, "invalid account-create attestation proof")
 	}
 	return nil

--- a/internal/tx/xchain/xchain.go
+++ b/internal/tx/xchain/xchain.go
@@ -411,7 +411,7 @@ type XChainAddClaimAttestation struct {
 	Signature string `json:"Signature" xrpl:"Signature"`
 
 	// WasLockingChainSend indicates if this was a locking chain send (required)
-	WasLockingChainSend bool `json:"WasLockingChainSend" xrpl:"WasLockingChainSend,boolint"`
+	WasLockingChainSend uint8 `json:"WasLockingChainSend" xrpl:"WasLockingChainSend"`
 }
 
 // NewXChainAddClaimAttestation creates a new XChainAddClaimAttestation transaction
@@ -505,7 +505,7 @@ type XChainAddAccountCreateAttestation struct {
 	Signature string `json:"Signature" xrpl:"Signature"`
 
 	// WasLockingChainSend indicates if this was a locking chain send (required)
-	WasLockingChainSend bool `json:"WasLockingChainSend" xrpl:"WasLockingChainSend,boolint"`
+	WasLockingChainSend uint8 `json:"WasLockingChainSend" xrpl:"WasLockingChainSend"`
 
 	// XChainAccountCreateCount is the create count (required)
 	XChainAccountCreateCount uint64 `json:"XChainAccountCreateCount" xrpl:"XChainAccountCreateCount"`


### PR DESCRIPTION
## Summary
- normalize binary-decoded UInt64 and bool-as-integer fields before unmarshalling concrete transaction types
- preserve the same base metadata used by transaction flattening, including nested Batch transactions
- add binary parse and byte-for-byte round-trip coverage for all four affected XChain transaction shapes

## Test plan
- [x] `go test ./internal/tx/xchain -run TestXChainUInt64BinaryRoundTrip -count=1`
- [x] `go test ./internal/tx/xchain/... -count=1`
- [x] `just test-tx`
- [x] `just test`
- [x] `just vet`
- [x] `just lint`
- [x] `just build-all`

Fixes #1742
