### PR TITLE
fix: preserve frozen pivot under replay pressure

### DIFF
--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -70,26 +70,25 @@ type FastSyncMetrics struct {
 	ReplayPipelineDiscarded              uint64
 	ReplayPipelineRetried                uint64
 	ReplayPipelineFallbacks              uint64
-	// ReplayPipelineCapacityRetargets remains zero for RPC counter compatibility.
-	ReplayPipelineCapacityRetargets     uint64
-	ReplayPipelineBackpressureEvents    uint64
-	ReplayPipelineRetargetFailures      uint64
-	ReplayPipelineAcquireUs             uint64
-	ReplayPipelineReadyWaitUs           uint64
-	ReplayPipelineApplyUs               uint64
-	ReplayPipelinePersistUs             uint64
-	ReplayPipelineWindow                uint32
-	ReplayPipelinePreparedLimit         uint32
-	ReplayPipelineDepth                 uint32
-	ReplayPipelineReadyDepth            uint32
-	ReplayPipelinePivotSeq              uint32
-	ReplayPipelinePreparedTailSeq       uint32
-	ReplayPipelineTrustedHeadSeq        uint32
-	ReplayPipelineGeneration            uint64
-	ReplayPipelinePivotStateNodesPerSec uint64
-	ReplayPipelineHeadSeq               uint32
-	ReplayPipelineTargetSeq             uint32
-	ReplayPipelineHeadBlockedUs         uint64
+	ReplayPipelineCapacityRetargets      uint64
+	ReplayPipelineBackpressureEvents     uint64
+	ReplayPipelineRetargetFailures       uint64
+	ReplayPipelineAcquireUs              uint64
+	ReplayPipelineReadyWaitUs            uint64
+	ReplayPipelineApplyUs                uint64
+	ReplayPipelinePersistUs              uint64
+	ReplayPipelineWindow                 uint32
+	ReplayPipelinePreparedLimit          uint32
+	ReplayPipelineDepth                  uint32
+	ReplayPipelineReadyDepth             uint32
+	ReplayPipelinePivotSeq               uint32
+	ReplayPipelinePreparedTailSeq        uint32
+	ReplayPipelineTrustedHeadSeq         uint32
+	ReplayPipelineGeneration             uint64
+	ReplayPipelinePivotStateNodesPerSec  uint64
+	ReplayPipelineHeadSeq                uint32
+	ReplayPipelineTargetSeq              uint32
+	ReplayPipelineHeadBlockedUs          uint64
 }
 
 type peerBootstrapAcknowledger interface {

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -70,24 +70,26 @@ type FastSyncMetrics struct {
 	ReplayPipelineDiscarded              uint64
 	ReplayPipelineRetried                uint64
 	ReplayPipelineFallbacks              uint64
-	ReplayPipelineCapacityRetargets      uint64
-	ReplayPipelineRetargetFailures       uint64
-	ReplayPipelineAcquireUs              uint64
-	ReplayPipelineReadyWaitUs            uint64
-	ReplayPipelineApplyUs                uint64
-	ReplayPipelinePersistUs              uint64
-	ReplayPipelineWindow                 uint32
-	ReplayPipelinePreparedLimit          uint32
-	ReplayPipelineDepth                  uint32
-	ReplayPipelineReadyDepth             uint32
-	ReplayPipelinePivotSeq               uint32
-	ReplayPipelinePreparedTailSeq        uint32
-	ReplayPipelineTrustedHeadSeq         uint32
-	ReplayPipelineGeneration             uint64
-	ReplayPipelinePivotStateNodesPerSec  uint64
-	ReplayPipelineHeadSeq                uint32
-	ReplayPipelineTargetSeq              uint32
-	ReplayPipelineHeadBlockedUs          uint64
+	// ReplayPipelineCapacityRetargets remains zero for RPC counter compatibility.
+	ReplayPipelineCapacityRetargets     uint64
+	ReplayPipelineBackpressureEvents    uint64
+	ReplayPipelineRetargetFailures      uint64
+	ReplayPipelineAcquireUs             uint64
+	ReplayPipelineReadyWaitUs           uint64
+	ReplayPipelineApplyUs               uint64
+	ReplayPipelinePersistUs             uint64
+	ReplayPipelineWindow                uint32
+	ReplayPipelinePreparedLimit         uint32
+	ReplayPipelineDepth                 uint32
+	ReplayPipelineReadyDepth            uint32
+	ReplayPipelinePivotSeq              uint32
+	ReplayPipelinePreparedTailSeq       uint32
+	ReplayPipelineTrustedHeadSeq        uint32
+	ReplayPipelineGeneration            uint64
+	ReplayPipelinePivotStateNodesPerSec uint64
+	ReplayPipelineHeadSeq               uint32
+	ReplayPipelineTargetSeq             uint32
+	ReplayPipelineHeadBlockedUs         uint64
 }
 
 type peerBootstrapAcknowledger interface {
@@ -317,7 +319,7 @@ type Router struct {
 	replayPipelineDiscarded              atomic.Uint64
 	replayPipelineRetried                atomic.Uint64
 	replayPipelineFallbacks              atomic.Uint64
-	replayPipelineCapacityRetargets      atomic.Uint64
+	replayPipelineBackpressureEvents     atomic.Uint64
 	replayPipelineRetargetFailures       atomic.Uint64
 	replayPipelineAcquireUs              atomic.Uint64
 	replayPipelineReadyWaitUs            atomic.Uint64

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -1842,7 +1842,7 @@ func (r *Router) FastSyncMetrics() FastSyncMetrics {
 		ReplayPipelineDiscarded:              r.replayPipelineDiscarded.Load(),
 		ReplayPipelineRetried:                r.replayPipelineRetried.Load(),
 		ReplayPipelineFallbacks:              r.replayPipelineFallbacks.Load(),
-		ReplayPipelineCapacityRetargets:      r.replayPipelineCapacityRetargets.Load(),
+		ReplayPipelineBackpressureEvents:     r.replayPipelineBackpressureEvents.Load(),
 		ReplayPipelineRetargetFailures:       r.replayPipelineRetargetFailures.Load(),
 		ReplayPipelineAcquireUs:              r.replayPipelineAcquireUs.Load(),
 		ReplayPipelineReadyWaitUs:            r.replayPipelineReadyWaitUs.Load(),

--- a/internal/consensus/adaptor/router_recovery_session.go
+++ b/internal/consensus/adaptor/router_recovery_session.go
@@ -10,10 +10,7 @@ import (
 
 type frozenPivotRetargetReason string
 
-const (
-	frozenPivotRetargetCapacity frozenPivotRetargetReason = "prepared_capacity"
-	frozenPivotRetargetStalled  frozenPivotRetargetReason = "replay_stalled"
-)
+const frozenPivotRetargetStalled frozenPivotRetargetReason = "replay_stalled"
 
 func (r *Router) beginFrozenPivotRecovery(seq uint32, hash [32]byte, peerID uint64) bool {
 	if seq == 0 || hash == ([32]byte{}) {
@@ -45,6 +42,7 @@ func (r *Router) beginFrozenPivotRecovery(seq uint32, hash [32]byte, peerID uint
 	r.standardReplay.sampleAnchorSeq = seq
 	r.standardReplay.stalledSamples = 0
 	r.standardReplay.retargetAttemptAt = time.Time{}
+	r.standardReplay.backpressured = false
 	if r.consensusRecovery.targetHash != ([32]byte{}) {
 		r.consensusRecovery.stepHash = hash
 	}
@@ -216,6 +214,7 @@ func (r *Router) completeFrozenPivotAcquisition(h *header.LedgerHeader, initialC
 		if current && r.standardReplay.targetSeq == h.LedgerIndex && r.standardReplay.targetHash == h.Hash {
 			r.standardReplay.active = false
 			r.standardReplay.entries = nil
+			r.standardReplay.backpressured = false
 		}
 		r.acquisitionMu.Unlock()
 		if !current {
@@ -236,39 +235,33 @@ func (r *Router) rebootstrapFrozenPivotIfStalled(now time.Time) bool {
 		return false
 	}
 
-	reason := frozenPivotRetargetReason("")
-	if !r.standardReplay.pivotReady && len(r.standardReplay.entries) >= standardReplayRetargetThreshold {
-		reason = frozenPivotRetargetCapacity
-	} else {
-		if !r.standardReplay.pivotReady || r.standardReplay.applying ||
-			r.standardReplay.targetSeq <= r.standardReplay.anchorSeq {
-			r.acquisitionMu.Unlock()
-			return false
-		}
-		if r.standardReplay.progressSampleAt.IsZero() {
-			r.standardReplay.progressSampleAt = now
-			r.standardReplay.sampleAnchorSeq = r.standardReplay.anchorSeq
-			r.acquisitionMu.Unlock()
-			return false
-		}
-		if now.Sub(r.standardReplay.progressSampleAt) < standardReplayProgressWindow {
-			r.acquisitionMu.Unlock()
-			return false
-		}
-
-		if r.standardReplay.anchorSeq > r.standardReplay.sampleAnchorSeq {
-			r.standardReplay.stalledSamples = 0
-			r.standardReplay.retargetAttemptAt = time.Time{}
-		} else if r.standardReplay.stalledSamples < ^uint8(0) {
-			r.standardReplay.stalledSamples++
-		}
+	if !r.standardReplay.pivotReady || r.standardReplay.applying ||
+		r.standardReplay.targetSeq <= r.standardReplay.anchorSeq {
+		r.acquisitionMu.Unlock()
+		return false
+	}
+	if r.standardReplay.progressSampleAt.IsZero() {
 		r.standardReplay.progressSampleAt = now
 		r.standardReplay.sampleAnchorSeq = r.standardReplay.anchorSeq
-		if r.standardReplay.stalledSamples < standardReplayStallWindows {
-			r.acquisitionMu.Unlock()
-			return false
-		}
-		reason = frozenPivotRetargetStalled
+		r.acquisitionMu.Unlock()
+		return false
+	}
+	if now.Sub(r.standardReplay.progressSampleAt) < standardReplayProgressWindow {
+		r.acquisitionMu.Unlock()
+		return false
+	}
+
+	if r.standardReplay.anchorSeq > r.standardReplay.sampleAnchorSeq {
+		r.standardReplay.stalledSamples = 0
+		r.standardReplay.retargetAttemptAt = time.Time{}
+	} else if r.standardReplay.stalledSamples < ^uint8(0) {
+		r.standardReplay.stalledSamples++
+	}
+	r.standardReplay.progressSampleAt = now
+	r.standardReplay.sampleAnchorSeq = r.standardReplay.anchorSeq
+	if r.standardReplay.stalledSamples < standardReplayStallWindows {
+		r.acquisitionMu.Unlock()
+		return false
 	}
 
 	if !r.standardReplay.retargetAttemptAt.IsZero() &&
@@ -282,7 +275,7 @@ func (r *Router) rebootstrapFrozenPivotIfStalled(now time.Time) bool {
 	pivotSeq := r.standardReplay.pivotSeq
 	r.acquisitionMu.Unlock()
 
-	return r.retargetFrozenPivot(generation, frontierSeq, pivotSeq, reason, now)
+	return r.retargetFrozenPivot(generation, frontierSeq, pivotSeq, frozenPivotRetargetStalled, now)
 }
 
 func (r *Router) retargetFrozenPivot(
@@ -295,11 +288,7 @@ func (r *Router) retargetFrozenPivot(
 	r.catchupMu.Lock()
 	target := r.catchup
 	r.catchupMu.Unlock()
-	minimumSeq := pivotSeq
-	if reason == frozenPivotRetargetStalled {
-		minimumSeq = frontierSeq
-	}
-	if target.source != catchupSourceQuorum || target.seq <= minimumSeq || target.hash == ([32]byte{}) {
+	if target.source != catchupSourceQuorum || target.seq <= frontierSeq || target.hash == ([32]byte{}) {
 		r.replayPipelineRetargetFailures.Add(1)
 		r.logger.Warn("cannot retarget frozen recovery pivot without a newer quorum target",
 			"reason", string(reason),
@@ -334,12 +323,10 @@ func (r *Router) retargetFrozenPivot(
 
 	r.replayCommitMu.Lock()
 	r.acquisitionMu.Lock()
-	capacityCurrent := reason == frozenPivotRetargetCapacity && !r.standardReplay.pivotReady &&
-		len(r.standardReplay.entries) >= standardReplayRetargetThreshold
 	stallCurrent := reason == frozenPivotRetargetStalled && r.standardReplay.pivotReady &&
 		!r.standardReplay.applying && r.standardReplay.stalledSamples >= standardReplayStallWindows
 	if !r.standardReplay.active || r.standardReplay.generation != generation ||
-		r.standardReplay.anchorSeq != frontierSeq || (!capacityCurrent && !stallCurrent) {
+		r.standardReplay.anchorSeq != frontierSeq || !stallCurrent {
 		r.acquisitionMu.Unlock()
 		r.replayCommitMu.Unlock()
 		return false
@@ -364,11 +351,7 @@ func (r *Router) retargetFrozenPivot(
 	r.acquisitionMu.Unlock()
 	r.replayCommitMu.Unlock()
 	r.retireLegacyAcquisitions(retired)
-	if reason == frozenPivotRetargetCapacity {
-		r.replayPipelineCapacityRetargets.Add(1)
-	} else {
-		r.replayPipelineFallbacks.Add(1)
-	}
+	r.replayPipelineFallbacks.Add(1)
 	r.logger.Warn("retargeting frozen recovery to a newer full-state pivot",
 		"reason", string(reason),
 		"pivot_seq", pivotSeq,

--- a/internal/consensus/adaptor/router_recovery_session_test.go
+++ b/internal/consensus/adaptor/router_recovery_session_test.go
@@ -1,9 +1,9 @@
 package adaptor
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
-	"io"
 	"log/slog"
 	"sync"
 	"testing"
@@ -316,77 +316,20 @@ func TestPendingConsensusLedgerReportsBlockedStart(t *testing.T) {
 	assert.Equal(t, consensusRecovery{targetHash: targetHash}, r.consensusRecovery)
 }
 
-func TestFrozenPivotCapacityRetargetRequiresQuorumTarget(t *testing.T) {
-	r, _, _, _ := makeRouter(t)
-	pivotHash := [32]byte{0xb1}
-	targetHash := [32]byte{0xb2}
-	now := time.Unix(300, 0)
-	r.standardReplay = standardReplayPipeline{
-		generation:     3,
-		active:         true,
-		pivotSeq:       100,
-		pivotHash:      pivotHash,
-		anchorSeq:      100,
-		entries:        make(map[uint32]*standardReplayEntry, standardReplayRetargetThreshold),
-		pivotStartedAt: now.Add(-time.Minute),
-	}
-	for i := range standardReplayRetargetThreshold {
-		seq := uint32(i) + 101
-		r.standardReplay.entries[seq] = &standardReplayEntry{seq: seq}
-	}
-	r.recordCatchupTarget(200, targetHash, 7)
-
-	assert.False(t, r.rebootstrapFrozenPivotIfStalled(now))
-	assert.True(t, r.standardReplay.active)
-	assert.Equal(t, uint64(3), r.standardReplay.generation)
-	assert.Equal(t, pivotHash, r.standardReplay.pivotHash)
-	assert.Equal(t, uint64(1), r.FastSyncMetrics().ReplayPipelineRetargetFailures)
-
-	assert.False(t, r.rebootstrapFrozenPivotIfStalled(now.Add(time.Second)))
-	assert.Equal(t, uint64(1), r.FastSyncMetrics().ReplayPipelineRetargetFailures)
-}
-
-func TestFrozenPivotCapacityRetargetKeepsSessionWhenTargetIsCoolingDown(t *testing.T) {
-	r, _, _, _ := makeRouter(t)
-	pivotHash := [32]byte{0xb3}
-	targetHash := [32]byte{0xb4}
-	now := time.Now()
-	r.standardReplay = standardReplayPipeline{
-		generation: 3,
-		active:     true,
-		pivotSeq:   100,
-		pivotHash:  pivotHash,
-		anchorSeq:  100,
-		entries:    make(map[uint32]*standardReplayEntry, standardReplayRetargetThreshold),
-	}
-	for i := range standardReplayRetargetThreshold {
-		seq := uint32(i) + 101
-		r.standardReplay.entries[seq] = &standardReplayEntry{seq: seq}
-	}
-	trackCatchupPeer(r, 7, 200, targetHash)
-	r.recordValidationCatchupTarget(200, targetHash, 7, catchupSourceQuorum)
-	r.catchupMu.Lock()
-	r.catchupFailures = map[[32]byte]time.Time{targetHash: now.Add(time.Minute)}
-	r.catchupMu.Unlock()
-
-	assert.False(t, r.rebootstrapFrozenPivotIfStalled(now))
-	assert.True(t, r.standardReplay.active)
-	assert.Equal(t, uint64(3), r.standardReplay.generation)
-	assert.Equal(t, pivotHash, r.standardReplay.pivotHash)
-	assert.Nil(t, r.fetchTracker.Find(targetHash))
-	assert.Equal(t, uint64(1), r.FastSyncMetrics().ReplayPipelineRetargetFailures)
-}
-
-func TestFrozenPivotRecoveryRetargetsBeforePreparedCapacityIsExhausted(t *testing.T) {
+func TestFrozenPivotRecoveryBackpressuresAtPreparedCapacity(t *testing.T) {
 	r, _, svc := makeProvisionalWarmRouter(t)
-	r.logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	var logs bytes.Buffer
+	r.logger = slog.New(slog.NewJSONHandler(&logs, nil))
 	pivotSeq := svc.GetClosedLedgerIndex() + maxForwardDeltaGap + 1
 	pivotHash := [32]byte{0xd4}
+	r.standardReplay.backpressured = true
 	trackCatchupPeer(r, 7, pivotSeq, pivotHash)
 	require.True(t, r.beginFrozenPivotRecovery(pivotSeq, pivotHash, 7))
-	initialGeneration := r.standardReplay.generation
+	require.False(t, r.standardReplay.backpressured)
+	pivotAcquisition := r.fetchTracker.Find(pivotHash)
+	require.NotNil(t, pivotAcquisition)
+	generation := r.standardReplay.generation
 	parentHash := pivotHash
-	now := time.Unix(500, 0)
 
 	for offset := uint32(1); offset <= standardReplayPreparedLimit+1; offset++ {
 		seq := pivotSeq + offset
@@ -408,72 +351,139 @@ func TestFrozenPivotRecoveryRetargetsBeforePreparedCapacityIsExhausted(t *testin
 			entry.durable = true
 		}
 		r.acquisitionMu.Unlock()
-
-		now = now.Add(time.Second)
-		r.rebootstrapFrozenPivotIfStalled(now)
 		parentHash = hash
 	}
 
+	assert.False(t, r.rebootstrapFrozenPivotIfStalled(time.Now()))
+	assert.True(t, r.standardReplay.active)
+	assert.False(t, r.standardReplay.pivotReady)
+	assert.Equal(t, generation, r.standardReplay.generation)
+	assert.Equal(t, pivotSeq, r.standardReplay.pivotSeq)
+	assert.Equal(t, pivotHash, r.standardReplay.pivotHash)
+	assert.Same(t, pivotAcquisition, r.fetchTracker.Find(pivotHash))
+	assert.Len(t, r.standardReplay.entries, standardReplayPreparedLimit)
 	metrics := r.FastSyncMetrics()
-	assert.GreaterOrEqual(t, metrics.ReplayPipelineCapacityRetargets, uint64(1))
-	assert.Zero(t, metrics.ReplayPipelineRetargetFailures)
-	assert.Greater(t, metrics.ReplayPipelineGeneration, initialGeneration)
-	assert.Greater(t, metrics.ReplayPipelinePivotSeq, pivotSeq)
-	assert.Equal(t, pivotSeq+standardReplayPreparedLimit+1, metrics.ReplayPipelinePreparedTailSeq)
+	assert.Equal(t, generation, metrics.ReplayPipelineGeneration)
+	assert.Equal(t, pivotSeq, metrics.ReplayPipelinePivotSeq)
+	assert.Equal(t, pivotSeq+standardReplayPreparedLimit, metrics.ReplayPipelinePreparedTailSeq)
 	assert.Equal(t, uint32(standardReplayPreparedLimit), metrics.ReplayPipelinePreparedLimit)
-	assert.Less(t, metrics.ReplayPipelineDepth, uint32(standardReplayPreparedLimit))
+	assert.Equal(t, uint32(standardReplayPreparedLimit), metrics.ReplayPipelineDepth)
 	assert.Equal(t, pivotSeq+standardReplayPreparedLimit+1, metrics.ReplayPipelineTrustedHeadSeq)
+	assert.Equal(t, uint64(1), metrics.ReplayPipelineBackpressureEvents)
+	assert.Zero(t, metrics.ReplayPipelineFallbacks)
+	assert.Zero(t, metrics.ReplayPipelineRetargetFailures)
+	assert.Contains(t, logs.String(), `"msg":"standard replay collector paused at prepared capacity"`)
+	assert.Contains(t, logs.String(), `"prepared_occupancy":2048`)
+	assert.NotContains(t, logs.String(), "retargeting frozen recovery")
 }
 
-func TestFrozenPivotCapacityRetargetReplaysToTrustedHead(t *testing.T) {
+func TestFrozenPivotBackpressureRefillsAsReplayDrains(t *testing.T) {
 	r, _, svc := makeProvisionalWarmRouter(t)
 	engine := &mockEngine{switchResult: consensus.LedgerSwitchAccepted}
 	r.engine = engine
 	closed := svc.GetClosedLedger()
 	require.NotNil(t, closed)
-	_, initialPivot, initialHash, initialSeq := buildSuccessorAgainstParent(t, closed)
-	_, replacement, replacementHash, replacementSeq := buildSuccessorAgainstParent(t, initialPivot)
-	links := buildStandardReplayTestChain(t, r, replacement, 3)
+	_, pivot, pivotHash, pivotSeq := buildSuccessorAgainstParent(t, closed)
+	head := buildStandardReplayTestChain(t, r, pivot, 1)[0]
 
-	trackCatchupPeer(r, 7, initialSeq, initialHash)
-	require.True(t, r.beginFrozenPivotRecovery(initialSeq, initialHash, 7))
+	trackCatchupPeer(r, 7, pivotSeq, pivotHash)
+	require.True(t, r.beginFrozenPivotRecovery(pivotSeq, pivotHash, 7))
+	generation := r.standardReplay.generation
+	trackCatchupPeer(r, 7, head.seq, head.hash)
+	require.True(t, r.continueFrozenPivotRecovery(head.seq, head.hash, 7))
+	completeStandardReplayTestLink(t, r, head)
+
 	r.acquisitionMu.Lock()
-	for i := range standardReplayRetargetThreshold {
-		seq := initialSeq + uint32(i) + 1
+	var tailHash [32]byte
+	for offset := uint32(2); offset <= standardReplayPreparedLimit; offset++ {
+		seq := pivotSeq + offset
+		tailHash = [32]byte{0xe1}
+		binary.BigEndian.PutUint32(tailHash[len(tailHash)-4:], seq)
 		r.standardReplay.entries[seq] = &standardReplayEntry{
 			generation: r.standardReplay.generation,
 			seq:        seq,
+			hash:       tailHash,
 			durable:    true,
 		}
 	}
-	r.standardReplay.collectSeq = initialSeq + standardReplayRetargetThreshold
+	r.standardReplay.collectSeq = pivotSeq + standardReplayPreparedLimit
+	r.standardReplay.collectHash = tailHash
 	r.acquisitionMu.Unlock()
 
-	trackCatchupPeer(r, 7, replacementSeq, replacementHash)
-	r.recordValidationCatchupTarget(replacementSeq, replacementHash, 7, catchupSourceQuorum)
-	require.True(t, r.rebootstrapFrozenPivotIfStalled(time.Now()))
-	assert.Equal(t, replacementSeq, r.standardReplay.pivotSeq)
-	assert.Equal(t, replacementHash, r.standardReplay.pivotHash)
+	nextSeq := pivotSeq + standardReplayPreparedLimit + 1
+	nextHash := [32]byte{0xe2}
+	r.recordSeqHash(nextSeq, nextHash, tailHash, true)
+	trackCatchupPeer(r, 7, nextSeq, nextHash)
+	r.recordValidationCatchupTarget(nextSeq, nextHash, 7, catchupSourceQuorum)
+	require.True(t, r.continueFrozenPivotRecovery(nextSeq, nextHash, 7))
+	assert.Nil(t, r.fetchTracker.Find(nextHash))
+	assert.Len(t, r.standardReplay.entries, standardReplayPreparedLimit)
 
-	trustedHead := links[len(links)-1]
-	trackCatchupPeer(r, 7, trustedHead.seq, trustedHead.hash)
-	r.recordValidationCatchupTarget(trustedHead.seq, trustedHead.hash, 7, catchupSourceQuorum)
-	require.True(t, r.continueFrozenPivotRecovery(trustedHead.seq, trustedHead.hash, 7))
+	pivotAcquisition := r.fetchTracker.Find(pivotHash)
+	require.NotNil(t, pivotAcquisition)
+	storeRecoveryLedger(t, svc, pivot)
+	require.True(t, r.fetchTracker.RemoveExpectedWithSnapshot(
+		pivotAcquisition, pivotAcquisition.Snapshot(), true,
+	))
+	pivotHeader := pivot.Header()
+	require.True(t, r.completeFrozenPivotAcquisition(&pivotHeader, false))
+
+	assert.True(t, r.standardReplay.active)
+	assert.True(t, r.standardReplay.pivotReady)
+	assert.Equal(t, generation, r.standardReplay.generation)
+	assert.Equal(t, pivotSeq, r.standardReplay.pivotSeq)
+	assert.Equal(t, head.seq, r.standardReplay.anchorSeq)
+	assert.Len(t, r.standardReplay.entries, standardReplayPreparedLimit)
+	next := r.standardReplay.entries[nextSeq]
+	require.NotNil(t, next)
+	assert.NotNil(t, next.acquisition)
+	assert.Same(t, next.acquisition, r.fetchTracker.Find(nextHash))
+	assert.Equal(t, uint64(1), r.FastSyncMetrics().ReplayPipelineApplied)
+}
+
+func TestFrozenPivotRecoveryReplaysToMovingTrustedHead(t *testing.T) {
+	r, _, svc := makeProvisionalWarmRouter(t)
+	engine := &mockEngine{switchResult: consensus.LedgerSwitchAccepted}
+	r.engine = engine
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	_, pivot, pivotHash, pivotSeq := buildSuccessorAgainstParent(t, closed)
+	links := buildStandardReplayTestChain(t, r, pivot, 3)
+
+	trackCatchupPeer(r, 7, pivotSeq, pivotHash)
+	require.True(t, r.beginFrozenPivotRecovery(pivotSeq, pivotHash, 7))
+	initialHead := links[len(links)-1]
+	trackCatchupPeer(r, 7, initialHead.seq, initialHead.hash)
+	r.recordValidationCatchupTarget(initialHead.seq, initialHead.hash, 7, catchupSourceQuorum)
+	require.True(t, r.continueFrozenPivotRecovery(initialHead.seq, initialHead.hash, 7))
 	for _, link := range links {
 		completeStandardReplayTestLink(t, r, link)
 	}
 
-	pivotAcquisition := r.fetchTracker.Find(replacementHash)
+	movingLinks := buildStandardReplayTestChain(t, r, initialHead.ledger, 2)
+	trustedHead := movingLinks[len(movingLinks)-1]
+	trackCatchupPeer(r, 7, trustedHead.seq, trustedHead.hash)
+	r.recordValidationCatchupTarget(trustedHead.seq, trustedHead.hash, 7, catchupSourceQuorum)
+	require.True(t, r.continueFrozenPivotRecovery(trustedHead.seq, trustedHead.hash, 7))
+	for _, link := range movingLinks {
+		completeStandardReplayTestLink(t, r, link)
+	}
+	r.acquisitionMu.Lock()
+	r.standardReplay.backpressured = true
+	r.acquisitionMu.Unlock()
+
+	pivotAcquisition := r.fetchTracker.Find(pivotHash)
 	require.NotNil(t, pivotAcquisition)
-	storeRecoveryLedger(t, svc, replacement)
+	storeRecoveryLedger(t, svc, pivot)
 	require.True(t, r.fetchTracker.RemoveExpectedWithSnapshot(
 		pivotAcquisition, pivotAcquisition.Snapshot(), true,
 	))
-	replacementHeader := replacement.Header()
-	require.True(t, r.completeFrozenPivotAcquisition(&replacementHeader, false))
+	pivotHeader := pivot.Header()
+	require.True(t, r.completeFrozenPivotAcquisition(&pivotHeader, false))
 
 	assert.False(t, r.standardReplay.active)
-	assert.Equal(t, uint64(len(links)), r.FastSyncMetrics().ReplayPipelineApplied)
+	assert.False(t, r.standardReplay.backpressured)
+	assert.Equal(t, uint64(len(links)+len(movingLinks)), r.FastSyncMetrics().ReplayPipelineApplied)
 	storedHead, err := svc.GetLedgerByHash(trustedHead.hash)
 	require.NoError(t, err)
 	require.NotNil(t, storedHead)

--- a/internal/consensus/adaptor/router_replay_pipeline.go
+++ b/internal/consensus/adaptor/router_replay_pipeline.go
@@ -14,13 +14,12 @@ import (
 )
 
 const (
-	standardReplayPipelineWindow    = 8
-	standardReplayPreparedLimit     = 2048
-	standardReplayRetargetThreshold = standardReplayPreparedLimit * 7 / 8
-	standardReplayProgressWindow    = time.Minute
-	standardReplayStallWindows      = 2
-	standardReplayApplyBatch        = 8
-	standardReplayApplyBudget       = 25 * time.Millisecond
+	standardReplayPipelineWindow = 8
+	standardReplayPreparedLimit  = 2048
+	standardReplayProgressWindow = time.Minute
+	standardReplayStallWindows   = 2
+	standardReplayApplyBatch     = 8
+	standardReplayApplyBudget    = 25 * time.Millisecond
 )
 
 type standardReplayPipeline struct {
@@ -44,6 +43,7 @@ type standardReplayPipeline struct {
 	sampleAnchorSeq   uint32
 	stalledSamples    uint8
 	retargetAttemptAt time.Time
+	backpressured     bool
 }
 
 type standardReplayIdentity struct {
@@ -297,6 +297,7 @@ func (r *Router) tryArmStandardReplayPipeline(
 		r.standardReplay.progressSampleAt = time.Now()
 		r.standardReplay.sampleAnchorSeq = anchor.Sequence()
 		r.standardReplay.stalledSamples = 0
+		r.standardReplay.backpressured = false
 	}
 	if targetSeq > r.standardReplay.targetSeq ||
 		(targetSeq == r.standardReplay.targetSeq && targetHash == r.standardReplay.targetHash) {
@@ -344,6 +345,19 @@ func (r *Router) tryArmStandardReplayPipeline(
 			r.replayPipelineRequested.Add(1)
 		}
 	}
+	backpressureStarted := len(r.standardReplay.entries) >= standardReplayPreparedLimit &&
+		r.standardReplay.collectSeq < r.standardReplay.targetSeq && !r.standardReplay.backpressured
+	if backpressureStarted {
+		r.standardReplay.backpressured = true
+		r.replayPipelineBackpressureEvents.Add(1)
+	} else if len(r.standardReplay.entries) < standardReplayPreparedLimit {
+		r.standardReplay.backpressured = false
+	}
+	backpressurePivotSeq := r.standardReplay.pivotSeq
+	backpressurePivotReady := r.standardReplay.pivotReady
+	backpressureTailSeq := r.standardReplay.collectSeq
+	backpressureTargetSeq := r.standardReplay.targetSeq
+	backpressureOccupancy := len(r.standardReplay.entries)
 
 	if r.consensusRecovery.targetHash == targetHash {
 		if head := r.standardReplay.entries[r.standardReplay.anchorSeq+1]; head != nil {
@@ -358,6 +372,16 @@ func (r *Router) tryArmStandardReplayPipeline(
 		return false
 	}
 	r.acquisitionMu.Unlock()
+	if backpressureStarted {
+		r.logger.Info("standard replay collector paused at prepared capacity",
+			"pivot_seq", backpressurePivotSeq,
+			"pivot_ready", backpressurePivotReady,
+			"prepared_tail_seq", backpressureTailSeq,
+			"trusted_head_seq", backpressureTargetSeq,
+			"prepared_occupancy", backpressureOccupancy,
+			"prepared_limit", standardReplayPreparedLimit,
+		)
+	}
 	return armed
 }
 
@@ -448,6 +472,7 @@ func (r *Router) cancelStandardReplayPipelineLocked() []*inbound.Ledger {
 	r.standardReplay.sampleAnchorSeq = 0
 	r.standardReplay.stalledSamples = 0
 	r.standardReplay.retargetAttemptAt = time.Time{}
+	r.standardReplay.backpressured = false
 	return retired
 }
 
@@ -707,11 +732,15 @@ func (r *Router) drainStandardReplayPipeline() {
 			r.standardReplay.applying = false
 			r.standardReplay.entries = nil
 			r.standardReplay.headBlockedAt = time.Time{}
+			r.standardReplay.backpressured = false
 		}
 		active := r.standardReplay.active
 		r.acquisitionMu.Unlock()
 		if !current {
 			return
+		}
+		if active {
+			r.refillStandardReplayCollector(entry.peerID)
 		}
 		applied++
 		if active && (applied >= standardReplayApplyBatch || time.Since(batchStarted) >= standardReplayApplyBudget) {

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -783,6 +783,7 @@ func (r *nodeRuntime) configureConsensus() error {
 					ReplayPipelineRetried:                snapshot.ReplayPipelineRetried,
 					ReplayPipelineFallbacks:              snapshot.ReplayPipelineFallbacks,
 					ReplayPipelineCapacityRetargets:      snapshot.ReplayPipelineCapacityRetargets,
+					ReplayPipelineBackpressureEvents:     snapshot.ReplayPipelineBackpressureEvents,
 					ReplayPipelineRetargetFailures:       snapshot.ReplayPipelineRetargetFailures,
 					ReplayPipelineAcquireUs:              snapshot.ReplayPipelineAcquireUs,
 					ReplayPipelineReadyWaitUs:            snapshot.ReplayPipelineReadyWaitUs,

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -245,6 +245,7 @@ func addServerDiagnostics(info map[string]any, services *types.ServiceGraph) {
 			"replay_pipeline_retried":                        strconv.FormatUint(metrics.ReplayPipelineRetried, 10),
 			"replay_pipeline_fallbacks":                      strconv.FormatUint(metrics.ReplayPipelineFallbacks, 10),
 			"replay_pipeline_capacity_retargets":             strconv.FormatUint(metrics.ReplayPipelineCapacityRetargets, 10),
+			"replay_pipeline_backpressure_events":            strconv.FormatUint(metrics.ReplayPipelineBackpressureEvents, 10),
 			"replay_pipeline_retarget_failures":              strconv.FormatUint(metrics.ReplayPipelineRetargetFailures, 10),
 			"replay_pipeline_acquire_us":                     strconv.FormatUint(metrics.ReplayPipelineAcquireUs, 10),
 			"replay_pipeline_ready_wait_us":                  strconv.FormatUint(metrics.ReplayPipelineReadyWaitUs, 10),

--- a/internal/rpc/server_diagnostics_test.go
+++ b/internal/rpc/server_diagnostics_test.go
@@ -76,6 +76,7 @@ func TestServerDiagnosticsWireShape(t *testing.T) {
 			ReplayPipelineTrustedHeadSeq:         42,
 			ReplayPipelineGeneration:             43,
 			ReplayPipelinePivotStateNodesPerSec:  44,
+			ReplayPipelineBackpressureEvents:     45,
 		}
 	}
 
@@ -149,6 +150,7 @@ func TestServerDiagnosticsWireShape(t *testing.T) {
 				"replay_pipeline_trusted_head_seq":               "42",
 				"replay_pipeline_generation":                     "43",
 				"replay_pipeline_pivot_state_nodes_per_sec":      "44",
+				"replay_pipeline_backpressure_events":            "45",
 			}
 			if !reflect.DeepEqual(fastSync, wantFastSync) {
 				t.Fatalf("fast_sync = %#v, want %#v", fastSync, wantFastSync)

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -1293,6 +1293,7 @@ type FastSyncMetrics struct {
 	ReplayPipelineRetried                uint64
 	ReplayPipelineFallbacks              uint64
 	ReplayPipelineCapacityRetargets      uint64
+	ReplayPipelineBackpressureEvents     uint64
 	ReplayPipelineRetargetFailures       uint64
 	ReplayPipelineAcquireUs              uint64
 	ReplayPipelineReadyWaitUs            uint64


### PR DESCRIPTION
## Summary
- keep the frozen full-state pivot alive when the prepared replay buffer reaches its bound
- resume replay collection as applied entries free capacity, preserving sequential drain and moving-head catch-up
- expose dedicated replay backpressure diagnostics while retaining the legacy capacity-retarget counter for wire compatibility

## Test plan
- [x] `go test -race ./internal/consensus/adaptor -run 'TestFrozenPivot(RecoveryBackpressuresAtPreparedCapacity|BackpressureRefillsAsReplayDrains|RecoveryReplaysToMovingTrustedHead)|TestStandardReplayPipelineDefersFailedEntryUntilFrozenPivotReady' -count=1`
- [x] `go test ./internal/consensus/adaptor -run 'TestFrozenPivot(RecoveryBackpressuresAtPreparedCapacity|BackpressureRefillsAsReplayDrains|RecoveryReplaysToMovingTrustedHead)|TestStandardReplayPipelineDefersFailedEntryUntilFrozenPivotReady' -count=10`
- [x] `just test`
- [x] `just build`
- [x] `just vet`
- [x] `just lint`

Fixes #1746
