### PR TITLE
perf(fast-sync): use checkpoint-relative Merkle diff for pivot acquisition

### DIFF
--- a/internal/consensus/adaptor/issue_1676_lock_test.go
+++ b/internal/consensus/adaptor/issue_1676_lock_test.go
@@ -81,6 +81,19 @@ func TestBlockedInboundTraversalDoesNotStallValidationOrConsensusTick(t *testing
 	engine := rcl.NewEngine(adaptor, engineConfig)
 	router := newTestRouter(engine, adaptor, nil)
 	router.fetchTracker.Track(candidate)
+	baseReleased := make(chan struct{})
+	router.standardReplay = standardReplayPipeline{
+		active:      true,
+		pivotSeq:    seq,
+		pivotHash:   candidateHash,
+		anchorSeq:   seq,
+		anchorHash:  candidateHash,
+		targetSeq:   seq,
+		targetHash:  candidateHash,
+		entries:     make(map[uint32]*standardReplayEntry),
+		baseLedger:  candidate,
+		baseRelease: func() { close(baseReleased) },
+	}
 	require.NoError(t, engine.Start(t.Context()))
 	t.Cleanup(func() { require.NoError(t, engine.Stop()) })
 
@@ -120,6 +133,11 @@ func TestBlockedInboundTraversalDoesNotStallValidationOrConsensusTick(t *testing
 		t.Fatal("trusted validation waited for the inbound completeness walk")
 	}
 	require.Nil(t, router.fetchTracker.Find(candidateHash))
+	select {
+	case <-baseReleased:
+		t.Fatal("checkpoint base released while discovery still used it")
+	default:
+	}
 
 	tickDone := make(chan struct{})
 	go func() {
@@ -134,4 +152,9 @@ func TestBlockedInboundTraversalDoesNotStallValidationOrConsensusTick(t *testing
 
 	releaseOnce.Do(func() { close(family.release) })
 	require.NoError(t, <-baseDone)
+	select {
+	case <-baseReleased:
+	case <-time.After(time.Second):
+		t.Fatal("checkpoint base was not released after discovery stopped")
+	}
 }

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -694,7 +694,7 @@ func (r *Router) StopAcquisitions() (legacy, replay int) {
 	if r.replayer != nil {
 		replay = r.replayer.Stop()
 	}
-	r.cancelStandardReplayPipelineLocked()
+	retirement := r.cancelStandardReplayPipelineLocked()
 	r.consensusRecovery = consensusRecovery{}
 	r.lastHandoffSeq = 0
 	r.acquisitionMu.Unlock()
@@ -706,6 +706,9 @@ func (r *Router) StopAcquisitions() (legacy, replay int) {
 	r.linkageWait = catchupLinkageWait{}
 	r.catchupMu.Unlock()
 	r.retireLegacyAcquisitions(legacyLedgers)
+	if releaseDone := r.retireStandardReplay(retirement); releaseDone != nil {
+		<-releaseDone
+	}
 	return legacy, replay
 }
 

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -1595,11 +1595,14 @@ func (r *Router) onLedgerFullyValidated(seq uint32, hash [32]byte) {
 	if entry := r.standardReplay.entries[seq]; entry != nil && entry.hash != hash {
 		pipelineConflict = true
 	}
+	var pipelineRetirement standardReplayRetirement
 	if pipelineConflict {
 		for _, pipelineEntry := range r.standardReplay.entries {
 			removed[pipelineEntry.hash] = struct{}{}
 		}
-		legacy = append(legacy, r.cancelStandardReplayPipelineLocked()...)
+		pipelineRetirement = r.cancelStandardReplayPipelineLocked()
+		legacy = append(legacy, pipelineRetirement.ledgers...)
+		pipelineRetirement.ledgers = nil
 	}
 	if victim := r.obsoleteCatchupVictimLocked(seq); victim != nil && r.fetchTracker.DiscardExpected(victim) {
 		legacy = append(legacy, victim)
@@ -1617,6 +1620,7 @@ func (r *Router) onLedgerFullyValidated(seq uint32, hash [32]byte) {
 	r.recordValidationCatchupTarget(seq, hash, 0, catchupSourceQuorum)
 
 	r.retireLegacyAcquisitions(legacy)
+	r.retireStandardReplay(pipelineRetirement)
 	if len(removed) > 0 {
 		r.logger.Info("canceled acquisitions superseded by trusted validation quorum",
 			"seq", seq,
@@ -1882,10 +1886,11 @@ func (r *Router) ClearFetchInfo() {
 	r.replayCommitMu.Lock()
 	r.acquisitionMu.Lock()
 	ledgers := r.fetchTracker.Clear()
-	r.cancelStandardReplayPipelineLocked()
+	retirement := r.cancelStandardReplayPipelineLocked()
 	r.acquisitionMu.Unlock()
 	r.replayCommitMu.Unlock()
 	r.retireLegacyAcquisitions(ledgers)
+	r.retireStandardReplay(retirement)
 }
 
 func (r *Router) retireLegacyAcquisitions(ledgers []*inbound.Ledger) {

--- a/internal/consensus/adaptor/router_recovery_session.go
+++ b/internal/consensus/adaptor/router_recovery_session.go
@@ -1,6 +1,7 @@
 package adaptor
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -20,6 +21,30 @@ func (r *Router) beginFrozenPivotRecovery(seq uint32, hash [32]byte, peerID uint
 	r.acquisitionMu.Lock()
 	if r.standardReplay.active {
 		r.acquisitionMu.Unlock()
+		return r.continueFrozenPivotRecovery(seq, hash, peerID)
+	}
+	r.acquisitionMu.Unlock()
+
+	var baseRoot [32]byte
+	var baseRelease func()
+	if r.adaptor != nil {
+		if svc := r.adaptor.LedgerService(); svc != nil {
+			root, release, ok, err := svc.AcquireFastLoadStateBase(context.Background())
+			if err != nil {
+				r.logger.Warn("checkpoint-relative pivot discovery unavailable", "error", err)
+			} else if ok {
+				baseRoot = root
+				baseRelease = release
+			}
+		}
+	}
+
+	r.acquisitionMu.Lock()
+	if r.standardReplay.active {
+		r.acquisitionMu.Unlock()
+		if baseRelease != nil {
+			baseRelease()
+		}
 		return r.continueFrozenPivotRecovery(seq, hash, peerID)
 	}
 	r.standardReplay.generation++
@@ -43,6 +68,7 @@ func (r *Router) beginFrozenPivotRecovery(seq uint32, hash [32]byte, peerID uint
 	r.standardReplay.stalledSamples = 0
 	r.standardReplay.retargetAttemptAt = time.Time{}
 	r.standardReplay.backpressured = false
+	r.standardReplay.baseRelease = baseRelease
 	if r.consensusRecovery.targetHash != ([32]byte{}) {
 		r.consensusRecovery.stepHash = hash
 	}
@@ -50,6 +76,14 @@ func (r *Router) beginFrozenPivotRecovery(seq uint32, hash [32]byte, peerID uint
 	r.startLedgerAcquisitionLegacyLocked(seq, hash, peerID)
 	il := r.fetchTracker.Find(hash)
 	if il != nil && !il.TransactionOnly() {
+		if baseRoot != ([32]byte{}) {
+			if err := il.SetVerifiedStateBaseContext(context.Background(), baseRoot); err != nil {
+				r.logger.Warn("checkpoint-relative pivot discovery unavailable", "error", err)
+				r.releaseStandardReplayBaseLocked()
+			} else {
+				r.standardReplay.baseLedger = il
+			}
+		}
 		r.acquisitionMu.Unlock()
 		return true
 	}
@@ -63,7 +97,7 @@ func (r *Router) beginFrozenPivotRecovery(seq uint32, hash [32]byte, peerID uint
 		retired := r.cancelStandardReplayPipelineLocked()
 		r.acquisitionMu.Unlock()
 		r.replayCommitMu.Unlock()
-		r.retireLegacyAcquisitions(retired)
+		r.retireStandardReplay(retired)
 		return false
 	}
 	r.acquisitionMu.Unlock()
@@ -215,6 +249,7 @@ func (r *Router) completeFrozenPivotAcquisition(h *header.LedgerHeader, initialC
 			r.standardReplay.active = false
 			r.standardReplay.entries = nil
 			r.standardReplay.backpressured = false
+			r.releaseStandardReplayBaseLocked()
 		}
 		r.acquisitionMu.Unlock()
 		if !current {
@@ -343,14 +378,14 @@ func (r *Router) retargetFrozenPivot(
 		}
 	}
 	retired := r.cancelStandardReplayPipelineLocked()
-	retired = append(retired, r.discardSupersededProvisionalFullStateLocked(target.hash)...)
+	retired.ledgers = append(retired.ledgers, r.discardSupersededProvisionalFullStateLocked(target.hash)...)
 	r.consensusRecovery.targetHash = target.hash
 	r.consensusRecovery.anchorSeq = 0
 	r.consensusRecovery.anchorHash = [32]byte{}
 	r.consensusRecovery.stepHash = [32]byte{}
 	r.acquisitionMu.Unlock()
 	r.replayCommitMu.Unlock()
-	r.retireLegacyAcquisitions(retired)
+	r.retireStandardReplay(retired)
 	r.replayPipelineFallbacks.Add(1)
 	r.logger.Warn("retargeting frozen recovery to a newer full-state pivot",
 		"reason", string(reason),
@@ -389,6 +424,6 @@ func (r *Router) failFrozenPivotRecovery(hash [32]byte) bool {
 	}
 	r.acquisitionMu.Unlock()
 	r.replayCommitMu.Unlock()
-	r.retireLegacyAcquisitions(retired)
+	r.retireStandardReplay(retired)
 	return true
 }

--- a/internal/consensus/adaptor/router_recovery_session_test.go
+++ b/internal/consensus/adaptor/router_recovery_session_test.go
@@ -185,11 +185,14 @@ func TestFrozenPivotRecoveryFailureReleasesPivotGeneration(t *testing.T) {
 	pivotHash := [32]byte{0xc1}
 	require.True(t, r.beginFrozenPivotRecovery(pivotSeq, pivotHash, 7))
 	generation := r.standardReplay.generation
+	released := 0
+	r.standardReplay.baseRelease = func() { released++ }
 
 	require.True(t, r.failFrozenPivotRecovery(pivotHash))
 	assert.False(t, r.standardReplay.active)
 	assert.Greater(t, r.standardReplay.generation, generation)
 	assert.Nil(t, r.fetchTracker.Find(pivotHash))
+	assert.Equal(t, 1, released)
 }
 
 func TestFrozenPivotFailedStartCannotBeKeptAliveByTargetAdvance(t *testing.T) {
@@ -452,6 +455,8 @@ func TestFrozenPivotRecoveryReplaysToMovingTrustedHead(t *testing.T) {
 
 	trackCatchupPeer(r, 7, pivotSeq, pivotHash)
 	require.True(t, r.beginFrozenPivotRecovery(pivotSeq, pivotHash, 7))
+	released := 0
+	r.standardReplay.baseRelease = func() { released++ }
 	initialHead := links[len(links)-1]
 	trackCatchupPeer(r, 7, initialHead.seq, initialHead.hash)
 	r.recordValidationCatchupTarget(initialHead.seq, initialHead.hash, 7, catchupSourceQuorum)
@@ -482,6 +487,7 @@ func TestFrozenPivotRecoveryReplaysToMovingTrustedHead(t *testing.T) {
 	require.True(t, r.completeFrozenPivotAcquisition(&pivotHeader, false))
 
 	assert.False(t, r.standardReplay.active)
+	assert.Equal(t, 1, released)
 	assert.False(t, r.standardReplay.backpressured)
 	assert.Equal(t, uint64(len(links)+len(movingLinks)), r.FastSyncMetrics().ReplayPipelineApplied)
 	storedHead, err := svc.GetLedgerByHash(trustedHead.hash)

--- a/internal/consensus/adaptor/router_replay_pipeline.go
+++ b/internal/consensus/adaptor/router_replay_pipeline.go
@@ -44,6 +44,8 @@ type standardReplayPipeline struct {
 	stalledSamples    uint8
 	retargetAttemptAt time.Time
 	backpressured     bool
+	baseLedger        *inbound.Ledger
+	baseRelease       func()
 }
 
 type standardReplayIdentity struct {
@@ -429,13 +431,19 @@ func (r *Router) cancelStandardReplayPipelineIdentity(identity standardReplayIde
 	current := r.standardReplayIdentityLocked()
 	r.acquisitionMu.Unlock()
 	r.replayCommitMu.Unlock()
-	r.retireLegacyAcquisitions(retired)
+	r.retireStandardReplay(retired)
 	return current, true
 }
 
-func (r *Router) cancelStandardReplayPipelineLocked() []*inbound.Ledger {
-	if !r.standardReplay.active && len(r.standardReplay.entries) == 0 {
-		return nil
+type standardReplayRetirement struct {
+	ledgers    []*inbound.Ledger
+	baseLedger *inbound.Ledger
+	release    func()
+}
+
+func (r *Router) cancelStandardReplayPipelineLocked() standardReplayRetirement {
+	if !r.standardReplay.active && len(r.standardReplay.entries) == 0 && r.standardReplay.baseRelease == nil {
+		return standardReplayRetirement{}
 	}
 	var retired []*inbound.Ledger
 	if !r.standardReplay.pivotReady {
@@ -473,7 +481,37 @@ func (r *Router) cancelStandardReplayPipelineLocked() []*inbound.Ledger {
 	r.standardReplay.stalledSamples = 0
 	r.standardReplay.retargetAttemptAt = time.Time{}
 	r.standardReplay.backpressured = false
-	return retired
+	baseLedger := r.standardReplay.baseLedger
+	r.standardReplay.baseLedger = nil
+	release := r.standardReplay.baseRelease
+	r.standardReplay.baseRelease = nil
+	return standardReplayRetirement{ledgers: retired, baseLedger: baseLedger, release: release}
+}
+
+func (r *Router) retireStandardReplay(retirement standardReplayRetirement) <-chan struct{} {
+	r.retireLegacyAcquisitions(retirement.ledgers)
+	if retirement.release == nil {
+		return nil
+	}
+	if retirement.baseLedger == nil {
+		retirement.release()
+		return nil
+	}
+	done := make(chan struct{})
+	go func() {
+		retirement.baseLedger.WaitForWork()
+		retirement.release()
+		close(done)
+	}()
+	return done
+}
+
+func (r *Router) releaseStandardReplayBaseLocked() {
+	r.standardReplay.baseLedger = nil
+	if release := r.standardReplay.baseRelease; release != nil {
+		r.standardReplay.baseRelease = nil
+		release()
+	}
 }
 
 func (r *Router) discardSupersededProvisionalFullStateLocked(keepHash [32]byte) []*inbound.Ledger {
@@ -648,7 +686,7 @@ func (r *Router) drainStandardReplayPipeline() {
 			retired, target, current := r.discardStandardReplayHeadLocked(entry, generation)
 			r.acquisitionMu.Unlock()
 			r.waitStandardReplayCommit()
-			r.retireLegacyAcquisitions(retired)
+			r.retireStandardReplay(retired)
 			if current {
 				r.replayPipelineFallbacks.Add(1)
 				r.fallbackStandardReplayAcquisition(entry.seq, entry.hash, entry.peerID, target)
@@ -670,7 +708,7 @@ func (r *Router) drainStandardReplayPipeline() {
 			continueDrain := !current && r.standardReplay.active
 			r.acquisitionMu.Unlock()
 			r.waitStandardReplayCommit()
-			r.retireLegacyAcquisitions(retired)
+			r.retireStandardReplay(retired)
 			if current {
 				r.replayPipelineFallbacks.Add(1)
 				r.logger.Error("standard transaction replay pipeline apply failed; falling back to full-state acquisition",
@@ -733,6 +771,7 @@ func (r *Router) drainStandardReplayPipeline() {
 			r.standardReplay.entries = nil
 			r.standardReplay.headBlockedAt = time.Time{}
 			r.standardReplay.backpressured = false
+			r.releaseStandardReplayBaseLocked()
 		}
 		active := r.standardReplay.active
 		r.acquisitionMu.Unlock()
@@ -756,7 +795,7 @@ func (r *Router) drainStandardReplayPipeline() {
 func (r *Router) discardStandardReplayHeadLocked(
 	entry *standardReplayEntry,
 	generation uint64,
-) ([]*inbound.Ledger, standardReplayTarget, bool) {
+) (standardReplayRetirement, standardReplayTarget, bool) {
 	target := standardReplayTarget{
 		seq:  r.standardReplay.targetSeq,
 		hash: r.standardReplay.targetHash,
@@ -766,7 +805,7 @@ func (r *Router) discardStandardReplayHeadLocked(
 		if !r.standardReplay.active {
 			r.standardReplay.applying = false
 		}
-		return nil, standardReplayTarget{}, false
+		return standardReplayRetirement{}, standardReplayTarget{}, false
 	}
 	retired := r.cancelStandardReplayPipelineLocked()
 	if r.consensusRecovery.targetHash != ([32]byte{}) {

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -145,8 +145,9 @@ type Ledger struct {
 	// family backs the acquisition SHAMaps with the persistent node store when
 	// set, so getMissingNodes only reports nodes not already held locally. nil
 	// leaves the maps unbacked. Set once at construction, never mutated after.
-	family          shamap.Family
-	headerAdmission func(uint32) error
+	family            shamap.Family
+	headerAdmission   func(uint32) error
+	verifiedStateBase [32]byte
 
 	// Retry-loop bookkeeping ported from rippled's TimeoutCounter. lastTimer
 	// is when OnTimer last evaluated; progress records a fresh node attach
@@ -291,11 +292,51 @@ func NewHistory(hash [32]byte, seq uint32, peerID uint64, logger *slog.Logger, o
 
 // newSyncMap builds an acquisition SHAMap, backed by the node-store family when
 // one is wired (see WithFamily) and unbacked otherwise.
-func (l *Ledger) newSyncMap(t shamap.Type) (*shamap.SHAMap, error) {
+func (l *Ledger) newSyncMap(ctx context.Context, t shamap.Type) (*shamap.SHAMap, error) {
 	if l.family != nil {
-		return shamap.NewBacked(t, l.family)
+		m, err := shamap.NewBacked(t, l.family)
+		if err != nil {
+			return nil, err
+		}
+		if t == shamap.TypeState && l.verifiedStateBase != ([32]byte{}) {
+			if err := m.SetVerifiedBaseContext(ctx, l.verifiedStateBase); err != nil {
+				l.logger.Warn("inbound ledger: verified state base unavailable; using strict discovery", "error", err)
+			}
+		}
+		return m, nil
 	}
 	return shamap.New(t), nil
+}
+
+// SetVerifiedStateBaseContext installs a base before or during account-state
+// acquisition. An existing discovery cursor is reset by the SHAMap.
+func (l *Ledger) SetVerifiedStateBaseContext(ctx context.Context, rootHash [32]byte) error {
+	l.workMu.Lock()
+	defer l.workMu.Unlock()
+	l.mu.Lock()
+	l.verifiedStateBase = rootHash
+	stateMap := l.stateMap
+	l.mu.Unlock()
+	if stateMap == nil {
+		return nil
+	}
+	if err := stateMap.SetVerifiedBaseContext(ctx, rootHash); err != nil {
+		l.mu.Lock()
+		if l.verifiedStateBase == rootHash {
+			l.verifiedStateBase = [32]byte{}
+		}
+		l.mu.Unlock()
+		return err
+	}
+	return nil
+}
+
+// WaitForWork waits for the ledger's current discovery or attachment operation
+// to leave its critical section. Callers must first prevent new work from being
+// submitted for the ledger.
+func (l *Ledger) WaitForWork() {
+	l.workMu.Lock()
+	l.workMu.Unlock()
 }
 
 // Reason returns why this acquisition was started.
@@ -724,7 +765,7 @@ func (l *Ledger) GotBaseUsefulContext(ctx context.Context, nodes []message.Ledge
 		// against h.AccountHash before the router adopts the ledger.
 		l.haveState = true
 	} else if l.stateMap == nil && len(nodes) >= 2 && len(nodes[1].NodeData) > 0 {
-		sm, createErr := l.newSyncMap(shamap.TypeState)
+		sm, createErr := l.newSyncMap(ctx, shamap.TypeState)
 		if createErr != nil {
 			return useful, fmt.Errorf("create state map: %w", createErr)
 		}
@@ -743,7 +784,7 @@ func (l *Ledger) GotBaseUsefulContext(ctx context.Context, nodes []message.Ledge
 	if h.TxHash == ([32]byte{}) {
 		l.haveTx = true
 	} else if l.txMap == nil && len(nodes) >= 3 && len(nodes[2].NodeData) > 0 {
-		tm, terr := l.newSyncMap(shamap.TypeTransaction)
+		tm, terr := l.newSyncMap(ctx, shamap.TypeTransaction)
 		if terr != nil {
 			return useful, fmt.Errorf("create tx map: %w", terr)
 		}
@@ -1597,22 +1638,27 @@ func (l *Ledger) ReleaseMissingPeer(peerID uint64) {
 // InboundLedger::getJson). Timeouts is the live no-progress retry count, and
 // Peers is the current broadened source-peer set size.
 type Snapshot struct {
-	Hash             [32]byte
-	Seq              uint32
-	HaveHeader       bool
-	HaveState        bool
-	HaveTransactions bool
-	Complete         bool
-	Failed           bool
-	Timeouts         int
-	Peers            int
-	RequestPeers     int
-	StateReceived    uint64
-	StateUseful      uint64
-	TxReceived       uint64
-	TxUseful         uint64
-	NeededState      [][32]byte // hashes of up to missingNodeBatch missing state nodes
-	NeededTx         [][32]byte // hashes of up to missingNodeBatch missing tx nodes
+	Hash                       [32]byte
+	Seq                        uint32
+	HaveHeader                 bool
+	HaveState                  bool
+	HaveTransactions           bool
+	Complete                   bool
+	Failed                     bool
+	Timeouts                   int
+	Peers                      int
+	RequestPeers               int
+	StateReceived              uint64
+	StateUseful                uint64
+	TxReceived                 uint64
+	TxUseful                   uint64
+	StateEqualSubtreesSkipped  uint64
+	StateNodesDescended        uint64
+	StateDurableReads          uint64
+	StateMissingDiscovered     uint64
+	StateVerifiedBaseFallbacks uint64
+	NeededState                [][32]byte // hashes of up to missingNodeBatch missing state nodes
+	NeededTx                   [][32]byte // hashes of up to missingNodeBatch missing tx nodes
 }
 
 func (s Snapshot) Phase() string {
@@ -1663,6 +1709,14 @@ func (l *Ledger) snapshotLocked() Snapshot {
 		StateUseful:      l.stateUseful,
 		TxReceived:       l.txRecv,
 		TxUseful:         l.txUseful,
+	}
+	if l.stateMap != nil {
+		stats := l.stateMap.BackedWalkStats()
+		s.StateEqualSubtreesSkipped = stats.EqualSubtreesSkipped
+		s.StateNodesDescended = stats.NodesDescended
+		s.StateDurableReads = stats.DurableReads
+		s.StateMissingDiscovered = stats.MissingNodes
+		s.StateVerifiedBaseFallbacks = stats.VerifiedBaseFallbacks
 	}
 	if !l.haveState {
 		s.NeededState = cloneHashes(l.neededState)

--- a/internal/ledger/inbound/tracker.go
+++ b/internal/ledger/inbound/tracker.go
@@ -319,13 +319,18 @@ func acquisitionKey(seq uint32, hash [32]byte) string {
 // scanned at least once.
 func AcquisitionJSON(snap Snapshot) map[string]any {
 	entry := map[string]any{
-		"hash":                 fmt.Sprintf("%X", snap.Hash),
-		"have_header":          snap.HaveHeader,
-		"request_peers":        snap.RequestPeers,
-		"state_received_total": snap.StateReceived,
-		"state_useful_total":   snap.StateUseful,
-		"tx_received_total":    snap.TxReceived,
-		"tx_useful_total":      snap.TxUseful,
+		"hash":                          fmt.Sprintf("%X", snap.Hash),
+		"have_header":                   snap.HaveHeader,
+		"request_peers":                 snap.RequestPeers,
+		"state_received_total":          snap.StateReceived,
+		"state_useful_total":            snap.StateUseful,
+		"tx_received_total":             snap.TxReceived,
+		"tx_useful_total":               snap.TxUseful,
+		"state_equal_subtrees_skipped":  snap.StateEqualSubtreesSkipped,
+		"state_nodes_descended":         snap.StateNodesDescended,
+		"state_durable_reads":           snap.StateDurableReads,
+		"state_missing_discovered":      snap.StateMissingDiscovered,
+		"state_verified_base_fallbacks": snap.StateVerifiedBaseFallbacks,
 		// Live no-progress retry count, mirroring InboundLedger::getJson's
 		// timeouts_ now that the acquisition runs a timer-driven retry loop.
 		"timeouts": snap.Timeouts,

--- a/internal/ledger/inbound/tracker_test.go
+++ b/internal/ledger/inbound/tracker_test.go
@@ -160,6 +160,17 @@ func TestTracker_ActiveAcquisitionSnapshot(t *testing.T) {
 	if entry["timeouts"] != 0 {
 		t.Errorf("timeouts = %v, want 0", entry["timeouts"])
 	}
+	for _, field := range []string{
+		"state_equal_subtrees_skipped",
+		"state_nodes_descended",
+		"state_durable_reads",
+		"state_missing_discovered",
+		"state_verified_base_fallbacks",
+	} {
+		if _, ok := entry[field]; !ok {
+			t.Errorf("missing discovery diagnostic %q", field)
+		}
+	}
 }
 
 func TestTracker_CompletedReportedThenSwept(t *testing.T) {

--- a/internal/ledger/service/fast_load_checkpoint.go
+++ b/internal/ledger/service/fast_load_checkpoint.go
@@ -355,6 +355,9 @@ func (s *Service) acceptFastLoadCheckpoint(
 		}
 		s.fastLoadStrictNodes.Store(checkpoint.strictNodes)
 		s.fastLoadStrictElapsed.Store(checkpoint.strictElapsed)
+		s.fastLoadBaseStateRoot = h.AccountHash
+		s.fastLoadBaseFingerprint = nodeFingerprint
+		s.fastLoadBaseVerified = true
 		s.markFastLoadCheckpointEligible()
 		s.logger.Info("Fast-load checkpoint accepted",
 			"sequence", h.LedgerIndex,
@@ -396,6 +399,46 @@ func (s *Service) InvalidateFastLoadCheckpointEligibility() {
 
 func (s *Service) markFastLoadCheckpointEligible() {
 	s.fastLoadCheckpointState.CompareAndSwap(fastLoadCheckpointIneligible, fastLoadCheckpointEligible)
+}
+
+// AcquireFastLoadStateBase pins the accepted checkpoint's durable NodeStore
+// generation for a frozen-pivot recovery session.
+func (s *Service) AcquireFastLoadStateBase(ctx context.Context) ([32]byte, func(), bool, error) {
+	s.mu.RLock()
+	root := s.fastLoadBaseStateRoot
+	expected := s.fastLoadBaseFingerprint
+	eligible := s.networkLedgerState == networkLedgerFastLoadProvisional && s.fastLoadBaseVerified
+	s.mu.RUnlock()
+	if !eligible {
+		return [32]byte{}, nil, false, nil
+	}
+	durable, ok := s.nodeStore.(nodestore.DurableSnapshotDatabase)
+	if !ok {
+		return [32]byte{}, nil, false, errors.New("NodeStore cannot retain a durable snapshot")
+	}
+	fingerprint, release, err := durable.AcquireDurableSnapshot(ctx)
+	if err != nil {
+		return [32]byte{}, nil, false, fmt.Errorf("acquire checkpoint NodeStore snapshot: %w", err)
+	}
+	if fingerprint != expected {
+		release()
+		return [32]byte{}, nil, false, errors.New("checkpoint NodeStore mutation generation changed before pivot acquisition")
+	}
+	s.mu.RLock()
+	current := s.networkLedgerState == networkLedgerFastLoadProvisional && s.fastLoadBaseVerified &&
+		s.fastLoadBaseStateRoot == root && s.fastLoadBaseFingerprint == expected
+	s.mu.RUnlock()
+	if !current {
+		release()
+		return [32]byte{}, nil, false, nil
+	}
+	return root, release, true, nil
+}
+
+func (s *Service) clearFastLoadBaseLocked() {
+	s.fastLoadBaseStateRoot = [32]byte{}
+	s.fastLoadBaseFingerprint = [32]byte{}
+	s.fastLoadBaseVerified = false
 }
 
 // PrepareFastLoadCheckpoint publishes a one-use checkpoint for the next clean

--- a/internal/ledger/service/fast_load_checkpoint_test.go
+++ b/internal/ledger/service/fast_load_checkpoint_test.go
@@ -138,6 +138,11 @@ func TestService_FastLoadCheckpointCleanRestartAndOneUse(t *testing.T) {
 	require.Equal(t, checkpoint.strictNodes, reader.fastLoadStrictNodes.Load())
 	require.Equal(t, checkpoint.strictElapsed, reader.fastLoadStrictElapsed.Load())
 	require.Equal(t, len(checkpoint.stateProofs)+len(checkpoint.txProofs), tracked.uncachedReads())
+	baseRoot, releaseBase, available, err := reader.AcquireFastLoadStateBase(ctx)
+	require.NoError(t, err)
+	require.True(t, available)
+	require.Equal(t, checkpoint.stateRoot, baseRoot)
+	releaseBase()
 	cache := reader.shamapFamily.(interface {
 		FullBelowCache() *shamap.FullBelowCache
 	}).FullBelowCache()
@@ -370,6 +375,28 @@ func TestService_FastLoadCheckpointManagedMutationFallsBackToStrictTraversal(t *
 	reader.Stop()
 }
 
+func TestService_FastLoadBaseRejectsMutationBeforePivot(t *testing.T) {
+	ctx := context.Background()
+	db := newTestNodeStore(t, 100_000)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	fingerprint, err := db.DurableFingerprint(ctx)
+	require.NoError(t, err)
+	svc := newFastLoadCheckpointService(t, db, newTestRepositories(t, ctx), false)
+	svc.mu.Lock()
+	svc.networkLedgerState = networkLedgerFastLoadProvisional
+	svc.fastLoadBaseStateRoot = [32]byte{0xaa}
+	svc.fastLoadBaseFingerprint = fingerprint
+	svc.fastLoadBaseVerified = true
+	svc.mu.Unlock()
+
+	_, err = db.DeleteBefore(ctx, 1, 1)
+	require.NoError(t, err)
+	_, release, available, err := svc.AcquireFastLoadStateBase(ctx)
+	require.ErrorContains(t, err, "mutation generation changed")
+	require.False(t, available)
+	require.Nil(t, release)
+}
+
 func TestService_FastLoadCheckpointPreparationOrderingAndFailures(t *testing.T) {
 	ctx := context.Background()
 	t.Run("store then sync", func(t *testing.T) {
@@ -595,6 +622,14 @@ func (d *checkpointTrackingDatabase) WithDurableSnapshot(
 		return errors.New("missing durable database capability")
 	}
 	return durable.WithDurableSnapshot(ctx, fn)
+}
+
+func (d *checkpointTrackingDatabase) AcquireDurableSnapshot(ctx context.Context) ([32]byte, func(), error) {
+	durable, ok := d.Database.(nodestore.DurableSnapshotDatabase)
+	if !ok {
+		return [32]byte{}, nil, errors.New("missing retained durable snapshot capability")
+	}
+	return durable.AcquireDurableSnapshot(ctx)
 }
 
 func (d *checkpointTrackingDatabase) uncachedReads() int {

--- a/internal/ledger/service/lifecycle.go
+++ b/internal/ledger/service/lifecycle.go
@@ -906,6 +906,7 @@ func (s *Service) setValidatedLedgerAt(seq uint32, expectedHash [32]byte, signTi
 	s.validatedSignTime = signTime
 	if !fromStored && s.networkLedgerState == networkLedgerFastLoadProvisional {
 		s.networkLedgerState = networkLedgerReady
+		s.clearFastLoadBaseLocked()
 	}
 	s.evictOldHistoryLocked(seq)
 
@@ -949,6 +950,7 @@ func (s *Service) confirmFastLoadLocked(seq uint32, hash [32]byte) {
 	}
 	if seq == s.validatedLedger.Sequence() && hash == s.validatedLedger.Hash() {
 		s.networkLedgerState = networkLedgerReady
+		s.clearFastLoadBaseLocked()
 	}
 }
 

--- a/internal/ledger/service/persistence.go
+++ b/internal/ledger/service/persistence.go
@@ -256,6 +256,9 @@ func (s *Service) Stop() {
 	s.stopNodeStoreSweeper()
 	s.persistenceWorker.stop()
 	s.eventPublisher.stop()
+	s.mu.Lock()
+	s.clearFastLoadBaseLocked()
+	s.mu.Unlock()
 
 	s.lifecycleMu.Lock()
 	s.lifecycleState = serviceStopped

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -180,6 +180,9 @@ type Service struct {
 	fastLoadCheckpointState   atomic.Uint32
 	fastLoadStrictNodes       atomic.Uint64
 	fastLoadStrictElapsed     atomic.Uint64
+	fastLoadBaseStateRoot     [32]byte
+	fastLoadBaseFingerprint   [32]byte
+	fastLoadBaseVerified      bool
 
 	// startupReplay is the one-shot replay staged for the first close and is
 	// guarded by mu together with the closed/open ledger frontier.
@@ -464,6 +467,13 @@ func (s *Service) Start() (err error) {
 			s.lifecycleState = serviceFailed
 		}
 	}()
+	defer func() {
+		if err != nil {
+			s.mu.Lock()
+			s.clearFastLoadBaseLocked()
+			s.mu.Unlock()
+		}
+	}()
 	if s.config.FastLoad && s.config.Startup.Mode == StartupNormal {
 		s.startupFastLoadCheckpoint, err = s.consumeFastLoadCheckpoint(context.Background())
 		if err != nil {
@@ -561,6 +571,9 @@ func (s *Service) Start() (err error) {
 		}
 	}
 	s.networkLedgerState = selection.networkState
+	if s.networkLedgerState != networkLedgerFastLoadProvisional {
+		s.clearFastLoadBaseLocked()
+	}
 	s.startupReplay = selection.replay
 
 	openLedger, err := ledger.NewOpen(s.closedLedger, time.Now())

--- a/internal/ledger/shamapstore/rotation.go
+++ b/internal/ledger/shamapstore/rotation.go
@@ -33,6 +33,23 @@ type NodeGenerationRotator interface {
 	GenerationState() (lastRotated, minimumOnline uint32)
 }
 
+type guardedNodePruner interface {
+	DeleteBeforeWithPrune(
+		ctx context.Context,
+		boundary uint32,
+		batchSize int,
+		beginPrune func() func(),
+	) (deleted uint64, err error)
+}
+
+type guardedNodeGenerationRotator interface {
+	RotateGenerationWithPrune(
+		ctx context.Context,
+		lastRotated, minimumOnline uint32,
+		beginPrune func() func(),
+	) (committed bool, err error)
+}
+
 // RelationalPruner deletes ledger and transaction index rows below a retention
 // boundary. It is the go-xrpl equivalent of rippled's clearSql over the
 // Ledgers / Transactions / AccountTransactions tables. A nil RelationalPruner
@@ -439,13 +456,25 @@ func (r *Rotator) rotate(ctx context.Context, validatedSeq, lastRotated uint32) 
 	}
 
 	deleted, committed, err := func() (uint64, bool, error) {
+		if generations, ok := r.nodes.(NodeGenerationRotator); ok {
+			if guarded, ok := generations.(guardedNodeGenerationRotator); ok {
+				committed, err := guarded.RotateGenerationWithPrune(ctx, refreshedSeq, minimumOnline, beginPrune)
+				return 0, committed, err
+			}
+			if beginPrune != nil {
+				unlock := beginPrune()
+				defer unlock()
+			}
+			committed, err := generations.RotateGeneration(ctx, refreshedSeq, minimumOnline)
+			return 0, committed, err
+		}
+		if guarded, ok := r.nodes.(guardedNodePruner); ok {
+			deleted, err := guarded.DeleteBeforeWithPrune(ctx, lastRotated, r.cfg.DeleteBatch, beginPrune)
+			return deleted, err == nil, err
+		}
 		if beginPrune != nil {
 			unlock := beginPrune()
 			defer unlock()
-		}
-		if generations, ok := r.nodes.(NodeGenerationRotator); ok {
-			committed, err := generations.RotateGeneration(ctx, refreshedSeq, minimumOnline)
-			return 0, committed, err
 		}
 		deleted, err := r.nodes.DeleteBefore(ctx, lastRotated, r.cfg.DeleteBatch)
 		return deleted, err == nil, err

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -1241,6 +1241,15 @@ func (r *nodeRuntime) shutdownWithin(timeout time.Duration) error {
 		errs = append(errs, errors.New("shutdown incomplete: dependencies left running because transport handlers did not stop"))
 		return errors.Join(errs...)
 	}
+	if r.consensus != nil && r.consensus.Router != nil {
+		legacy, replay := r.consensus.Router.StopAcquisitions()
+		if legacy > 0 || replay > 0 {
+			r.serverLog.Info("Ledger acquisitions drained before producer shutdown",
+				"legacy_in_flight_at_stop", legacy,
+				"replay_in_flight_at_stop", replay,
+			)
+		}
+	}
 
 	producersStopped := true
 	if r.rotator != nil {

--- a/shamap/backed_walk.go
+++ b/shamap/backed_walk.go
@@ -3,12 +3,37 @@ package shamap
 import (
 	"context"
 	"crypto/sha512"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
 )
 
 const backedWalkProofChunkSize = 1024
+
+var errVerifiedBaseUnavailable = errors.New("verified SHAMap base is unavailable")
+
+// BackedWalkStats reports local discovery work performed by a backed SHAMap.
+type BackedWalkStats struct {
+	EqualSubtreesSkipped  uint64
+	NodesDescended        uint64
+	DurableReads          uint64
+	MissingNodes          uint64
+	VerifiedBaseFallbacks uint64
+}
+
+type backedWalkStats struct {
+	equalSubtreesSkipped  atomic.Uint64
+	nodesDescended        atomic.Uint64
+	durableReads          atomic.Uint64
+	missingNodes          atomic.Uint64
+	verifiedBaseFallbacks atomic.Uint64
+}
+
+type verifiedWalkBase struct {
+	rootHash [32]byte
+	root     traversalNode
+}
 
 type traversalBudgetKey struct{}
 
@@ -84,6 +109,7 @@ func (proofs *backedWalkProofs) clear() {
 
 type backedWalkItem struct {
 	hash       [32]byte
+	baseHash   [32]byte
 	parentHash [32]byte
 	nodeID     NodeID
 	depth      int
@@ -95,12 +121,14 @@ type backedWalkItem struct {
 type backedWalkFrame struct {
 	item       backedWalkItem
 	view       traversalNode
+	baseView   traversalNode
 	nextBranch int
 	full       bool
 	stored     bool
 	loaded     bool
 	topLevel   bool
 	proofStart int
+	usedBase   bool
 }
 
 type backedWalkLane struct {
@@ -116,6 +144,7 @@ type backedWalkLane struct {
 type backedWalkCursor struct {
 	generation uint32
 	rootHash   [32]byte
+	baseRoot   [32]byte
 	lanes      [BranchFactor]backedWalkLane
 }
 
@@ -124,6 +153,52 @@ type traversalNode struct {
 	branches uint16
 	hashes   [BranchFactor][32]byte
 	children [BranchFactor]mapNode
+}
+
+// SetVerifiedBaseContext installs a durable, position-aligned comparison base
+// for subsequent backed walks. The caller must keep managed destructive store
+// mutations excluded until the acquisition using the base has completed.
+func (sm *SHAMap) SetVerifiedBaseContext(ctx context.Context, rootHash [32]byte) error {
+	if rootHash == ([32]byte{}) {
+		return errors.New("verified SHAMap base has an empty root hash")
+	}
+	sm.acquisition.walkMu.Lock()
+	defer sm.acquisition.walkMu.Unlock()
+	sm.backing.mu.RLock()
+	access := sm.backing.access
+	sm.backing.mu.RUnlock()
+	if !access.available() || access.durable == nil {
+		return errors.New("verified SHAMap base requires a durable backing family")
+	}
+	sm.acquisition.stats.durableReads.Add(1)
+	data, err := access.fetchDurable(ctx, rootHash)
+	if err != nil {
+		return fmt.Errorf("load verified SHAMap base root: %w", err)
+	}
+	if len(data) == 0 {
+		return fmt.Errorf("%w: root %x is missing", errVerifiedBaseUnavailable, rootHash[:8])
+	}
+	view, err := decodeTraversalNode(data, rootHash)
+	if err != nil {
+		return fmt.Errorf("%w: root %x: %v", errVerifiedBaseUnavailable, rootHash[:8], err)
+	}
+	if !view.inner {
+		return fmt.Errorf("%w: root %x is not an inner node", errVerifiedBaseUnavailable, rootHash[:8])
+	}
+	sm.acquisition.base = &verifiedWalkBase{rootHash: rootHash, root: view}
+	sm.acquisition.cursor = nil
+	return nil
+}
+
+// BackedWalkStats returns a consistent snapshot of the acquisition counters.
+func (sm *SHAMap) BackedWalkStats() BackedWalkStats {
+	return BackedWalkStats{
+		EqualSubtreesSkipped:  sm.acquisition.stats.equalSubtreesSkipped.Load(),
+		NodesDescended:        sm.acquisition.stats.nodesDescended.Load(),
+		DurableReads:          sm.acquisition.stats.durableReads.Load(),
+		MissingNodes:          sm.acquisition.stats.missingNodes.Load(),
+		VerifiedBaseFallbacks: sm.acquisition.stats.verifiedBaseFallbacks.Load(),
+	}
 }
 
 func (sm *SHAMap) walkBackedContext(
@@ -139,8 +214,20 @@ func (sm *SHAMap) walkBackedContext(
 	if cache.Has(gen, rootHash) {
 		return nil, nil
 	}
-	if sm.acquisition.cursor == nil || sm.acquisition.cursor.generation != gen || sm.acquisition.cursor.rootHash != rootHash {
-		sm.acquisition.cursor = newBackedWalkCursor(root, rootHash, gen)
+	base := sm.acquisition.base
+	baseRoot := [32]byte{}
+	if base != nil {
+		baseRoot = base.rootHash
+		if baseRoot == rootHash {
+			sm.acquisition.stats.equalSubtreesSkipped.Add(1)
+			root.setFullBelowGen(gen)
+			cacheFullBelow(cache, gen, rootHash, 0)
+			return nil, nil
+		}
+	}
+	if sm.acquisition.cursor == nil || sm.acquisition.cursor.generation != gen ||
+		sm.acquisition.cursor.rootHash != rootHash || sm.acquisition.cursor.baseRoot != baseRoot {
+		sm.acquisition.cursor = newBackedWalkCursor(root, rootHash, gen, base)
 	}
 	cursor := sm.acquisition.cursor
 
@@ -166,6 +253,7 @@ func (sm *SHAMap) walkBackedContext(
 			return
 		}
 		reported[item.hash] = struct{}{}
+		sm.acquisition.stats.missingNodes.Add(1)
 		missing = append(missing, MissingNode{
 			Hash:       item.hash,
 			Depth:      item.depth,
@@ -230,8 +318,11 @@ func (sm *SHAMap) walkBackedContext(
 	return missing, nil
 }
 
-func newBackedWalkCursor(root *innerNode, rootHash [32]byte, gen uint32) *backedWalkCursor {
+func newBackedWalkCursor(root *innerNode, rootHash [32]byte, gen uint32, base *verifiedWalkBase) *backedWalkCursor {
 	cursor := &backedWalkCursor{generation: gen, rootHash: rootHash}
+	if base != nil {
+		cursor.baseRoot = base.rootHash
+	}
 	rootID := newRootNodeID()
 	for branch := range BranchFactor {
 		child, hash, set := root.LoadChild(branch)
@@ -245,8 +336,13 @@ func newBackedWalkCursor(root *innerNode, rootHash [32]byte, gen uint32) *backed
 			cursor.lanes[branch].complete = true
 			continue
 		}
+		baseHash := [32]byte{}
+		if base != nil && base.root.branches&(1<<branch) != 0 {
+			baseHash = base.root.hashes[branch]
+		}
 		item := backedWalkItem{
-			hash: hash, parentHash: rootHash, nodeID: childID, depth: 1, branch: branch, parent: root, node: child,
+			hash: hash, baseHash: baseHash, parentHash: rootHash, nodeID: childID,
+			depth: 1, branch: branch, parent: root, node: child,
 		}
 		cursor.lanes[branch].root = item
 		cursor.lanes[branch].stack = []backedWalkFrame{{item: item, topLevel: true, proofStart: 0}}
@@ -285,13 +381,19 @@ func (sm *SHAMap) walkBackedLane(
 		last := len(lane.stack) - 1
 		frame := &lane.stack[last]
 		if !frame.loaded {
+			if frame.item.baseHash != ([32]byte{}) && frame.item.baseHash == frame.item.hash {
+				sm.acquisition.stats.equalSubtreesSkipped.Add(1)
+				sm.finishBackedWalkFrame(lane, cache, gen, true, true, true)
+				continue
+			}
 			if cache.Has(gen, frame.item.hash) {
-				sm.finishBackedWalkFrame(lane, cache, gen, true, true)
+				sm.finishBackedWalkFrame(lane, cache, gen, true, true, false)
 				continue
 			}
 			if !takeTraversalVisit(ctx) {
 				return ErrTraversalBudget
 			}
+			sm.acquisition.stats.nodesDescended.Add(1)
 			view, found, stored, err := sm.loadTraversalNode(ctx, access, root, frame.item)
 			if err != nil {
 				return err
@@ -301,14 +403,21 @@ func (sm *SHAMap) walkBackedLane(
 				if filter.ShouldFetch(frame.item.hash) {
 					report(frame.item)
 				}
-				sm.finishBackedWalkFrame(lane, cache, gen, false, false)
+				sm.finishBackedWalkFrame(lane, cache, gen, false, false, false)
 				continue
 			}
 			if !view.inner {
-				sm.finishBackedWalkFrame(lane, cache, gen, true, stored)
+				sm.finishBackedWalkFrame(lane, cache, gen, true, stored, false)
 				continue
 			}
 			frame.view = view
+			if frame.item.baseHash != ([32]byte{}) {
+				baseView, err := sm.loadVerifiedBaseTraversalNode(ctx, access, frame.item.baseHash)
+				if err != nil {
+					return err
+				}
+				frame.baseView = baseView
+			}
 			frame.full = true
 			frame.stored = stored
 			frame.loaded = true
@@ -318,8 +427,8 @@ func (sm *SHAMap) walkBackedLane(
 			frame.nextBranch++
 		}
 		if frame.nextBranch == BranchFactor {
-			full, stored := frame.full, frame.stored
-			sm.finishBackedWalkFrame(lane, cache, gen, full, stored)
+			full, stored, usedBase := frame.full, frame.stored, frame.usedBase
+			sm.finishBackedWalkFrame(lane, cache, gen, full, stored, usedBase)
 			continue
 		}
 
@@ -333,9 +442,14 @@ func (sm *SHAMap) walkBackedLane(
 		if attached, ok := frame.item.node.(*innerNode); ok {
 			parent = attached
 		}
+		baseHash := [32]byte{}
+		if frame.baseView.inner && frame.baseView.branches&(1<<branch) != 0 {
+			baseHash = frame.baseView.hashes[branch]
+		}
 		lane.stack = append(lane.stack, backedWalkFrame{
 			item: backedWalkItem{
 				hash:       frame.view.hashes[branch],
+				baseHash:   baseHash,
 				parentHash: frame.item.hash,
 				nodeID:     childID,
 				depth:      frame.item.depth + 1,
@@ -366,22 +480,23 @@ func (sm *SHAMap) finishBackedWalkFrame(
 	generation uint32,
 	full bool,
 	stored bool,
+	usedBase bool,
 ) {
 	frame := &lane.stack[len(lane.stack)-1]
 	if full {
 		lane.proofs.truncate(frame.proofStart)
 		lane.rememberProof(frame.item.hash, frame.item.depth)
-		if stored {
+		if stored && !usedBase {
 			cacheFullBelow(cache, generation, frame.item.hash, frame.item.depth)
-			if frame.item.parent != nil && frame.item.node != nil {
-				sm.releaseChild(frame.item.parent, frame.item.branch, frame.item.node)
-			}
+		}
+		if stored && frame.item.parent != nil && frame.item.node != nil {
+			sm.releaseChild(frame.item.parent, frame.item.branch, frame.item.node)
 		}
 	}
-	finishBackedWalkFrame(lane, full, stored)
+	finishBackedWalkFrame(lane, full, stored, usedBase)
 }
 
-func finishBackedWalkFrame(lane *backedWalkLane, full, stored bool) {
+func finishBackedWalkFrame(lane *backedWalkLane, full, stored, usedBase bool) {
 	last := len(lane.stack) - 1
 	topLevel := lane.stack[last].topLevel
 	lane.stack = lane.stack[:last]
@@ -392,6 +507,7 @@ func finishBackedWalkFrame(lane *backedWalkLane, full, stored bool) {
 	parent := &lane.stack[len(lane.stack)-1]
 	parent.full = parent.full && full
 	parent.stored = parent.stored && stored
+	parent.usedBase = parent.usedBase || usedBase
 }
 
 func dedupeBackedWalkItems(items []backedWalkItem) []backedWalkItem {
@@ -411,6 +527,7 @@ func dedupeBackedWalkItems(items []backedWalkItem) []backedWalkItem {
 }
 
 func (sm *SHAMap) loadTraversalNode(ctx context.Context, access *familyAccess, root *innerNode, item backedWalkItem) (traversalNode, bool, bool, error) {
+	sm.acquisition.stats.durableReads.Add(1)
 	data, stored, err := access.fetchPreferDurable(ctx, item.hash)
 	if err != nil {
 		return traversalNode{}, false, false, err
@@ -430,6 +547,29 @@ func (sm *SHAMap) loadTraversalNode(ctx context.Context, access *familyAccess, r
 		return traversalNodeFromNode(attached), true, false, nil
 	}
 	return traversalNode{}, false, false, nil
+}
+
+func (sm *SHAMap) loadVerifiedBaseTraversalNode(
+	ctx context.Context,
+	access *familyAccess,
+	hash [32]byte,
+) (traversalNode, error) {
+	sm.acquisition.stats.durableReads.Add(1)
+	data, err := access.fetchDurable(ctx, hash)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return traversalNode{}, ctxErr
+		}
+		return traversalNode{}, fmt.Errorf("%w: read %x: %v", errVerifiedBaseUnavailable, hash[:8], err)
+	}
+	if len(data) == 0 {
+		return traversalNode{}, fmt.Errorf("%w: node %x is missing", errVerifiedBaseUnavailable, hash[:8])
+	}
+	view, err := decodeTraversalNode(data, hash)
+	if err != nil {
+		return traversalNode{}, fmt.Errorf("%w: node %x: %v", errVerifiedBaseUnavailable, hash[:8], err)
+	}
+	return view, nil
 }
 
 func attachedNode(root *innerNode, nodeID NodeID) mapNode {

--- a/shamap/backed_walk_test.go
+++ b/shamap/backed_walk_test.go
@@ -35,6 +35,40 @@ type oneShotMissingFamily struct {
 	failed      bool
 }
 
+type cancelOnceBaseFamily struct {
+	base    *memoryFamily
+	target  [32]byte
+	entered chan struct{}
+	once    sync.Once
+}
+
+func (f *cancelOnceBaseFamily) Fetch(ctx context.Context, hash [32]byte) ([]byte, error) {
+	return f.base.Fetch(ctx, hash)
+}
+
+func (f *cancelOnceBaseFamily) FetchDurable(ctx context.Context, hash [32]byte) ([]byte, error) {
+	blocked := false
+	if hash == f.target {
+		f.once.Do(func() {
+			blocked = true
+			close(f.entered)
+		})
+	}
+	if blocked {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return f.base.FetchDurable(ctx, hash)
+}
+
+func (f *cancelOnceBaseFamily) StoreBatch(ctx context.Context, entries []FlushEntry) error {
+	return f.base.StoreBatch(ctx, entries)
+}
+
+func (f *cancelOnceBaseFamily) FullBelowCache() *FullBelowCache {
+	return f.base.FullBelowCache()
+}
+
 func (f *oneShotMissingFamily) Fetch(ctx context.Context, hash [32]byte) ([]byte, error) {
 	if hash == f.target {
 		return nil, nil
@@ -211,6 +245,420 @@ func (f *countingDurableFamily) snapshotReads() map[[32]byte]int {
 		reads[hash] = count
 	}
 	return reads
+}
+
+func TestBackedWalkVerifiedBaseMatchesStrictFrontierWithFewerReads(t *testing.T) {
+	base := buildRandomState(t, 2000)
+	pivot, err := base.SnapshotMutable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var changedKey [32]byte
+	for i := range changedKey {
+		changedKey[i] = 0xff
+	}
+	if err := pivot.Put(changedKey, make([]byte, 12)); err != nil {
+		t.Fatal(err)
+	}
+
+	baseRoot, err := base.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pivotRoot, err := pivot.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pivotRootData, err := pivot.SerializeRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseEntries, err := collectDirtyForTest(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pivotEntries, err := collectDirtyForTest(pivot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newDestination := func(useBase bool) (*SHAMap, *countingDurableFamily) {
+		t.Helper()
+		memory := newMemoryFamily()
+		if err := memory.StoreBatch(t.Context(), baseEntries); err != nil {
+			t.Fatal(err)
+		}
+		family := &countingDurableFamily{base: memory, reads: make(map[[32]byte]int)}
+		dest, err := NewBacked(TypeState, family)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := dest.AddRootNode(pivotRoot, pivotRootData); err != nil {
+			t.Fatal(err)
+		}
+		if useBase {
+			if err := dest.SetVerifiedBaseContext(t.Context(), baseRoot); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return dest, family
+	}
+
+	strict, strictFamily := newDestination(false)
+	strictMissing, err := strict.GetMissingNodesContext(t.Context(), 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	optimized, optimizedFamily := newDestination(true)
+	optimizedMissing, err := optimized.GetMissingNodesContext(t.Context(), 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	strictFrontier := make(map[[32]byte]NodeID, len(strictMissing))
+	for _, missing := range strictMissing {
+		strictFrontier[missing.Hash] = missing.NodeID
+	}
+	if len(optimizedMissing) != len(strictFrontier) {
+		t.Fatalf("optimized frontier has %d nodes, strict has %d", len(optimizedMissing), len(strictFrontier))
+	}
+	for _, missing := range optimizedMissing {
+		if nodeID, ok := strictFrontier[missing.Hash]; !ok || nodeID != missing.NodeID {
+			t.Fatalf("optimized frontier contains unexpected node %x at %x", missing.Hash[:8], missing.NodeID.Bytes())
+		}
+	}
+	countReads := func(reads map[[32]byte]int) int {
+		total := 0
+		for _, count := range reads {
+			total += count
+		}
+		return total
+	}
+	strictReads := countReads(strictFamily.snapshotReads())
+	optimizedReads := countReads(optimizedFamily.snapshotReads())
+	if optimizedReads >= strictReads {
+		t.Fatalf("optimized durable reads = %d, strict = %d", optimizedReads, strictReads)
+	}
+	stats := optimized.BackedWalkStats()
+	if stats.EqualSubtreesSkipped == 0 || stats.NodesDescended == 0 || stats.MissingNodes != uint64(len(optimizedMissing)) {
+		t.Fatalf("unexpected backed-walk stats: %+v", stats)
+	}
+	corruptHash := optimizedMissing[0].Hash
+	optimizedFamily.base.mu.Lock()
+	optimizedFamily.base.store[corruptHash] = []byte("corrupt")
+	optimizedFamily.base.mu.Unlock()
+	if _, err := optimized.GetMissingNodesContext(t.Context(), 0, nil); !errors.Is(err, ErrInvalidNodeData) {
+		t.Fatalf("corrupt pivot node error = %v", err)
+	}
+	if fallbacks := optimized.BackedWalkStats().VerifiedBaseFallbacks; fallbacks != 0 {
+		t.Fatalf("pivot corruption disabled verified base: fallbacks = %d", fallbacks)
+	}
+	if err := optimizedFamily.base.StoreBatch(t.Context(), pivotEntries); err != nil {
+		t.Fatal(err)
+	}
+	missing, err := optimized.GetMissingNodesContext(t.Context(), 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("completed pivot still reports %d missing nodes", len(missing))
+	}
+	if err := optimized.FinishSyncContext(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	gotRoot, err := optimized.Hash()
+	if err != nil || gotRoot != pivotRoot {
+		t.Fatalf("completed pivot root = %x, err = %v", gotRoot[:8], err)
+	}
+}
+
+func TestBackedWalkVerifiedBaseIdenticalRootSkipsDescendants(t *testing.T) {
+	source := buildRandomState(t, 1000)
+	rootHash, err := source.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootData, err := source.SerializeRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := collectDirtyForTest(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	memory := newMemoryFamily()
+	if err := memory.StoreBatch(t.Context(), entries); err != nil {
+		t.Fatal(err)
+	}
+	family := &countingDurableFamily{base: memory, reads: make(map[[32]byte]int)}
+	dest, err := NewBacked(TypeState, family)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := dest.AddRootNode(rootHash, rootData); err != nil {
+		t.Fatal(err)
+	}
+	if err := dest.SetVerifiedBaseContext(t.Context(), rootHash); err != nil {
+		t.Fatal(err)
+	}
+	missing, err := dest.GetMissingNodesContext(t.Context(), 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("identical root reported %d missing nodes", len(missing))
+	}
+	stats := dest.BackedWalkStats()
+	if stats.EqualSubtreesSkipped != 1 || stats.NodesDescended != 0 || stats.DurableReads != 1 {
+		t.Fatalf("unexpected identical-root stats: %+v", stats)
+	}
+}
+
+func TestBackedWalkVerifiedBaseFailureFallsBackToStrictWalk(t *testing.T) {
+	base := buildRandomState(t, 1000)
+	pivot, err := base.SnapshotMutable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var changedKey [32]byte
+	for i := range changedKey {
+		changedKey[i] = 0xee
+	}
+	if err := pivot.Put(changedKey, make([]byte, 12)); err != nil {
+		t.Fatal(err)
+	}
+
+	baseRoot, err := base.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pivotRoot, err := pivot.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pivotRootData, err := pivot.SerializeRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseEntries, err := collectDirtyForTest(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pivotEntries, err := collectDirtyForTest(pivot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	branch := selectBranchForPath(changedKey, 0)
+	_, damagedHash, set := base.tree.root.LoadChild(branch)
+	if !set || damagedHash == ([32]byte{}) {
+		t.Fatal("changed branch is absent from verified base")
+	}
+
+	for _, test := range []struct {
+		name   string
+		damage func(*memoryFamily, [32]byte)
+	}{
+		{
+			name: "missing",
+			damage: func(family *memoryFamily, hash [32]byte) {
+				delete(family.store, hash)
+			},
+		},
+		{
+			name: "corrupt",
+			damage: func(family *memoryFamily, hash [32]byte) {
+				family.store[hash] = []byte("corrupt")
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			family := newMemoryFamily()
+			if err := family.StoreBatch(t.Context(), append(baseEntries, pivotEntries...)); err != nil {
+				t.Fatal(err)
+			}
+			dest, err := NewBacked(TypeState, family)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := dest.AddRootNode(pivotRoot, pivotRootData); err != nil {
+				t.Fatal(err)
+			}
+			if err := dest.SetVerifiedBaseContext(t.Context(), baseRoot); err != nil {
+				t.Fatal(err)
+			}
+			family.mu.Lock()
+			test.damage(family, damagedHash)
+			family.mu.Unlock()
+
+			missing, err := dest.GetMissingNodesContext(t.Context(), 0, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(missing) != 0 {
+				t.Fatalf("strict fallback reported %d missing pivot nodes", len(missing))
+			}
+			stats := dest.BackedWalkStats()
+			if stats.VerifiedBaseFallbacks != 1 {
+				t.Fatalf("verified-base fallbacks = %d, want 1", stats.VerifiedBaseFallbacks)
+			}
+		})
+	}
+}
+
+func TestBackedWalkVerifiedBaseCancellationResumes(t *testing.T) {
+	base := buildRandomState(t, 1000)
+	pivot, err := base.SnapshotMutable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var changedKey [32]byte
+	for i := range changedKey {
+		changedKey[i] = 0xdd
+	}
+	if err := pivot.Put(changedKey, make([]byte, 12)); err != nil {
+		t.Fatal(err)
+	}
+	baseRoot, err := base.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pivotRoot, err := pivot.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pivotRootData, err := pivot.SerializeRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseEntries, err := collectDirtyForTest(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pivotEntries, err := collectDirtyForTest(pivot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	branch := selectBranchForPath(changedKey, 0)
+	_, target, set := base.tree.root.LoadChild(branch)
+	if !set {
+		t.Fatal("changed branch is absent from verified base")
+	}
+	memory := newMemoryFamily()
+	if err := memory.StoreBatch(t.Context(), append(baseEntries, pivotEntries...)); err != nil {
+		t.Fatal(err)
+	}
+	family := &cancelOnceBaseFamily{base: memory, target: target, entered: make(chan struct{})}
+	dest, err := NewBacked(TypeState, family)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := dest.AddRootNode(pivotRoot, pivotRootData); err != nil {
+		t.Fatal(err)
+	}
+	if err := dest.SetVerifiedBaseContext(t.Context(), baseRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		_, walkErr := dest.GetMissingNodesContext(ctx, 0, nil)
+		done <- walkErr
+	}()
+	<-family.entered
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled walk error = %v", err)
+	}
+	missing, err := dest.GetMissingNodesContext(t.Context(), 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("resumed walk reported %d missing nodes", len(missing))
+	}
+	if fallbacks := dest.BackedWalkStats().VerifiedBaseFallbacks; fallbacks != 0 {
+		t.Fatalf("cancellation disabled the verified base: fallbacks = %d", fallbacks)
+	}
+}
+
+func BenchmarkBackedWalkVerifiedBaseSparseChange(b *testing.B) {
+	base := buildRandomState(b, 10_000)
+	pivot, err := base.SnapshotMutable()
+	if err != nil {
+		b.Fatal(err)
+	}
+	var changedKey [32]byte
+	for i := range changedKey {
+		changedKey[i] = 0xcc
+	}
+	if err := pivot.Put(changedKey, make([]byte, 12)); err != nil {
+		b.Fatal(err)
+	}
+	baseRoot, err := base.Hash()
+	if err != nil {
+		b.Fatal(err)
+	}
+	pivotRoot, err := pivot.Hash()
+	if err != nil {
+		b.Fatal(err)
+	}
+	pivotRootData, err := pivot.SerializeRoot()
+	if err != nil {
+		b.Fatal(err)
+	}
+	baseEntries, err := collectDirtyForTest(base)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for _, benchmark := range []struct {
+		name    string
+		useBase bool
+	}{
+		{name: "strict"},
+		{name: "verified-base", useBase: true},
+	} {
+		b.Run(benchmark.name, func(b *testing.B) {
+			b.ReportAllocs()
+			var reads, skipped uint64
+			for range b.N {
+				b.StopTimer()
+				memory := newMemoryFamily()
+				if err := memory.StoreBatch(b.Context(), baseEntries); err != nil {
+					b.Fatal(err)
+				}
+				family := &countingDurableFamily{base: memory, reads: make(map[[32]byte]int)}
+				dest, err := NewBacked(TypeState, family)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if err := dest.AddRootNode(pivotRoot, pivotRootData); err != nil {
+					b.Fatal(err)
+				}
+				if benchmark.useBase {
+					if err := dest.SetVerifiedBaseContext(b.Context(), baseRoot); err != nil {
+						b.Fatal(err)
+					}
+				}
+				b.StartTimer()
+				missing, err := dest.GetMissingNodesContext(b.Context(), 0, nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+				b.StopTimer()
+				if len(missing) == 0 {
+					b.Fatal("sparse pivot change produced no missing frontier")
+				}
+				for _, count := range family.snapshotReads() {
+					reads += uint64(count)
+				}
+				skipped += dest.BackedWalkStats().EqualSubtreesSkipped
+			}
+			b.ReportMetric(float64(reads)/float64(b.N), "durable_reads/op")
+			b.ReportMetric(float64(skipped)/float64(b.N), "equal_subtrees/op")
+		})
+	}
 }
 
 func (f *countingDurableFamily) totalReads() int {
@@ -1079,7 +1527,7 @@ func TestBackedWalkCompletionRetainsMaximalCheckpointProof(t *testing.T) {
 				proofStart: 0,
 			}}
 
-			sm.finishBackedWalkFrame(&lane, cache, gen, true, stored)
+			sm.finishBackedWalkFrame(&lane, cache, gen, true, stored, false)
 
 			if got := lane.proofs.count(); got != 1 {
 				t.Fatalf("proof count = %d, want one maximal proof", got)

--- a/shamap/shamap.go
+++ b/shamap/shamap.go
@@ -49,6 +49,8 @@ type acquisitionState struct {
 	walkMu       sync.Mutex
 	attachmentMu sync.Mutex
 	cursor       *backedWalkCursor
+	base         *verifiedWalkBase
+	stats        backedWalkStats
 }
 
 // Type defines the SHAMap type
@@ -129,6 +131,7 @@ func (sm *SHAMap) SetFamily(family Family) {
 	sm.backing.mu.Lock()
 	sm.backing.access = access
 	sm.acquisition.cursor = nil
+	sm.acquisition.base = nil
 	if family != nil {
 		sm.backing.fullBelow = fullBelow
 	}

--- a/shamap/sync_missing.go
+++ b/shamap/sync_missing.go
@@ -2,6 +2,7 @@ package shamap
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 )
@@ -63,6 +64,13 @@ func (sm *SHAMap) walkMapParallelContext(ctx context.Context, maxMissing int, fi
 	rootID := newRootNodeID()
 	rootHash := root.Hash()
 	if backed {
+		missing, err := sm.walkBackedContext(ctx, root, access, cache, gen, maxMissing, filter)
+		if !errors.Is(err, errVerifiedBaseUnavailable) {
+			return missing, err
+		}
+		sm.acquisition.base = nil
+		sm.acquisition.cursor = nil
+		sm.acquisition.stats.verifiedBaseFallbacks.Add(1)
 		return sm.walkBackedContext(ctx, root, access, cache, gen, maxMissing, filter)
 	}
 

--- a/storage/nodestore/durability.go
+++ b/storage/nodestore/durability.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sync"
 
 	"github.com/LeJamon/go-xrpl/storage/kvstore"
 )
@@ -29,21 +30,44 @@ type DurableDatabase interface {
 	WithDurableSnapshot(context.Context, func([32]byte) error) error
 }
 
-// WithDurableSnapshot prevents managed destructive mutations while fn checks
-// the fingerprint and publishes work derived from the current store contents.
-func (d *KVDatabase) WithDurableSnapshot(ctx context.Context, fn func([32]byte) error) error {
+// DurableSnapshotDatabase can retain a stable durable generation beyond one
+// callback, for work that spans multiple resumable operations.
+type DurableSnapshotDatabase interface {
+	DurableDatabase
+	AcquireDurableSnapshot(context.Context) ([32]byte, func(), error)
+}
+
+// AcquireDurableSnapshot prevents managed destructive mutations until the
+// returned release function is called. Ordinary writes remain available.
+func (d *KVDatabase) AcquireDurableSnapshot(ctx context.Context) ([32]byte, func(), error) {
 	if err := ctx.Err(); err != nil {
-		return err
+		return [32]byte{}, nil, err
 	}
 	d.mutationMu.RLock()
-	defer d.mutationMu.RUnlock()
+	var once sync.Once
+	release := func() {
+		once.Do(d.mutationMu.RUnlock)
+	}
 	if err := ctx.Err(); err != nil {
-		return err
+		release()
+		return [32]byte{}, nil, err
 	}
 	fingerprint, err := d.DurableFingerprint(ctx)
 	if err != nil {
+		release()
+		return [32]byte{}, nil, err
+	}
+	return fingerprint, release, nil
+}
+
+// WithDurableSnapshot prevents managed destructive mutations while fn checks
+// the fingerprint and publishes work derived from the current store contents.
+func (d *KVDatabase) WithDurableSnapshot(ctx context.Context, fn func([32]byte) error) error {
+	fingerprint, release, err := d.AcquireDurableSnapshot(ctx)
+	if err != nil {
 		return err
 	}
+	defer release()
 	return fn(fingerprint)
 }
 

--- a/storage/nodestore/durability_test.go
+++ b/storage/nodestore/durability_test.go
@@ -244,3 +244,67 @@ func TestDurableSnapshotExcludesManagedPruneThroughPublication(t *testing.T) {
 		t.Fatalf("publication missing after serialized prune: node=%v err=%v", stored, err)
 	}
 }
+
+func TestAcquireDurableSnapshotPinsManagedMutationUntilRelease(t *testing.T) {
+	database := testDatabase(t, memorydb.New(), noCacheConfig())
+	before, release, err := database.AcquireDurableSnapshot(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	releaseAgain := release
+
+	pruneDone := make(chan error, 1)
+	go func() {
+		_, pruneErr := database.DeleteBefore(context.Background(), 2, 1)
+		pruneDone <- pruneErr
+	}()
+	select {
+	case err := <-pruneDone:
+		t.Fatalf("prune crossed the retained durable snapshot: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	release()
+	releaseAgain()
+	if err := <-pruneDone; err != nil {
+		t.Fatal(err)
+	}
+	after, err := database.DurableFingerprint(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after == before {
+		t.Fatal("released snapshot did not permit the prune generation to advance")
+	}
+}
+
+func TestDurableSnapshotOrdersPruneInvalidationAfterLease(t *testing.T) {
+	database := testDatabase(t, memorydb.New(), noCacheConfig())
+	_, release, err := database.AcquireDurableSnapshot(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	pruneStarted := make(chan struct{})
+	pruneDone := make(chan error, 1)
+	go func() {
+		_, pruneErr := database.DeleteBeforeWithPrune(context.Background(), 2, 1, func() func() {
+			close(pruneStarted)
+			return func() {}
+		})
+		pruneDone <- pruneErr
+	}()
+	select {
+	case <-pruneStarted:
+		t.Fatal("prune invalidated SHAMap proofs before acquiring the durable mutation gate")
+	case <-time.After(25 * time.Millisecond):
+	}
+	release()
+	select {
+	case <-pruneStarted:
+	case <-time.After(time.Second):
+		t.Fatal("prune did not start after the durable snapshot was released")
+	}
+	if err := <-pruneDone; err != nil {
+		t.Fatal(err)
+	}
+}

--- a/storage/nodestore/prune.go
+++ b/storage/nodestore/prune.go
@@ -16,11 +16,26 @@ func (d *KVDatabase) DeleteBefore(
 	boundary uint32,
 	batchSize int,
 ) (deleted uint64, err error) {
+	return d.DeleteBeforeWithPrune(ctx, boundary, batchSize, nil)
+}
+
+// DeleteBeforeWithPrune acquires the durable mutation gate before invalidating
+// SHAMap completeness proofs, preserving the global lock order.
+func (d *KVDatabase) DeleteBeforeWithPrune(
+	ctx context.Context,
+	boundary uint32,
+	batchSize int,
+	beginPrune func() func(),
+) (deleted uint64, err error) {
 	if boundary == 0 {
 		return 0, nil
 	}
 	d.mutationMu.Lock()
 	defer d.mutationMu.Unlock()
+	if beginPrune != nil {
+		finish := beginPrune()
+		defer finish()
+	}
 	if err := d.bumpDurableMutation(ctx); err != nil {
 		return 0, fmt.Errorf("delete-before durable generation: %w", err)
 	}

--- a/storage/nodestore/rotating_database.go
+++ b/storage/nodestore/rotating_database.go
@@ -91,8 +91,22 @@ func (d *RotatingKVDatabase) RotateGeneration(
 	ctx context.Context,
 	lastRotated, minimumOnline uint32,
 ) (bool, error) {
+	return d.RotateGenerationWithPrune(ctx, lastRotated, minimumOnline, nil)
+}
+
+// RotateGenerationWithPrune acquires the durable mutation gate before
+// invalidating SHAMap completeness proofs, preserving the global lock order.
+func (d *RotatingKVDatabase) RotateGenerationWithPrune(
+	ctx context.Context,
+	lastRotated, minimumOnline uint32,
+	beginPrune func() func(),
+) (bool, error) {
 	d.mutationMu.Lock()
 	defer d.mutationMu.Unlock()
+	if beginPrune != nil {
+		finish := beginPrune()
+		defer finish()
+	}
 	if err := d.begin(ctx); err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## Summary

- compare the frozen pivot state SHAMap against the cleanly accepted startup checkpoint at matching positions and skip equal subtrees
- pin the checkpoint NodeStore generation through pivot discovery and replay handoff, with cancellation-safe release and online-delete lock ordering
- fall back to the ordinary strict backed walk when checkpoint-base nodes are missing or corrupt, while preserving pivot-node hash verification
- expose discovery counters for equal subtrees skipped, nodes descended, durable reads, missing nodes, and verified-base fallbacks

## Correctness

- strict and checkpoint-relative walks produce the same missing-node frontier and final pivot root
- remote pivot nodes still use the existing content-hash verification and final root/completeness gates
- managed prune/rotation cannot delete checkpoint-base nodes while the retained snapshot is active
- cancellation does not block validation or consensus ticks, and shutdown waits for the retained snapshot to release
- reviewed against the clean rippled 3.3.0 oracle at 00a178fb92ca49521b937ae1a99d863765ea8a90; same-position hash skipping follows SHAMap::visitDifferences semantics

## Benchmark

Apple M3 Pro, synthetic verified base with sparse deep pivot changes, three runs:

| mode | wall time/op | durable reads/op | equal subtrees/op | allocations/op |
| --- | ---: | ---: | ---: | ---: |
| strict | 13.7-21.7 ms | 13,051 | 0 | ~39,698 |
| verified base | 43.2-43.8 us | 2 | 15 | 76 |

Command:

    go test ./shamap -run ^$ -bench ^BenchmarkBackedWalkVerifiedBaseSparseChange$ -benchmem -count=3

A copied production-like testnet database is not present in this workspace, so deployment-specific physical block-read and peak-memory measurements are not claimed here. The benchmark and diagnostics are included so the operator dataset can be measured directly.

## Tests

- just fmt
- just lint
- just vet
- just build-all
- just test
- go test -race ./shamap ./storage/nodestore ./internal/ledger/shamapstore ./internal/ledger/service ./internal/ledger/inbound ./internal/consensus/adaptor -count=1

Fixes #1749