### PR TITLE
fix: preserve fast-load pivot retarget liveness

### DIFF
--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -70,13 +70,21 @@ type FastSyncMetrics struct {
 	ReplayPipelineDiscarded              uint64
 	ReplayPipelineRetried                uint64
 	ReplayPipelineFallbacks              uint64
+	ReplayPipelineCapacityRetargets      uint64
+	ReplayPipelineRetargetFailures       uint64
 	ReplayPipelineAcquireUs              uint64
 	ReplayPipelineReadyWaitUs            uint64
 	ReplayPipelineApplyUs                uint64
 	ReplayPipelinePersistUs              uint64
 	ReplayPipelineWindow                 uint32
+	ReplayPipelinePreparedLimit          uint32
 	ReplayPipelineDepth                  uint32
 	ReplayPipelineReadyDepth             uint32
+	ReplayPipelinePivotSeq               uint32
+	ReplayPipelinePreparedTailSeq        uint32
+	ReplayPipelineTrustedHeadSeq         uint32
+	ReplayPipelineGeneration             uint64
+	ReplayPipelinePivotStateNodesPerSec  uint64
 	ReplayPipelineHeadSeq                uint32
 	ReplayPipelineTargetSeq              uint32
 	ReplayPipelineHeadBlockedUs          uint64
@@ -309,6 +317,8 @@ type Router struct {
 	replayPipelineDiscarded              atomic.Uint64
 	replayPipelineRetried                atomic.Uint64
 	replayPipelineFallbacks              atomic.Uint64
+	replayPipelineCapacityRetargets      atomic.Uint64
+	replayPipelineRetargetFailures       atomic.Uint64
 	replayPipelineAcquireUs              atomic.Uint64
 	replayPipelineReadyWaitUs            atomic.Uint64
 	replayPipelineApplyUs                atomic.Uint64

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -824,11 +824,12 @@ func (r *Router) armPendingConsensusLedger() bool {
 		} else {
 			r.startLedgerAcquisitionLegacyLocked(acquisitionSeq, acquisitionHash, peerID)
 		}
-		if r.fetchTracker.Find(acquisitionHash) != nil {
+		started := r.fetchTracker.Find(acquisitionHash) != nil
+		if started {
 			r.consensusRecovery.stepHash = acquisitionHash
 		}
 		r.acquisitionMu.Unlock()
-		return true
+		return started
 	}
 }
 
@@ -1810,7 +1811,24 @@ func (r *Router) FastSyncMetrics() FastSyncMetrics {
 		}
 	}
 	targetSeq := r.standardReplay.targetSeq
+	pivotSeq := r.standardReplay.pivotSeq
+	preparedTailSeq := r.standardReplay.collectSeq
+	generation := r.standardReplay.generation
+	pivotHash := r.standardReplay.pivotHash
+	pivotStartedAt := r.standardReplay.pivotStartedAt
 	r.acquisitionMu.Unlock()
