### PR TITLE
fix(catchup): preserve progress during state acquisition

### DIFF
--- a/internal/consensus/adaptor/acquisition_work.go
+++ b/internal/consensus/adaptor/acquisition_work.go
@@ -314,6 +314,11 @@ func (l *acquisitionWorkLane) runBatch(batch *acquisitionWorkBatch) bool {
 	if errors.Is(result.err, shamap.ErrTraversalBudget) && batch.ctx.Err() == nil {
 		result.err = nil
 		result.yielded = true
+		// Exhausting a slice means the resumable SHAMap cursor made bounded
+		// local progress; it is not a stalled acquisition. Keep the retry timer
+		// behind the active walk so a large on-disk tree cannot consume the
+		// terminal no-progress budget before the next missing frontier is found.
+		result.rearmTimer = true
 	}
 	if result.err == nil && !result.complete && !result.remove {
 		useful := 0
@@ -574,7 +579,10 @@ func processAcquisitionWorkWithBudget(ctx context.Context, ledger *inbound.Ledge
 
 	workCtx := shamap.WithTraversalBudget(ctx, visitBudget)
 
-	if runLocal || runTimer {
+	// Fetch-pack arrivals explicitly enqueue acquisitionWorkLocal. A timeout
+	// must schedule network retries first rather than repeating the full local
+	// SHAMap/fetch-pack scan before it can send a request.
+	if runLocal {
 		_, complete, err := ledger.CheckLocalContext(workCtx, fetch)
 		if err != nil {
 			result.err = err
@@ -596,7 +604,7 @@ func processAcquisitionWorkWithBudget(ctx context.Context, ledger *inbound.Ledge
 			return result
 		}
 		if len(addedPeers) > 0 {
-			result.requests, result.complete, result.err = ledger.CollectMissingAddedRequestsContext(workCtx, addedPeers)
+			result.requests = ledger.CollectMissingCachedAddedRequests(addedPeers)
 		}
 		return result
 	}

--- a/internal/consensus/adaptor/acquisition_work.go
+++ b/internal/consensus/adaptor/acquisition_work.go
@@ -110,6 +110,7 @@ type acquisitionWorkResult struct {
 	timerEscalate  bool
 	timerAt        time.Time
 	rearmTimer     bool
+	localFetch     func([32]byte) ([]byte, bool)
 	retryBase      bool
 	retarget       bool
 	queryDepth     uint32
@@ -606,6 +607,7 @@ func processAcquisitionWorkWithBudget(ctx context.Context, ledger *inbound.Ledge
 		if len(addedPeers) > 0 {
 			result.requests = ledger.CollectMissingCachedAddedRequests(addedPeers)
 		}
+		result.localFetch = fetch
 		return result
 	}
 	if preferred := selectUsefulAcquisitionPeers(usefulByPeer); len(preferred) > 0 {
@@ -826,6 +828,11 @@ func (r *Router) handleAcquisitionWorkResult(result acquisitionWorkResult) {
 		peers := ledger.Peers()
 		r.sendNodesByHash(peers, ledger.Hash(), ledger.Seq(), result.byHashState, message.ObjectTypeStateNode)
 		r.sendNodesByHash(peers, ledger.Hash(), ledger.Seq(), result.byHashTx, message.ObjectTypeTransactionNode)
+	}
+	if result.localFetch != nil && !r.submitAcquisitionWork(ledger, acquisitionWorkEvent{
+		kind: acquisitionWorkLocal, fetch: result.localFetch,
+	}) {
+		r.logger.Warn("inbound ledger: post-timeout local refresh deferred; acquisition worker unavailable", "seq", ledger.Seq())
 	}
 }
 

--- a/internal/consensus/adaptor/acquisition_work_test.go
+++ b/internal/consensus/adaptor/acquisition_work_test.go
@@ -280,6 +280,31 @@ func TestProcessAcquisitionWork_TimeoutSeparatesExistingAndAddedPeerRequests(t *
 	}
 }
 
+func TestProcessAcquisitionWork_TimeoutSchedulesCachedFrontierBeforeLocalScan(t *testing.T) {
+	ledger, _ := newWideWorkLedger(t)
+	require.True(t, ledger.AddPeer(22))
+	seeded, _ := ledger.CollectMissingRequest(false)
+	require.NotEmpty(t, seeded)
+
+	localFetches := 0
+	result := processAcquisitionWorkWithBudget(t.Context(), ledger, []acquisitionWorkEvent{{
+		kind:  acquisitionWorkTimer,
+		peers: []uint64{1},
+		added: []uint64{22},
+		fetch: func([32]byte) ([]byte, bool) {
+			localFetches++
+			return nil, false
+		},
+	}}, 1)
+
+	require.NoError(t, result.err)
+	assert.Equal(t, []uint64{1}, result.targets)
+	assert.NotEmpty(t, result.stateIDs)
+	require.Len(t, result.requests, 1)
+	assert.Equal(t, uint64(22), result.requests[0].PeerID)
+	assert.Zero(t, localFetches, "timeout must not run the fetch-pack/local traversal")
+}
+
 func TestProcessAcquisitionWork_BaseSplitsBlindFrontierAcrossSeededPeers(t *testing.T) {
 	peers := []uint64{101, 102, 103, 104, 105}
 	ledger, base := newWantBaseWorkLedger(t, newWideWorkSource(t, 16), peers)
@@ -1384,7 +1409,7 @@ func TestAcquisitionWork_TerminalTimerPreemptsRetainedTraversal(t *testing.T) {
 	require.Equal(t, 7, ledger.Timeouts())
 }
 
-func TestAcquisitionWork_TimerCheckPreemptsYieldedTraversal(t *testing.T) {
+func TestAcquisitionWork_YieldedLocalTraversalRearmsTimer(t *testing.T) {
 	source := newWideWorkSource(t, 16)
 	rootHash, err := source.Hash()
 	require.NoError(t, err)
@@ -1419,23 +1444,26 @@ func TestAcquisitionWork_TimerCheckPreemptsYieldedTraversal(t *testing.T) {
 		lane.stop()
 	}()
 	require.True(t, lane.submit(ledger, acquisitionWorkEvent{
-		kind:  acquisitionWorkTimer,
+		kind:  acquisitionWorkLocal,
 		fetch: func([32]byte) ([]byte, bool) { return nil, false },
 	}))
 
 	first := <-lane.results()
 	require.True(t, first.yielded, "result: %+v", first)
+	require.True(t, first.rearmTimer)
 	require.Equal(t, inbound.TimerRefresh, ledger.OnTimer(timerAt))
 	require.True(t, lane.submit(ledger, acquisitionWorkEvent{
 		kind: acquisitionWorkTimerCheck,
 		at:   timerAt.Add(4 * time.Second),
 	}))
+	first.ledger.RearmTimer(timerAt.Add(4 * time.Second))
 	close(first.ack)
 
 	second := <-lane.results()
-	require.False(t, second.yielded)
-	require.True(t, second.timerEscalate)
-	require.Equal(t, 1, ledger.Timeouts())
+	require.True(t, second.yielded)
+	require.True(t, second.rearmTimer)
+	require.False(t, second.timerEscalate)
+	require.Equal(t, 0, ledger.Timeouts())
 	close(second.ack)
 }
 
@@ -1467,7 +1495,7 @@ func TestAcquisitionWork_EscalationDoesNotRearmPreemptedTraversal(t *testing.T) 
 	require.True(t, <-done)
 }
 
-func TestAcquisitionWork_YieldedWantStateEscalationRearmsAfterWork(t *testing.T) {
+func TestAcquisitionWork_YieldedWantStateDefersEscalation(t *testing.T) {
 	source := newWideWorkSource(t, 16)
 	require.NoError(t, source.Delete([32]byte{}))
 	rootHash, err := source.Hash()
@@ -1488,26 +1516,7 @@ func TestAcquisitionWork_YieldedWantStateEscalationRearmsAfterWork(t *testing.T)
 	router := newTestRouter(nil, newTestAdaptor(t), nil)
 	router.fetchTracker.Track(ledger)
 	lane := newAcquisitionWorkLane(1)
-	var blockMu sync.Mutex
-	blockEscalation := false
-	escalationStarted := make(chan struct{})
-	releaseEscalation := make(chan struct{})
 	lane.process = func(ctx context.Context, current *inbound.Ledger, events []acquisitionWorkEvent) acquisitionWorkResult {
-		blockMu.Lock()
-		block := blockEscalation
-		if block {
-			blockEscalation = false
-		}
-		blockMu.Unlock()
-		if block {
-			close(escalationStarted)
-			select {
-			case <-ctx.Done():
-				return acquisitionWorkResult{ledger: current, err: ctx.Err()}
-			case <-releaseEscalation:
-			}
-			return processAcquisitionWork(ctx, current, events)
-		}
 		return processAcquisitionWorkWithBudget(ctx, current, events, 1)
 	}
 	ctx, cancel := context.WithCancel(t.Context())
@@ -1524,39 +1533,20 @@ func TestAcquisitionWork_YieldedWantStateEscalationRearmsAfterWork(t *testing.T)
 	}))
 	first := <-lane.results()
 	require.True(t, first.yielded)
+	require.True(t, first.rearmTimer)
 	require.True(t, lane.submit(ledger, acquisitionWorkEvent{
 		kind: acquisitionWorkTimerCheck,
 		at:   timerAt,
 	}))
 	router.handleAcquisitionWorkResult(first)
 
-	escalate := <-lane.results()
-	require.True(t, escalate.timerEscalate)
-	blockMu.Lock()
-	blockEscalation = true
-	blockMu.Unlock()
-	router.handleAcquisitionWorkResult(escalate)
-	select {
-	case <-escalationStarted:
-	case <-time.After(time.Second):
-		t.Fatal("timer escalation work was not enqueued on the pending batch")
-	}
-	assert.True(t, lane.has(ledger))
-	assert.True(t, ledger.TimerDue(time.Now()), "timer rearmed before escalation work completed")
-	close(releaseEscalation)
-
-	for {
-		result := <-lane.results()
-		if !result.yielded {
-			require.NoError(t, result.err)
-			require.True(t, result.rearmTimer)
-			assert.True(t, ledger.TimerDue(time.Now()))
-			router.handleAcquisitionWorkResult(result)
-			break
-		}
-		router.handleAcquisitionWorkResult(result)
-	}
-	assert.False(t, ledger.TimerDue(time.Now()), "timer was not rearmed after escalation work completed")
+	second := <-lane.results()
+	require.True(t, second.yielded)
+	require.True(t, second.rearmTimer)
+	require.False(t, second.timerEscalate)
+	require.Zero(t, ledger.Timeouts())
+	router.handleAcquisitionWorkResult(second)
+	assert.False(t, ledger.TimerDue(time.Now()), "timer was not rearmed after the traversal slice")
 }
 
 func TestRouter_MaintenanceDrainsBufferedReplyBeforeTerminalTimer(t *testing.T) {

--- a/internal/consensus/adaptor/acquisition_work_test.go
+++ b/internal/consensus/adaptor/acquisition_work_test.go
@@ -302,7 +302,36 @@ func TestProcessAcquisitionWork_TimeoutSchedulesCachedFrontierBeforeLocalScan(t 
 	assert.NotEmpty(t, result.stateIDs)
 	require.Len(t, result.requests, 1)
 	assert.Equal(t, uint64(22), result.requests[0].PeerID)
-	assert.Zero(t, localFetches, "timeout must not run the fetch-pack/local traversal")
+	require.NotNil(t, result.localFetch)
+	assert.Zero(t, localFetches, "timeout must defer the local traversal until requests are sent")
+}
+
+func TestHandleAcquisitionWorkResult_TimeoutRequestsPrecedeLocalRefresh(t *testing.T) {
+	events := &orderedAcquisitionEvents{}
+	sender := &orderedAcquisitionSender{events: events}
+	adaptor := newTestAdaptor(t)
+	adaptor.sender = sender
+	router := newTestRouter(nil, adaptor, nil)
+	router.acquisition = sender
+	ledger, _ := newWideWorkLedger(t)
+	router.fetchTracker.Track(ledger)
+
+	result := processAcquisitionWork(t.Context(), ledger, []acquisitionWorkEvent{{
+		kind:  acquisitionWorkTimer,
+		peers: []uint64{1},
+		fetch: func([32]byte) ([]byte, bool) {
+			events.add("local fetch")
+			return nil, false
+		},
+	}})
+	require.NoError(t, result.err)
+	require.NotEmpty(t, result.stateIDs)
+
+	router.handleAcquisitionWorkResult(result)
+	got := events.snapshot()
+	require.NotEmpty(t, got)
+	assert.Equal(t, "state request", got[0])
+	assert.Contains(t, got, "local fetch")
 }
 
 func TestProcessAcquisitionWork_BaseSplitsBlindFrontierAcrossSeededPeers(t *testing.T) {

--- a/internal/consensus/adaptor/router_catchup_incident_test.go
+++ b/internal/consensus/adaptor/router_catchup_incident_test.go
@@ -144,8 +144,6 @@ func TestRouter_Issue1663CatchupCascadeRecoversToFull(t *testing.T) {
 	now := base.Add(3900 * time.Millisecond)
 	for range 2 {
 		require.True(t, lane.submit(stale1, acquisitionWorkEvent{
-			// Fetch-pack arrivals, rather than timer retries, now own the
-			// resumable local traversal exercised by this cascade regression.
 			kind:  acquisitionWorkLocal,
 			fetch: func([32]byte) ([]byte, bool) { return nil, false },
 		}))

--- a/internal/consensus/adaptor/router_catchup_incident_test.go
+++ b/internal/consensus/adaptor/router_catchup_incident_test.go
@@ -144,7 +144,9 @@ func TestRouter_Issue1663CatchupCascadeRecoversToFull(t *testing.T) {
 	now := base.Add(3900 * time.Millisecond)
 	for range 2 {
 		require.True(t, lane.submit(stale1, acquisitionWorkEvent{
-			kind:  acquisitionWorkTimer,
+			// Fetch-pack arrivals, rather than timer retries, now own the
+			// resumable local traversal exercised by this cascade regression.
+			kind:  acquisitionWorkLocal,
 			fetch: func([32]byte) ([]byte, bool) { return nil, false },
 		}))
 		yielded := <-lane.results()

--- a/internal/consensus/adaptor/router_replay_pipeline.go
+++ b/internal/consensus/adaptor/router_replay_pipeline.go
@@ -556,7 +556,12 @@ func (r *Router) failStandardReplayPipelineEntry(il *inbound.Ledger) bool {
 	entry.acquisition = nil
 	entry.peerID = il.PeerID()
 	r.replayPipelineRetried.Add(uint64(il.Timeouts()))
-	startDrain := !r.standardReplay.applying
+	// A failed entry may be far ahead of a frozen pivot that is still being
+	// acquired. Do not let that failure wake the drain before the pivot is
+	// installed: the prepared head has no locally available parent until then,
+	// so applying it would cancel the replay pipeline and incorrectly fall back
+	// to another full-state acquisition.
+	startDrain := r.standardReplay.pivotReady && !r.standardReplay.applying
 	if startDrain {
 		r.standardReplay.applying = true
 	}

--- a/internal/consensus/adaptor/router_replay_pipeline_test.go
+++ b/internal/consensus/adaptor/router_replay_pipeline_test.go
@@ -322,6 +322,40 @@ func TestStandardReplayPipelineFallsBackWhenHeadFails(t *testing.T) {
 	assert.GreaterOrEqual(t, metrics.ReplayPipelineDiscarded, uint64(len(links)))
 }
 
+func TestStandardReplayPipelineDefersFailedEntryUntilFrozenPivotReady(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	_, err := svc.AcceptLedger(context.Background())
+	require.NoError(t, err)
+	links := buildStandardReplayTestChain(t, r, svc.GetClosedLedger(), 3)
+	armStandardReplayTestPipeline(t, r, a, sender, links)
+
+	r.acquisitionMu.Lock()
+	r.standardReplay.pivotReady = false
+	r.standardReplay.applying = false
+	generation := r.standardReplay.generation
+	pivotSeq := r.standardReplay.anchorSeq
+	r.acquisitionMu.Unlock()
+
+	// The first successor may be ready while the full-state pivot is still
+	// being verified. A failure farther ahead must not wake the drain yet.
+	completeStandardReplayTestLink(t, r, links[0])
+	failed := r.fetchTracker.Find(links[2].hash)
+	require.NotNil(t, failed)
+	r.failInboundAcquisition(failed)
+
+	r.acquisitionMu.Lock()
+	require.True(t, r.standardReplay.active)
+	assert.Equal(t, generation, r.standardReplay.generation)
+	assert.Equal(t, pivotSeq, r.standardReplay.anchorSeq)
+	assert.False(t, r.standardReplay.applying)
+	assert.False(t, r.standardReplay.entries[links[0].seq].readyAt.IsZero())
+	assert.True(t, r.standardReplay.entries[links[2].seq].failed)
+	r.acquisitionMu.Unlock()
+
+	assert.Zero(t, r.FastSyncMetrics().ReplayPipelineApplied)
+	assert.Zero(t, r.FastSyncMetrics().ReplayPipelineFallbacks)
+}
+
 func TestStandardReplayPipelineFallsBackWhenPersistenceFails(t *testing.T) {
 	r, a, sender, svc := makeRouter(t)
 	_, err := svc.AcceptLedger(context.Background())

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -163,8 +163,14 @@ type Ledger struct {
 	// recentNodes keeps request frontiers disjoint within a timer interval.
 	// requestPeers caps the acquisition at one active request per peer and six
 	// active peer streams. Both are cleared when the timer advances.
-	recentNodes      map[[32]byte]uint64
-	requestPeers     map[uint64]struct{}
+	recentNodes  map[[32]byte]uint64
+	requestPeers map[uint64]struct{}
+	// missingState and missingTx retain the last verified path frontier. Timeout
+	// retries can resend it without walking the durable SHAMap again; useful
+	// replies still perform a fresh walk and replace the frontier. neededState
+	// and neededTx are the bounded diagnostic views exposed in Snapshot.
+	missingState     []shamap.MissingNode
+	missingTx        []shamap.MissingNode
 	neededState      [][32]byte
 	neededTx         [][32]byte
 	stateRecv        uint64
@@ -528,6 +534,19 @@ func (l *Ledger) TakeByHashRequestContext(ctx context.Context, max int) (state, 
 		return nil, nil, nil
 	}
 	l.byHash = false // consumed; re-armed by the next no-progress OnTimer
+	if !l.haveState {
+		state = missingNodeHashes(l.missingState, max)
+	}
+	if !l.haveTx {
+		tx = missingNodeHashes(l.missingTx, max)
+	}
+	// A cached frontier is already sufficient to make network progress. Do not
+	// follow it with another durable traversal merely to fill the other tree's
+	// aggressive request; a later reply or timeout will advance that tree.
+	if len(state) > 0 || len(tx) > 0 {
+		l.mu.Unlock()
+		return state, tx, nil
+	}
 	var stateMap, txMap *shamap.SHAMap
 	if !l.haveState && l.stateMap != nil {
 		stateMap = l.stateMap
@@ -897,6 +916,11 @@ func (l *Ledger) applyKnownNodes(ctx context.Context, m *shamap.SHAMap, nodes []
 		if parsedID.IsRoot() {
 			continue
 		}
+		// A reply for a cached path is no longer an outstanding frontier item,
+		// whether it proves useful, is already local, or contains bad data. A
+		// failed/invalid attachment therefore forces discovery of a fresh path
+		// instead of blindly retrying the same cached NodeID forever.
+		l.removeMissingNodeLocked(m == l.txMap, parsedID)
 		res, entry, err := m.AddKnownNodeByIDWithEntryContext(ctx, parsedID, node.NodeData)
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return added, stored, err
@@ -1164,6 +1188,24 @@ func (l *Ledger) CollectMissingRequestContext(ctx context.Context, isReply bool)
 	if m == nil {
 		return nil, nil, false, nil
 	}
+	if !isReply {
+		l.mu.Lock()
+		var cached []shamap.MissingNode
+		if stateTree && l.stateMap == m && !l.haveState {
+			cached = l.missingState
+		} else if !stateTree && l.txMap == m && !l.haveTx {
+			cached = l.missingTx
+		}
+		if len(cached) > 0 {
+			nodeIDs := l.filterMissingResultLocked(cached, false)
+			l.mu.Unlock()
+			if stateTree {
+				return nodeIDs, nil, false, nil
+			}
+			return nil, nodeIDs, false, nil
+		}
+		l.mu.Unlock()
+	}
 
 	started := time.Now()
 	missing, err := m.GetMissingNodesContext(ctx, missingNodesFind, nil)
@@ -1196,8 +1238,12 @@ func (l *Ledger) CollectMissingRequestContext(ctx context.Context, isReply bool)
 		if finishErr == nil {
 			if stateTree {
 				l.haveState = true
+				l.missingState = nil
+				l.neededState = nil
 			} else {
 				l.haveTx = true
+				l.missingTx = nil
+				l.neededTx = nil
 			}
 			l.recomputeComplete()
 			return nil, nil, l.state == StateComplete, nil
@@ -1265,6 +1311,79 @@ func (l *Ledger) CollectMissingReplyRequestsContext(ctx context.Context, peerIDs
 // newly admitted to an active acquisition.
 func (l *Ledger) CollectMissingAddedRequestsContext(ctx context.Context, peerIDs []uint64) ([]MissingRequest, bool, error) {
 	return l.collectMissingPeerRequestsContext(ctx, peerIDs, reqNodes, true)
+}
+
+// CollectMissingCachedAddedRequests assigns newly-added peers work from the
+// last verified frontier without touching the backing store. It is used only
+// by the timeout path, after CollectMissingRequestContext has guaranteed that
+// a frontier exists (or established that discovery itself must continue).
+func (l *Ledger) CollectMissingCachedAddedRequests(peerIDs []uint64) []MissingRequest {
+	l.workMu.Lock()
+	defer l.workMu.Unlock()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	available := requestPeerLimit - len(l.requestPeers)
+	peers := make([]uint64, 0, min(len(peerIDs), available))
+	for _, peerID := range peerIDs {
+		if available == 0 {
+			break
+		}
+		if peerID == 0 || slices.Contains(peers, peerID) {
+			continue
+		}
+		if _, busy := l.requestPeers[peerID]; busy {
+			continue
+		}
+		peers = append(peers, peerID)
+		available--
+	}
+	if l.state != StateWantState || len(peers) == 0 {
+		return nil
+	}
+
+	requests := make([]MissingRequest, 0, len(peers))
+	for _, transaction := range []bool{false, true} {
+		var frontier []shamap.MissingNode
+		if transaction {
+			if !l.haveTx {
+				frontier = l.missingTx
+			}
+		} else if !l.haveState {
+			frontier = l.missingState
+		}
+		fresh := make([]shamap.MissingNode, 0, len(frontier))
+		for i := range frontier {
+			if _, reserved := l.recentNodes[frontier[i].Hash]; !reserved {
+				fresh = append(fresh, frontier[i])
+			}
+		}
+		for len(peers) > 0 && len(fresh) > 0 {
+			peerID := peers[0]
+			peers = peers[1:]
+			n := min(reqNodes, len(fresh))
+			batch := fresh[:n]
+			fresh = fresh[n:]
+			request := MissingRequest{
+				PeerID:      peerID,
+				NodeIDs:     make([][]byte, 0, n),
+				NodeHashes:  make([][32]byte, 0, n),
+				Transaction: transaction,
+				Blind:       true,
+			}
+			for i := range batch {
+				request.NodeIDs = append(request.NodeIDs, batch[i].NodeID.Bytes())
+				request.NodeHashes = append(request.NodeHashes, batch[i].Hash)
+				l.recentNodes[batch[i].Hash] = peerID
+			}
+			l.requestPeers[peerID] = struct{}{}
+			requests = append(requests, request)
+		}
+		if len(peers) == 0 {
+			break
+		}
+	}
+	return requests
 }
 
 func (l *Ledger) collectMissingPeerRequestsContext(ctx context.Context, peerIDs []uint64, batchLimit int, blind bool) ([]MissingRequest, bool, error) {
@@ -1345,8 +1464,12 @@ func (l *Ledger) collectMissingPeerRequestsContext(ctx context.Context, peerIDs 
 				}
 				if transaction {
 					l.haveTx = true
+					l.missingTx = nil
+					l.neededTx = nil
 				} else {
 					l.haveState = true
+					l.missingState = nil
+					l.neededState = nil
 					clear(l.requestPeers)
 					clear(l.recentNodes)
 				}
@@ -1549,11 +1672,32 @@ func (l *Ledger) snapshotLocked() Snapshot {
 func (l *Ledger) cacheMissingLocked(transaction bool, missing []shamap.MissingNode) {
 	hashes := missingHashes(missing)
 	if transaction {
+		l.missingTx = slices.Clone(missing)
 		l.neededTx = hashes
 	} else {
+		l.missingState = slices.Clone(missing)
 		l.neededState = hashes
 	}
 	l.publishSnapshotLocked()
+}
+
+// removeMissingNodeLocked invalidates a path satisfied (or explicitly
+// answered) by a peer. Caller holds l.mu; the next useful-reply walk replaces
+// the remainder with the newly exposed frontier.
+func (l *Ledger) removeMissingNodeLocked(transaction bool, nodeID shamap.NodeID) {
+	frontier := &l.missingState
+	needed := &l.neededState
+	if transaction {
+		frontier = &l.missingTx
+		needed = &l.neededTx
+	}
+	for i := range *frontier {
+		if (*frontier)[i].NodeID == nodeID {
+			*frontier = slices.Delete(*frontier, i, i+1)
+			*needed = missingHashes(*frontier)
+			return
+		}
+	}
 }
 
 func (l *Ledger) publishSnapshotLocked() {
@@ -1578,6 +1722,20 @@ func cloneHashes(src [][32]byte) [][32]byte {
 func missingHashes(missing []shamap.MissingNode) [][32]byte {
 	if len(missing) > missingNodeBatch {
 		missing = missing[:missingNodeBatch]
+	}
+	hashes := make([][32]byte, len(missing))
+	for i := range missing {
+		hashes[i] = missing[i].Hash
+	}
+	return hashes
+}
+
+func missingNodeHashes(missing []shamap.MissingNode, max int) [][32]byte {
+	if max <= 0 || len(missing) == 0 {
+		return nil
+	}
+	if len(missing) > max {
+		missing = missing[:max]
 	}
 	hashes := make([][32]byte, len(missing))
 	for i := range missing {
@@ -1681,9 +1839,10 @@ func (l *Ledger) CheckLocalContext(ctx context.Context, fetch func(hash [32]byte
 
 	stateProgress, stateComplete := false, false
 	var stateStored []shamap.FlushEntry
+	var stateMissing []shamap.MissingNode
 	if stateMap != nil {
 		loadsBefore := stateMap.FamilyLoadCount()
-		stateProgress, stateStored, err = fillFromLocalContext(ctx, stateMap, fetch)
+		stateProgress, stateStored, stateMissing, err = fillFromLocalContext(ctx, stateMap, fetch)
 		stateProgress = stateProgress || stateMap.FamilyLoadCount() > loadsBefore
 		l.persistReceived(ctx, stateStored, "locally recovered state nodes")
 		if err != nil {
@@ -1694,9 +1853,10 @@ func (l *Ledger) CheckLocalContext(ctx context.Context, fetch func(hash [32]byte
 	}
 	txProgress, txComplete := false, false
 	var txStored []shamap.FlushEntry
+	var txMissing []shamap.MissingNode
 	if txMap != nil {
 		loadsBefore := txMap.FamilyLoadCount()
-		txProgress, txStored, err = fillFromLocalContext(ctx, txMap, fetch)
+		txProgress, txStored, txMissing, err = fillFromLocalContext(ctx, txMap, fetch)
 		txProgress = txProgress || txMap.FamilyLoadCount() > loadsBefore
 		l.persistReceived(ctx, txStored, "locally recovered transaction nodes")
 		if err != nil {
@@ -1712,11 +1872,23 @@ func (l *Ledger) CheckLocalContext(ctx context.Context, fetch func(hash [32]byte
 	if l.state != StateWantState {
 		return false, l.state == StateComplete, nil
 	}
-	if stateMap != nil && l.stateMap == stateMap && stateComplete {
-		l.haveState = true
+	if stateMap != nil && l.stateMap == stateMap {
+		if stateComplete {
+			l.haveState = true
+			l.missingState = nil
+			l.neededState = nil
+		} else if len(stateMissing) > 0 {
+			l.cacheMissingLocked(false, stateMissing)
+		}
 	}
-	if txMap != nil && l.txMap == txMap && txComplete {
-		l.haveTx = true
+	if txMap != nil && l.txMap == txMap {
+		if txComplete {
+			l.haveTx = true
+			l.missingTx = nil
+			l.neededTx = nil
+		} else if len(txMissing) > 0 {
+			l.cacheMissingLocked(true, txMissing)
+		}
 	}
 	progressed = stateProgress || txProgress
 	if progressed {
@@ -1744,16 +1916,20 @@ func (l *Ledger) recordLocalProgress(stateMap, txMap *shamap.SHAMap, progressed 
 	l.markProgressLocked()
 }
 
-func fillFromLocalContext(ctx context.Context, m *shamap.SHAMap, fetch func(hash [32]byte) ([]byte, bool)) (bool, []shamap.FlushEntry, error) {
+func fillFromLocalContext(
+	ctx context.Context,
+	m *shamap.SHAMap,
+	fetch func(hash [32]byte) ([]byte, bool),
+) (bool, []shamap.FlushEntry, []shamap.MissingNode, error) {
 	added := false
 	var stored []shamap.FlushEntry
 	for {
 		missing, err := m.GetMissingNodesContext(ctx, localFillBatch, nil)
 		if err != nil {
-			return added, stored, err
+			return added, stored, nil, err
 		}
 		if len(missing) == 0 {
-			return added, stored, nil
+			return added, stored, nil, nil
 		}
 		passAdded := 0
 		for i := range missing {
@@ -1771,7 +1947,7 @@ func fillFromLocalContext(ctx context.Context, m *shamap.SHAMap, fetch func(hash
 			}
 		}
 		if passAdded == 0 {
-			return added, stored, nil
+			return added, stored, missing, nil
 		}
 		added = true
 	}

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -1489,7 +1489,11 @@ func (l *Ledger) collectMissingPeerRequestsContext(ctx context.Context, peerIDs 
 				l.mu.Unlock()
 				return requests, complete, nil
 			}
-			l.cacheMissingLocked(transaction, missing)
+			// Filtered walks expose extra work for additional peers, but the
+			// unfiltered result remains the authoritative timeout retry frontier.
+			if filter == nil {
+				l.cacheMissingLocked(transaction, missing)
+			}
 			fresh := missing[:0]
 			for i := range missing {
 				if _, exists := l.recentNodes[missing[i].Hash]; !exists {

--- a/internal/ledger/inbound/recent_nodes_test.go
+++ b/internal/ledger/inbound/recent_nodes_test.go
@@ -40,11 +40,11 @@ func (f *countingMissingFamily) FullBelowCache() *shamap.FullBelowCache {
 // newAcquisitionWithMissingNodes builds an acquisition parked in StateWantState
 // with an incomplete state tree, so CollectMissingRequest has outstanding nodes
 // to hand out. Modeled on TestNeedsMissingNodeIDs_RequestsActualMissingNodes.
-func newAcquisitionWithMissingNodes(t *testing.T) *Ledger {
+func newAcquisitionWithMissingNodes(t testing.TB) *Ledger {
 	return newAcquisitionWithMissingNodesAndOptions(t)
 }
 
-func newAcquisitionWithMissingNodesAndOptions(t *testing.T, opts ...Option) *Ledger {
+func newAcquisitionWithMissingNodesAndOptions(t testing.TB, opts ...Option) *Ledger {
 	t.Helper()
 	source := shamap.New(shamap.TypeState)
 	for branch := range byte(8) {
@@ -342,5 +342,82 @@ func TestCollectMissingRequest_TimeoutStillFiresWhenAllDuplicates(t *testing.T) 
 	}
 	if state, _ := il.CollectMissingRequest(false); len(state) == 0 {
 		t.Fatal("timeout path must still fan out even when every node is a duplicate")
+	}
+}
+
+func TestCollectMissingRequest_TimeoutReusesCachedFrontier(t *testing.T) {
+	family := &countingMissingFamily{base: backend.NewMemory()}
+	il := newAcquisitionWithMissingNodesAndOptions(t, WithFamily(family))
+
+	first, _, complete, err := il.CollectMissingRequestContext(t.Context(), false)
+	if err != nil || complete || len(first) == 0 {
+		t.Fatalf("first collect = %d nodes, complete=%t, err=%v", len(first), complete, err)
+	}
+	if reads := family.reads.Load(); reads == 0 {
+		t.Fatal("precondition: initial frontier discovery performed no durable reads")
+	}
+
+	// A due timer clears the request reservations, but the missing paths remain
+	// valid until a reply advances them. Retrying those paths must not rescan the
+	// durable tree.
+	il.OnTimer(time.Now().Add(2 * acquireTimerInterval))
+	family.reads.Store(0)
+	second, _, complete, err := il.CollectMissingRequestContext(t.Context(), false)
+	if err != nil || complete {
+		t.Fatalf("cached collect complete=%t, err=%v", complete, err)
+	}
+	if !slices.EqualFunc(first, second, func(a, b []byte) bool { return slices.Equal(a, b) }) {
+		t.Fatalf("cached frontier differs: first=%x second=%x", first, second)
+	}
+	if reads := family.reads.Load(); reads != 0 {
+		t.Fatalf("cached timeout retry performed %d durable reads, want 0", reads)
+	}
+}
+
+func TestTakeByHashRequest_ReusesCachedFrontier(t *testing.T) {
+	family := &countingMissingFamily{base: backend.NewMemory()}
+	il := newAcquisitionWithMissingNodesAndOptions(t, WithFamily(family))
+	if state, _ := il.CollectMissingRequest(false); len(state) == 0 {
+		t.Fatal("precondition: initial collect produced no state frontier")
+	}
+
+	base := time.Now()
+	il.RearmTimer(base)
+	if action := il.OnTimer(base.Add(4 * time.Second)); action != TimerRefresh {
+		t.Fatalf("initial timer action = %v, want refresh", action)
+	}
+	for i := 2; i <= 6; i++ {
+		if action := il.OnTimer(base.Add(time.Duration(i) * 4 * time.Second)); action != TimerEscalate {
+			t.Fatalf("timer %d action = %v, want escalate", i, action)
+		}
+	}
+
+	family.reads.Store(0)
+	state, _, err := il.TakeByHashRequestContext(t.Context(), missingNodeBatch)
+	if err != nil || len(state) == 0 {
+		t.Fatalf("by-hash request = %d nodes, err=%v", len(state), err)
+	}
+	if reads := family.reads.Load(); reads != 0 {
+		t.Fatalf("cached by-hash retry performed %d durable reads, want 0", reads)
+	}
+}
+
+func BenchmarkCollectMissingRequest_CachedTimeout(b *testing.B) {
+	family := &countingMissingFamily{base: backend.NewMemory()}
+	il := newAcquisitionWithMissingNodesAndOptions(b, WithFamily(family))
+	if state, _ := il.CollectMissingRequest(false); len(state) == 0 {
+		b.Fatal("precondition: initial collect produced no state frontier")
+	}
+	family.reads.Store(0)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, _, complete, err := il.CollectMissingRequestContext(b.Context(), false); err != nil || complete {
+			b.Fatalf("cached timeout collect complete=%t err=%v", complete, err)
+		}
+	}
+	b.StopTimer()
+	if reads := family.reads.Load(); reads != 0 {
+		b.Fatalf("cached timeout benchmark performed %d durable reads, want 0", reads)
 	}
 }

--- a/internal/ledger/inbound/recent_nodes_test.go
+++ b/internal/ledger/inbound/recent_nodes_test.go
@@ -179,6 +179,19 @@ func TestCollectMissingReplyRequests_SixDisjointFrontiers(t *testing.T) {
 					t.Fatal("next frontier repeated an in-flight node")
 				}
 			}
+
+			il.OnTimer(time.Now().Add(2 * acquireTimerInterval))
+			retry, _ := il.CollectMissingRequest(false)
+			if len(retry) == 0 {
+				t.Fatal("timeout did not retain the original retry frontier")
+			}
+			for _, nodeID := range retry {
+				if !slices.ContainsFunc(requests, func(request MissingRequest) bool {
+					return slices.ContainsFunc(request.NodeIDs, func(prior []byte) bool { return string(prior) == string(nodeID) })
+				}) {
+					t.Fatal("timeout replaced the original frontier with filtered follow-on work")
+				}
+			}
 		})
 	}
 }

--- a/internal/ledger/inbound/tracker_test.go
+++ b/internal/ledger/inbound/tracker_test.go
@@ -471,7 +471,9 @@ func TestTracker_InfoDoesNotWaitForWorkerStoreRead(t *testing.T) {
 		_, err := il.GotStateNodesUseful([]message.LedgerNode{depthOne})
 		close(applied)
 		if err == nil {
-			_, _, _, err = il.CollectMissingRequestContext(context.Background(), false)
+			// Force fresh frontier discovery. A timeout collect intentionally
+			// reuses the cached frontier and no longer touches durable storage.
+			_, _, _, err = il.CollectMissingRequestContext(context.Background(), true)
 		}
 		workerDone <- err
 	}()

--- a/shamap/backend/durable_read.go
+++ b/shamap/backend/durable_read.go
@@ -16,6 +16,61 @@ type durableReadCoalescer struct {
 	flights map[[32]byte]*durableReadFlight
 }
 
+const durableReadWorkers = 32
+
+type durableReadTask struct {
+	coalescer *durableReadCoalescer
+	ctx       context.Context
+	hash      [32]byte
+	flight    *durableReadFlight
+	read      func(context.Context, [32]byte) ([]byte, error)
+}
+
+// durableReads is shared by every NodeStore. Backed SHAMap walks already fan
+// out over 16 root branches; a bounded pool preserves that I/O parallelism
+// without creating another goroutine for every Pebble point lookup.
+var durableReads durableReadPool
+
+type durableReadPool struct {
+	once  sync.Once
+	mu    sync.Mutex
+	ready *sync.Cond
+	queue []durableReadTask
+	head  int
+}
+
+func (p *durableReadPool) submit(task durableReadTask) {
+	p.once.Do(func() {
+		p.ready = sync.NewCond(&p.mu)
+		for range durableReadWorkers {
+			go p.run()
+		}
+	})
+	p.mu.Lock()
+	p.queue = append(p.queue, task)
+	p.ready.Signal()
+	p.mu.Unlock()
+}
+
+func (p *durableReadPool) run() {
+	for {
+		p.mu.Lock()
+		for p.head == len(p.queue) {
+			p.ready.Wait()
+		}
+		task := p.queue[p.head]
+		p.queue[p.head] = durableReadTask{}
+		p.head++
+		if p.head >= 1024 && p.head*2 >= len(p.queue) {
+			p.queue = append(p.queue[:0], p.queue[p.head:]...)
+			p.head = 0
+		}
+		p.mu.Unlock()
+
+		task.coalescer.read(task.ctx, task.hash, task.flight, task.read)
+	}
+}
+
 func (c *durableReadCoalescer) fetch(
 	ctx context.Context,
 	hash [32]byte,
@@ -30,12 +85,21 @@ func (c *durableReadCoalescer) fetch(
 		c.flights = make(map[[32]byte]*durableReadFlight)
 	}
 	flight := c.flights[hash]
+	created := flight == nil
 	if flight == nil {
 		flight = &durableReadFlight{done: make(chan struct{})}
 		c.flights[hash] = flight
-		go c.read(context.WithoutCancel(ctx), hash, flight, read)
 	}
 	c.mu.Unlock()
+	if created {
+		durableReads.submit(durableReadTask{
+			coalescer: c,
+			ctx:       context.WithoutCancel(ctx),
+			hash:      hash,
+			flight:    flight,
+			read:      read,
+		})
+	}
 
 	select {
 	case <-ctx.Done():

--- a/shamap/backend/durable_read.go
+++ b/shamap/backend/durable_read.go
@@ -17,6 +17,7 @@ type durableReadCoalescer struct {
 }
 
 const durableReadWorkers = 32
+const durableReadQueue = durableReadWorkers
 
 type durableReadTask struct {
 	coalescer *durableReadCoalescer
@@ -33,41 +34,42 @@ var durableReads durableReadPool
 
 type durableReadPool struct {
 	once  sync.Once
-	mu    sync.Mutex
-	ready *sync.Cond
-	queue []durableReadTask
-	head  int
+	slots chan struct{}
+	tasks chan durableReadTask
 }
 
-func (p *durableReadPool) submit(task durableReadTask) {
+func (p *durableReadPool) start() {
 	p.once.Do(func() {
-		p.ready = sync.NewCond(&p.mu)
+		p.slots = make(chan struct{}, durableReadWorkers+durableReadQueue)
+		p.tasks = make(chan durableReadTask, durableReadQueue)
 		for range durableReadWorkers {
 			go p.run()
 		}
 	})
-	p.mu.Lock()
-	p.queue = append(p.queue, task)
-	p.ready.Signal()
-	p.mu.Unlock()
+}
+
+func (p *durableReadPool) reserve(ctx context.Context) bool {
+	p.start()
+	select {
+	case p.slots <- struct{}{}:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (p *durableReadPool) release() {
+	<-p.slots
+}
+
+func (p *durableReadPool) submit(task durableReadTask) {
+	p.tasks <- task
 }
 
 func (p *durableReadPool) run() {
-	for {
-		p.mu.Lock()
-		for p.head == len(p.queue) {
-			p.ready.Wait()
-		}
-		task := p.queue[p.head]
-		p.queue[p.head] = durableReadTask{}
-		p.head++
-		if p.head >= 1024 && p.head*2 >= len(p.queue) {
-			p.queue = append(p.queue[:0], p.queue[p.head:]...)
-			p.head = 0
-		}
-		p.mu.Unlock()
-
+	for task := range p.tasks {
 		task.coalescer.read(task.ctx, task.hash, task.flight, task.read)
+		p.release()
 	}
 }
 
@@ -81,24 +83,35 @@ func (c *durableReadCoalescer) fetch(
 	}
 
 	c.mu.Lock()
-	if c.flights == nil {
-		c.flights = make(map[[32]byte]*durableReadFlight)
-	}
 	flight := c.flights[hash]
-	created := flight == nil
-	if flight == nil {
-		flight = &durableReadFlight{done: make(chan struct{})}
-		c.flights[hash] = flight
-	}
 	c.mu.Unlock()
-	if created {
-		durableReads.submit(durableReadTask{
-			coalescer: c,
-			ctx:       context.WithoutCancel(ctx),
-			hash:      hash,
-			flight:    flight,
-			read:      read,
-		})
+	if flight == nil {
+		if !durableReads.reserve(ctx) {
+			return nil, ctx.Err()
+		}
+		created := false
+		c.mu.Lock()
+		if c.flights == nil {
+			c.flights = make(map[[32]byte]*durableReadFlight)
+		}
+		flight = c.flights[hash]
+		if flight == nil {
+			flight = &durableReadFlight{done: make(chan struct{})}
+			c.flights[hash] = flight
+			created = true
+		}
+		c.mu.Unlock()
+		if created {
+			durableReads.submit(durableReadTask{
+				coalescer: c,
+				ctx:       context.WithoutCancel(ctx),
+				hash:      hash,
+				flight:    flight,
+				read:      read,
+			})
+		} else {
+			durableReads.release()
+		}
 	}
 
 	select {

--- a/shamap/backend/nodestore_test.go
+++ b/shamap/backend/nodestore_test.go
@@ -58,6 +58,28 @@ type controlledFetchNodeStore struct {
 	once     sync.Once
 }
 
+type concurrentFetchNodeStore struct {
+	nodestore.Database
+	active  atomic.Int32
+	maximum atomic.Int32
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *concurrentFetchNodeStore) Fetch(ctx context.Context, hash nodestore.Hash256) (*nodestore.Node, error) {
+	active := s.active.Add(1)
+	defer s.active.Add(-1)
+	for maximum := s.maximum.Load(); active > maximum && !s.maximum.CompareAndSwap(maximum, active); maximum = s.maximum.Load() {
+	}
+	s.entered <- struct{}{}
+	select {
+	case <-s.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return &nodestore.Node{Hash: hash, Data: []byte("node")}, nil
+}
+
 func (s *controlledFetchNodeStore) Fetch(ctx context.Context, hash nodestore.Hash256) (*nodestore.Node, error) {
 	call := s.calls.Add(1)
 	if call == 1 {
@@ -328,5 +350,46 @@ func TestNodeStoreFetchDurableErrorPropagatesAndRetries(t *testing.T) {
 	}
 	if got := store.calls.Load(); got != 2 {
 		t.Fatalf("backend fetches after retry = %d, want 2", got)
+	}
+}
+
+func TestNodeStoreFetchDurableBoundsBackendConcurrency(t *testing.T) {
+	store := &concurrentFetchNodeStore{
+		Database: NewMemory().db,
+		entered:  make(chan struct{}, durableReadWorkers+8),
+		release:  make(chan struct{}),
+	}
+	family := New(store)
+
+	const queued = durableReadWorkers + 8
+	results := make(chan error, queued)
+	for i := range queued {
+		hash := [32]byte{byte(i + 1)}
+		go func() {
+			_, err := family.FetchDurable(t.Context(), hash)
+			results <- err
+		}()
+	}
+	for range durableReadWorkers {
+		select {
+		case <-store.entered:
+		case <-time.After(time.Second):
+			t.Fatal("durable read pool did not fill")
+		}
+	}
+	select {
+	case <-store.entered:
+		t.Fatal("durable reads exceeded the worker bound")
+	case <-time.After(20 * time.Millisecond):
+	}
+	if maximum := store.maximum.Load(); maximum != durableReadWorkers {
+		t.Fatalf("maximum concurrent backend reads = %d, want %d", maximum, durableReadWorkers)
+	}
+
+	close(store.release)
+	for range queued {
+		if err := <-results; err != nil {
+			t.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- cache the last verified missing-node frontier so timeout and by-hash retries can issue network requests without repeating a durable SHAMap walk;
- make timeout handling network-first while fetch-pack arrivals retain ownership of resumable local traversal;
- treat traversal-budget exhaustion as bounded local progress and rearm the acquisition timer instead of consuming the terminal no-progress budget;
- bound shared durable NodeStore reads to 32 workers while preserving same-hash coalescing;
- prevent a failed replay entry ahead of the head from waking replay before the frozen pivot is installed.

## Why

On the testnet fast-sync path, full-state acquisition was spending most of its time in Pebble point reads. Timer retries repeated local traversal work before they could request the cached missing frontier, and each durable cache miss could create another backend goroutine. Separately, a failed transaction-only entry far ahead of the replay head could wake the drain while `pivotReady == false`; replay then looked up the unavailable pivot parent, returned `ledger not found`, cancelled the pipeline, and fell back to another full-state acquisition.

The changes preserve traversal progress, prioritize useful network work on timeout, bound storage concurrency, and keep replay dormant until its parent pivot exists.

## Validation

- `go test ./internal/consensus/adaptor -count=1`
- `go test ./internal/ledger/inbound ./shamap/backend -count=1`
- focused replay-pipeline regression suite
- Docker testnet run using the existing Pebble database

The live run confirmed that a transaction-only acquisition failure while the pivot was not ready no longer produced the premature `ledger not found` replay fallback.

## Follow-up

The run also exposed a separate capacity-retarget treadmill: reaching the prepared replay threshold still discards an unfinished pivot. This PR does not remove that policy. The requested frozen-pivot/backpressure behavior and testnet evidence are tracked in #1746.