+	pivotStateRate := uint64(0)
+	if pivot := r.fetchTracker.Find(pivotHash); pivot != nil && !pivotStartedAt.IsZero() {
+		if elapsed := time.Since(pivotStartedAt); elapsed > 0 {
+			pivotStateRate = uint64(float64(pivot.Snapshot().StateUseful) / elapsed.Seconds())
+		}
+	}
+	r.catchupMu.Lock()
+	trustedHeadSeq := uint32(0)
+	if r.catchup.source == catchupSourceQuorum {
+		trustedHeadSeq = r.catchup.seq
+	}
+	r.catchupMu.Unlock()
 	return FastSyncMetrics{
 		CompletionRecheckAccepted:            r.completionRecheckAccepted.Load(),
 		CompletionRecheckRejectedNoEvidence:  r.completionRecheckRejectedNoEvidence.Load(),
@@ -1824,13 +1842,21 @@ func (r *Router) FastSyncMetrics() FastSyncMetrics {
 		ReplayPipelineDiscarded:              r.replayPipelineDiscarded.Load(),
 		ReplayPipelineRetried:                r.replayPipelineRetried.Load(),
 		ReplayPipelineFallbacks:              r.replayPipelineFallbacks.Load(),
+		ReplayPipelineCapacityRetargets:      r.replayPipelineCapacityRetargets.Load(),
+		ReplayPipelineRetargetFailures:       r.replayPipelineRetargetFailures.Load(),
 		ReplayPipelineAcquireUs:              r.replayPipelineAcquireUs.Load(),
 		ReplayPipelineReadyWaitUs:            r.replayPipelineReadyWaitUs.Load(),
 		ReplayPipelineApplyUs:                r.replayPipelineApplyUs.Load(),
 		ReplayPipelinePersistUs:              r.replayPipelinePersistUs.Load(),
 		ReplayPipelineWindow:                 standardReplayPipelineWindow,
+		ReplayPipelinePreparedLimit:          standardReplayPreparedLimit,
 		ReplayPipelineDepth:                  uint32(depth),
 		ReplayPipelineReadyDepth:             uint32(readyDepth),
+		ReplayPipelinePivotSeq:               pivotSeq,
+		ReplayPipelinePreparedTailSeq:        preparedTailSeq,
+		ReplayPipelineTrustedHeadSeq:         trustedHeadSeq,
+		ReplayPipelineGeneration:             generation,
+		ReplayPipelinePivotStateNodesPerSec:  pivotStateRate,
 		ReplayPipelineHeadSeq:                headSeq,
 		ReplayPipelineTargetSeq:              targetSeq,
 		ReplayPipelineHeadBlockedUs:          blockedUs,

--- a/internal/consensus/adaptor/router_recovery_session.go
+++ b/internal/consensus/adaptor/router_recovery_session.go
@@ -8,6 +8,13 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
 )
 
+type frozenPivotRetargetReason string
+
+const (
+	frozenPivotRetargetCapacity frozenPivotRetargetReason = "prepared_capacity"
+	frozenPivotRetargetStalled  frozenPivotRetargetReason = "replay_stalled"
+)
+
 func (r *Router) beginFrozenPivotRecovery(seq uint32, hash [32]byte, peerID uint64) bool {
 	if seq == 0 || hash == ([32]byte{}) {
 		return false
@@ -33,9 +40,11 @@ func (r *Router) beginFrozenPivotRecovery(seq uint32, hash [32]byte, peerID uint
 	r.standardReplay.targetHash = hash
 	r.standardReplay.entries = make(map[uint32]*standardReplayEntry, standardReplayPreparedLimit)
 	r.standardReplay.headBlockedAt = time.Time{}
+	r.standardReplay.pivotStartedAt = time.Now()
 	r.standardReplay.progressSampleAt = time.Time{}
 	r.standardReplay.sampleAnchorSeq = seq
 	r.standardReplay.stalledSamples = 0
+	r.standardReplay.retargetAttemptAt = time.Time{}
 	if r.consensusRecovery.targetHash != ([32]byte{}) {
 		r.consensusRecovery.stepHash = hash
 	}
@@ -222,65 +231,165 @@ func (r *Router) completeFrozenPivotAcquisition(h *header.LedgerHeader, initialC
 
 func (r *Router) rebootstrapFrozenPivotIfStalled(now time.Time) bool {
 	r.acquisitionMu.Lock()
-	if !r.standardReplay.active || !r.standardReplay.pivotReady || r.standardReplay.applying ||
-		r.standardReplay.targetSeq <= r.standardReplay.anchorSeq {
-		r.acquisitionMu.Unlock()
-		return false
-	}
-	if r.standardReplay.progressSampleAt.IsZero() {
-		r.standardReplay.progressSampleAt = now
-		r.standardReplay.sampleAnchorSeq = r.standardReplay.anchorSeq
-		r.acquisitionMu.Unlock()
-		return false
-	}
-	if now.Sub(r.standardReplay.progressSampleAt) < standardReplayProgressWindow {
+	if !r.standardReplay.active {
 		r.acquisitionMu.Unlock()
 		return false
 	}
 
-	if r.standardReplay.anchorSeq > r.standardReplay.sampleAnchorSeq {
-		r.standardReplay.stalledSamples = 0
-	} else if r.standardReplay.stalledSamples < ^uint8(0) {
-		r.standardReplay.stalledSamples++
+	reason := frozenPivotRetargetReason("")
+	if !r.standardReplay.pivotReady && len(r.standardReplay.entries) >= standardReplayRetargetThreshold {
+		reason = frozenPivotRetargetCapacity
+	} else {
+		if !r.standardReplay.pivotReady || r.standardReplay.applying ||
+			r.standardReplay.targetSeq <= r.standardReplay.anchorSeq {
+			r.acquisitionMu.Unlock()
+			return false
+		}
+		if r.standardReplay.progressSampleAt.IsZero() {
+			r.standardReplay.progressSampleAt = now
+			r.standardReplay.sampleAnchorSeq = r.standardReplay.anchorSeq
+			r.acquisitionMu.Unlock()
+			return false
+		}
+		if now.Sub(r.standardReplay.progressSampleAt) < standardReplayProgressWindow {
+			r.acquisitionMu.Unlock()
+			return false
+		}
+
+		if r.standardReplay.anchorSeq > r.standardReplay.sampleAnchorSeq {
+			r.standardReplay.stalledSamples = 0
+			r.standardReplay.retargetAttemptAt = time.Time{}
+		} else if r.standardReplay.stalledSamples < ^uint8(0) {
+			r.standardReplay.stalledSamples++
+		}
+		r.standardReplay.progressSampleAt = now
+		r.standardReplay.sampleAnchorSeq = r.standardReplay.anchorSeq
+		if r.standardReplay.stalledSamples < standardReplayStallWindows {
+			r.acquisitionMu.Unlock()
+			return false
+		}
+		reason = frozenPivotRetargetStalled
 	}
-	r.standardReplay.progressSampleAt = now
-	r.standardReplay.sampleAnchorSeq = r.standardReplay.anchorSeq
-	if r.standardReplay.stalledSamples < standardReplayStallWindows {
+
+	if !r.standardReplay.retargetAttemptAt.IsZero() &&
+		now.Sub(r.standardReplay.retargetAttemptAt) < standardReplayProgressWindow {
 		r.acquisitionMu.Unlock()
 		return false
 	}
+	r.standardReplay.retargetAttemptAt = now
 	generation := r.standardReplay.generation
 	frontierSeq := r.standardReplay.anchorSeq
+	pivotSeq := r.standardReplay.pivotSeq
 	r.acquisitionMu.Unlock()
+
+	return r.retargetFrozenPivot(generation, frontierSeq, pivotSeq, reason, now)
+}
+
+func (r *Router) retargetFrozenPivot(
+	generation uint64,
+	frontierSeq uint32,
+	pivotSeq uint32,
+	reason frozenPivotRetargetReason,
+	now time.Time,
+) bool {
+	r.catchupMu.Lock()
+	target := r.catchup
+	r.catchupMu.Unlock()
+	minimumSeq := pivotSeq
+	if reason == frozenPivotRetargetStalled {
+		minimumSeq = frontierSeq
+	}
+	if target.source != catchupSourceQuorum || target.seq <= minimumSeq || target.hash == ([32]byte{}) {
+		r.replayPipelineRetargetFailures.Add(1)
+		r.logger.Warn("cannot retarget frozen recovery pivot without a newer quorum target",
+			"reason", string(reason),
+			"pivot_seq", pivotSeq,
+			"frontier_seq", frontierSeq,
+			"trusted_head_seq", target.seq,
+		)
+		return false
+	}
+
+	peerID, ok := r.resolveAcquisitionPeer(target.seq, target.peerID)
+	if !ok {
+		r.replayPipelineRetargetFailures.Add(1)
+		r.logger.Warn("cannot retarget frozen recovery pivot without an acquisition peer",
+			"reason", string(reason),
+			"pivot_seq", pivotSeq,
+			"frontier_seq", frontierSeq,
+			"trusted_head_seq", target.seq,
+		)
+		return false
+	}
+	if r.belowFloor(target.seq) || r.catchupRetryBlocked(target.hash, now) {
+		r.replayPipelineRetargetFailures.Add(1)
+		r.logger.Warn("cannot retarget frozen recovery pivot while the quorum target is not admissible",
+			"reason", string(reason),
+			"pivot_seq", pivotSeq,
+			"frontier_seq", frontierSeq,
+			"trusted_head_seq", target.seq,
+		)
+		return false
+	}
 
 	r.replayCommitMu.Lock()
 	r.acquisitionMu.Lock()
-	if !r.standardReplay.active || !r.standardReplay.pivotReady ||
-		r.standardReplay.generation != generation || r.standardReplay.anchorSeq != frontierSeq ||
-		r.standardReplay.stalledSamples < standardReplayStallWindows {
+	capacityCurrent := reason == frozenPivotRetargetCapacity && !r.standardReplay.pivotReady &&
+		len(r.standardReplay.entries) >= standardReplayRetargetThreshold
+	stallCurrent := reason == frozenPivotRetargetStalled && r.standardReplay.pivotReady &&
+		!r.standardReplay.applying && r.standardReplay.stalledSamples >= standardReplayStallWindows
+	if !r.standardReplay.active || r.standardReplay.generation != generation ||
+		r.standardReplay.anchorSeq != frontierSeq || (!capacityCurrent && !stallCurrent) {
 		r.acquisitionMu.Unlock()
 		r.replayCommitMu.Unlock()
 		return false
 	}
-	targetSeq := r.standardReplay.targetSeq
-	targetHash := r.standardReplay.targetHash
+	preparedTailSeq := r.standardReplay.collectSeq
+	preparedOccupancy := len(r.standardReplay.entries)
+	pivotHash := r.standardReplay.pivotHash
+	pivotStartedAt := r.standardReplay.pivotStartedAt
+	pivotStateRate := uint64(0)
+	if pivot := r.fetchTracker.Find(pivotHash); pivot != nil && !pivotStartedAt.IsZero() {
+		elapsed := now.Sub(pivotStartedAt)
+		if elapsed > 0 {
+			pivotStateRate = uint64(float64(pivot.Snapshot().StateUseful) / elapsed.Seconds())
+		}
+	}
 	retired := r.cancelStandardReplayPipelineLocked()
+	retired = append(retired, r.discardSupersededProvisionalFullStateLocked(target.hash)...)
+	r.consensusRecovery.targetHash = target.hash
 	r.consensusRecovery.anchorSeq = 0
 	r.consensusRecovery.anchorHash = [32]byte{}
 	r.consensusRecovery.stepHash = [32]byte{}
 	r.acquisitionMu.Unlock()
 	r.replayCommitMu.Unlock()
 	r.retireLegacyAcquisitions(retired)
-	r.replayPipelineFallbacks.Add(1)
-	r.logger.Warn("replay recovery is not converging; selecting a new full-state pivot",
-		"frontier_seq", frontierSeq,
-		"target_seq", targetSeq,
-		"target_hash", fmt.Sprintf("%x", targetHash[:8]),
-	)
-	if peerID, ok := r.resolveAcquisitionPeer(targetSeq, 0); ok {
-		r.beginFrozenPivotRecovery(targetSeq, targetHash, peerID)
+	if reason == frozenPivotRetargetCapacity {
+		r.replayPipelineCapacityRetargets.Add(1)
+	} else {
+		r.replayPipelineFallbacks.Add(1)
 	}
-	return true
+	r.logger.Warn("retargeting frozen recovery to a newer full-state pivot",
+		"reason", string(reason),
+		"pivot_seq", pivotSeq,
+		"frontier_seq", frontierSeq,
+		"prepared_tail_seq", preparedTailSeq,
+		"trusted_head_seq", target.seq,
+		"trusted_head_hash", fmt.Sprintf("%x", target.hash[:8]),
+		"prepared_occupancy", preparedOccupancy,
+		"prepared_limit", standardReplayPreparedLimit,
+		"pivot_state_nodes_per_sec", pivotStateRate,
+	)
+	if r.beginFrozenPivotRecovery(target.seq, target.hash, peerID) {
+		return true
+	}
+	r.replayPipelineRetargetFailures.Add(1)
+	r.logger.Warn("failed to start replacement full-state pivot",
+		"reason", string(reason),
+		"target_seq", target.seq,
+		"target_hash", fmt.Sprintf("%x", target.hash[:8]),
+	)
+	return false
 }
 
 func (r *Router) failFrozenPivotRecovery(hash [32]byte) bool {

--- a/internal/consensus/adaptor/router_recovery_session_test.go
+++ b/internal/consensus/adaptor/router_recovery_session_test.go
@@ -2,6 +2,9 @@ package adaptor
 
 import (
 	"context"
+	"encoding/binary"
+	"io"
+	"log/slog"
 	"sync"
 	"testing"
 	"time"
@@ -221,6 +224,7 @@ func TestFrozenPivotRecoveryRebootstrapsAfterTwoNoProgressWindows(t *testing.T) 
 	started := time.Unix(100, 0)
 	targetHash := [32]byte{0xd1}
 	trackCatchupPeer(r, 7, 200, targetHash)
+	r.recordValidationCatchupTarget(200, targetHash, 7, catchupSourceQuorum)
 	r.standardReplay = standardReplayPipeline{
 		generation:       3,
 		active:           true,
@@ -248,6 +252,236 @@ func TestFrozenPivotRecoveryRebootstrapsAfterTwoNoProgressWindows(t *testing.T) 
 	require.NotNil(t, pivot)
 	assert.False(t, pivot.TransactionOnly())
 	assert.Equal(t, uint64(1), r.FastSyncMetrics().ReplayPipelineFallbacks)
+}
+
+func TestFrozenPivotRecoveryRebootstrapRetiresObsoleteProvisionalFullState(t *testing.T) {
+	r, _, svc := makeProvisionalWarmRouter(t)
+	started := time.Unix(100, 0)
+	frontierSeq := svc.GetClosedLedgerIndex() + maxForwardDeltaGap + 1
+	oldPivotHash := [32]byte{0xd1}
+	obsoleteSeq := frontierSeq + 50
+	obsoleteHash := [32]byte{0xd2}
+	targetSeq := obsoleteSeq + 50
+	targetHash := [32]byte{0xd3}
+
+	trackCatchupPeer(r, 7, targetSeq, targetHash)
+	r.recordValidationCatchupTarget(targetSeq, targetHash, 7, catchupSourceQuorum)
+	r.acquisitionMu.Lock()
+	r.startLedgerAcquisitionLegacyLocked(obsoleteSeq, obsoleteHash, 7)
+	r.standardReplay = standardReplayPipeline{
+		generation:       3,
+		active:           true,
+		pivotReady:       true,
+		pivotSeq:         frontierSeq,
+		pivotHash:        oldPivotHash,
+		anchorSeq:        frontierSeq,
+		targetSeq:        targetSeq,
+		targetHash:       targetHash,
+		entries:          make(map[uint32]*standardReplayEntry),
+		progressSampleAt: started,
+		sampleAnchorSeq:  frontierSeq,
+		stalledSamples:   standardReplayStallWindows - 1,
+	}
+	r.acquisitionMu.Unlock()
+	require.NotNil(t, r.fetchTracker.Find(obsoleteHash))
+
+	require.True(t, r.rebootstrapFrozenPivotIfStalled(started.Add(standardReplayProgressWindow)))
+
+	assert.Nil(t, r.fetchTracker.Find(obsoleteHash))
+	replacement := r.fetchTracker.Find(targetHash)
+	require.NotNil(t, replacement)
+	assert.False(t, replacement.TransactionOnly())
+	assert.True(t, r.standardReplay.active)
+	assert.False(t, r.standardReplay.pivotReady)
+	assert.Equal(t, targetSeq, r.standardReplay.pivotSeq)
+	assert.Equal(t, targetHash, r.standardReplay.pivotHash)
+	replacementGeneration := r.standardReplay.generation
+	assert.False(t, r.completeFrozenPivotAcquisition(&header.LedgerHeader{
+		LedgerIndex: frontierSeq,
+		Hash:        oldPivotHash,
+	}, false))
+	assert.Equal(t, replacementGeneration, r.standardReplay.generation)
+	assert.Equal(t, targetHash, r.standardReplay.pivotHash)
+}
+
+func TestPendingConsensusLedgerReportsBlockedStart(t *testing.T) {
+	r, _, _, _ := makeRouter(t)
+	targetHash := [32]byte{0xA4}
+	r.consensusRecovery.targetHash = targetHash
+	r.catchupFailures = make(map[[32]byte]time.Time)
+	r.catchupFailures[targetHash] = time.Now().Add(time.Minute)
+
+	require.False(t, r.armPendingConsensusLedger())
+	assert.Nil(t, r.fetchTracker.Find(targetHash))
+	assert.Equal(t, consensusRecovery{targetHash: targetHash}, r.consensusRecovery)
+}
+
+func TestFrozenPivotCapacityRetargetRequiresQuorumTarget(t *testing.T) {
+	r, _, _, _ := makeRouter(t)
+	pivotHash := [32]byte{0xb1}
+	targetHash := [32]byte{0xb2}
+	now := time.Unix(300, 0)
+	r.standardReplay = standardReplayPipeline{
+		generation:     3,
+		active:         true,
+		pivotSeq:       100,
+		pivotHash:      pivotHash,
+		anchorSeq:      100,
+		entries:        make(map[uint32]*standardReplayEntry, standardReplayRetargetThreshold),
+		pivotStartedAt: now.Add(-time.Minute),
+	}
+	for i := range standardReplayRetargetThreshold {
+		seq := uint32(i) + 101
+		r.standardReplay.entries[seq] = &standardReplayEntry{seq: seq}
+	}
+	r.recordCatchupTarget(200, targetHash, 7)
+
+	assert.False(t, r.rebootstrapFrozenPivotIfStalled(now))
+	assert.True(t, r.standardReplay.active)
+	assert.Equal(t, uint64(3), r.standardReplay.generation)
+	assert.Equal(t, pivotHash, r.standardReplay.pivotHash)
+	assert.Equal(t, uint64(1), r.FastSyncMetrics().ReplayPipelineRetargetFailures)
+
+	assert.False(t, r.rebootstrapFrozenPivotIfStalled(now.Add(time.Second)))
+	assert.Equal(t, uint64(1), r.FastSyncMetrics().ReplayPipelineRetargetFailures)
+}
+
+func TestFrozenPivotCapacityRetargetKeepsSessionWhenTargetIsCoolingDown(t *testing.T) {
+	r, _, _, _ := makeRouter(t)
+	pivotHash := [32]byte{0xb3}
+	targetHash := [32]byte{0xb4}
+	now := time.Now()
+	r.standardReplay = standardReplayPipeline{
+		generation: 3,
+		active:     true,
+		pivotSeq:   100,
+		pivotHash:  pivotHash,
+		anchorSeq:  100,
+		entries:    make(map[uint32]*standardReplayEntry, standardReplayRetargetThreshold),
+	}
+	for i := range standardReplayRetargetThreshold {
+		seq := uint32(i) + 101
+		r.standardReplay.entries[seq] = &standardReplayEntry{seq: seq}
+	}
+	trackCatchupPeer(r, 7, 200, targetHash)
+	r.recordValidationCatchupTarget(200, targetHash, 7, catchupSourceQuorum)
+	r.catchupMu.Lock()
+	r.catchupFailures = map[[32]byte]time.Time{targetHash: now.Add(time.Minute)}
+	r.catchupMu.Unlock()
+
+	assert.False(t, r.rebootstrapFrozenPivotIfStalled(now))
+	assert.True(t, r.standardReplay.active)
+	assert.Equal(t, uint64(3), r.standardReplay.generation)
+	assert.Equal(t, pivotHash, r.standardReplay.pivotHash)
+	assert.Nil(t, r.fetchTracker.Find(targetHash))
+	assert.Equal(t, uint64(1), r.FastSyncMetrics().ReplayPipelineRetargetFailures)
+}
+
+func TestFrozenPivotRecoveryRetargetsBeforePreparedCapacityIsExhausted(t *testing.T) {
+	r, _, svc := makeProvisionalWarmRouter(t)
+	r.logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	pivotSeq := svc.GetClosedLedgerIndex() + maxForwardDeltaGap + 1
+	pivotHash := [32]byte{0xd4}
+	trackCatchupPeer(r, 7, pivotSeq, pivotHash)
+	require.True(t, r.beginFrozenPivotRecovery(pivotSeq, pivotHash, 7))
+	initialGeneration := r.standardReplay.generation
+	parentHash := pivotHash
+	now := time.Unix(500, 0)
+
+	for offset := uint32(1); offset <= standardReplayPreparedLimit+1; offset++ {
+		seq := pivotSeq + offset
+		var hash [32]byte
+		hash[0] = 0xd5
+		binary.BigEndian.PutUint32(hash[len(hash)-4:], seq)
+		r.recordSeqHash(seq, hash, parentHash, true)
+		trackCatchupPeer(r, 7, seq, hash)
+		r.recordValidationCatchupTarget(seq, hash, 7, catchupSourceQuorum)
+		require.True(t, r.continueFrozenPivotRecovery(seq, hash, 7))
+
+		r.acquisitionMu.Lock()
+		for _, entry := range r.standardReplay.entries {
+			if entry.acquisition == nil {
+				continue
+			}
+			require.True(t, r.fetchTracker.DiscardExpected(entry.acquisition))
+			entry.acquisition = nil
+			entry.durable = true
+		}
+		r.acquisitionMu.Unlock()
+
+		now = now.Add(time.Second)
+		r.rebootstrapFrozenPivotIfStalled(now)
+		parentHash = hash
+	}
+
+	metrics := r.FastSyncMetrics()
+	assert.GreaterOrEqual(t, metrics.ReplayPipelineCapacityRetargets, uint64(1))
+	assert.Zero(t, metrics.ReplayPipelineRetargetFailures)
+	assert.Greater(t, metrics.ReplayPipelineGeneration, initialGeneration)
+	assert.Greater(t, metrics.ReplayPipelinePivotSeq, pivotSeq)
+	assert.Equal(t, pivotSeq+standardReplayPreparedLimit+1, metrics.ReplayPipelinePreparedTailSeq)
+	assert.Equal(t, uint32(standardReplayPreparedLimit), metrics.ReplayPipelinePreparedLimit)
+	assert.Less(t, metrics.ReplayPipelineDepth, uint32(standardReplayPreparedLimit))
+	assert.Equal(t, pivotSeq+standardReplayPreparedLimit+1, metrics.ReplayPipelineTrustedHeadSeq)
+}
+
+func TestFrozenPivotCapacityRetargetReplaysToTrustedHead(t *testing.T) {
+	r, _, svc := makeProvisionalWarmRouter(t)
+	engine := &mockEngine{switchResult: consensus.LedgerSwitchAccepted}
+	r.engine = engine
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	_, initialPivot, initialHash, initialSeq := buildSuccessorAgainstParent(t, closed)
+	_, replacement, replacementHash, replacementSeq := buildSuccessorAgainstParent(t, initialPivot)
+	links := buildStandardReplayTestChain(t, r, replacement, 3)
+
+	trackCatchupPeer(r, 7, initialSeq, initialHash)
+	require.True(t, r.beginFrozenPivotRecovery(initialSeq, initialHash, 7))
+	r.acquisitionMu.Lock()
+	for i := range standardReplayRetargetThreshold {
+		seq := initialSeq + uint32(i) + 1
+		r.standardReplay.entries[seq] = &standardReplayEntry{
+			generation: r.standardReplay.generation,
+			seq:        seq,
+			durable:    true,
+		}
+	}
+	r.standardReplay.collectSeq = initialSeq + standardReplayRetargetThreshold
+	r.acquisitionMu.Unlock()
+
+	trackCatchupPeer(r, 7, replacementSeq, replacementHash)
+	r.recordValidationCatchupTarget(replacementSeq, replacementHash, 7, catchupSourceQuorum)
+	require.True(t, r.rebootstrapFrozenPivotIfStalled(time.Now()))
+	assert.Equal(t, replacementSeq, r.standardReplay.pivotSeq)
+	assert.Equal(t, replacementHash, r.standardReplay.pivotHash)
+
+	trustedHead := links[len(links)-1]
+	trackCatchupPeer(r, 7, trustedHead.seq, trustedHead.hash)
+	r.recordValidationCatchupTarget(trustedHead.seq, trustedHead.hash, 7, catchupSourceQuorum)
+	require.True(t, r.continueFrozenPivotRecovery(trustedHead.seq, trustedHead.hash, 7))
+	for _, link := range links {
+		completeStandardReplayTestLink(t, r, link)
+	}
+
+	pivotAcquisition := r.fetchTracker.Find(replacementHash)
+	require.NotNil(t, pivotAcquisition)
+	storeRecoveryLedger(t, svc, replacement)
+	require.True(t, r.fetchTracker.RemoveExpectedWithSnapshot(
+		pivotAcquisition, pivotAcquisition.Snapshot(), true,
+	))
+	replacementHeader := replacement.Header()
+	require.True(t, r.completeFrozenPivotAcquisition(&replacementHeader, false))
+
+	assert.False(t, r.standardReplay.active)
+	assert.Equal(t, uint64(len(links)), r.FastSyncMetrics().ReplayPipelineApplied)
+	storedHead, err := svc.GetLedgerByHash(trustedHead.hash)
+	require.NoError(t, err)
+	require.NotNil(t, storedHead)
+	assert.Equal(t, trustedHead.seq, storedHead.Sequence())
+	switched := engine.getLedgers()
+	require.NotEmpty(t, switched)
+	assert.Equal(t, consensus.LedgerID(trustedHead.hash), switched[len(switched)-1])
+	assert.Equal(t, consensus.OpModeTracking, r.adaptor.GetOperatingMode())
 }
 
 func TestFrozenPivotRecoveryKeepsAdvancingReplayAtMovingTipRate(t *testing.T) {

--- a/internal/consensus/adaptor/router_replay_pipeline.go
+++ b/internal/consensus/adaptor/router_replay_pipeline.go
@@ -14,33 +14,36 @@ import (
 )
 
 const (
-	standardReplayPipelineWindow = 8
-	standardReplayPreparedLimit  = 2048
-	standardReplayProgressWindow = time.Minute
-	standardReplayStallWindows   = 2
-	standardReplayApplyBatch     = 8
-	standardReplayApplyBudget    = 25 * time.Millisecond
+	standardReplayPipelineWindow    = 8
+	standardReplayPreparedLimit     = 2048
+	standardReplayRetargetThreshold = standardReplayPreparedLimit * 7 / 8
+	standardReplayProgressWindow    = time.Minute
+	standardReplayStallWindows      = 2
+	standardReplayApplyBatch        = 8
+	standardReplayApplyBudget       = 25 * time.Millisecond
 )
 
 type standardReplayPipeline struct {
-	generation       uint64
-	active           bool
-	applying         bool
-	pivotReady       bool
-	initialCandidate bool
-	pivotSeq         uint32
-	pivotHash        [32]byte
-	anchorSeq        uint32
-	anchorHash       [32]byte
-	collectSeq       uint32
-	collectHash      [32]byte
-	targetSeq        uint32
-	targetHash       [32]byte
-	entries          map[uint32]*standardReplayEntry
-	headBlockedAt    time.Time
-	progressSampleAt time.Time
-	sampleAnchorSeq  uint32
-	stalledSamples   uint8
+	generation        uint64
+	active            bool
+	applying          bool
+	pivotReady        bool
+	initialCandidate  bool
+	pivotSeq          uint32
+	pivotHash         [32]byte
+	anchorSeq         uint32
+	anchorHash        [32]byte
+	collectSeq        uint32
+	collectHash       [32]byte
+	targetSeq         uint32
+	targetHash        [32]byte
+	entries           map[uint32]*standardReplayEntry
+	headBlockedAt     time.Time
+	pivotStartedAt    time.Time
+	progressSampleAt  time.Time
+	sampleAnchorSeq   uint32
+	stalledSamples    uint8
+	retargetAttemptAt time.Time
 }
 
 type standardReplayIdentity struct {
@@ -440,9 +443,32 @@ func (r *Router) cancelStandardReplayPipelineLocked() []*inbound.Ledger {
 	r.standardReplay.targetHash = [32]byte{}
 	r.standardReplay.entries = nil
 	r.standardReplay.headBlockedAt = time.Time{}
+	r.standardReplay.pivotStartedAt = time.Time{}
 	r.standardReplay.progressSampleAt = time.Time{}
 	r.standardReplay.sampleAnchorSeq = 0
 	r.standardReplay.stalledSamples = 0
+	r.standardReplay.retargetAttemptAt = time.Time{}
+	return retired
+}
+
+func (r *Router) discardSupersededProvisionalFullStateLocked(keepHash [32]byte) []*inbound.Ledger {
+	if r.adaptor == nil {
+		return nil
+	}
+	svc := r.adaptor.LedgerService()
+	if svc == nil || !svc.IsFastLoadProvisional() {
+		return nil
+	}
+
+	var retired []*inbound.Ledger
+	for _, candidate := range r.fetchTracker.Active() {
+		if candidate.Hash() == keepHash || candidate.Reason() != inbound.ReasonConsensus || candidate.TransactionOnly() {
+			continue
+		}
+		if r.fetchTracker.DiscardExpected(candidate) {
+			retired = append(retired, candidate)
+		}
+	}
 	return retired
 }
 

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -782,6 +782,8 @@ func (r *nodeRuntime) configureConsensus() error {
 					ReplayPipelineDiscarded:              snapshot.ReplayPipelineDiscarded,
 					ReplayPipelineRetried:                snapshot.ReplayPipelineRetried,
 					ReplayPipelineFallbacks:              snapshot.ReplayPipelineFallbacks,
+					ReplayPipelineCapacityRetargets:      snapshot.ReplayPipelineCapacityRetargets,
+					ReplayPipelineRetargetFailures:       snapshot.ReplayPipelineRetargetFailures,
 					ReplayPipelineAcquireUs:              snapshot.ReplayPipelineAcquireUs,
 					ReplayPipelineReadyWaitUs:            snapshot.ReplayPipelineReadyWaitUs,
 					ReplayPipelineApplyUs:                snapshot.ReplayPipelineApplyUs,
@@ -791,6 +793,12 @@ func (r *nodeRuntime) configureConsensus() error {
 					ReplayPipelineReadyDepth:             snapshot.ReplayPipelineReadyDepth,
 					ReplayPipelineHeadSeq:                snapshot.ReplayPipelineHeadSeq,
 					ReplayPipelineTargetSeq:              snapshot.ReplayPipelineTargetSeq,
+					ReplayPipelinePreparedLimit:          snapshot.ReplayPipelinePreparedLimit,
+					ReplayPipelinePivotSeq:               snapshot.ReplayPipelinePivotSeq,
+					ReplayPipelinePreparedTailSeq:        snapshot.ReplayPipelinePreparedTailSeq,
+					ReplayPipelineTrustedHeadSeq:         snapshot.ReplayPipelineTrustedHeadSeq,
+					ReplayPipelineGeneration:             snapshot.ReplayPipelineGeneration,
+					ReplayPipelinePivotStateNodesPerSec:  snapshot.ReplayPipelinePivotStateNodesPerSec,
 					ReplayPipelineHeadBlockedUs:          snapshot.ReplayPipelineHeadBlockedUs,
 				}
 			}

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -244,6 +244,8 @@ func addServerDiagnostics(info map[string]any, services *types.ServiceGraph) {
 			"replay_pipeline_discarded":                      strconv.FormatUint(metrics.ReplayPipelineDiscarded, 10),
 			"replay_pipeline_retried":                        strconv.FormatUint(metrics.ReplayPipelineRetried, 10),
 			"replay_pipeline_fallbacks":                      strconv.FormatUint(metrics.ReplayPipelineFallbacks, 10),
+			"replay_pipeline_capacity_retargets":             strconv.FormatUint(metrics.ReplayPipelineCapacityRetargets, 10),
+			"replay_pipeline_retarget_failures":              strconv.FormatUint(metrics.ReplayPipelineRetargetFailures, 10),
 			"replay_pipeline_acquire_us":                     strconv.FormatUint(metrics.ReplayPipelineAcquireUs, 10),
 			"replay_pipeline_ready_wait_us":                  strconv.FormatUint(metrics.ReplayPipelineReadyWaitUs, 10),
 			"replay_pipeline_apply_us":                       strconv.FormatUint(metrics.ReplayPipelineApplyUs, 10),
@@ -253,6 +255,12 @@ func addServerDiagnostics(info map[string]any, services *types.ServiceGraph) {
 			"replay_pipeline_ready_depth":                    strconv.FormatUint(uint64(metrics.ReplayPipelineReadyDepth), 10),
 			"replay_pipeline_head_seq":                       strconv.FormatUint(uint64(metrics.ReplayPipelineHeadSeq), 10),
 			"replay_pipeline_target_seq":                     strconv.FormatUint(uint64(metrics.ReplayPipelineTargetSeq), 10),
+			"replay_pipeline_prepared_limit":                 strconv.FormatUint(uint64(metrics.ReplayPipelinePreparedLimit), 10),
+			"replay_pipeline_pivot_seq":                      strconv.FormatUint(uint64(metrics.ReplayPipelinePivotSeq), 10),
+			"replay_pipeline_prepared_tail_seq":              strconv.FormatUint(uint64(metrics.ReplayPipelinePreparedTailSeq), 10),
+			"replay_pipeline_trusted_head_seq":               strconv.FormatUint(uint64(metrics.ReplayPipelineTrustedHeadSeq), 10),
+			"replay_pipeline_generation":                     strconv.FormatUint(metrics.ReplayPipelineGeneration, 10),
+			"replay_pipeline_pivot_state_nodes_per_sec":      strconv.FormatUint(metrics.ReplayPipelinePivotStateNodesPerSec, 10),
 			"replay_pipeline_head_blocked_us":                strconv.FormatUint(metrics.ReplayPipelineHeadBlockedUs, 10),
 		}
 	}

--- a/internal/rpc/server_diagnostics_test.go
+++ b/internal/rpc/server_diagnostics_test.go
@@ -68,6 +68,14 @@ func TestServerDiagnosticsWireShape(t *testing.T) {
 			ReplayPipelineHeadSeq:                34,
 			ReplayPipelineTargetSeq:              35,
 			ReplayPipelineHeadBlockedUs:          36,
+			ReplayPipelineCapacityRetargets:      37,
+			ReplayPipelineRetargetFailures:       38,
+			ReplayPipelinePreparedLimit:          39,
+			ReplayPipelinePivotSeq:               40,
+			ReplayPipelinePreparedTailSeq:        41,
+			ReplayPipelineTrustedHeadSeq:         42,
+			ReplayPipelineGeneration:             43,
+			ReplayPipelinePivotStateNodesPerSec:  44,
 		}
 	}
 
@@ -133,6 +141,14 @@ func TestServerDiagnosticsWireShape(t *testing.T) {
 				"replay_pipeline_head_seq":                       "34",
 				"replay_pipeline_target_seq":                     "35",
 				"replay_pipeline_head_blocked_us":                "36",
+				"replay_pipeline_capacity_retargets":             "37",
+				"replay_pipeline_retarget_failures":              "38",
+				"replay_pipeline_prepared_limit":                 "39",
+				"replay_pipeline_pivot_seq":                      "40",
+				"replay_pipeline_prepared_tail_seq":              "41",
+				"replay_pipeline_trusted_head_seq":               "42",
+				"replay_pipeline_generation":                     "43",
+				"replay_pipeline_pivot_state_nodes_per_sec":      "44",
 			}
 			if !reflect.DeepEqual(fastSync, wantFastSync) {
 				t.Fatalf("fast_sync = %#v, want %#v", fastSync, wantFastSync)

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -1292,6 +1292,8 @@ type FastSyncMetrics struct {
 	ReplayPipelineDiscarded              uint64
 	ReplayPipelineRetried                uint64
 	ReplayPipelineFallbacks              uint64
+	ReplayPipelineCapacityRetargets      uint64
+	ReplayPipelineRetargetFailures       uint64
 	ReplayPipelineAcquireUs              uint64
 	ReplayPipelineReadyWaitUs            uint64
 	ReplayPipelineApplyUs                uint64
@@ -1301,6 +1303,12 @@ type FastSyncMetrics struct {
 	ReplayPipelineReadyDepth             uint32
 	ReplayPipelineHeadSeq                uint32
 	ReplayPipelineTargetSeq              uint32
+	ReplayPipelinePreparedLimit          uint32
+	ReplayPipelinePivotSeq               uint32
+	ReplayPipelinePreparedTailSeq        uint32
+	ReplayPipelineTrustedHeadSeq         uint32
+	ReplayPipelineGeneration             uint64
+	ReplayPipelinePivotStateNodesPerSec  uint64
 	ReplayPipelineHeadBlockedUs          uint64
 }
 


### PR DESCRIPTION
## Summary

- retarget frozen fast-load pivots before the 2,048-entry prepared replay limit can strand catch-up
- require a newer quorum-derived target, preserve the active generation when replacement is unavailable, and retire obsolete provisional full-state acquisitions before rearming
- expose retarget outcomes, pivot/prepared/trusted-head state, generation, and pivot download progress through `server_info`
- cover obsolete acquisition ownership, raw-peer rejection, cooldown handling, stale generation completion, more than 2,048 prepared ledgers, and convergence through the trusted head

## Test plan

- [x] `go test ./internal/consensus/adaptor -run 'Test(FrozenPivot|PendingConsensusLedgerReportsBlockedStart)' -count=1`
- [x] critical regression set with `-count=10`
- [x] focused regression set with `-race`
- [x] `go test ./internal/consensus/adaptor -count=1`
- [x] `go test ./internal/rpc/... ./internal/node/... -count=1`
- [x] `just build`
- [x] `just vet`
- [x] `just lint`
- [x] `just test-core`
- [x] `just test`

Fixes #1744
